### PR TITLE
feat(release): publish prebuilt default-microvm kernel + rootfs (closes #4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,50 @@ jobs:
             staging/dev-rootfs-${{ matrix.arch }}.ext4
             staging/dev-image-${{ matrix.arch }}-checksums-sha256.txt
 
+  default-microvm:
+    # Build the bundled default microVM image used by `mvmctl exec` /
+    # `mvmctl up` when no --flake or --template was given. Mirrors the
+    # dev-image job: native per-arch builds, unsigned artifacts.
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+          - arch: x86_64
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build default microVM image
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          SYSTEM="${ARCH}-linux"
+          nix build "./nix/default-microvm#packages.${SYSTEM}.default" \
+            --no-link --print-out-paths > /tmp/store-path.txt
+          STORE_PATH=$(head -1 /tmp/store-path.txt)
+          mkdir -p staging
+          cp "$STORE_PATH/vmlinux" "staging/default-microvm-vmlinux-${ARCH}"
+          cp "$STORE_PATH/rootfs.ext4" "staging/default-microvm-rootfs-${ARCH}.ext4"
+          cd staging
+          sha256sum "default-microvm-vmlinux-${ARCH}" "default-microvm-rootfs-${ARCH}.ext4" \
+            > "default-microvm-${ARCH}-checksums-sha256.txt"
+
+      - name: Upload default microVM image artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: default-microvm-${{ matrix.arch }}
+          path: |
+            staging/default-microvm-vmlinux-${{ matrix.arch }}
+            staging/default-microvm-rootfs-${{ matrix.arch }}.ext4
+            staging/default-microvm-${{ matrix.arch }}-checksums-sha256.txt
+
   release:
-    needs: [build, dev-image]
+    needs: [build, dev-image, default-microvm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -218,6 +260,9 @@ jobs:
             artifacts/dev-vmlinux-* \
             artifacts/dev-rootfs-* \
             artifacts/dev-image-*-checksums-sha256.txt \
+            artifacts/default-microvm-vmlinux-* \
+            artifacts/default-microvm-rootfs-* \
+            artifacts/default-microvm-*-checksums-sha256.txt \
             sbom.cdx.json \
             sbom.cdx.json.bundle
 

--- a/crates/mvm-cli/src/commands.rs
+++ b/crates/mvm-cli/src/commands.rs
@@ -2261,7 +2261,13 @@ fn download_file(url: &str, dest: &str) -> Result<()> {
         // Clean up partial download
         let _ = std::fs::remove_file(dest);
         anyhow::bail!(
-            "Download failed. The dev image may not be available for v{version}.\n\
+            "Download failed. Pre-built images for v{version} may not yet be\n\
+             published — release tags are pushed before the artifact-build\n\
+             matrix completes, so a 404 here often just means the build is\n\
+             still in flight. Check the release page or retry in a few\n\
+             minutes:\n\
+             \n\
+             \x20   https://github.com/auser/mvm/releases/tag/v{version}\n\
              \n\
              To build locally instead, set up a Nix Linux builder:\n\
              \n\
@@ -2270,9 +2276,7 @@ fn download_file(url: &str, dest: &str) -> Result<()> {
              \n\
              \x20 Option 2 — Permanent (add to /etc/nix/nix.conf):\n\
              \x20   builders = ssh-ng://builder@linux-builder aarch64-linux /etc/nix/builder_ed25519 4 1 kvm,big-parallel - -\n\
-             \x20   builders-use-substitutes = true\n\
-             \n\
-             Then re-run: mvmctl dev up",
+             \x20   builders-use-substitutes = true",
             version = env!("CARGO_PKG_VERSION")
         );
     }
@@ -2348,9 +2352,9 @@ fn find_default_microvm_flake() -> Result<String> {
 /// supplied. Builds via Nix on first use and caches under
 /// `~/.cache/mvm/default-microvm/`. Returns `(kernel_path, rootfs_path)`.
 ///
-/// Unlike the dev image, there is no download fallback — if Nix isn't
-/// available (or can't cross-compile a Linux image on this host), the
-/// caller is asked to install Nix or pass an explicit `--template`/`--flake`.
+/// On hosts without Nix (or where the local Nix build fails — e.g. macOS
+/// without a Linux builder configured), falls back to downloading a
+/// pre-built image from the matching GitHub release.
 pub(crate) fn ensure_default_microvm_image() -> Result<(String, String)> {
     let cache_dir = format!("{}/default-microvm", mvm_core::config::mvm_cache_dir());
     std::fs::create_dir_all(&cache_dir)?;
@@ -2363,65 +2367,89 @@ pub(crate) fn ensure_default_microvm_image() -> Result<(String, String)> {
     }
 
     let plat = mvm_core::platform::current();
-    if !plat.has_host_nix() {
-        anyhow::bail!(
-            "Nix is required to build the default exec image, but it isn't installed.\n\
-             Install Nix (https://nixos.org/download.html) or pass an explicit\n\
-             --template that you've already built with `mvmctl template create`."
-        );
-    }
-    let flake_dir = find_default_microvm_flake()?;
-    let nix_bin = find_nix_binary();
+    if plat.has_host_nix()
+        && let Ok(flake_dir) = find_default_microvm_flake()
+    {
+        let nix_bin = find_nix_binary();
 
-    if cfg!(target_os = "macos") && ensure_linux_builder_ssh_config() {
-        ui::info("  Linux builder detected and SSH configured.");
-    }
-
-    ui::info("Building default microVM image via Nix (first time only)...");
-    let mut child = std::process::Command::new(&nix_bin)
-        .args([
-            "build",
-            &format!(
-                "{flake_dir}#packages.{}.default",
-                mvm_build::dev_build::linux_system()
-            ),
-            "--no-link",
-            "--print-out-paths",
-        ])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::inherit())
-        .spawn()
-        .context("Failed to run nix build")?;
-
-    let stdout = {
-        let mut buf = String::new();
-        if let Some(mut out) = child.stdout.take() {
-            use std::io::Read;
-            let _ = out.read_to_string(&mut buf);
+        if cfg!(target_os = "macos") && ensure_linux_builder_ssh_config() {
+            ui::info("  Linux builder detected and SSH configured.");
         }
-        buf
+
+        ui::info("Building default microVM image via Nix (first time only)...");
+        let mut child = std::process::Command::new(&nix_bin)
+            .args([
+                "build",
+                &format!(
+                    "{flake_dir}#packages.{}.default",
+                    mvm_build::dev_build::linux_system()
+                ),
+                "--no-link",
+                "--print-out-paths",
+            ])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .context("Failed to run nix build")?;
+
+        let stdout = {
+            let mut buf = String::new();
+            if let Some(mut out) = child.stdout.take() {
+                use std::io::Read;
+                let _ = out.read_to_string(&mut buf);
+            }
+            buf
+        };
+        let status = child.wait().context("nix build process failed")?;
+
+        if status.success() {
+            let store_path = stdout.trim().to_string();
+            let ks = format!("{store_path}/vmlinux");
+            let rs = format!("{store_path}/rootfs.ext4");
+            if std::path::Path::new(&ks).exists() && std::path::Path::new(&rs).exists() {
+                std::fs::copy(&ks, &kernel_path)?;
+                std::fs::copy(&rs, &rootfs_path)?;
+                ui::success("Default microVM image built and cached.");
+                return Ok((kernel_path, rootfs_path));
+            }
+        }
+
+        ui::warn("Local Nix build failed; falling back to pre-built download.");
+    }
+
+    download_default_microvm_image(&kernel_path, &rootfs_path)
+}
+
+/// Download a pre-built default microVM image (kernel + rootfs) from the
+/// matching GitHub release. Mirrors `download_dev_image`.
+fn download_default_microvm_image(
+    kernel_path: &str,
+    rootfs_path: &str,
+) -> Result<(String, String)> {
+    let version = env!("CARGO_PKG_VERSION");
+    let base_url = format!("https://github.com/auser/mvm/releases/download/v{version}");
+    let arch = if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
     };
-    let status = child.wait().context("nix build process failed")?;
+    let kernel_url = format!("{base_url}/default-microvm-vmlinux-{arch}");
+    let rootfs_url = format!("{base_url}/default-microvm-rootfs-{arch}.ext4");
 
-    if !status.success() {
-        anyhow::bail!(
-            "nix build of the default microVM image failed.\n\
-             If you're on macOS without a Linux builder, either start one\n\
-             (`nix run 'nixpkgs#darwin.linux-builder'`) or pass an explicit\n\
-             --template/--flake that you've already built."
-        );
-    }
+    ui::info(&format!(
+        "Downloading default microVM image (v{version})..."
+    ));
 
-    let store_path = stdout.trim().to_string();
-    let ks = format!("{store_path}/vmlinux");
-    let rs = format!("{store_path}/rootfs.ext4");
-    if !std::path::Path::new(&ks).exists() || !std::path::Path::new(&rs).exists() {
-        anyhow::bail!("nix build succeeded but expected outputs are missing under {store_path}");
-    }
-    std::fs::copy(&ks, &kernel_path)?;
-    std::fs::copy(&rs, &rootfs_path)?;
-    ui::success("Default microVM image built and cached.");
-    Ok((kernel_path, rootfs_path))
+    ui::info("  Fetching kernel...");
+    download_file(&kernel_url, kernel_path)
+        .with_context(|| format!("Failed to download kernel from {kernel_url}"))?;
+
+    ui::info("  Fetching rootfs...");
+    download_file(&rootfs_url, rootfs_path)
+        .with_context(|| format!("Failed to download rootfs from {rootfs_url}"))?;
+
+    ui::success("Default microVM image downloaded and cached.");
+    Ok((kernel_path.to_string(), rootfs_path.to_string()))
 }
 
 fn run_setup_steps(force: bool, lima_cpus: u32, lima_mem: u32) -> Result<()> {

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -67,7 +67,7 @@ on a real Linux/KVM host.
 Tracked as GitHub issues so they're individually grabbable:
 
 - [ ] [#3](https://github.com/tinylabscom/mvm/issues/3) — Live smoke for `mvmctl exec` on Linux/KVM and Lima dev VM (boot+exec+teardown, `--add-dir`, SIGINT, `nix build` of `nix/default-microvm/`). _Needs real hardware._
-- [ ] [#4](https://github.com/tinylabscom/mvm/issues/4) — Release artifacts for the bundled default microVM image so `ensure_default_microvm_image()` can fall back to download when Nix is unavailable.
+- [x] [#4](https://github.com/tinylabscom/mvm/issues/4) — Release artifacts for the bundled default microVM image. Release workflow now builds `nix/default-microvm/` per-arch and uploads `default-microvm-vmlinux-{arch}` / `default-microvm-rootfs-{arch}.ext4` / `default-microvm-{arch}-checksums-sha256.txt`. `ensure_default_microvm_image()` falls back to `download_default_microvm_image()` when Nix is unavailable or the local build fails. Cosign scope unchanged (artifacts unsigned, mirroring `dev-image`).
 - [x] [#5](https://github.com/tinylabscom/mvm/issues/5) — mvmforge `launch.json` consumption: `ExecTarget::LaunchPlan` + entrypoint parser + `--launch-plan` flag. Image-from-launch-plan remains a future variant (mvmforge v0 `apps[].source` is itself "deferred").
 - [ ] [#6](https://github.com/tinylabscom/mvm/issues/6) — Writable `--add-dir` (virtio-fs or 9p) — separate design / ADR required.
 - [x] [#7](https://github.com/tinylabscom/mvm/issues/7) — Snapshot restore for `mvmctl exec` (easy branch: registered template, no `--add-dir`). The harder branch (parameterized snapshots for the `--add-dir` case) stays open under the same issue.


### PR DESCRIPTION
## Summary

- Adds a `default-microvm` matrix job to `.github/workflows/release.yml` mirroring the existing `dev-image` job. Per-arch (`aarch64`/`x86_64`) builds of `./nix/default-microvm#packages.<system>.default`, uploading `default-microvm-vmlinux-{arch}`, `default-microvm-rootfs-{arch}.ext4`, and `default-microvm-{arch}-checksums-sha256.txt`. Wired into the `release` job's `needs:` and the final `gh release create` call.
- Adds `download_default_microvm_image()` in `crates/mvm-cli/src/commands.rs` mirroring `download_dev_image()` (curl + atomic destination + on-failure cleanup). `ensure_default_microvm_image()` now falls through to it when Nix isn't installed **or** the local Nix build fails — so a vanilla macOS host without a Linux builder gets the prebuilt image automatically.
- Reworded the shared `download_file` 404 error so the merge-to-tag gap (release tag exists, artifact-build matrix still in flight) doesn't read as "image unavailable forever."
- Ticked #4 in `specs/SPRINT.md` with a brief note.

Cache layout (`~/.cache/mvm/default-microvm/{vmlinux,rootfs.ext4}`) is unchanged.

## Cosign scope

Issue #4's acceptance criteria says "match existing dev-image artifacts (per Sprint 21)." Looking at the current workflow, cosign only signs `*.tar.gz` files — `dev-vmlinux-*` / `dev-rootfs-*.ext4` are **not** signed. To stay symmetric with `dev-image`, the new `default-microvm-*` artifacts are also unsigned. If we want to sign all raw image artifacts (dev + default), that's a separate change that should cover both.

## Test plan

- [x] `cargo test --workspace` — 1030+ tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [ ] After merge + a release tag is cut, verify `gh release view <tag> --json assets` lists all six new files: `default-microvm-vmlinux-{aarch64,x86_64}`, `default-microvm-rootfs-{aarch64,x86_64}.ext4`, `default-microvm-{aarch64,x86_64}-checksums-sha256.txt`.
- [ ] On a macOS host without a Linux builder, `mvmctl exec` (with no flake/template) downloads the prebuilt image into `~/.cache/mvm/default-microvm/` instead of erroring out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)