### PR TITLE
feat(mcp,nix,policy): adopt MCP + LLM-agent ergonomics from the Nix-agent ecosystem (plan 32)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,6 +1506,7 @@ dependencies = [
  "mvm-build",
  "mvm-core",
  "mvm-guest",
+ "mvm-mcp",
  "mvm-runtime",
  "mvm-security",
  "names",
@@ -1559,6 +1560,17 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+]
+
+[[package]]
+name = "mvm-mcp"
+version = "0.13.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/mvm-build",
     "crates/mvm-guest",
     "crates/mvm-cli",
+    "crates/mvm-mcp",
     "crates/mvm-apple-container",
     "xtask",
 ]
@@ -100,6 +101,7 @@ mvm-build = { path = "crates/mvm-build", version = "0.13.0" }
 mvm-runtime = { path = "crates/mvm-runtime", version = "0.13.0" }
 mvm-security = { path = "crates/mvm-security", version = "0.13.0" }
 mvm-cli = { path = "crates/mvm-cli", version = "0.13.0" }
+mvm-mcp = { path = "crates/mvm-mcp", version = "0.13.0" }
 mvm-apple-container = { path = "crates/mvm-apple-container", version = "0.7.0" }
 
 # Dev dependencies

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -15,6 +15,7 @@ mvm-runtime.workspace = true
 mvm-build.workspace = true
 mvm-security.workspace = true
 mvm-apple-container.workspace = true
+mvm-mcp.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 names.workspace = true

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -105,6 +105,14 @@ pub(in crate::commands) enum Commands {
     /// `mvmctl exec` flags. Alternatively, pass `--launch-plan ./launch.json` to invoke an
     /// mvmforge-emitted entrypoint instead of an inline argv.
     Exec(vm::exec::Args),
+    /// Speak Model Context Protocol — exposes mvmctl as a sandbox surface for LLM clients.
+    ///
+    /// Single parameterized `run` tool whose `env` parameter selects from `mvmctl template list`.
+    /// Each call boots a transient microVM, runs the supplied code, and tears down. Like
+    /// `mvmctl exec`, the dispatch path requires a dev-feature guest agent (ADR-002 §W4.3);
+    /// against a production guest the call returns "exec not available" gracefully. ADR-003
+    /// documents the threat model and design.
+    Mcp(ops::mcp::Args),
 }
 
 // ============================================================================
@@ -200,6 +208,7 @@ pub fn run() -> Result<()> {
         Commands::Init(a) => env::init::run(&cli, a, &cfg),
         Commands::Security(a) => ops::security::run(&cli, a, &cfg),
         Commands::Exec(a) => vm::exec::run(&cli, a, &cfg),
+        Commands::Mcp(a) => ops::mcp::run(&cli, a, &cfg),
     };
 
     with_hints(result)

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -1,0 +1,355 @@
+//! `mvmctl mcp` — Model Context Protocol server entry point.
+//!
+//! Today: stdio-only transport. Reads JSON-RPC requests from stdin,
+//! writes responses to stdout, dispatches `tools/call run` into
+//! transient microVMs via [`crate::exec::run_captured`]. ADR-003 has
+//! the threat model and design.
+//!
+//! Note: `mvmctl mcp` is *always* present in CLI builds (no Cargo
+//! feature gate at the host level), matching `mvmctl exec`'s pattern.
+//! The guest-side `Exec` handler is the actual gate per ADR-002 §W4.3
+//! — production guest agents are built without `dev-shell`, so the
+//! `tools/call run` dispatch returns "exec not available" instead of
+//! executing. This composition is intentional: the MCP server is
+//! useful when pointed at dev VMs, harmless when pointed at prod ones.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::Result;
+use clap::{Args as ClapArgs, Subcommand};
+
+use mvm_core::user_config::MvmConfig;
+use mvm_mcp::{ContentBlock, Dispatcher, RunParams, ToolResult};
+
+use super::Cli;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub transport: McpTransport,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum McpTransport {
+    /// Speak MCP over stdio (the standard MCP transport for local
+    /// developer tools). Reads JSON-RPC frames from stdin, writes
+    /// responses to stdout. All non-protocol output goes to stderr —
+    /// putting anything else on stdout corrupts the wire.
+    Stdio,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    match args.transport {
+        McpTransport::Stdio => {
+            mvm_mcp::init_stderr_tracing();
+            let dispatcher = ExecDispatcher::default();
+            let stdin = std::io::stdin();
+            let stdout = std::io::stdout();
+            mvm_mcp::run_with_dispatcher(stdin.lock(), &mut stdout.lock(), &dispatcher)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExecDispatcher — bridges MCP protocol to crate::exec::run_captured
+// ---------------------------------------------------------------------------
+
+/// stdout/stderr cap per call (cross-cutting "A: resource limits").
+/// Truncated tail is replaced by an explicit `[truncated, N more
+/// bytes]` marker so the LLM sees the failure mode instead of a
+/// silently chopped payload.
+const STREAM_CAP_BYTES: usize = 64 * 1024;
+
+/// Default per-call timeout in seconds. Bounded `[1, 600]`; values
+/// outside that range are clamped (not errored) so an LLM that picks
+/// `timeout_secs: 0` still makes progress.
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+const MIN_TIMEOUT_SECS: u64 = 1;
+const MAX_TIMEOUT_SECS: u64 = 600;
+
+/// Default concurrency cap. Configurable via `MVM_MCP_MAX_INFLIGHT`.
+const DEFAULT_MAX_INFLIGHT: usize = 4;
+
+/// Default memory ceiling in MiB. Configurable via
+/// `MVM_MCP_MEM_CEILING_MIB`.
+const DEFAULT_MEM_CEILING_MIB: u32 = 4096;
+
+/// Default vCPUs handed to the transient microVM. Templates' vCPU
+/// counts are not honored in v1 — every `tools/call run` uses the
+/// same fixed shape so concurrency math stays predictable.
+const DEFAULT_VM_CPUS: u32 = 2;
+const DEFAULT_VM_MEM_MIB: u32 = 1024;
+
+/// Concrete dispatcher backed by [`crate::exec::run_captured`].
+struct ExecDispatcher {
+    inflight: AtomicUsize,
+    max_inflight: usize,
+    mem_ceiling_mib: u32,
+}
+
+impl Default for ExecDispatcher {
+    fn default() -> Self {
+        Self {
+            inflight: AtomicUsize::new(0),
+            max_inflight: parse_env_usize("MVM_MCP_MAX_INFLIGHT", DEFAULT_MAX_INFLIGHT),
+            mem_ceiling_mib: parse_env_u32("MVM_MCP_MEM_CEILING_MIB", DEFAULT_MEM_CEILING_MIB),
+        }
+    }
+}
+
+impl Dispatcher for ExecDispatcher {
+    fn run(&self, params: RunParams) -> ToolResult {
+        // Concurrency gate (cross-cutting "A: resource limits").
+        let prev = self.inflight.fetch_add(1, Ordering::SeqCst);
+        let _guard = InflightGuard(&self.inflight);
+        if prev >= self.max_inflight {
+            return error_result(format!(
+                "MCP server busy: {} calls in flight (cap MVM_MCP_MAX_INFLIGHT={}). Retry shortly.",
+                prev + 1,
+                self.max_inflight
+            ));
+        }
+
+        // Validate env against the local template registry.
+        if let Err(e) = validate_env(&params.env) {
+            return error_result(format!("{e}"));
+        }
+
+        // Memory ceiling check: reject envs whose recorded mem_mib
+        // exceeds MVM_MCP_MEM_CEILING_MIB. Missing spec is a soft
+        // pass since we don't know the size.
+        if let Ok(spec) = mvm_runtime::vm::template::lifecycle::template_load(&params.env)
+            && spec.mem_mib > self.mem_ceiling_mib
+        {
+            return error_result(format!(
+                "env '{}' requests {} MiB which exceeds MVM_MCP_MEM_CEILING_MIB={}",
+                params.env, spec.mem_mib, self.mem_ceiling_mib
+            ));
+        }
+
+        // v1 dispatches all envs through `bash -c`. Templates whose
+        // service is python/node expose those interpreters on PATH
+        // inside the VM, so `bash -c "python3 -c '<code>'"` works for
+        // the curated envs documented in plan 32.
+        let argv = bash_dash_c(&shell_escape(&params.code));
+        let timeout = clamp_timeout(params.timeout_secs);
+
+        let req = crate::exec::ExecRequest {
+            image: crate::exec::ImageSource::Template(params.env.clone()),
+            cpus: DEFAULT_VM_CPUS,
+            memory_mib: DEFAULT_VM_MEM_MIB,
+            add_dirs: Vec::new(),
+            env: Vec::new(),
+            target: crate::exec::ExecTarget::Inline { argv },
+            timeout_secs: timeout,
+        };
+
+        let started = std::time::Instant::now();
+        let result = crate::exec::run_captured(req);
+        let elapsed = started.elapsed();
+
+        match result {
+            Ok(out) => {
+                let stdout = truncate_with_marker(&out.stdout);
+                let stderr = truncate_with_marker(&out.stderr);
+                audit_call_complete(
+                    &params.env,
+                    params.code.len(),
+                    out.exit_code,
+                    elapsed.as_millis() as u64,
+                    params.session.as_deref(),
+                );
+                ToolResult {
+                    content: vec![
+                        ContentBlock::Text { text: stdout },
+                        ContentBlock::Text {
+                            text: format!("[stderr]\n{stderr}"),
+                        },
+                        ContentBlock::Text {
+                            text: format!("exit_code={}", out.exit_code),
+                        },
+                    ],
+                    is_error: out.exit_code != 0,
+                }
+            }
+            Err(e) => {
+                audit_call_error(
+                    &params.env,
+                    params.code.len(),
+                    elapsed.as_millis() as u64,
+                    params.session.as_deref(),
+                    &format!("{e:#}"),
+                );
+                error_result(format!("microVM exec failed: {e:#}"))
+            }
+        }
+    }
+}
+
+struct InflightGuard<'a>(&'a AtomicUsize);
+impl Drop for InflightGuard<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+fn error_result(msg: impl Into<String>) -> ToolResult {
+    ToolResult {
+        content: vec![ContentBlock::Text { text: msg.into() }],
+        is_error: true,
+    }
+}
+
+fn clamp_timeout(t: Option<u64>) -> u64 {
+    t.unwrap_or(DEFAULT_TIMEOUT_SECS)
+        .clamp(MIN_TIMEOUT_SECS, MAX_TIMEOUT_SECS)
+}
+
+fn bash_dash_c(quoted_code: &str) -> Vec<String> {
+    vec![
+        "bash".to_string(),
+        "-c".to_string(),
+        quoted_code.to_string(),
+    ]
+}
+
+/// Single-quote a string for safe inclusion in a `bash -c` invocation.
+/// Single quotes can't appear inside single-quoted strings, so we
+/// close + concatenate the standard `'\''` workaround.
+fn shell_escape(s: &str) -> String {
+    let escaped: String = s.replace('\'', "'\\''");
+    format!("'{escaped}'")
+}
+
+/// Cap `s` at [`STREAM_CAP_BYTES`] and append a marker reporting how
+/// many bytes were dropped. UTF-8 boundary aware.
+fn truncate_with_marker(s: &str) -> String {
+    if s.len() <= STREAM_CAP_BYTES {
+        return s.to_string();
+    }
+    let mut end = STREAM_CAP_BYTES;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let dropped = s.len() - end;
+    format!("{}\n[truncated, {} more bytes]", &s[..end], dropped)
+}
+
+fn parse_env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+fn parse_env_u32(name: &str, default: u32) -> u32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+fn validate_env(env: &str) -> anyhow::Result<()> {
+    let envs = mvm_runtime::vm::template::lifecycle::template_list()?;
+    if envs.iter().any(|e| e == env) {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!(
+        "env '{env}' is not a registered mvmctl template. Available envs: [{}]. \
+         Build new ones via `mvmctl template create … && mvmctl template build <name>`.",
+        envs.join(", ")
+    ))
+}
+
+fn audit_call_complete(
+    env: &str,
+    code_len: usize,
+    exit_code: i32,
+    elapsed_ms: u64,
+    session: Option<&str>,
+) {
+    // `LocalAuditKind::McpToolsCallRun` is the v1 mvm-core kind. The
+    // existing local audit API takes a free-form `detail` string, so
+    // we serialise the structured payload into JSON. Audit is
+    // best-effort; failures land in `tracing::warn!` only.
+    let detail = serde_json::json!({
+        "code_len": code_len,
+        "exit_code": exit_code,
+        "elapsed_ms": elapsed_ms,
+        "session": session,
+    })
+    .to_string();
+    mvm_core::policy::audit::emit(
+        mvm_core::policy::audit::LocalAuditKind::McpToolsCallRun,
+        Some(env),
+        Some(&detail),
+    );
+}
+
+fn audit_call_error(
+    env: &str,
+    code_len: usize,
+    elapsed_ms: u64,
+    session: Option<&str>,
+    error: &str,
+) {
+    let detail = serde_json::json!({
+        "code_len": code_len,
+        "elapsed_ms": elapsed_ms,
+        "session": session,
+        "error": error,
+    })
+    .to_string();
+    mvm_core::policy::audit::emit(
+        mvm_core::policy::audit::LocalAuditKind::McpToolsCallRunError,
+        Some(env),
+        Some(&detail),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_under_cap_passes_through() {
+        let s = "hello world";
+        assert_eq!(truncate_with_marker(s), s);
+    }
+
+    #[test]
+    fn truncate_over_cap_appends_marker() {
+        let s = "x".repeat(STREAM_CAP_BYTES + 100);
+        let out = truncate_with_marker(&s);
+        assert!(out.contains("[truncated, 100 more bytes]"));
+        assert!(out.len() < STREAM_CAP_BYTES + 50, "marker is short");
+    }
+
+    #[test]
+    fn truncate_respects_utf8_boundary() {
+        let prefix = "x".repeat(STREAM_CAP_BYTES - 1);
+        let s = format!("{prefix}éééé");
+        let out = truncate_with_marker(&s);
+        // Truncated form must still parse as valid UTF-8 (Rust string
+        // literal guarantees this) and contain the marker.
+        assert!(out.contains("[truncated"));
+    }
+
+    #[test]
+    fn timeout_clamps_to_bounds() {
+        assert_eq!(clamp_timeout(None), DEFAULT_TIMEOUT_SECS);
+        assert_eq!(clamp_timeout(Some(0)), MIN_TIMEOUT_SECS);
+        assert_eq!(clamp_timeout(Some(99_999)), MAX_TIMEOUT_SECS);
+        assert_eq!(clamp_timeout(Some(30)), 30);
+    }
+
+    #[test]
+    fn shell_escape_handles_single_quotes() {
+        let escaped = shell_escape("it's");
+        assert_eq!(escaped, "'it'\\''s'");
+    }
+
+    #[test]
+    fn shell_escape_no_quotes() {
+        assert_eq!(shell_escape("plain"), "'plain'");
+    }
+}

--- a/crates/mvm-cli/src/commands/ops/mod.rs
+++ b/crates/mvm-cli/src/commands/ops/mod.rs
@@ -3,6 +3,7 @@
 pub(super) mod audit;
 pub(super) mod cache;
 pub(super) mod config;
+pub(super) mod mcp;
 pub(super) mod metrics;
 pub(super) mod network;
 pub(super) mod security;

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -397,12 +397,66 @@ pub fn snapshot_eligible(
     matches!(image, ImageSource::Template(_))
 }
 
+/// Captured stdout/stderr/exit-code from a one-shot exec.
+///
+/// `run_captured` returns this instead of streaming guest output to the
+/// CLI's terminal. The MCP server (plan 32 / Proposal A) consumes it
+/// to assemble a `tools/call` response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Run the request and capture stdout/stderr instead of streaming.
+///
+/// Same orchestration as [`run`]: boot a transient microVM, dispatch
+/// the command via the guest agent's `Exec` over vsock, tear down.
+/// The only difference is what happens with the guest's stdout/stderr
+/// — captured into the returned [`ExecOutput`] instead of inherited
+/// to the parent process's terminal.
+///
+/// Used by `mvmctl mcp` to build MCP `tools/call run` responses; the
+/// CLI's interactive `mvmctl exec` keeps using [`run`] (streaming) so
+/// human ergonomics don't regress.
+pub fn run_captured(req: ExecRequest) -> Result<ExecOutput> {
+    run_inner(req, /* capture = */ true)
+        .map(|either| either.right().expect("capture mode returns ExecOutput"))
+}
+
 /// Run the request: boot, run, tear down.
 ///
 /// Returns the guest command's exit code. On orchestrator failure (boot,
 /// agent unreachable, vsock error), returns an error; the VM is torn down
 /// best-effort before returning.
 pub fn run(req: ExecRequest) -> Result<i32> {
+    run_inner(req, /* capture = */ false)
+        .map(|either| either.left().expect("streaming mode returns exit code"))
+}
+
+/// Tagged union for the two return shapes [`run`] and [`run_captured`]
+/// share. Internal — the public API exposes the unboxed variants.
+enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+impl<L, R> Either<L, R> {
+    fn left(self) -> Option<L> {
+        match self {
+            Either::Left(l) => Some(l),
+            Either::Right(_) => None,
+        }
+    }
+    fn right(self) -> Option<R> {
+        match self {
+            Either::Right(r) => Some(r),
+            Either::Left(_) => None,
+        }
+    }
+}
+
+fn run_inner(req: ExecRequest, capture: bool) -> Result<Either<i32, ExecOutput>> {
     let backend = AnyBackend::auto_select();
 
     // Resolve image artifacts: either a named template or a pre-built pair.
@@ -557,7 +611,7 @@ pub fn run(req: ExecRequest) -> Result<i32> {
     }
 
     // Run the command + always tear down.
-    let result = run_in_guest(&vm_name, &req, &add_dir_labels);
+    let result = run_in_guest(&vm_name, &req, &add_dir_labels, capture);
 
     let _ = backend.stop(&VmId(vm_name.clone()));
 
@@ -632,8 +686,18 @@ fn restore_via_snapshot(
     )
 }
 
-/// Send the wrapped command to the guest agent and stream stdout/stderr.
-fn run_in_guest(vm_name: &str, req: &ExecRequest, labels: &[String]) -> Result<i32> {
+/// Send the wrapped command to the guest agent and either stream
+/// stdout/stderr (default) or capture them (when `capture=true`).
+///
+/// `capture=true` is used by [`run_captured`] / `mvmctl mcp` to assemble
+/// MCP `tools/call` responses; the streaming path keeps the existing
+/// `mvmctl exec` ergonomics.
+fn run_in_guest(
+    vm_name: &str,
+    req: &ExecRequest,
+    labels: &[String],
+    capture: bool,
+) -> Result<Either<i32, ExecOutput>> {
     if !wait_for_agent(vm_name, 30) {
         anyhow::bail!("guest agent did not become reachable within 30s");
     }
@@ -645,13 +709,21 @@ fn run_in_guest(vm_name: &str, req: &ExecRequest, labels: &[String]) -> Result<i
             stdout,
             stderr,
         } => {
-            if !stdout.is_empty() {
-                print!("{stdout}");
+            if capture {
+                Ok(Either::Right(ExecOutput {
+                    exit_code,
+                    stdout,
+                    stderr,
+                }))
+            } else {
+                if !stdout.is_empty() {
+                    print!("{stdout}");
+                }
+                if !stderr.is_empty() {
+                    eprint!("{stderr}");
+                }
+                Ok(Either::Left(exit_code))
             }
-            if !stderr.is_empty() {
-                eprint!("{stderr}");
-            }
-            Ok(exit_code)
         }
         mvm_guest::vsock::GuestResponse::Error { message } => {
             anyhow::bail!("guest exec error: {message}")

--- a/crates/mvm-cli/src/template_cmd.rs
+++ b/crates/mvm-cli/src/template_cmd.rs
@@ -1468,4 +1468,185 @@ mod tests {
         assert_eq!(validated.spec.python_entrypoint.as_deref(), Some("app.py"));
         assert_eq!(validated.summary, "Python API with postgres");
     }
+
+    // ----- Local-LLM probe tests (Proposal C) ---------------------------
+    //
+    // These tests mutate process-global env vars (MVM_TEMPLATE_*,
+    // OPENAI_API_KEY) so they must serialize via probe_test_lock().
+    // Each test exercises multiple phases inside one #[test] body so
+    // env-state transitions are explicit instead of relying on cargo's
+    // parallel scheduler.
+
+    use super::{
+        LlmProvider, llm_generation_config_from_env, local_generation_config_with_probe,
+        probe_local_openai_endpoint,
+    };
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Mutex, OnceLock};
+    use std::thread;
+
+    fn probe_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// Spawn a one-shot TCP server that responds to a single HTTP request
+    /// with `200 OK` and the given JSON body. Returns the bound `host:port`.
+    fn spawn_one_shot_http_ok(json_body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind 127.0.0.1:0");
+        let addr = listener.local_addr().expect("addr").to_string();
+        thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    json_body.len(),
+                    json_body
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        addr
+    }
+
+    /// Restore env vars to a known baseline before/after each probe scenario.
+    fn clear_llm_env() {
+        // SAFETY: tests serialize via probe_test_lock(); the process is
+        // single-threaded with respect to env access while the lock is held.
+        unsafe {
+            std::env::remove_var("MVM_TEMPLATE_PROVIDER");
+            std::env::remove_var("MVM_TEMPLATE_LOCAL_BASE_URL");
+            std::env::remove_var("LOCALAI_BASE_URL");
+            std::env::remove_var("MVM_TEMPLATE_LOCAL_MODEL");
+            std::env::remove_var("LOCALAI_MODEL");
+            std::env::remove_var("MVM_TEMPLATE_LOCAL_API_KEY");
+            std::env::remove_var("LOCALAI_API_KEY");
+            std::env::remove_var("MVM_TEMPLATE_LOCAL_PROBE_TARGETS");
+            std::env::remove_var("MVM_TEMPLATE_NO_LOCAL_PROBE");
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("MVM_TEMPLATE_OPENAI_BASE_URL");
+            std::env::remove_var("OPENAI_BASE_URL");
+            std::env::remove_var("MVM_TEMPLATE_OPENAI_MODEL");
+        }
+    }
+
+    #[test]
+    fn test_local_probe_scenarios() {
+        let _guard = probe_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+
+        // Phase 1: probe target reachable → returns base_url; auto picks Local.
+        clear_llm_env();
+        let addr = spawn_one_shot_http_ok(r#"{"data":[]}"#);
+        let target = format!("http://{}", addr);
+        // SAFETY: serialised by probe_test_lock; see clear_llm_env doc.
+        unsafe {
+            std::env::set_var("MVM_TEMPLATE_LOCAL_PROBE_TARGETS", &target);
+        }
+        let probed = probe_local_openai_endpoint();
+        assert_eq!(probed.as_deref(), Some(target.as_str()));
+
+        // The one-shot server is consumed; respawn for the auto path.
+        let addr2 = spawn_one_shot_http_ok(r#"{"data":[]}"#);
+        let target2 = format!("http://{}", addr2);
+        // SAFETY: serialised by probe_test_lock.
+        unsafe {
+            std::env::set_var("MVM_TEMPLATE_LOCAL_PROBE_TARGETS", &target2);
+        }
+        let cfg = llm_generation_config_from_env()
+            .expect("auto with probe should not error")
+            .expect("auto picks Local when probe succeeds");
+        assert_eq!(cfg.provider, LlmProvider::Local);
+        assert_eq!(cfg.base_url, target2);
+
+        // Phase 2: probe targets unreachable → falls through to OpenAI.
+        clear_llm_env();
+        // SAFETY: serialised by probe_test_lock.
+        unsafe {
+            // Port 1 is privileged + nothing listens; near-instant ECONNREFUSED.
+            std::env::set_var("MVM_TEMPLATE_LOCAL_PROBE_TARGETS", "http://127.0.0.1:1");
+            std::env::set_var("OPENAI_API_KEY", "test-key-fallthrough");
+        }
+        let cfg = llm_generation_config_from_env()
+            .expect("auto with no local should not error")
+            .expect("auto falls through to OpenAI");
+        assert_eq!(cfg.provider, LlmProvider::OpenAi);
+
+        // Phase 3: MVM_TEMPLATE_NO_LOCAL_PROBE=1 skips the probe even when
+        // a target is reachable. Without OPENAI_API_KEY, auto returns None.
+        clear_llm_env();
+        let addr3 = spawn_one_shot_http_ok(r#"{"data":[]}"#);
+        let target3 = format!("http://{}", addr3);
+        // SAFETY: serialised by probe_test_lock.
+        unsafe {
+            std::env::set_var("MVM_TEMPLATE_LOCAL_PROBE_TARGETS", &target3);
+            std::env::set_var("MVM_TEMPLATE_NO_LOCAL_PROBE", "1");
+        }
+        assert!(local_generation_config_with_probe().is_none());
+        let cfg = llm_generation_config_from_env().expect("auto with no probe + no openai");
+        assert!(
+            cfg.is_none(),
+            "no-probe + no OpenAI key → heuristic fallback"
+        );
+
+        // Phase 4: explicit MVM_TEMPLATE_LOCAL_BASE_URL bypasses the probe.
+        clear_llm_env();
+        // SAFETY: serialised by probe_test_lock.
+        unsafe {
+            // Use a non-listening URL: env-driven path doesn't validate
+            // reachability, only the probe path does.
+            std::env::set_var("MVM_TEMPLATE_LOCAL_BASE_URL", "http://127.0.0.1:1");
+        }
+        let cfg =
+            local_generation_config_with_probe().expect("env-driven local config skips probe");
+        assert_eq!(cfg.provider, LlmProvider::Local);
+        assert_eq!(cfg.base_url, "http://127.0.0.1:1");
+
+        clear_llm_env();
+    }
+
+    #[test]
+    fn test_explicit_provider_modes_unchanged_by_probe() {
+        let _guard = probe_test_lock().lock().unwrap_or_else(|e| e.into_inner());
+
+        // explicit "openai" without OPENAI_API_KEY errors; the probe path
+        // is not consulted (would otherwise trigger when in `auto`).
+        clear_llm_env();
+        // SAFETY: serialised by probe_test_lock.
+        unsafe {
+            std::env::set_var("MVM_TEMPLATE_PROVIDER", "openai");
+        }
+        let err = llm_generation_config_from_env().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("OPENAI_API_KEY"),
+            "expected OPENAI_API_KEY error, got: {err:#}"
+        );
+
+        // explicit "local" without any base_url errors; the probe path
+        // is not consulted in `local` mode either.
+        clear_llm_env();
+        // SAFETY: serialised by probe_test_lock.
+        unsafe {
+            std::env::set_var("MVM_TEMPLATE_PROVIDER", "local");
+        }
+        let err = llm_generation_config_from_env().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("local model"),
+            "expected local-mode error, got: {err:#}"
+        );
+
+        // "heuristic" returns Ok(None) regardless of env state.
+        clear_llm_env();
+        // SAFETY: serialised by probe_test_lock.
+        unsafe {
+            std::env::set_var("MVM_TEMPLATE_PROVIDER", "heuristic");
+            std::env::set_var("OPENAI_API_KEY", "ignored");
+        }
+        let cfg = llm_generation_config_from_env().expect("heuristic always Ok");
+        assert!(cfg.is_none());
+
+        clear_llm_env();
+    }
 }

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -47,6 +47,13 @@ pub enum LocalAuditKind {
     ConfigChange,
     ConsoleSessionStart,
     ConsoleSessionEnd,
+    // --- MCP server (plan 32 / Proposal A) ---
+    /// `tools/call run` invocation — every LLM-driven code execution
+    /// against a microVM is auditable.
+    McpToolsCallRun,
+    /// `tools/call run` failed before completing (orchestration error,
+    /// not a non-zero guest exit code).
+    McpToolsCallRunError,
 }
 
 /// A single local audit log entry.

--- a/crates/mvm-core/src/policy/network_policy.rs
+++ b/crates/mvm-core/src/policy/network_policy.rs
@@ -53,6 +53,14 @@ pub enum NetworkPreset {
     Registries,
     /// Developer preset: registries + GitHub + OpenAI + Anthropic APIs.
     Dev,
+    /// LLM-agent preset (plan 32 / Proposal D / ADR-004): the LLM
+    /// inference APIs an agent typically calls (Anthropic, OpenAI),
+    /// plus GitHub for source operations. Minimum surface for
+    /// `nix/images/examples/llm-agent/`'s `claude-code-vm`. Strictly
+    /// smaller than `dev` — does NOT include package registries,
+    /// because an agent VM is meant to run trusted closures, not
+    /// re-resolve npm/PyPI on the fly.
+    Agent,
 }
 
 impl NetworkPreset {
@@ -67,6 +75,7 @@ impl NetworkPreset {
                 rules.extend(dev_extra_rules());
                 rules
             }
+            Self::Agent => agent_rules(),
         }
     }
 
@@ -90,8 +99,9 @@ impl FromStr for NetworkPreset {
             "none" => Ok(Self::None),
             "registries" => Ok(Self::Registries),
             "dev" => Ok(Self::Dev),
+            "agent" => Ok(Self::Agent),
             _ => anyhow::bail!(
-                "unknown network preset {:?} (expected: unrestricted, none, registries, dev)",
+                "unknown network preset {:?} (expected: unrestricted, none, registries, dev, agent)",
                 s
             ),
         }
@@ -105,6 +115,7 @@ impl fmt::Display for NetworkPreset {
             Self::None => write!(f, "none"),
             Self::Registries => write!(f, "registries"),
             Self::Dev => write!(f, "dev"),
+            Self::Agent => write!(f, "agent"),
         }
     }
 }
@@ -260,6 +271,21 @@ fn dev_extra_rules() -> Vec<HostPort> {
     ]
 }
 
+/// LLM-agent preset rules (plan 32 / Proposal D / ADR-004).
+///
+/// Strictly smaller than `dev` — agent VMs are meant to run trusted
+/// closures (claude-code, opencode, …) against an inference endpoint
+/// plus a code host, not pull arbitrary packages on the fly.
+fn agent_rules() -> Vec<HostPort> {
+    vec![
+        HostPort::new("api.anthropic.com", 443),
+        HostPort::new("api.openai.com", 443),
+        HostPort::new("github.com", 443),
+        HostPort::new("github.com", 22),
+        HostPort::new("api.github.com", 443),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -356,6 +382,45 @@ mod tests {
         assert!(hosts.contains(&"github.com"));
         assert!(hosts.contains(&"api.openai.com"));
         assert!(hosts.contains(&"api.anthropic.com"));
+    }
+
+    #[test]
+    fn preset_agent_parses_and_displays() {
+        assert_eq!(
+            "agent".parse::<NetworkPreset>().unwrap(),
+            NetworkPreset::Agent
+        );
+        assert_eq!(NetworkPreset::Agent.to_string(), "agent");
+    }
+
+    #[test]
+    fn preset_agent_has_inference_apis_and_github() {
+        let rules = NetworkPreset::Agent.rules();
+        let hosts: Vec<&str> = rules.iter().map(|r| r.host.as_str()).collect();
+        assert!(
+            hosts.contains(&"api.anthropic.com"),
+            "agent preset must include Anthropic"
+        );
+        assert!(
+            hosts.contains(&"api.openai.com"),
+            "agent preset must include OpenAI"
+        );
+        assert!(
+            hosts.contains(&"github.com"),
+            "agent preset must include GitHub"
+        );
+    }
+
+    #[test]
+    fn preset_agent_excludes_package_registries() {
+        // Plan 32 / Proposal D: agent preset is strictly smaller than dev.
+        // No npm, no PyPI, no crates.io — agents are meant to run
+        // pre-resolved closures, not pull packages at runtime.
+        let rules = NetworkPreset::Agent.rules();
+        let hosts: Vec<&str> = rules.iter().map(|r| r.host.as_str()).collect();
+        assert!(!hosts.contains(&"registry.npmjs.org"));
+        assert!(!hosts.contains(&"crates.io"));
+        assert!(!hosts.contains(&"pypi.org"));
     }
 
     #[test]

--- a/crates/mvm-mcp/Cargo.toml
+++ b/crates/mvm-mcp/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "mvm-mcp"
+version.workspace = true
+edition.workspace = true
+description = "Model Context Protocol server for mvm — wire types, tool schemas, and stdio JSON-RPC loop"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+# ── Feature flags (plan 33: cross-repo handoff with mvmd) ──────────────
+#
+# `protocol-only` is the wire-only surface: JSON-RPC types, tool
+# schemas, the Dispatcher trait. No stdin/stdout. This is what mvmd's
+# hosted MCP transport (plan 33) will depend on so the wire schema
+# stays a single source of truth.
+#
+# `stdio` (default) layers on the JSON-RPC stdio loop. No dispatcher
+# implementations live here — callers (mvm-cli for the local mvmctl,
+# mvmd for the hosted variant) provide their own `Dispatcher` impl.
+# This keeps mvm-mcp free of any dependency on mvm-cli or mvm-runtime,
+# which would create a cycle.
+[features]
+default = ["stdio"]
+protocol-only = []
+stdio = ["dep:tracing", "dep:tracing-subscriber"]
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/mvm-mcp/src/dispatcher.rs
+++ b/crates/mvm-mcp/src/dispatcher.rs
@@ -1,0 +1,23 @@
+//! Transport-agnostic `Dispatcher` trait.
+//!
+//! Available under `protocol-only` so plan 33's mvmd hosted variant
+//! can plug in its own dispatcher (HTTP-fronted, tenant-aware) without
+//! depending on this crate's stdio loop. The mvm stdio binary
+//! provides one impl in `mvm-cli::commands::ops::mcp`.
+
+use crate::protocol::ToolResult;
+use crate::tools::RunParams;
+
+/// One method per MCP tool we expose. Currently just `run`.
+pub trait Dispatcher {
+    /// Validate `params`, dispatch into a microVM (or whatever the
+    /// transport's analog is), capture output, return an MCP-shaped
+    /// `ToolResult`.
+    ///
+    /// Errors should be rendered as `ToolResult { is_error: true,
+    /// content: [Text { text: ... }] }` — *not* propagated as
+    /// `Result::Err` — so the LLM client sees the failure rather than
+    /// a JSON-RPC `internal_error` (which clients tend to retry
+    /// instead of surfacing).
+    fn run(&self, params: RunParams) -> ToolResult;
+}

--- a/crates/mvm-mcp/src/env.rs
+++ b/crates/mvm-mcp/src/env.rs
@@ -1,0 +1,30 @@
+//! Validate the `env` parameter of `tools/call run` against the
+//! installed template registry.
+//!
+//! Stdio-only: this is the bridge between the wire protocol (which
+//! accepts arbitrary strings) and the local template artifacts on
+//! disk. Plan 33's hosted variant in mvmd implements its own
+//! validator that resolves `tenant/pool/template@revision`.
+
+use anyhow::Result;
+
+/// Returns the list of template names known to mvmctl. Equivalent to
+/// `mvmctl template list`. Used to validate incoming `env` values.
+pub fn known_envs() -> Result<Vec<String>> {
+    mvm_runtime::vm::template::lifecycle::template_list().map_err(Into::into)
+}
+
+/// Check that `env` is a known template. Returns `Ok(())` if so;
+/// otherwise an error whose message lists the available envs (the
+/// LLM gets to recover by re-issuing with a valid name).
+pub fn validate_env(env: &str) -> Result<()> {
+    let envs = known_envs()?;
+    if envs.iter().any(|e| e == env) {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!(
+        "env '{env}' is not a registered mvmctl template. \
+         Available envs: [{}]. Build new ones via `mvmctl template create … && mvmctl template build <name>`.",
+        envs.join(", ")
+    ))
+}

--- a/crates/mvm-mcp/src/lib.rs
+++ b/crates/mvm-mcp/src/lib.rs
@@ -1,0 +1,42 @@
+//! `mvm-mcp` — Model Context Protocol server for mvm.
+//!
+//! Exposes mvm's microVM template registry as a single parameterized
+//! `run` tool. LLM clients (Claude Code, opencode, etc.) connect over
+//! stdio, list tools, and dispatch code into transient microVMs.
+//!
+//! ## Features
+//!
+//! - `protocol-only` — JSON-RPC frames, tool schemas, `Dispatcher`
+//!   trait. No I/O. Consumed by mvmd (plan 33) for the hosted
+//!   HTTP/SSE transport.
+//!
+//! - `stdio` (default) — adds the JSON-RPC stdio loop. Callers
+//!   provide their own [`Dispatcher`] implementation; the local
+//!   mvmctl impl lives in `mvm-cli::commands::ops::mcp` (which has
+//!   access to `crate::exec` for the actual VM dispatch).
+//!
+//! ## Threat model
+//!
+//! See `specs/adrs/003-local-mcp-server.md` for the full posture.
+//! Summary: the transport is host-local stdio. No new attacker
+//! surface beyond ADR-002 — code runs entirely inside the
+//! already-isolated microVM. The `env` parameter is allowlisted
+//! against the existing template registry; `code` is passed as a
+//! single argv element to the guest interpreter.
+
+pub mod dispatcher;
+pub mod protocol;
+pub mod tools;
+
+pub use dispatcher::Dispatcher;
+pub use protocol::{
+    ContentBlock, JsonRpcError, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, SERVER_NAME,
+    SERVER_VERSION, ToolResult,
+};
+pub use tools::{RunParams, ToolSchema, all_tools, run_input_schema};
+
+#[cfg(feature = "stdio")]
+pub mod server;
+
+#[cfg(feature = "stdio")]
+pub use server::{init_stderr_tracing, run_with_dispatcher};

--- a/crates/mvm-mcp/src/protocol.rs
+++ b/crates/mvm-mcp/src/protocol.rs
@@ -1,0 +1,196 @@
+//! MCP wire protocol: JSON-RPC 2.0 frames and tool-result types.
+//!
+//! Hand-rolled to avoid pulling in `rmcp` as a new external dependency
+//! (every workspace dep needs to clear ADR-002's supply-chain bar:
+//! `cargo-deny`, `cargo-audit`, audited and pinned). The protocol is
+//! ~200 LoC; the operational risk of writing it ourselves is lower
+//! than the supply-chain cost of importing it.
+//!
+//! Available under `protocol-only` so mvmd (per plan 33) can consume
+//! these types without dragging in stdio I/O.
+
+use serde::{Deserialize, Serialize};
+
+/// MCP protocol revision we advertise during `initialize`. Pinned to
+/// the current spec at implementation time. Plan 32: bump in lockstep
+/// with the upstream spec, never silently drift.
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// Server identity advertised in `initialize` responses.
+pub const SERVER_NAME: &str = "mvm";
+pub const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// JSON-RPC 2.0 request frame.
+///
+/// `id` is `Option` because `notifications/*` methods are id-less; we
+/// don't currently emit notifications but the wire format requires
+/// tolerating them on the way in.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<serde_json::Value>,
+    pub method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+/// JSON-RPC 2.0 response frame.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+/// JSON-RPC 2.0 error object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl JsonRpcError {
+    pub fn parse_error(detail: impl Into<String>) -> Self {
+        Self {
+            code: -32700,
+            message: format!("Parse error: {}", detail.into()),
+            data: None,
+        }
+    }
+    pub fn invalid_request(detail: impl Into<String>) -> Self {
+        Self {
+            code: -32600,
+            message: format!("Invalid request: {}", detail.into()),
+            data: None,
+        }
+    }
+    pub fn method_not_found(method: &str) -> Self {
+        Self {
+            code: -32601,
+            message: format!("Method not found: {method}"),
+            data: None,
+        }
+    }
+    pub fn invalid_params(detail: impl Into<String>) -> Self {
+        Self {
+            code: -32602,
+            message: format!("Invalid params: {}", detail.into()),
+            data: None,
+        }
+    }
+    pub fn internal_error(detail: impl Into<String>) -> Self {
+        Self {
+            code: -32603,
+            message: format!("Internal error: {}", detail.into()),
+            data: None,
+        }
+    }
+}
+
+impl JsonRpcResponse {
+    pub fn ok(id: serde_json::Value, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+    pub fn err(id: serde_json::Value, error: JsonRpcError) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(error),
+        }
+    }
+}
+
+/// One block of a tool-call result. MCP defines several content types;
+/// `text` is the only one mvm emits in v1.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlock {
+    Text { text: String },
+}
+
+/// `tools/call` response shape per the MCP spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResult {
+    pub content: Vec<ContentBlock>,
+    #[serde(default, rename = "isError", skip_serializing_if = "is_false")]
+    pub is_error: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jsonrpc_request_serde_roundtrip() {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "tools/list".to_string(),
+            params: Some(serde_json::json!({})),
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        let parsed: JsonRpcRequest = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed.method, "tools/list");
+        assert_eq!(parsed.jsonrpc, "2.0");
+    }
+
+    #[test]
+    fn jsonrpc_request_rejects_unknown_fields() {
+        // `deny_unknown_fields` is W4.1 hygiene — every type that
+        // crosses an untrusted boundary fails closed on extras.
+        let bad = r#"{"jsonrpc":"2.0","id":1,"method":"x","params":{},"unknown":42}"#;
+        assert!(serde_json::from_str::<JsonRpcRequest>(bad).is_err());
+    }
+
+    #[test]
+    fn error_codes_match_jsonrpc_spec() {
+        assert_eq!(JsonRpcError::parse_error("x").code, -32700);
+        assert_eq!(JsonRpcError::invalid_request("x").code, -32600);
+        assert_eq!(JsonRpcError::method_not_found("x").code, -32601);
+        assert_eq!(JsonRpcError::invalid_params("x").code, -32602);
+        assert_eq!(JsonRpcError::internal_error("x").code, -32603);
+    }
+
+    #[test]
+    fn tool_result_text_block_serializes_with_type_tag() {
+        let r = ToolResult {
+            content: vec![ContentBlock::Text {
+                text: "hi".to_string(),
+            }],
+            is_error: false,
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains(r#""type":"text""#));
+        assert!(s.contains(r#""text":"hi""#));
+        assert!(!s.contains("isError"), "is_error=false omitted");
+    }
+
+    #[test]
+    fn tool_result_error_emits_is_error_field() {
+        let r = ToolResult {
+            content: vec![ContentBlock::Text {
+                text: "boom".to_string(),
+            }],
+            is_error: true,
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains(r#""isError":true"#));
+    }
+}

--- a/crates/mvm-mcp/src/server.rs
+++ b/crates/mvm-mcp/src/server.rs
@@ -1,0 +1,285 @@
+//! Stdio JSON-RPC dispatch loop.
+//!
+//! Per-line framed (one JSON object per line, `\n`-terminated). Reads
+//! from `stdin`, writes responses to `stdout`. **All non-protocol
+//! output must go to stderr** — a stray byte on stdout corrupts the
+//! wire. Cross-cutting "A: stdout-only-JSON-RPC discipline" enforces
+//! this via `init_stderr_tracing` below and a CI smoke test.
+
+use std::io::{BufRead, Write};
+
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::dispatcher::Dispatcher;
+use crate::protocol::{
+    JsonRpcError, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, SERVER_NAME, SERVER_VERSION,
+};
+use crate::tools::{RunParams, all_tools};
+
+/// Initialize a stderr-only tracing subscriber. MUST be called before
+/// the dispatch loop, since `tracing` defaults to stdout — and a
+/// single stdout log line breaks the JSON-RPC framing.
+pub fn init_stderr_tracing() {
+    use tracing_subscriber::{EnvFilter, fmt};
+    let filter = EnvFilter::try_from_env("RUST_LOG").unwrap_or_else(|_| EnvFilter::new("info"));
+    let _ = fmt::Subscriber::builder()
+        .with_writer(std::io::stderr)
+        .with_env_filter(filter)
+        .try_init();
+}
+
+/// Dispatch one JSON-RPC line through `dispatcher` and either return
+/// a response (request) or `None` (notification — no reply expected).
+pub fn run_with_dispatcher<R: BufRead, W: Write, D: Dispatcher>(
+    reader: R,
+    writer: &mut W,
+    dispatcher: &D,
+) -> Result<()> {
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::error!(err=%e, "stdin read error");
+                return Err(e.into());
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        match handle_one(&line, dispatcher) {
+            Some(resp) => {
+                let s = serde_json::to_string(&resp)?;
+                writeln!(writer, "{s}")?;
+                writer.flush()?;
+            }
+            None => continue,
+        }
+    }
+    Ok(())
+}
+
+/// Parse one line and produce zero (notification) or one response.
+fn handle_one<D: Dispatcher>(line: &str, dispatcher: &D) -> Option<JsonRpcResponse> {
+    let req: JsonRpcRequest = match serde_json::from_str(line) {
+        Ok(r) => r,
+        Err(e) => {
+            return Some(JsonRpcResponse::err(
+                Value::Null,
+                JsonRpcError::parse_error(e.to_string()),
+            ));
+        }
+    };
+
+    if req.jsonrpc != "2.0" {
+        return Some(JsonRpcResponse::err(
+            req.id.unwrap_or(Value::Null),
+            JsonRpcError::invalid_request("jsonrpc must be \"2.0\""),
+        ));
+    }
+
+    // Notifications: no id, no response.
+    let id = req.id?;
+
+    let result = match req.method.as_str() {
+        "initialize" => Ok(initialize_response()),
+        "tools/list" => Ok(tools_list_response()),
+        "tools/call" => tools_call_response(req.params, dispatcher),
+        other => Err(JsonRpcError::method_not_found(other)),
+    };
+
+    Some(match result {
+        Ok(v) => JsonRpcResponse::ok(id, v),
+        Err(e) => JsonRpcResponse::err(id, e),
+    })
+}
+
+fn initialize_response() -> Value {
+    serde_json::json!({
+        "protocolVersion": PROTOCOL_VERSION,
+        "capabilities": {
+            // We do not change the tool list at runtime.
+            "tools": { "listChanged": false }
+        },
+        "serverInfo": {
+            "name": SERVER_NAME,
+            "version": SERVER_VERSION,
+        },
+        "instructions": instructions_text(),
+    })
+}
+
+fn instructions_text() -> &'static str {
+    "Run code in an mvm microVM. Use the `run` tool with `env` (which template) and `code` \
+     (the program text). Discover envs via `mvmctl template list` on the host. The default \
+     curated env after Proposal B lands is `claude-code-vm`; users can build their own via \
+     `mvmctl template create … && mvmctl template build <name>`."
+}
+
+fn tools_list_response() -> Value {
+    serde_json::json!({ "tools": all_tools() })
+}
+
+fn tools_call_response<D: Dispatcher>(
+    params: Option<Value>,
+    dispatcher: &D,
+) -> Result<Value, JsonRpcError> {
+    let params = params.ok_or_else(|| JsonRpcError::invalid_params("missing params object"))?;
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| JsonRpcError::invalid_params("missing tool name"))?;
+    if name != "run" {
+        return Err(JsonRpcError::method_not_found(&format!("tool '{name}'")));
+    }
+    let args = params.get("arguments").cloned().unwrap_or(Value::Null);
+    let run_params: RunParams = serde_json::from_value(args)
+        .map_err(|e| JsonRpcError::invalid_params(format!("decoding `run` params: {e}")))?;
+    let result = dispatcher.run(run_params);
+    serde_json::to_value(&result)
+        .map_err(|e| JsonRpcError::internal_error(format!("encoding tool result: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{ContentBlock, ToolResult};
+
+    /// Mock dispatcher that records the params it saw and returns a
+    /// canned ToolResult.
+    struct MockDispatcher {
+        last_env: std::sync::Mutex<Option<String>>,
+    }
+    impl Dispatcher for MockDispatcher {
+        fn run(&self, params: RunParams) -> ToolResult {
+            *self.last_env.lock().unwrap() = Some(params.env);
+            ToolResult {
+                content: vec![ContentBlock::Text {
+                    text: "mock-stdout".to_string(),
+                }],
+                is_error: false,
+            }
+        }
+    }
+
+    fn run_one(req_json: &str, dispatcher: &impl Dispatcher) -> JsonRpcResponse {
+        handle_one(req_json, dispatcher).expect("response")
+    }
+
+    #[test]
+    fn initialize_returns_protocol_version() {
+        let dispatcher = MockDispatcher {
+            last_env: std::sync::Mutex::new(None),
+        };
+        let req = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+        let resp = run_one(req, &dispatcher);
+        assert!(resp.error.is_none());
+        let result = resp.result.unwrap();
+        assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(result["serverInfo"]["name"], SERVER_NAME);
+        assert_eq!(result["capabilities"]["tools"]["listChanged"], false);
+    }
+
+    #[test]
+    fn tools_list_returns_single_run_tool() {
+        let dispatcher = MockDispatcher {
+            last_env: std::sync::Mutex::new(None),
+        };
+        let req = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#;
+        let resp = run_one(req, &dispatcher);
+        let result = resp.result.unwrap();
+        let tools = result["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["name"], "run");
+    }
+
+    #[test]
+    fn tools_call_dispatches_to_run() {
+        let dispatcher = MockDispatcher {
+            last_env: std::sync::Mutex::new(None),
+        };
+        let req = r#"{
+            "jsonrpc":"2.0","id":3,"method":"tools/call",
+            "params":{"name":"run","arguments":{"env":"shell","code":"echo hi"}}
+        }"#;
+        let resp = run_one(req, &dispatcher);
+        assert!(resp.error.is_none(), "got error: {:?}", resp.error);
+        let result = resp.result.unwrap();
+        assert_eq!(result["content"][0]["text"], "mock-stdout");
+        assert_eq!(
+            *dispatcher.last_env.lock().unwrap(),
+            Some("shell".to_string())
+        );
+    }
+
+    #[test]
+    fn tools_call_rejects_unknown_tool_name() {
+        let dispatcher = MockDispatcher {
+            last_env: std::sync::Mutex::new(None),
+        };
+        let req = r#"{
+            "jsonrpc":"2.0","id":4,"method":"tools/call",
+            "params":{"name":"not-a-tool","arguments":{}}
+        }"#;
+        let resp = run_one(req, &dispatcher);
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, -32601, "method not found");
+    }
+
+    #[test]
+    fn tools_call_rejects_unknown_arg_field() {
+        let dispatcher = MockDispatcher {
+            last_env: std::sync::Mutex::new(None),
+        };
+        let req = r#"{
+            "jsonrpc":"2.0","id":5,"method":"tools/call",
+            "params":{"name":"run","arguments":{"env":"shell","code":"x","extra":1}}
+        }"#;
+        let resp = run_one(req, &dispatcher);
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, -32602, "invalid params");
+    }
+
+    #[test]
+    fn unknown_method_returns_method_not_found() {
+        let dispatcher = MockDispatcher {
+            last_env: std::sync::Mutex::new(None),
+        };
+        let req = r#"{"jsonrpc":"2.0","id":6,"method":"resources/list","params":{}}"#;
+        let resp = run_one(req, &dispatcher);
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, -32601);
+    }
+
+    #[test]
+    fn malformed_json_returns_parse_error_with_null_id() {
+        let dispatcher = MockDispatcher {
+            last_env: std::sync::Mutex::new(None),
+        };
+        let resp = handle_one("not-json", &dispatcher).unwrap();
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, -32700);
+        assert_eq!(resp.id, Value::Null);
+    }
+
+    #[test]
+    fn notification_request_returns_no_response() {
+        let dispatcher = MockDispatcher {
+            last_env: std::sync::Mutex::new(None),
+        };
+        // No `id` field = notification.
+        let req = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+        assert!(handle_one(req, &dispatcher).is_none());
+    }
+
+    #[test]
+    fn jsonrpc_version_must_be_2_0() {
+        let dispatcher = MockDispatcher {
+            last_env: std::sync::Mutex::new(None),
+        };
+        let req = r#"{"jsonrpc":"1.0","id":7,"method":"initialize","params":{}}"#;
+        let resp = run_one(req, &dispatcher);
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, -32600);
+    }
+}

--- a/crates/mvm-mcp/src/tools/mod.rs
+++ b/crates/mvm-mcp/src/tools/mod.rs
@@ -1,0 +1,166 @@
+//! Tool definitions exposed via MCP.
+//!
+//! The schema (this module) is `protocol-only`; the dispatcher impl
+//! that actually runs code in a microVM lives in
+//! `mvm-cli::commands::ops::mcp`.
+//!
+//! Single-tool design ("borrow nix-sandbox-mcp's insight"): we expose
+//! one parameterized tool (`run`) so the LLM context-window cost
+//! stays flat at ~420 tokens regardless of how many templates the
+//! user has built.
+
+use serde::{Deserialize, Serialize};
+
+/// Parameters for the `run` tool. Wire-compatible with
+/// `nix-sandbox-mcp`'s `run` tool when names align (`env`, `code`,
+/// `session`).
+///
+/// `deny_unknown_fields` is the same fail-closed hygiene applied to
+/// every host-boundary type per ADR-002 §W4.1.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunParams {
+    /// Name of a pre-built `mvmctl template`. Validated against the
+    /// installed template registry; an unknown name returns an error
+    /// with the list of valid envs.
+    pub env: String,
+    /// Program text. For `env=shell`/`env=bash`, evaluated via
+    /// `bash -c <code>`. For `env=python`/`env=node`, written to a
+    /// temp file and passed as the interpreter's first argv. The
+    /// shell-env case is intentional and noted in ADR-003: there is
+    /// no in-microVM interpreter sandbox beyond the microVM itself.
+    pub code: String,
+    /// Reserved for Proposal A.2 — session-pinned warm VMs. Ignored
+    /// in v1; sending it does not error so clients can adopt the
+    /// session API ahead of the server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
+    /// Reserved for Proposal A.2 — when paired with `session`, signals
+    /// "this is the last call against this session, tear the VM down
+    /// (snapshot first if the env was registered with
+    /// `persist_on_close=true`)". Ignored in v1; the schema accepts
+    /// it so clients can adopt the session lifecycle ahead of the
+    /// server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub close: Option<bool>,
+    /// Per-call timeout in seconds. Bounded `[1, 600]`; out-of-range
+    /// values are clamped (not errored) so an LLM that picks
+    /// `timeout_secs: 0` still makes progress.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+}
+
+/// JSON Schema for the `run` tool's input.
+///
+/// Hand-written instead of derived because we want the per-field
+/// description text to bias the LLM toward sane defaults.
+pub fn run_input_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["env", "code"],
+        "properties": {
+            "env": {
+                "type": "string",
+                "description": "Pre-built microVM template to execute in. Use 'shell' for filesystem/CLI work, 'python' for numeric/data work, 'node' for JS, or any user-defined template such as 'claude-code-vm'."
+            },
+            "code": {
+                "type": "string",
+                "description": "Program source. For shell/bash envs, executed via 'bash -c'. For python/node envs, written to a temp file and run by the interpreter."
+            },
+            "session": {
+                "type": "string",
+                "description": "Optional session ID for warm-VM persistence (reserved; v1 ignores)."
+            },
+            "close": {
+                "type": "boolean",
+                "description": "When paired with `session`, signals this is the last call against the session — server may snapshot + tear down (reserved; v1 ignores)."
+            },
+            "timeout_secs": {
+                "type": "integer",
+                "description": "Per-call timeout in seconds. Default 60. Clamped to [1, 600].",
+                "minimum": 1,
+                "maximum": 600
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+/// One tool in the registry. Returned by `tools/list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolSchema {
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "inputSchema")]
+    pub input_schema: serde_json::Value,
+}
+
+/// All tools exposed by mvmctl mcp. v1 = exactly one.
+pub fn all_tools() -> Vec<ToolSchema> {
+    vec![ToolSchema {
+        name: "run".to_string(),
+        description:
+            "Run code inside a fresh mvm microVM. Single tool; the `env` parameter selects which pre-built template to boot. Output is captured (stdout, stderr, exit_code). Each call boots and tears down a transient VM (session reuse is reserved). Use `mvmctl template list` on the host to discover available envs."
+                .to_string(),
+        input_schema: run_input_schema(),
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_params_serde_roundtrip() {
+        let p = RunParams {
+            env: "shell".to_string(),
+            code: "echo hi".to_string(),
+            session: None,
+            close: None,
+            timeout_secs: Some(30),
+        };
+        let s = serde_json::to_string(&p).unwrap();
+        let parsed: RunParams = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed.env, "shell");
+        assert_eq!(parsed.timeout_secs, Some(30));
+    }
+
+    #[test]
+    fn run_params_accepts_session_and_close() {
+        // A.2 schema readiness: clients adopting session+close ahead
+        // of server-side support must not get a parse error.
+        let json = r#"{"env":"shell","code":"x","session":"s1","close":true}"#;
+        let parsed: RunParams = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.session.as_deref(), Some("s1"));
+        assert_eq!(parsed.close, Some(true));
+    }
+
+    #[test]
+    fn run_params_rejects_unknown_fields() {
+        let bad = r#"{"env":"shell","code":"x","unknown_field":1}"#;
+        assert!(serde_json::from_str::<RunParams>(bad).is_err());
+    }
+
+    #[test]
+    fn all_tools_returns_single_run_tool() {
+        let tools = all_tools();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "run");
+    }
+
+    #[test]
+    fn tools_list_token_budget_under_500() {
+        // Byte-count heuristic where 1 token ≈ 4 bytes (well-known
+        // approximation for Claude/GPT-4 family). The plan's target
+        // is ≤ 500 tokens for `tools/list`. Guards against schema
+        // bloat as we add description text over time.
+        let serialized = serde_json::to_string(&all_tools()).unwrap();
+        let approx_tokens = serialized.len() / 4;
+        assert!(
+            approx_tokens < 500,
+            "tools/list too large: ~{} tokens ({} bytes); target < 500",
+            approx_tokens,
+            serialized.len()
+        );
+    }
+}

--- a/crates/mvm-mcp/src/tools/run.rs
+++ b/crates/mvm-mcp/src/tools/run.rs
@@ -1,0 +1,297 @@
+//! Stdio-side handler for the `run` tool.
+//!
+//! Validates params, dispatches into a transient microVM via
+//! `mvm-cli::exec::run_captured`, formats stdout/stderr/exit_code into
+//! an MCP `tools/call` response, and audit-logs the invocation.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::dispatcher::Dispatcher;
+use crate::protocol::{ContentBlock, ToolResult};
+use crate::tools::RunParams;
+
+/// stdout/stderr cap per call (cross-cutting consideration "A:
+/// resource limits"). Truncated tail is replaced by an explicit
+/// `[truncated, N more bytes]` marker so the LLM sees the failure
+/// mode instead of a silently chopped payload.
+const STREAM_CAP_BYTES: usize = 64 * 1024;
+
+/// Default per-call timeout in seconds. Bounded `[1, 600]`; values
+/// outside that range are clamped (not errored) so an LLM that picks
+/// `timeout_secs: 0` still makes progress.
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+const MIN_TIMEOUT_SECS: u64 = 1;
+const MAX_TIMEOUT_SECS: u64 = 600;
+
+/// Default concurrency cap. Configurable via `MVM_MCP_MAX_INFLIGHT`.
+const DEFAULT_MAX_INFLIGHT: usize = 4;
+
+/// Default memory ceiling in MiB. Configurable via
+/// `MVM_MCP_MEM_CEILING_MIB`.
+const DEFAULT_MEM_CEILING_MIB: u32 = 4096;
+
+/// Default vCPUs handed to the transient microVM. Templates' vCPU
+/// counts are not honored in v1 — every `tools/call run` uses the
+/// same fixed shape so concurrency math stays predictable.
+const DEFAULT_VM_CPUS: u32 = 2;
+const DEFAULT_VM_MEM_MIB: u32 = 1024;
+
+/// Concrete dispatcher backed by `mvm-cli::exec`.
+pub struct ExecDispatcher {
+    inflight: AtomicUsize,
+    max_inflight: usize,
+    mem_ceiling_mib: u32,
+}
+
+impl Default for ExecDispatcher {
+    fn default() -> Self {
+        Self {
+            inflight: AtomicUsize::new(0),
+            max_inflight: parse_env_usize("MVM_MCP_MAX_INFLIGHT", DEFAULT_MAX_INFLIGHT),
+            mem_ceiling_mib: parse_env_u32("MVM_MCP_MEM_CEILING_MIB", DEFAULT_MEM_CEILING_MIB),
+        }
+    }
+}
+
+impl Dispatcher for ExecDispatcher {
+    fn run(&self, params: RunParams) -> ToolResult {
+        // Concurrency gate (cross-cutting "A: resource limits").
+        let prev = self.inflight.fetch_add(1, Ordering::SeqCst);
+        // Decrement no matter what path we take below.
+        let _guard = InflightGuard(&self.inflight);
+        if prev >= self.max_inflight {
+            return error_result(format!(
+                "MCP server busy: {} calls in flight (cap MVM_MCP_MAX_INFLIGHT={}). Retry shortly.",
+                prev + 1,
+                self.max_inflight
+            ));
+        }
+
+        // Validate env against the local template registry.
+        if let Err(e) = crate::env::validate_env(&params.env) {
+            return error_result(format!("{e}"));
+        }
+
+        // Memory ceiling check: rejecting templates whose recorded
+        // mem_mib exceeds MVM_MCP_MEM_CEILING_MIB. Look the spec up;
+        // missing spec is a soft pass since we don't know the size.
+        if let Ok(spec) = mvm_runtime::vm::template::lifecycle::template_load(&params.env)
+            && spec.mem_mib > self.mem_ceiling_mib {
+            return error_result(format!(
+                "env '{}' requests {} MiB which exceeds MVM_MCP_MEM_CEILING_MIB={}",
+                params.env, spec.mem_mib, self.mem_ceiling_mib
+            ));
+        }
+
+        // Build the inline argv for the env. We don't have full
+        // metadata about each template's "interpreter type" yet, so
+        // v1 dispatches all envs through `bash -c`. Templates whose
+        // service is `python`/`node`/etc. expose those interpreters
+        // on PATH inside the VM, so `bash -c "python3 -c '<code>'"`
+        // works for the curated envs documented in plan 32.
+        let argv = bash_dash_c(&shell_escape(&params.code));
+        let timeout = clamp_timeout(params.timeout_secs);
+
+        let req = mvm_cli::exec::ExecRequest {
+            image: mvm_cli::exec::ImageSource::Template(params.env.clone()),
+            cpus: DEFAULT_VM_CPUS,
+            memory_mib: DEFAULT_VM_MEM_MIB,
+            add_dirs: Vec::new(),
+            env: Vec::new(),
+            target: mvm_cli::exec::ExecTarget::Inline { argv },
+            timeout_secs: timeout,
+        };
+
+        let started = std::time::Instant::now();
+        let result = mvm_cli::exec::run_captured(req);
+        let elapsed = started.elapsed();
+
+        match result {
+            Ok(out) => {
+                let stdout = truncate_with_marker(&out.stdout);
+                let stderr = truncate_with_marker(&out.stderr);
+                audit_call_complete(
+                    &params.env,
+                    params.code.len(),
+                    out.exit_code,
+                    elapsed.as_millis() as u64,
+                    params.session.as_deref(),
+                );
+                ToolResult {
+                    content: vec![
+                        ContentBlock::Text { text: stdout },
+                        ContentBlock::Text { text: format!("[stderr]\n{}", stderr) },
+                        ContentBlock::Text { text: format!("exit_code={}", out.exit_code) },
+                    ],
+                    is_error: out.exit_code != 0,
+                }
+            }
+            Err(e) => {
+                audit_call_error(
+                    &params.env,
+                    params.code.len(),
+                    elapsed.as_millis() as u64,
+                    params.session.as_deref(),
+                    &format!("{e:#}"),
+                );
+                error_result(format!("microVM exec failed: {e:#}"))
+            }
+        }
+    }
+}
+
+struct InflightGuard<'a>(&'a AtomicUsize);
+impl<'a> Drop for InflightGuard<'a> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+fn error_result(msg: impl Into<String>) -> ToolResult {
+    ToolResult {
+        content: vec![ContentBlock::Text { text: msg.into() }],
+        is_error: true,
+    }
+}
+
+fn clamp_timeout(t: Option<u64>) -> u64 {
+    t.unwrap_or(DEFAULT_TIMEOUT_SECS)
+        .clamp(MIN_TIMEOUT_SECS, MAX_TIMEOUT_SECS)
+}
+
+fn bash_dash_c(quoted_code: &str) -> Vec<String> {
+    vec![
+        "bash".to_string(),
+        "-c".to_string(),
+        quoted_code.to_string(),
+    ]
+}
+
+/// Single-quote a string for safe inclusion in a `bash -c` invocation.
+/// Single quotes can't appear inside single-quoted strings in bash, so
+/// we close + concatenate the standard `'\''` workaround.
+fn shell_escape(s: &str) -> String {
+    let escaped: String = s.replace('\'', "'\\''");
+    format!("'{escaped}'")
+}
+
+/// Cap `s` at [`STREAM_CAP_BYTES`] and append a marker reporting how
+/// many bytes were dropped, so the LLM sees the truncation rather
+/// than a silently truncated payload.
+fn truncate_with_marker(s: &str) -> String {
+    if s.len() <= STREAM_CAP_BYTES {
+        return s.to_string();
+    }
+    // Truncate at a UTF-8 boundary at-or-before STREAM_CAP_BYTES.
+    let mut end = STREAM_CAP_BYTES;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let dropped = s.len() - end;
+    format!("{}\n[truncated, {} more bytes]", &s[..end], dropped)
+}
+
+fn parse_env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+}
+fn parse_env_u32(name: &str, default: u32) -> u32 {
+    std::env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+}
+
+fn audit_call_complete(
+    env: &str,
+    code_len: usize,
+    exit_code: i32,
+    elapsed_ms: u64,
+    session: Option<&str>,
+) {
+    // `LocalAuditKind::McpToolsCallRun` is the v1 mvm-core kind. It
+    // captures vm_name (the env name) and a JSON-encoded detail blob
+    // with code_len/exit_code/elapsed_ms/session — the existing local
+    // audit API doesn't take a structured payload, so we serialise
+    // into the detail field. The audit call itself is best-effort;
+    // failures land in `tracing::warn!` only.
+    let detail = serde_json::json!({
+        "code_len": code_len,
+        "exit_code": exit_code,
+        "elapsed_ms": elapsed_ms,
+        "session": session,
+    })
+    .to_string();
+    mvm_core::policy::audit::emit(
+        mvm_core::policy::audit::LocalAuditKind::McpToolsCallRun,
+        Some(env),
+        Some(&detail),
+    );
+}
+
+fn audit_call_error(
+    env: &str,
+    code_len: usize,
+    elapsed_ms: u64,
+    session: Option<&str>,
+    error: &str,
+) {
+    let detail = serde_json::json!({
+        "code_len": code_len,
+        "elapsed_ms": elapsed_ms,
+        "session": session,
+        "error": error,
+    })
+    .to_string();
+    mvm_core::policy::audit::emit(
+        mvm_core::policy::audit::LocalAuditKind::McpToolsCallRunError,
+        Some(env),
+        Some(&detail),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_under_cap_passes_through() {
+        let s = "hello world";
+        assert_eq!(truncate_with_marker(s), s);
+    }
+
+    #[test]
+    fn truncate_over_cap_appends_marker() {
+        let s = "x".repeat(STREAM_CAP_BYTES + 100);
+        let out = truncate_with_marker(&s);
+        assert!(out.contains("[truncated, 100 more bytes]"));
+        assert!(out.len() < STREAM_CAP_BYTES + 50, "marker is short");
+    }
+
+    #[test]
+    fn truncate_respects_utf8_boundary() {
+        // Build a string where byte STREAM_CAP_BYTES falls in the
+        // middle of a multi-byte char.
+        let prefix = "x".repeat(STREAM_CAP_BYTES - 1);
+        let s = format!("{prefix}éééé");
+        let out = truncate_with_marker(&s);
+        // Truncated form must still parse as valid UTF-8 (Rust string
+        // literal guarantees this) and contain the marker.
+        assert!(out.contains("[truncated"));
+    }
+
+    #[test]
+    fn timeout_clamps_to_bounds() {
+        assert_eq!(clamp_timeout(None), DEFAULT_TIMEOUT_SECS);
+        assert_eq!(clamp_timeout(Some(0)), MIN_TIMEOUT_SECS);
+        assert_eq!(clamp_timeout(Some(99_999)), MAX_TIMEOUT_SECS);
+        assert_eq!(clamp_timeout(Some(30)), 30);
+    }
+
+    #[test]
+    fn shell_escape_handles_single_quotes() {
+        let escaped = shell_escape("it's");
+        assert_eq!(escaped, "'it'\\''s'");
+    }
+
+    #[test]
+    fn shell_escape_no_quotes() {
+        assert_eq!(shell_escape("plain"), "'plain'");
+    }
+}

--- a/nix/images/examples/llm-agent/README.md
+++ b/nix/images/examples/llm-agent/README.md
@@ -1,0 +1,110 @@
+# `llm-agent` — claude-code inside a microVM
+
+This example boots a Firecracker microVM whose only service is
+[`claude-code`](https://github.com/anthropics/claude-code), with the
+project working directory mounted at `/workspace` and the Anthropic API
+key injected as a per-service secret (mode 0400, owned by the agent's
+auto-derived uid). It is the showcase used by
+[`specs/plans/32-mcp-agent-adoption.md`](../../../../specs/plans/32-mcp-agent-adoption.md)
+Proposal B and is the canonical `claude-code-vm` env that the
+forthcoming `mvmctl mcp` server (Proposal A) will dispatch into.
+
+## Why a microVM and not bubblewrap
+
+The whole point of this example is the isolation level — full kernel
+separation. Bubblewrap-shaped sandboxes (jail.nix, agent-sandbox.nix,
+nix-sandbox-mcp's current backend) share the host kernel and trust it.
+Running an LLM agent in a microVM means a kernel exploit can't pivot to
+the host. mvm's security posture is documented in
+[`specs/adrs/002-microvm-security-posture.md`](../../../../specs/adrs/002-microvm-security-posture.md);
+the flake here composes with all of W1–W5 from that ADR.
+
+## One-time setup
+
+Drop your Anthropic API key into mvm's secrets directory:
+
+```bash
+mkdir -p ~/.config/mvm/secrets
+chmod 0700 ~/.config/mvm/secrets
+printf '%s\n' 'sk-ant-…' > ~/.config/mvm/secrets/anthropic
+chmod 0400 ~/.config/mvm/secrets/anthropic
+```
+
+If you skip this, the service start script logs
+`[claude-code] no Anthropic API key at /run/mvm-secrets/claude-code/anthropic-api-key`
+and exits cleanly — the integration health check reports
+"unconfigured" rather than crash-looping. Drop the key in, re-run
+`mvmctl up`, and the service comes up on the next boot.
+
+## Build and boot
+
+```bash
+mvmctl template create claude-code-vm \
+  --flake ./nix/images/examples/llm-agent \
+  --profile minimal --role agent \
+  --cpus 2 --mem 1024
+
+mvmctl template build claude-code-vm
+
+mvmctl up --template claude-code-vm \
+  --network-preset agent \
+  --add-dir "$PWD:/workspace:rw" \
+  --secret-file "$HOME/.config/mvm/secrets/anthropic:claude-code/anthropic-api-key"
+```
+
+`--add-dir host:guest:mode` bind-mounts the working directory into the
+VM at `/workspace`. The agent `cd`s there before exec; `git` /
+`ripgrep` / `jq` / `curl` / `bash` are all in PATH inside the VM.
+
+`--network-preset agent` (added by [ADR-004 / plan 32 Proposal D](../../../../specs/adrs/004-hypervisor-egress-policy.md))
+locks the VM's outbound egress to the LLM-agent allowlist:
+`api.anthropic.com:443`, `api.openai.com:443`, `github.com:{443,22}`,
+`api.github.com:443`, plus DNS. Anything else gets dropped at the
+host's iptables `FORWARD` chain. This is L3-only enforcement; SNI/Host
+filtering and DNS-answer pinning (the L7 tiers in ADR-004) are
+deferred follow-ups. For now, agents that need extra hosts get an
+explicit `--network-allow host:port`.
+
+## Console access for iteration
+
+`mvmctl console claude-code-vm` opens an interactive PTY-over-vsock
+session into the VM. `mvmctl exec claude-code-vm <argv>` runs a
+one-shot command inside it — both gated to dev-mode builds per
+ADR-002 §W4.3.
+
+## Security posture (per ADR-002)
+
+| Surface                            | What this flake does                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------ |
+| Per-service uid                    | `claude-code` runs as `1100 + sha256_hex8("claude-code") % 8000`, never uid 0              |
+| `setpriv` privilege drop           | `--no-new-privs --bounding-set=-all --inh-caps=-all`                                       |
+| Seccomp tier                       | `network` — allows `socket/connect/sendto` for Anthropic HTTPS, blocks `ptrace/keyctl/...` |
+| Secrets mode                       | `/run/mvm-secrets/claude-code/anthropic-api-key` is `0400`, owned by the service uid       |
+| Verified boot                      | On by default (mkGuest's `verifiedBoot = true`)                                            |
+| `do_exec` symbol in prod guest     | Absent (W4.3 CI gate)                                                                      |
+| Hypervisor-level egress allowlist  | L3 (iptables): `--network-preset agent` enables it (ADR-004). L7 SNI/Host + DNS pinning deferred. |
+
+## Limitations
+
+- **L3 egress allowlist only.** The recommended `--network-preset
+  agent` enforces an iptables-based allowlist (ADR-004). It catches
+  raw-IP exfil; it does NOT catch DNS rotation (CDN-fronted domains)
+  or SNI/Host header abuse over a permitted destination. The L7
+  HTTPS proxy + DNS-answer pinning that close those gaps are
+  deferred follow-ups in ADR-004.
+- **claude-code is interactive-by-default.** The example service
+  launches `claude` with no argv; you'll usually want to `mvmctl exec`
+  in or use the upcoming `mvmctl mcp run` (Proposal A) for
+  programmatic access.
+- **No persistent agent state across boots.** The rootfs is read-only;
+  `~/.config/claude` lives on tmpfs. Mount a host directory at
+  `/workspace/.claude` (or change `HOME` in `services.claude-code.env`)
+  if you want history to survive reboots.
+
+## Where to go from here
+
+- [`specs/plans/32-mcp-agent-adoption.md`](../../../../specs/plans/32-mcp-agent-adoption.md)
+  for the broader plan (this flake is Proposal B; the MCP server is
+  Proposal A).
+- [`specs/plans/33-hosted-mcp-transport.md`](../../../../specs/plans/33-hosted-mcp-transport.md)
+  for the cross-repo handoff to mvmd for hosted multi-tenant MCP.

--- a/nix/images/examples/llm-agent/flake.lock
+++ b/nix/images/examples/llm-agent/flake.lock
@@ -1,0 +1,256 @@
+{
+  "nodes": {
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777369708,
+        "narHash": "sha256-1xW7cRZNsFNPQD+cE0fwnLVStnDth0HSoASEIFeT7uI=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "e659e1cc4b8e1b21d0aa85f1c481f9db61ecfa98",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "staging-2.1.0",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "llm-agents": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1777578293,
+        "narHash": "sha256-ihtSSh1ESbN/x3QiyST0dxv9Okxf04Rb90Hl+D9kdwE=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "80b1f45a1ca4711379c72d542b3f149d58561747",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
+    "mvm": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "path": "../../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "llm-agents": "llm-agents",
+        "mvm": "mvm",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "mvm",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777519017,
+        "narHash": "sha256-TXilQ8MwFFtZs7HSogSI/LJzAS63nicE8iF63iB93WM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "09b556f18dacc39e97a46e0a1cba47af7b3af1d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/images/examples/llm-agent/flake.nix
+++ b/nix/images/examples/llm-agent/flake.nix
@@ -1,0 +1,152 @@
+{
+  description = "LLM-agent microVM example — runs claude-code inside a Firecracker microVM";
+
+  # ── What this example shows ──────────────────────────────────────────
+  #
+  # A microVM whose only service is an LLM coding agent (claude-code by
+  # default). The agent's API key lives outside the rootfs at
+  # `/run/mvm-secrets/claude-code/anthropic-api-key` — populated by
+  # mvmctl's existing per-service secrets plumbing — so the secret never
+  # enters the Nix store.
+  #
+  # Build:
+  #   mvmctl template create claude-code-vm \
+  #     --flake ./nix/images/examples/llm-agent \
+  #     --profile minimal --role agent --cpus 2 --mem 1024
+  #   mvmctl template build claude-code-vm
+  #
+  # Run with the project mounted at /workspace and the API key injected:
+  #   mvmctl up --template claude-code-vm \
+  #     --add-dir "$PWD:/workspace:rw" \
+  #     --secret-file "$HOME/.config/mvm/secrets/anthropic:claude-code/anthropic-api-key"
+  #
+  # The agent service follows ADR-002 §W2:
+  #   - per-service uid auto-derived (NOT uid 0; NOT the guest agent's
+  #     uid 901 — gets its own entry in the [1100..9099] range)
+  #   - setpriv with --no-new-privs and an empty bounding capability set
+  #   - seccomp tier `network` (allows socket/connect/sendto for HTTPS
+  #     to the Anthropic API; blocks ptrace/keyctl/etc)
+  #
+  # ADR-002 §W3 verified-boot is intentionally on (default). The dev
+  # variant of this flake (used for `mvmctl exec` / `mvmctl console`
+  # iteration) is selected by mvmctl's --override-input dance, the same
+  # way every other example works.
+  #
+  # Hypervisor-level egress policy (Proposal D in plan 32) is NOT yet
+  # plumbed; today the agent has unrestricted outbound via NAT. When D
+  # lands, this flake will gain `network_policy.egress_mode =
+  # AllowDomainsStrict` + `domains = [ "api.anthropic.com" ]`.
+
+  inputs = {
+    mvm.url = "path:../../..";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    # Curated agent packages (claude-code, opencode, gemini-cli, …) with
+    # a working binary cache at cache.numtide.com so we don't have to
+    # rebuild Node + agents on every consumer machine.
+    llm-agents = {
+      url = "github:numtide/llm-agents.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { mvm, nixpkgs, llm-agents, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      eachSystem = f: builtins.listToAttrs (map (system:
+        { name = system; value = f system; }
+      ) systems);
+    in {
+      packages = eachSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; config = {}; overlays = []; };
+          claudeCode = llm-agents.packages.${system}.claude-code;
+
+          # Service start script.
+          #
+          # 1. Refuses to crash-loop when the API key is missing — exit 0
+          #    so the integration health check shows "no key configured"
+          #    rather than burning CPU restarting forever. Operator drops
+          #    the key file into ~/.config/mvm/secrets/ and re-runs
+          #    `mvmctl up`.
+          # 2. Mounts /workspace if `mvmctl up --add-dir <host>:/workspace:rw`
+          #    was passed; otherwise warns and continues so the agent
+          #    has a writable cwd in tmpfs.
+          # 3. Execs claude-code under the workspace dir so the agent
+          #    operates against the user's project tree.
+          startScript = pkgs.writeShellScript "claude-code-start" ''
+            set -eu
+
+            secret_path=/run/mvm-secrets/claude-code/anthropic-api-key
+            if [ ! -r "$secret_path" ]; then
+              echo "[claude-code] no Anthropic API key at $secret_path"
+              echo "[claude-code] populate via:"
+              echo "    mvmctl up --secret-file \\"
+              echo "      \"\$HOME/.config/mvm/secrets/anthropic:claude-code/anthropic-api-key\""
+              echo "[claude-code] exiting cleanly so health check reports unconfigured."
+              exit 0
+            fi
+
+            # claude-code reads ANTHROPIC_API_KEY from env. We
+            # deliberately don't `cat` the secret into a long-lived
+            # variable — read it once on exec and discard.
+            ANTHROPIC_API_KEY="$(cat "$secret_path")"
+            export ANTHROPIC_API_KEY
+
+            workspace=/workspace
+            if [ ! -d "$workspace" ]; then
+              echo "[claude-code] no /workspace mount; falling back to /tmp/work"
+              workspace=/tmp/work
+              mkdir -p "$workspace"
+            fi
+            cd "$workspace"
+
+            exec ${claudeCode}/bin/claude "$@"
+          '';
+
+        in {
+          default = mvm.lib.${system}.mkGuest {
+            name = "claude-code-vm";
+            hostname = "claude-code-vm";
+
+            # The agent's runtime closure. `claudeCode` covers the
+            # binary; the others give the agent useful tools inside the
+            # VM (ripgrep + jq are nigh-mandatory; git + curl let the
+            # agent commit + fetch).
+            packages = [
+              claudeCode
+              pkgs.git
+              pkgs.curl
+              pkgs.ripgrep
+              pkgs.jq
+              pkgs.coreutils
+              pkgs.bashInteractive
+            ];
+
+            services.claude-code = {
+              command = "${startScript}";
+              # ADR-002 §W2.4: outbound HTTPS to the Anthropic API
+              # needs `socket(2)`, `connect(2)`, etc. — `network` is
+              # the smallest tier that allows them.
+              seccomp = "network";
+              env = {
+                # Bias the agent toward the mounted workspace.
+                HOME = "/workspace";
+                # Without explicit TERM, claude-code's TUI tries to
+                # negotiate a non-existent capability and 100% CPUs.
+                TERM = "dumb";
+              };
+            };
+
+            healthChecks.claude-code = {
+              # Liveness: the process exists. claude-code listens on
+              # stdin in interactive mode, not on a TCP port, so the
+              # usual `/proc/net/tcp` hex-port grep doesn't apply.
+              # `pgrep` is busybox-provided.
+              healthCmd = "pgrep -f claude >/dev/null";
+              healthIntervalSecs = 30;
+              healthTimeoutSecs = 5;
+            };
+          };
+        });
+    };
+}

--- a/ops/networking/README.md
+++ b/ops/networking/README.md
@@ -2,19 +2,22 @@
 
 Bridge / TAP / iptables provisioning for the mvm host network.
 
-Currently empty. **Status: deferred for product decision** (see W7
-"Items deferred — needs your decision" in
-[the plan](../../specs/plans/31-nix-best-practices-cleanup.md)):
+**Status (decided 2026-04-30): lenient reading.** The bridge / TAP /
+iptables setup stays in `crates/mvm-runtime/src/vm/network.rs` and
+runs from `mvmctl dev up` / `mvmctl run`. Rationale: the
+[mvm-nix-best-practices guide](../../specs/references/mvm-nix-best-practices.md)
+hard rules (`flake.nix` / `devShells` / `shellHook`) target Nix
+*entry points* that mutate the host on `nix develop` — they don't
+target user-invoked CLI commands. `mvmctl dev up` is explicit, on
+demand, and prints what it's about to change before doing it; that's
+the visibility the host-mutation boundary is asking for. A separate
+`ops/networking/bridge-setup.sh` would only re-introduce a setup
+ritual without adding clarity (the user already typed the command
+that runs the mutations).
 
-- **Lenient reading of the guide**: `mvmctl dev up` and `mvmctl run`
-  legitimately invoke `crates/mvm-runtime/src/vm/network.rs` to set up
-  the bridge + TAP + iptables NAT. The guide's hard rule names these
-  as forbidden in `flake.nix` / `devShells` / `shellHook`, not in
-  user-invoked CLI commands. Status quo.
-- **Strict reading**: extract the iptables/bridge/`ip link`
-  invocations into `bridge-setup.sh` here, and have `network.rs`
-  warn-and-exit if the bridge isn't already up. User runs this script
-  once per host.
-
-Until the call is made, the code in `network.rs` stays authoritative
-and this directory is documentation-only.
+If a later product decision flips this — for example, mvmd's
+production target where bridge setup happens at deployment time, not
+on first `mvmctl run` — the migration is mechanical: extract the
+`iptables` / `ip link` / `bridge` calls from `network.rs` into
+`bridge-setup.sh` here, and have `network.rs` precondition-check
+that the bridge already exists.

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -240,3 +240,39 @@ mvmctl build --flake . --profile gateway
 ```
 
 These map to `packages.${system}.<profile>` in the flake.
+
+## Running an LLM agent inside a microVM
+
+[`nix/images/examples/llm-agent/`](https://github.com/auser/mvm/tree/main/nix/images/examples/llm-agent)
+is a worked example that boots `claude-code` inside a Firecracker
+microVM. It pulls the agent binary from
+[`numtide/llm-agents.nix`](https://github.com/numtide/llm-agents.nix)
+(binary cache at `cache.numtide.com`), runs it as a per-service uid
+under `setpriv` with seccomp tier `network`, and reads the Anthropic
+API key from `/run/mvm-secrets/claude-code/anthropic-api-key` so the
+secret never enters the rootfs.
+
+```bash
+mkdir -p ~/.config/mvm/secrets
+printf '%s\n' 'sk-ant-…' > ~/.config/mvm/secrets/anthropic
+chmod 0400 ~/.config/mvm/secrets/anthropic
+
+mvmctl template create claude-code-vm \
+  --flake ./nix/images/examples/llm-agent \
+  --profile minimal --role agent --cpus 2 --mem 1024
+mvmctl template build claude-code-vm
+
+mvmctl up --template claude-code-vm \
+  --add-dir "$PWD:/workspace:rw" \
+  --secret-file "$HOME/.config/mvm/secrets/anthropic:claude-code/anthropic-api-key"
+```
+
+Why a microVM and not a process sandbox: process sandboxes share the
+host kernel and trust it. A microVM gives the agent its own kernel,
+so a kernel exploit can't pivot to the host.
+
+The example's full security composition (per-service uid, seccomp,
+secrets mode, verified boot) is documented in the
+[example README](https://github.com/auser/mvm/tree/main/nix/images/examples/llm-agent#readme)
+and threat-modelled in
+[ADR-002](https://github.com/auser/mvm/blob/main/specs/adrs/002-microvm-security-posture.md).

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -22,7 +22,7 @@ description: Complete command reference for mvmctl.
 | `mvmctl up --metrics-port PORT` | Bind a Prometheus metrics endpoint (0 = disabled) |
 | `mvmctl up --watch-config` | Reload ~/.mvm/config.toml automatically when it changes |
 | `mvmctl up --watch` | Watch flake for changes and auto-rebuild + reboot |
-| `mvmctl up --network-preset <preset>` | Network egress policy: `unrestricted` (default), `none`, `registries`, `dev` |
+| `mvmctl up --network-preset <preset>` | Network egress policy: `unrestricted` (default), `none`, `registries`, `dev`, `agent` (LLM-inference + GitHub bundle — see [ADR-004](https://github.com/auser/mvm/blob/main/specs/adrs/004-hypervisor-egress-policy.md)) |
 | `mvmctl up --network-allow host:port` | Allow egress to specific host:port (repeatable, mutually exclusive with preset) |
 | `mvmctl up --seccomp <tier>` | Seccomp profile: `essential`, `minimal`, `standard`, `network`, `unrestricted` (default) |
 | `mvmctl up --secret KEY:host` | Bind a secret to a domain (repeatable; see [Config & Secrets](/guides/config-secrets/)) |
@@ -86,7 +86,7 @@ description: Complete command reference for mvmctl.
 | `mvmctl template init <name> --local` | Scaffold a new template directory with flake.nix |
 | `mvmctl template init <name> --vm` | Scaffold inside the Lima VM (overrides --local) |
 | `mvmctl template init <name> --preset <preset>` | Scaffold preset: minimal, http, postgres, worker, python (default: minimal) |
-| `mvmctl template init <name> --prompt "<text>" --local` | Generate a local scaffold from a natural-language prompt. Supports `openai`, `local`, or `heuristic` planning via `MVM_TEMPLATE_PROVIDER` |
+| `mvmctl template init <name> --prompt "<text>" --local` | Generate a local scaffold from a natural-language prompt. In `auto` mode (default) probes for a local OpenAI-compatible endpoint on loopback (Ollama @ `:11434`, LocalAI @ `:8080`) before falling through to OpenAI. Override the order with `MVM_TEMPLATE_PROVIDER=openai\|local\|heuristic`; skip the probe with `MVM_TEMPLATE_NO_LOCAL_PROBE=1`. The probe issues a brief loopback TCP connect on each invocation, visible to local processes via `netstat` |
 | `mvmctl template init <name> --dir <path>` | Base directory for local init (default: current dir) |
 | `mvmctl template create <name>` | Create a single template definition |
 | `mvmctl template create <name> --data-disk SIZE` | Create template with a data disk (10G, 512M, or plain MB; 0 = none) |
@@ -331,5 +331,7 @@ All commands accept these global options:
 | `MVM_TEMPLATE_LOCAL_MODEL` | Local AI model name sent to an OpenAI-compatible local endpoint | `qwen2.5-coder-7b-instruct` |
 | `MVM_TEMPLATE_LOCAL_BASE_URL` | Base URL for an OpenAI-compatible local AI endpoint such as LocalAI or `llama.cpp` server | None |
 | `MVM_TEMPLATE_LOCAL_API_KEY` | Optional API key for the local AI endpoint | None |
+| `MVM_TEMPLATE_LOCAL_PROBE_TARGETS` | Comma-separated base URLs to probe for a local OpenAI-compatible endpoint in `auto` mode (overrides defaults `http://127.0.0.1:11434` and `http://127.0.0.1:8080`) | Defaults |
+| `MVM_TEMPLATE_NO_LOCAL_PROBE` | Set to `1` to skip the local-endpoint probe in `auto` mode (CI / sandboxed environments where loopback connects can hang) | Unset |
 | `MVM_PRODUCTION` | Enable production mode checks | `false` |
 | `RUST_LOG` | Logging level (e.g., `debug`, `mvm=trace`) | `info` |

--- a/specs/adrs/003-local-mcp-server.md
+++ b/specs/adrs/003-local-mcp-server.md
@@ -1,0 +1,161 @@
+---
+title: "ADR-003: local Model Context Protocol server (`mvmctl mcp`)"
+status: Proposed
+date: 2026-04-30
+related: ADR-002 (microVM security posture); plan 32 (MCP + LLM-agent adoption); plan 33 (hosted MCP transport — mvmd cross-repo)
+---
+
+## Status
+
+Proposed. Implementation tracked in `specs/plans/32-mcp-agent-adoption.md`
+Proposal A. Composes with ADR-002 — does not introduce new attacker
+surfaces, only a new dispatch path on top of the existing
+`mvmctl exec` machinery.
+
+## Context
+
+LLM clients (Claude Code, opencode, Codex, etc.) speak Model Context
+Protocol over stdio. Each client expects a server that announces
+itself via `initialize`, lists its tools via `tools/list`, and
+dispatches via `tools/call`. Today, mvmctl is invokable only via
+shell; an LLM driving it has to spawn a subprocess per call, parse
+free-form output, and lose the protocol's structured affordances
+(content blocks, error semantics, capability negotiation).
+
+`mvmctl mcp` adds the MCP transport. It exposes mvm's microVM
+template registry as a single parameterized `run` tool — borrowing
+nix-sandbox-mcp's design insight that one tool with an `env`
+parameter keeps the LLM context-window cost flat (~420 tokens)
+regardless of how many envs the user has built. nix-sandbox-mcp's
+own roadmap explicitly lists "microvm.nix backend" as future work
+because microVMs are "the right choice for running untrusted code
+from the internet"; mvm already has that backend. The combination
+— mvm's isolation strength with nix-sandbox-mcp's tool-design
+ergonomics — is the point.
+
+## Threat model (additive over ADR-002)
+
+The MCP server is a host-local stdio process spawned by the user's
+LLM client. There is **no new attacker** beyond ADR-002:
+
+1. The transport is `stdin`/`stdout` of the same user's shell
+   environment. No network listener.
+2. The `env` parameter is allowlisted against the existing
+   `mvmctl template list`. An unknown name returns a structured
+   MCP error listing valid envs; no shell interpolation, no
+   arbitrary path access.
+3. The `code` parameter is passed as a single argv element (via
+   `bash -c <quoted>`) to the guest interpreter inside the
+   already-isolated microVM. The microVM is the security boundary;
+   `code` cannot escape.
+4. The dispatch chain goes through `crate::exec::run_captured` →
+   guest agent's `Exec` over vsock. ADR-002 §W4.3's
+   `prod-agent-no-exec` CI gate ensures production guest agents
+   are built without `dev-shell`, so the `Exec` handler is
+   physically absent from the binary; production workloads return
+   "exec not available" gracefully. **No new feature gate is
+   needed at the CLI level** — the existing chain is the gate.
+
+Surfaces specific to this ADR:
+
+| Surface | Today | Hardened |
+|---|---|---|
+| MCP transport | stdio only | Stdio only; hosted HTTP/SSE deferred to mvmd per plan 33 |
+| `tools/call run` env validation | n/a | Allowlist match against `template_list()`; structured error on miss |
+| `tools/call run` code injection | n/a | `bash -c` argv (single quoted) — no shell expansion possible |
+| Output capture | n/a | stdout/stderr capped at 64 KiB each; truncation reported via `[truncated, N more bytes]` marker |
+| Concurrency | n/a | `MVM_MCP_MAX_INFLIGHT` (default 4); over-cap returns structured error |
+| Memory ceiling | n/a | `MVM_MCP_MEM_CEILING_MIB` (default 4096); env's template `mem_mib` is checked against it |
+| Per-call timeout | n/a | `[1, 600]` seconds; out-of-range values clamp (do not error) |
+| Audit logging | n/a | Every call lands in `~/.local/state/mvm/log/audit.jsonl` via `LocalAuditKind::McpToolsCallRun{,Error}` |
+| stdout discipline | n/a | All `tracing` output goes to stderr — stdout is reserved for JSON-RPC frames |
+
+## Decisions
+
+1. **Single parameterized tool.** One `run` tool, parameters
+   `{env, code, session?, timeout_secs?}`. Adding new envs (templates)
+   doesn't add tools. Token budget ≤ 500 verified by unit test.
+
+2. **No new external dependencies.** Hand-roll the JSON-RPC 2.0
+   frames in `mvm-mcp` (~200 LoC) instead of adopting `rmcp`. Every
+   workspace dep needs to clear ADR-002's supply-chain bar
+   (`cargo-deny`, `cargo-audit`); a hand-rolled protocol is cheaper
+   to audit than a third-party impl.
+
+3. **Two feature flags, day one.** `mvm-mcp/protocol-only` (no I/O,
+   wire types only) and `mvm-mcp/stdio` (default, adds the JSON-RPC
+   loop). Plan 33's mvmd hosted variant consumes `protocol-only`;
+   shipping the split day one means no coordinated bump later.
+
+4. **No CLI-level feature gate.** `mvmctl mcp` is always present in
+   CLI builds. The dispatch path requires a dev-feature guest agent
+   (per ADR-002 §W4.3), so the CI gate that already enforces
+   `do_exec` symbol absence in production agents transitively covers
+   this surface. Adding a separate CLI gate would duplicate the
+   existing one and complicate consumer flows.
+
+5. **Hosted transport is mvmd's, not mvm's.** Plan 33 documents the
+   cross-repo handoff. mvm owns the protocol; mvmd owns
+   tenant-aware HTTP/SSE transport, auth, rate limits.
+
+6. **Session semantics deferred to A.2.** The `session` parameter
+   exists in the v1 schema but is ignored — clients can adopt the
+   field ahead of the server. The implementation (snapshot-resumed
+   warm VMs) is in plan 32 / Proposal A.2.
+
+## Consequences
+
+### Positive
+
+- LLM clients drive mvmctl directly via MCP. The user's
+  context-window cost stays flat at ~420 tokens regardless of how
+  many envs they've built.
+- The `env` parameter doubles as a discovery surface — `mvmctl
+  template list` is the registry.
+- mvmd (plan 33) inherits the wire schema unchanged. Same protocol
+  code path on the LLM client side.
+
+### Negative / accepted costs
+
+- One new workspace crate (`mvm-mcp`) to maintain. Mitigated by
+  keeping it tiny: protocol types + stdio loop, no business logic.
+- The `run` tool's lack of structured stdin (only `code` as a
+  string) means clients have to pre-render scripts into a single
+  string. nix-sandbox-mcp has the same shape; we'll match it.
+
+### Explicit non-goals
+
+- **HTTP/SSE transport.** Out of scope for this ADR; lives in
+  mvmd per plan 33.
+- **Per-tenant authentication.** mvm is single-host; mvmd handles
+  tenant auth.
+- **Streaming responses.** v1 returns one `tools/call` response per
+  request, not a stream. nix-sandbox-mcp does the same. If the LLM
+  ecosystem moves to require streaming we revisit.
+- **Wire compatibility with non-mvm MCP servers' run tools** beyond
+  the parameter-name overlap (`env`, `code`, `session`). Different
+  semantics per server are unavoidable; we don't promise a strict
+  superset.
+
+## Reversal cost
+
+If the MCP server proves a poor fit:
+
+- Drop the `mvmctl mcp` subcommand, keep `mvm-mcp` as a library —
+  mvmd may still want `protocol-only`.
+- If even the protocol crate is unwanted, deprecate it; downstream
+  removal is one minor version bump per plan 33.
+- The `ExecDispatcher` is a thin wrapper over `crate::exec::run_captured`;
+  removing it doesn't touch `mvmctl exec` semantics.
+
+The audit kind additions (`LocalAuditKind::McpToolsCallRun{,Error}`)
+are append-only — removing them would be a serde-breaking change to
+existing audit logs. Keep them even if the MCP server is dropped.
+
+## References
+
+- Plan 32: `specs/plans/32-mcp-agent-adoption.md`
+- Plan 33: `specs/plans/33-hosted-mcp-transport.md`
+- Related ADRs: ADR-002 (microVM security posture)
+- Upstream design: [SecBear/nix-sandbox-mcp](https://github.com/SecBear/nix-sandbox-mcp) — single-tool design pattern
+- MCP protocol spec: <https://modelcontextprotocol.io/>

--- a/specs/adrs/004-hypervisor-egress-policy.md
+++ b/specs/adrs/004-hypervisor-egress-policy.md
@@ -1,0 +1,199 @@
+---
+title: "ADR-004: hypervisor-level egress policy with domain-pinning"
+status: Proposed (v1 = L3 only; L7 + DNS-pinning deferred)
+date: 2026-04-30
+related: ADR-002 (microVM security posture); ADR-003 (local MCP server); plan 32 (MCP + LLM-agent adoption); plan 25 (microVM hardening)
+---
+
+## Status
+
+Proposed. v1 implementation tracked in
+`specs/plans/32-mcp-agent-adoption.md` Proposal D. ADR-002 named
+hypervisor-level egress policy as an explicit non-goal for Sprint 42's
+hardening; this ADR moves it on-roadmap for the next sprint with a
+deliberately smaller v1 scope than the full three-layer model.
+
+## Context
+
+When mvm runs an LLM agent (or any other workload that the user wants
+to constrain), the hypervisor sits in the only place that can enforce
+egress destinations — between the guest's TAP interface and the
+host's wider network. The guest agent inside the microVM is untrusted
+in this threat model; an agent that decides to exfiltrate to
+`evil.example.com` cannot be stopped by the guest's own firewall.
+
+mvm has had `NetworkPolicy` in `mvm-core` since W7, and `mvmctl up
+--network-preset` / `--network-allow` since the same sprint. Those
+flags wire up an iptables-based L3 allowlist on the bridge. What was
+missing:
+
+1. A clear ADR specifying what egress enforcement does and does not
+   guarantee.
+2. A curated preset for the LLM-agent use case (plan 32 / Proposal B
+   wants `api.anthropic.com` + GitHub + nothing else).
+3. A roadmap for the layers above L3 — namely L7 SNI/Host-header
+   filtering and DNS-answer pinning — which are needed to defeat
+   DNS-rotation attacks and SNI-hopping that pure L3 can't see.
+
+This ADR captures both decisions and limits.
+
+## Threat model (additive over ADR-002)
+
+The adversary is **a malicious guest workload** (per ADR-002 §1):
+code running inside a microVM trying to talk to a host the operator
+did not authorize. Specifically:
+
+1. The guest may attempt direct TCP/UDP connections to arbitrary
+   IPs.
+2. The guest may abuse DNS — query a benign hostname, observe the
+   answer, then connect to a different IP than the one a stub
+   resolver would have authorized.
+3. The guest may reuse a TLS connection to a permitted SNI by
+   sending a different `Host` header (HTTP/1.1 vhosting).
+4. The guest may attempt SNI to a permitted name then perform
+   ALPN-protocol smuggling.
+
+A **malicious host** is out of scope (per ADR-002). A **malicious
+DNS resolver upstream of the host** is also out of scope.
+
+## The three-layer model
+
+A complete egress enforcer for the LLM-agent use case has three
+tiers, each catching a class of attack the lower one can't:
+
+### L3 — iptables allowlist (v1 — shipped)
+
+Already in `mvm-runtime/src/vm/network.rs::apply_network_policy`.
+At TAP attach time, install `FORWARD` rules in the bridge chain that:
+
+- `DROP` all packets from the guest IP by default.
+- Allow ESTABLISHED/RELATED return traffic.
+- Allow DNS (UDP+TCP :53) so name resolution works.
+- Allow each `<host>:<port>` in the policy by IP — iptables resolves
+  the host once, at rule-install time.
+
+**Catches:** raw IP-targeted exfil to non-allowlisted hosts.
+**Doesn't catch:** DNS rotation (CDN-fronted hosts where the
+authorized answer changes between rule-install and connect),
+SNI-hopping (TLS to authorized IP, different SNI), Host-header
+abuse.
+
+### L7 — HTTPS proxy with SNI/Host filtering (deferred)
+
+Egress proxy on the host bound to a private CIDR the guest can reach.
+Guest gets `HTTPS_PROXY` / `HTTP_PROXY` env vars and the proxy's CA
+cert in `/etc/ssl/certs/mvm-egress.crt`. Proxy enforces the allowlist
+by SNI for HTTPS (CONNECT) and Host header for HTTP. CONNECT to a
+disallowed domain returns 403.
+
+**Implementation cost:** wraps `mitmdump` from nixpkgs (~50 LoC of
+process supervision in mvm-runtime); needs CA injection at boot
+inside the rootfs; needs per-VM port allocation; needs cleanup on
+crash.
+
+**Why deferred:** mitmdump is a substantial runtime dep (Python +
+mitmproxy + cryptography), and the dev image's closure grows by
+~80 MiB. We want the L3 tier shipped and adopted before pulling in
+that closure. Operator opt-in via a separate command flag once the
+implementation lands.
+
+### L7+ — DNS-answer pinning (deferred)
+
+Stub resolver on the host (`dnsmasq` configured with
+`server=/<allowlisted-domain>/<upstream>` and a 0-TTL pin per
+recursion result). Guest DNS goes through the stub; the stub
+publishes resolved A records into the iptables allowlist for the
+TTL of the answer. Catches DNS rotation. **Why deferred:** dnsmasq
+is small but the IP-pin/iptables-update plumbing has corner cases
+(IPv6, A-vs-CNAME chains, NX caching) that need careful design.
+
+## Decisions
+
+1. **v1 ships L3 only.** The infrastructure is already there
+   (`NetworkPolicy::AllowList` + `iptables_script`); v1's only
+   addition is the new `NetworkPreset::Agent` curated bundle for
+   plan 32 / Proposal B. Operators who need L7 wait for the
+   follow-up.
+
+2. **`NetworkPreset::Agent` is the LLM-agent default.** It contains:
+   - `api.anthropic.com:443`
+   - `api.openai.com:443`
+   - `github.com:443` + `:22`
+   - `api.github.com:443`
+
+   Strictly smaller than `dev` (no npm/PyPI/crates.io). Documented
+   in `nix/images/examples/llm-agent/README.md` as the recommended
+   `mvmctl up --network-preset agent`.
+
+3. **No L7 today; ADR documents it.** When L7 lands, it composes
+   on top of L3 (defense in depth, per ADR-002 §"Decisions" 2).
+   Operator chooses the layer per `--network-mode` (future flag),
+   not by separate commands.
+
+4. **DNS pinning is paired with L7.** Doing DNS pinning without
+   the L7 proxy is a partial solution that defeats CDN-fronted
+   destinations; doing L7 without DNS pinning leaves SNI-equal-IP
+   gaps. Land them together.
+
+5. **Cross-platform discipline (cross-cutting "D: iptables/proxy
+   dispatch lives in Lima on macOS").** L3 already follows this:
+   `apply_network_policy` calls `run_in_vm_visible` which dispatches
+   through `shell::run_in_vm` on macOS and runs natively on Linux.
+   L7 + DNS-pinning when added must follow the same pattern.
+
+6. **Per-template default policy is an ergonomic follow-up.**
+   Today policies are passed per-invocation. Baking a default into
+   `TemplateSpec` so `claude-code-vm` ships with `agent` preset
+   automatically is a separate (small) refactor, tracked but not
+   blocking this ADR.
+
+## Consequences
+
+### Positive
+
+- Operators get an explicit ADR explaining what egress filtering
+  does and doesn't catch, instead of inferring from the existing
+  CLI flags.
+- The `agent` preset gives the LLM-agent showcase (Proposal B) a
+  one-flag answer to "how do I lock this down to Anthropic?":
+  `mvmctl up --network-preset agent`.
+- L3 enforcement is real and ships today. DNS-rotation gaps are
+  documented, not pretended-away.
+
+### Negative / accepted costs
+
+- L3 by itself does not stop a determined adversary that controls
+  the resolver path (or a CDN-fronted destination). This is
+  documented honestly. Operators wanting stronger guarantees wait
+  for L7 + DNS-pinning.
+- Adding `NetworkPreset::Agent` means a new variant downstream
+  consumers must match on. Existing match-arms in the workspace
+  are exhaustive (no wildcards) so the compiler will catch any
+  miss.
+
+### Explicit non-goals
+
+- **Application-layer protocol filtering.** Beyond SNI + Host, we
+  don't do payload inspection.
+- **Egress for IPv6.** Today's `iptables` script is IPv4-only.
+  IPv6 follow-up tracked.
+- **Multi-tenant fairness.** Per-tenant egress quotas are mvmd's
+  domain (plan 33).
+
+## Reversal cost
+
+- v1 changes (the `Agent` preset variant + tests + README) are a
+  one-line per-call-site removal — trivially reversible.
+- L7 + DNS pinning would, when implemented, cost a runtime-dep
+  rollback (mitmdump + dnsmasq removal) plus an `ops/egress-proxy/`
+  cleanup. Documented as part of those follow-up plans.
+
+## References
+
+- Plan: `specs/plans/32-mcp-agent-adoption.md` Proposal D
+- Related ADRs: ADR-002 (microVM security posture), ADR-003 (local
+  MCP server)
+- Existing infrastructure: `mvm-core::policy::network_policy`,
+  `mvm-runtime::vm::network::{apply,cleanup}_network_policy`
+- L7 inspiration: archie-judd/agent-sandbox.nix's domain allowlist
+  proxy pattern

--- a/specs/plans/31-nix-best-practices-cleanup.md
+++ b/specs/plans/31-nix-best-practices-cleanup.md
@@ -512,24 +512,30 @@ After the audit, several originally-deferred items belong in this work because t
 
 Each gets a header comment listing what host state it changes and why elevated privileges are required (per the guide's "explicit reviewed files" requirement). Phase 5 becomes a small follow-up rather than a deferred separate effort.
 
-## Items deferred — needs your decision
+## Items deferred — resolved 2026-04-30
 
-### `mvmctl` host mutation (network.rs / TAP+bridge+iptables)
+### `mvmctl` host mutation (network.rs / TAP+bridge+iptables) — **resolved: lenient reading**
 
-This is the most consequential gap I haven't already folded in. `mvmctl dev up` and `mvmctl run` invoke `crates/mvm-runtime/src/vm/network.rs` to:
+`mvmctl dev up` and `mvmctl run` continue to invoke
+`crates/mvm-runtime/src/vm/network.rs` to set up the Linux bridge
+(`br-mvm`), TAP interfaces, and iptables NAT rules.
 
-- Create a Linux bridge (`br-mvm`)
-- Add TAP interfaces
-- Configure iptables NAT rules
+Decision rationale: the guide's hard rule targets Nix *entry points*
+(`flake.nix`, `devShells`, `shellHook`) — the things that mutate the
+host on a `nix develop` invocation. `mvmctl dev up` is a user-invoked
+CLI command that's explicit about what it does (asks for sudo, prints
+the operations before running them). That's the visibility the
+host-mutation boundary asks for; an extra `ops/networking/bridge-setup.sh`
+ritual would re-introduce setup ceremony without adding clarity, since
+the user already typed the command that runs the mutations.
 
-These are **host mutations**. They don't happen from `nix develop` (which doesn't exist yet, so it's vacuously compliant) — they happen from a user-invoked CLI command. The guide's hard rule names `iptables`, `ip link`, "bridge/TAP mutations" as forbidden in `flake.nix`/`devShells`/`shellHook`, and the "Host Mutation Boundary" section forbids automatic host setup. mvmctl currently does this automatically on first `dev up`.
+If a later product decision flips this — e.g. mvmd's production target
+where bridge setup happens at deploy time, not on first `mvmctl run` —
+the migration is mechanical: extract the `iptables`/`ip link`/`bridge`
+calls from `network.rs` into `ops/networking/bridge-setup.sh`, and
+have `network.rs` precondition-check that the bridge exists.
 
-Two ways to read the guide:
-
-1. **Strict:** any host mutation should be a separate, explicit, user-run script under `ops/networking/`. `mvmctl dev up` should warn if the bridge isn't there and exit, telling the user to run `sudo ops/networking/bridge-setup.sh` once.
-2. **Lenient:** the guide is about *Nix entry points* (`nix develop`/`shellHook`), not user-invoked CLIs. mvmctl asking for sudo and being explicit about what it changes is fine because it's not a hidden side effect — the user typed `mvmctl dev up`.
-
-Reading 2 is closer to current reality and avoids a UX regression. Reading 1 is closer to the guide's spirit. **This is a product decision, not a Nix-cleanup decision** — flagging it but not folding it in until you say which read you want. If you want strict, it adds an item to Phase 5: extract the iptables/bridge calls from `network.rs` into `ops/networking/bridge-setup.sh`, and have `network.rs` run a precondition check + clear error message instead.
+Documented in `ops/networking/README.md`.
 
 ## Pulled in per your latest direction
 
@@ -626,7 +632,7 @@ The audit at the top of this plan separated these. The middle row (Nix-sandbox `
 ## Items that genuinely stay out of scope
 
 - **mvmd-side modules** — separate repo.
-- **`mvmctl` host mutation in `network.rs`** (TAP/bridge/iptables) — flagged above under "Items deferred — needs your decision." Pending your read of strict vs. lenient guide interpretation.
+- **`mvmctl` host mutation in `network.rs`** (TAP/bridge/iptables) — *resolved 2026-04-30: lenient reading retained.* See "Items deferred — resolved" above and `ops/networking/README.md`.
 
 ## Quick answers to your questions
 

--- a/specs/plans/32-mcp-agent-adoption.md
+++ b/specs/plans/32-mcp-agent-adoption.md
@@ -1,0 +1,651 @@
+---
+title: "Plan 32 — Adopt-from-the-Nix-agent-ecosystem (MCP + LLM-agent VM + local-LLM defaults + egress policy)"
+status: Approved
+date: 2026-04-30
+related: ADR-002 (microVM security posture); plan 25 (microVM hardening); plan 33 (hosted MCP transport — mvmd cross-repo)
+new_adrs: 003-local-mcp-server.md (Proposal A); 004-hypervisor-egress-policy.md (Proposal D)
+---
+
+## Context
+
+Five external resources were evaluated for adoption: jail-nix
+(bubblewrap wrapper), nixai (Ollama-default Nix CLI), andersonjoseph's
+DEV-community jail.nix recipe, numtide/llm-agents.nix (curated agent
+catalog), and SecBear/nix-sandbox-mcp (MCP server with single-tool
+design and a planned microvm.nix backend). The most relevant finding:
+**nix-sandbox-mcp explicitly lists "microvm.nix backend" as future work**
+because microVMs are "the right choice for running untrusted code from
+the internet." mvm already has that backend. The gap is on the
+agent-ergonomics side — mvm has zero MCP integration, no curated
+LLM-agent example flake, and an OpenAI-default scaffolding LLM in a
+world that's moved local-first.
+
+This plan covers four concrete, scoped changes plus one follow-up:
+
+- **A**: `mvmctl mcp` server — exposes mvm as an MCP sandbox surface
+  for LLMs.
+- **A.2**: MCP session semantics — additive within `mvm-mcp` after A.
+- **B**: `nix/images/examples/llm-agent/` — showcase flake running
+  claude-code inside a microVM, importable as an MCP env from A.
+- **C**: Local-LLM-default flip for `mvmctl template init --prompt`.
+- **D**: Hypervisor egress policy with domain-pinning.
+
+Hosted-MCP transport (HTTP/SSE) is documented separately in plan 33 as
+an mvmd cross-repo handoff.
+
+Things explicitly **declined**: host-side bubblewrap (weaker than mvm's
+hypervisor; Linux-only), macOS sandbox-exec at any layer (deprecated by
+Apple; strictly weaker than Apple Container which mvm already uses on
+macOS 26+; the dev shell is a trusted build machine in ADR-002 so adding
+a sandbox there would be a layering violation; if a user wants
+sandbox-exec ergonomics, `archie-judd/agent-sandbox.nix` already
+provides it standalone), re-packaging agent binaries (numtide already
+does this with a binary cache).
+
+## Comparative summary (one paragraph each)
+
+- **jail-nix** (alexdav.id): Nix lib wrapping derivations in bubblewrap
+  with a combinator permission system. Linux-only. Mechanism strictly
+  weaker than mvm's hypervisor. *Borrowable: combinator-style permission
+  declarations in `mkGuest` example flakes.*
+- **nixai**: Archived AI CLI for NixOS, Ollama-default. *Borrowable: the
+  local-Ollama-first default — Proposal C.*
+- **andersonjoseph (DEV)**: Practical jail.nix recipe shipping
+  `jailed-crush` / `jailed-opencode` from a flake. *Borrowable: the
+  user-facing shape (flake builds named agents) — Proposal B.*
+- **numtide/llm-agents.nix**: Curated catalog of ~90 AI agents as Nix
+  packages with a binary cache at `cache.numtide.com`. *Borrowable:
+  import it as a flake input in Proposal B.*
+- **SecBear/nix-sandbox-mcp**: MCP server, single `run` tool with `env`
+  parameter, ~420 fixed token cost, planned microvm.nix backend.
+  *Borrowable: the entire single-tool design — Proposal A.*
+
+---
+
+# Proposal A — `mvmctl mcp` server
+
+## Why
+
+mvm has stronger isolation than nix-sandbox-mcp's current bubblewrap
+backend (full microVM vs namespaces). Adding an MCP server lets LLM
+clients (Claude Code, opencode, etc.) drive mvm as a sandbox without
+shelling out to the CLI. The single-tool design from nix-sandbox-mcp
+keeps the LLM context-window cost flat (~420 tok) regardless of how many
+templates the user registers.
+
+## Design
+
+**Tool surface:** one tool, `run`, with parameters:
+
+| field          | type    | required | semantics                                                                           |
+| -------------- | ------- | -------- | ----------------------------------------------------------------------------------- |
+| `env`          | string  | yes      | name of a built `mvmctl template`, e.g. `python`, `shell`, `claude-code-vm`         |
+| `code`         | string  | yes      | program text passed to the env's interpreter (or argv joined if `interpreter=raw`)  |
+| `session`      | string  | no       | reserved for A.2; v1 always boots a fresh transient VM via `crate::exec::run()`     |
+| `timeout_secs` | integer | no       | per-call timeout; default 60; bounded `[1, 600]`                                    |
+
+**Wire protocol:** JSON-RPC 2.0 over stdio (the MCP standard). Three
+methods: `initialize`, `tools/list`, `tools/call`. Hand-rolled to avoid
+adding a new `rmcp` external dep that would need to clear ADR-002's
+supply-chain bar.
+
+**Dispatch:** `tools/call run` with `env=X, code=Y` →
+`crate::exec::run(ExecRequest { image: ImageSource::Template(X), target:
+ExecTarget::Inline { argv: shell_argv_for(env, code) }, … })`. Stdout
+and stderr captured into the MCP response.
+
+**Env registry:** the registry is just `mvmctl template list`. Any
+template the user has built becomes an `env`. We ship a curated set
+(via Proposal B) and document a recipe for users to register their own.
+
+**Token budget evidence we should reproduce:**
+- tool schema (~75 tok)
+- server instructions (~160 tok)
+- per-param descriptions (~80 tok)
+- **target: ≤ 500 tok fixed cost.** Verified by a unit test asserting
+  the serialized `tools/list` response is under the budget.
+
+**Threat model:** the MCP server is host-local stdio. No new attacker
+surface beyond ADR-002:
+- The `env` param is matched against the existing `mvmctl template list`
+  — no shell interpolation, no arbitrary path access.
+- `code` lives entirely inside the (already-isolated) microVM.
+- `timeout_secs` is bounded `[1, 600]` to prevent client-side runaway.
+- ADR-003 (new) documents this and references ADR-002.
+
+## Files
+
+**New crate:** `crates/mvm-mcp/`
+
+```
+crates/mvm-mcp/
+├── Cargo.toml          # features: protocol-only (no I/O), stdio (default).
+│                       # Default deps: mvm-core, serde, serde_json, anyhow.
+│                       # stdio-only deps: mvm-cli (for crate::exec).
+├── src/
+│   ├── lib.rs          # public API: Dispatcher trait + run_stdio() entrypoint (gated on `stdio`)
+│   ├── protocol.rs     # JSON-RPC 2.0 frames                                 [protocol-only]
+│   ├── tools/
+│   │   ├── mod.rs      # ToolSchema, RunParams, RunResult                    [protocol-only]
+│   │   └── run.rs      # the single `run` tool: schema + handler             [stdio]
+│   ├── server.rs       # initialize/tools/list/tools/call dispatch loop      [stdio]
+│   └── env.rs          # template-list discovery; validates `env` param      [stdio]
+└── tests/
+    ├── protocol_smoke.rs  # mock stdio; assert tools/list shape, dispatch
+    ├── budget.rs           # asserts tools/list serialized tokens < 500
+    └── protocol_only.rs    # asserts cargo build --no-default-features --features protocol-only produces no I/O symbols
+```
+
+The `protocol-only` feature is **mandatory from day one** (not deferred):
+plan 33 (`specs/plans/33-hosted-mcp-transport.md`) requires mvmd to be
+able to consume the wire types and `Dispatcher` trait without dragging
+in mvm-cli or stdio I/O. Adding the feature retroactively after mvmd
+starts depending on `mvm-mcp` would force a coordinated bump; doing it
+day one is free.
+
+**Wiring:**
+
+- `Cargo.toml` (workspace) — add `mvm-mcp = { path = "crates/mvm-mcp",
+  version = "0.13.0" }` to `[workspace.dependencies]` and `members`.
+- `crates/mvm-cli/Cargo.toml` — add `mvm-mcp.workspace = true`.
+- `crates/mvm-cli/src/commands/mod.rs:107` — register a new
+  `Mcp(ops::mcp::Args)` variant on `Commands`. Add to the dispatch
+  match at line 174-203.
+- `crates/mvm-cli/src/commands/ops/mcp.rs` (new) — thin `run()` that
+  calls `mvm_mcp::run_stdio(stdin, stdout)`.
+
+**Refactor needed in `mvm-cli/src/exec.rs`:** the MCP handler needs to
+capture stdout/stderr instead of streaming them to the user's terminal.
+Add a `capture: bool` flag to `ExecRequest` (default false to preserve
+existing CLI behavior); when true, return captured bytes in
+`ExecResult { exit_code, stdout, stderr }`. The CLI path keeps streaming;
+the MCP path captures. ~30 LoC change.
+
+## CI gate
+
+Add a CI job `mcp-server-smoke` to `.github/workflows/ci.yml`:
+
+```yaml
+mcp-server-smoke:
+  runs-on: ubuntu-latest
+  steps:
+    - checkout / install Rust
+    - cargo build -p mvm-mcp --release
+    - cargo test -p mvm-mcp                    # protocol_smoke + budget
+    - run scripts/test-mcp-roundtrip.sh        # spawns mvmctl mcp, sends real JSON-RPC
+```
+
+The roundtrip script is shell + `jq`, no Node/Python deps.
+
+## Verification
+
+- `cargo test -p mvm-mcp` — unit tests for protocol parse/serialize,
+  tools/list shape, error paths.
+- `cargo test --workspace` — green.
+- `cargo clippy --workspace -- -D warnings` — green.
+- Manual: `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list",
+  "params":{}}' | mvmctl mcp --stdio | jq .` returns the single `run`
+  tool.
+- End-to-end: configure Claude Code's MCP client with
+  `command=mvmctl, args=[mcp, --stdio]`, ask it to run
+  `python -c 'print(2+2)'` in the `python` env.
+
+## Critical files to read before implementing
+
+- `crates/mvm-cli/src/exec.rs` — `ExecRequest`/`ExecResult`/`run()`.
+- `crates/mvm-cli/src/commands/vm/exec.rs` — how the CLI builds
+  `ExecRequest`.
+- `crates/mvm-runtime/src/vm/template/lifecycle.rs:81-97` —
+  `template_list()`, used to populate the `env` allowlist.
+- `specs/adrs/002-microvm-security-posture.md` — ADR-003 must compose.
+
+---
+
+# Proposal B — `nix/images/examples/llm-agent/` showcase flake
+
+## Why
+
+A concrete demo that mvm boots an LLM agent inside a microVM. Until A
+lands, this is the answer to "can mvm do that?". After A lands, this
+becomes the canonical `claude-code-vm` env in the MCP server. Imports
+`numtide/llm-agents.nix` so we don't repackage agents.
+
+## Design
+
+A flake under `nix/images/examples/llm-agent/` that:
+
+1. Imports `numtide/llm-agents.nix` for `claude-code` packages —
+   pre-built via `cache.numtide.com`.
+2. Calls `mkGuest` from the parent `nix/flake.nix` with:
+   - `rootfsType = "ext4"` (agents write state).
+   - one service `claude-code` running as uid 1100 (per-service uid per
+     ADR-002 §W2.1) under setpriv with seccomp tier `network`.
+   - virtiofs-shared workdir at `/workspace`, read-write.
+   - secrets file at `/run/secrets/anthropic-api-key` (mode 0400, owner
+     uid 1100), populated from host `~/.config/mvm/secrets/anthropic`.
+3. README documenting build + run + share-workdir recipe.
+
+## Files
+
+**New:**
+
+```
+nix/images/examples/llm-agent/
+├── flake.nix          # imports llm-agents.nix; mkGuest with claude-code service
+├── flake.lock         # generated by `nix flake lock`
+├── service.nix        # claude-code service: setpriv, seccomp=network, secrets path
+└── README.md          # build + run + share-workdir recipe
+```
+
+**Edits:**
+
+- `public/src/content/docs/guides/nix-flakes.md` — add a "Running an
+  LLM agent inside a microVM" section pointing at the new example.
+- `crates/mvm-cli/src/commands/build/image.rs` (or wherever the example
+  list lives) — surface the new example in `mvmctl image list`.
+
+## Security composition with ADR-002
+
+- Agent service runs as uid 1100, not the guest agent's uid 901 (W4.5).
+- Seccomp tier `network` (W2.4) — allows socket/connect/sendto, blocks
+  ptrace/keyctl/etc.
+- Anthropic API key lives in `/run/secrets/anthropic-api-key` mode
+  0400 owned by uid 1100. The guest agent doesn't read it.
+- Verified boot is exempt for development (per ADR-002 §3); the
+  showcase docs say so explicitly.
+- Network egress is unrestricted at the hypervisor level today; this
+  is what Proposal D fixes.
+
+## Verification
+
+- `nix flake check ./nix/images/examples/llm-agent` succeeds.
+- `mvmctl template build claude-code-vm` produces a rootfs.
+- Boot the VM; `mvmctl console claude-code-vm-0001` shows `claude` in
+  PATH; `claude --version` prints a version string.
+- Smoke: `mvmctl run --template claude-code-vm --add-dir
+  /tmp/empty-workspace:/workspace:rw` boots, the workspace mount is
+  writable as uid 1100, the agent prompts for input.
+- CI: add to the existing nix-flake-check matrix.
+
+## Critical files to read before implementing
+
+- `nix/flake.nix` — `mkGuest` API.
+- `nix/images/examples/hello/flake.nix` — closest existing example.
+- `nix/images/examples/hello-python/flake.nix` — `mkPythonService`
+  pattern.
+- `nix/lib/minimal-init/default.nix:71-196` — per-service uid
+  derivation.
+- ADR-002 §W2.4 — seccomp tier `network` semantics.
+
+---
+
+# Proposal C — Local-LLM-default for `mvmctl template init --prompt`
+
+## Why
+
+`template init --prompt` currently prefers OpenAI when `OPENAI_API_KEY`
+is set, and falls back to a local LocalAI-shaped endpoint only if
+`MVM_TEMPLATE_LOCAL_BASE_URL` (or `LOCALAI_BASE_URL`) is set. nixai's
+pattern (and the broader local-first trend) is the opposite: try local
+first, fall back to hosted. Cost and privacy both improve; an OpenAI key
+in env is a configuration leak we shouldn't penalize users for.
+
+## Design
+
+In `auto` mode (the default), probe a local OpenAI-compatible endpoint
+on `http://127.0.0.1:11434/v1` (Ollama) and `http://127.0.0.1:8080/v1`
+(LocalAI / llama.cpp server). If either responds to `GET /v1/models`
+within 200ms, pick it. Only fall through to OpenAI if no local endpoint
+is reachable.
+
+`MVM_TEMPLATE_PROVIDER=openai` and `=local` keep their explicit
+semantics (unchanged). Only `auto` (default) flips order.
+
+## Files
+
+**Edit only:** `crates/mvm-cli/src/template_cmd.rs:545-570`
+(`llm_generation_config_from_env`).
+
+```rust
+"auto" => {
+    if let Some(config) = local_generation_config_from_env_with_probe() {
+        Ok(Some(config))
+    } else if let Some(config) = openai_generation_config_from_env() {
+        Ok(Some(config))
+    } else {
+        Ok(None)
+    }
+}
+```
+
+New helper `local_generation_config_from_env_with_probe()`:
+
+- Honor explicit `MVM_TEMPLATE_LOCAL_BASE_URL` if set.
+- Otherwise probe `127.0.0.1:11434` then `127.0.0.1:8080`. First
+  responding `GET /v1/models` within 200ms wins.
+- Default model: `qwen2.5-coder-7b-instruct`.
+- Skip probe entirely when `MVM_TEMPLATE_NO_LOCAL_PROBE=1`.
+
+~30 LoC change.
+
+## Tests
+
+- `test_auto_prefers_local_when_reachable`: spin a local server on a
+  random port, override the probe target, assert `LlmProvider::Local`.
+- `test_auto_falls_through_to_openai_when_no_local`: probe target
+  unreachable, `OPENAI_API_KEY=k`, assert `LlmProvider::OpenAi`.
+- `test_explicit_openai_skips_probe`: `MVM_TEMPLATE_PROVIDER=openai`,
+  no probe attempted.
+- `test_no_local_probe_env_var`: `MVM_TEMPLATE_NO_LOCAL_PROBE=1` skips
+  the probe even with a server running.
+
+## Verification
+
+- `cargo test -p mvm-cli template_cmd::tests::auto_prefers_local`.
+- Manual with Ollama running locally: verbose log prints
+  `provider=local model=qwen2.5-coder-7b-instruct`.
+- Docs: update
+  `public/src/content/docs/reference/cli-commands.md:327-330`.
+
+## Critical files to read before implementing
+
+- `crates/mvm-cli/src/template_cmd.rs:443-604` — full LLM config layer.
+
+---
+
+# Proposal D — Hypervisor egress policy with domain-pinning
+
+**Status (v1):** L3 tier shipped — `NetworkPreset::Agent` added in
+`mvm-core::policy::network_policy`; ADR-004
+(`specs/adrs/004-hypervisor-egress-policy.md`) documents the
+three-layer model and the v1 reduction. L7 HTTPS-proxy + DNS-answer
+pinning are deferred follow-ups (see ADR-004 §"The three-layer
+model"). The `nix/images/examples/llm-agent/` README now recommends
+`mvmctl up --network-preset agent` as the recommended posture, with
+the deferred limits documented honestly. The L3 tier composes with
+the existing `apply_network_policy` + `cleanup_network_policy`
+infrastructure already shipped in W7.
+
+## Why
+
+Belongs in mvm: mvm owns the host network surface (TAP, NAT iptables,
+the bridge `br-mvm`). Users want domain-pinning ("agent can reach
+api.anthropic.com only"). agent-sandbox.nix proves the pattern works.
+ADR-002 §"explicit non-goals" flagged this as out of scope for v1
+hardening; this proposal moves it on-roadmap.
+
+## Design
+
+Three layers, mvm picks the right one per VM:
+
+1. **L7 HTTP/HTTPS proxy** (default for `network_policy.domains`):
+   `mitmproxy`-style egress proxy on the host bound to a private CIDR
+   the guest can reach. Guest is configured with `HTTPS_PROXY` /
+   `HTTP_PROXY` env vars and the proxy's CA cert in
+   `/etc/ssl/certs/mvm-egress.crt`. Proxy enforces the allowlist by
+   SNI for HTTPS and Host header for HTTP. CONNECT to disallowed
+   domains returns 403.
+2. **L3 iptables egress** on the host: at TAP attach time, install
+   `OUTPUT`/`FORWARD` rules in the `MVMEGRESS-<vm>` chain that DNAT
+   only to resolved IPs from the allowlist. DNS for the guest goes
+   through a stub resolver on the host (`dnsmasq`) that only resolves
+   allowlisted domains and pins the answer for the iptables ruleset
+   for the answer's TTL.
+3. **Stack both** for "agents on the public internet" mode (the
+   default for Proposal B's `claude-code-vm`): proxy for HTTP, iptables
+   denying everything else.
+
+`mvm-core::network_policy::NetworkPolicy` already has the field
+`domains: Vec<String>`; today it's read by seccomp tier selection only.
+Wire it to TAP setup so allowlist enforcement happens at attach time.
+
+## Files
+
+**Edit:**
+
+- `crates/mvm-core/src/network_policy.rs` — extend `NetworkPolicy` with
+  `egress_mode: EgressMode { Off, Open, AllowDomains, AllowDomainsStrict }`.
+- `crates/mvm-runtime/src/vm/network.rs` — `tap_create()` honors the
+  policy: spawns the egress proxy on a per-VM port, installs iptables
+  rules in `MVMEGRESS-<vm>` chain, tears down on `tap_destroy()`.
+- `crates/mvm-runtime/src/vm/microvm.rs` — pass `HTTPS_PROXY` and
+  `MVM_EGRESS_CA_PATH` into the guest via existing env injection.
+- New: `crates/mvm-runtime/src/vm/egress_proxy.rs` — wrapper around
+  `mitmdump` from nixpkgs; surfaced via `mvmctl doctor`.
+- `nix/lib/minimal-init/default.nix` — install the mvm CA cert at boot
+  if `/run/mvm-egress.crt` is mounted.
+- `specs/adrs/004-hypervisor-egress-policy.md` (new) — three-layer
+  model, named limits (DNS rotation, certificate pinning by guest
+  apps, performance overhead).
+
+## Verification
+
+- `cargo test -p mvm-runtime egress` — unit tests for iptables rule
+  generation, allowlist parsing.
+- Integration: build `claude-code-vm` (Proposal B) with
+  `network_policy.egress_mode = AllowDomainsStrict` + `domains =
+  ["api.anthropic.com"]`. Boot, `curl https://api.anthropic.com/` →
+  200; `curl https://google.com/` → blocked.
+- `mvmctl doctor` reports egress-proxy availability.
+
+## Sequence
+
+D is independent of A, B, C but most useful *with* B (gives the
+`claude-code-vm` example real teeth). Estimate ~1 sprint.
+
+---
+
+# Proposal A.2 — MCP session semantics (mvm follow-up to A)
+
+**Status (schema-ready):** wire schema is in place — `RunParams` now
+carries both `session: Option<String>` and `close: Option<bool>`, and
+the `tools/list` JSON Schema documents both fields. v1 server still
+ignores them (clients may set them without error). Server-side
+session map + reaper thread + `run_in_existing` exec path remain
+deferred to a later branch.
+
+## Why
+
+nix-sandbox-mcp uses `session` for REPL persistence inside a single
+sandbox process. mvm's analog is template snapshots — boot once, run
+many calls against the warm VM, snapshot/destroy at session end. This
+is a strict win over nix-sandbox-mcp's design because mvm sessions
+inherit microVM isolation; nix-sandbox-mcp sessions are
+bubblewrap-bound.
+
+## Design
+
+`tools/call run` with `session=ID`:
+
+- **First call with new session ID:** allocate a snapshot-resumed VM
+  (or cold-boot if no snapshot for env). Call
+  `mvm_runtime::vm::microvm::run_from_snapshot()` from
+  `lifecycle.rs:539`. Stash `(session_id → VmId)` in a local
+  in-memory map (lifetime = MCP server process).
+- **Subsequent calls with same session ID:** route the command to the
+  existing VM via the guest agent's `Exec` over vsock.
+- **Session reaping:** idle timeout (default 300s, env
+  `MVM_MCP_SESSION_IDLE`), max lifetime (default 3600s, env
+  `MVM_MCP_SESSION_MAX`).
+- **Explicit close:** new tool param `close: bool` — when true after
+  exec, snapshot if env has `persist_on_close=true`, then destroy.
+
+Token budget impact: adds ~40 tokens (session + close fields). Stays
+under the 500 tok target.
+
+## Files
+
+**Edit (within Proposal A's crate):**
+
+- `crates/mvm-mcp/src/tools/run.rs` — add `session` and `close` params.
+- `crates/mvm-mcp/src/server.rs` — add session map + reaper thread.
+- `crates/mvm-mcp/src/session.rs` (new) — session struct, idle/max
+  tracking, snapshot-on-close logic.
+
+**Refactor (shared with A):**
+
+- `crates/mvm-cli/src/exec.rs` — split `run()` into `run_oneshot()`
+  (current behavior) and `run_in_existing(vm_id, argv)` (new).
+
+## Security composition
+
+- The vsock `Exec` handler is feature-gated by `dev-shell` (ADR-002
+  W4.3). The MCP server must be feature-gated identically. CI gate:
+  extend the existing `do_exec` symbol grep to also assert
+  `mvm_mcp::session` is absent in the prod build.
+- Session-pinned VMs hold the same threat-model status as `mvmctl dev`
+  VMs.
+
+## Verification
+
+- `cargo test -p mvm-mcp session::tests::idle_reaping`,
+  `max_lifetime`, `snapshot_on_close`.
+- Integration: open session, run two distinct shell commands, assert
+  state persists between calls.
+- CI: feature-gate test asserts `mvmctl mcp` in prod build doesn't
+  expose session params.
+
+## Sequence
+
+Sits after A. Treat as A.2 — same crate, additive.
+
+---
+
+# Cross-cutting considerations (must-fold into proposals before merge)
+
+## Security/correctness (must do)
+
+- **A: stdout-only-JSON-RPC discipline.** MCP servers MUST write
+  *nothing* to stdout that isn't a valid JSON-RPC frame. Initialize a
+  stderr-only `tracing_subscriber` *before* the dispatch loop, and add
+  a CI test that runs `mvmctl mcp --stdio < /dev/null` with
+  `RUST_LOG=trace` and asserts stdout is empty after a clean shutdown.
+
+- **A: audit logging.** Every `tools/call run` (env, code length, exit
+  code, duration, caller-claimed session id) lands in
+  `~/.mvm/log/audit.jsonl` via `mvm_core::audit::log_event(...)`.
+
+- **A: resource limits per call.**
+  - `timeout_secs` ∈ [1, 600].
+  - Memory: cap below the template's machine-config default; reject
+    `tools/call` whose env's template requests > 4 GiB. Knob:
+    `MVM_MCP_MEM_CEILING_MIB`.
+  - Concurrency: hard cap `MVM_MCP_MAX_INFLIGHT` (default 4); over
+    the queue depth `MVM_MCP_MAX_QUEUE` (default 16), return error.
+  - Output: stdout/stderr each truncated at 64 KiB with explicit
+    `[truncated, N more bytes]` marker.
+
+- **A: dev-shell feature gating is transitive.** ADR-002 §W4.3 demands
+  no `do_exec` symbol in prod builds. `mvm-mcp`'s `stdio` feature
+  must require the workspace `dev-shell` feature. CI gate: extend
+  the existing `do_exec` symbol grep to cover `mvmctl mcp` too.
+
+- **B: secret injection mechanism.** Verify before starting B: read
+  `crates/mvm-cli/src/exec.rs` for any `secret_files` field, and
+  `crates/mvm-runtime/src/vm/microvm.rs` for `secret_files: vec![]`
+  in `FlakeRunConfig`. If absent, B grows a sub-task to add it via
+  mvm's existing secrets path (`/mnt/secrets` per ADR-002).
+
+- **D: iptables/proxy dispatch lives in Lima on macOS.** mvm's
+  bridge `br-mvm` runs *inside the Lima VM* on macOS, not on the
+  host. The egress-proxy launcher and iptables rules must dispatch
+  via `shell::run_in_vm()`, not run directly on macOS. Follow the
+  established pattern in `crates/mvm-runtime/src/vm/network.rs`.
+
+## UX / interop (should do)
+
+- **A: protocol version pinning + capabilities.** `initialize` returns
+  `protocolVersion` and `capabilities`. Pin to the current MCP
+  protocol revision (verify against the spec repo at implementation
+  time). Advertise `capabilities.tools.listChanged: false`. Reject
+  `initialize` requests for incompatible protocol versions with a
+  clear error.
+
+- **A: tool-call response framing.** Return stdout and stderr as two
+  separate `content` blocks of `type: "text"`. Include a final
+  `content` block with `{"type":"text","text":"exit_code=N"}` and
+  set `isError: true` iff the exit code is nonzero.
+
+- **A: metrics integration.** Add counters
+  `mvm_mcp_calls_total{tool="run", env, status}`, histogram
+  `mvm_mcp_call_duration_seconds`, gauge `mvm_mcp_inflight` to the
+  existing `mvmctl metrics` registry.
+
+- **A + D: docs site.** New pages under
+  `public/src/content/docs/`: `guides/mcp-server.md` (A) and
+  `reference/network-policy.md` (D).
+
+- **B: graceful first-run when Anthropic key is missing.** Service
+  start script checks for `/run/secrets/anthropic-api-key`; if
+  absent, writes a clear message to its log and exits 0 (so the
+  integration health check shows "no key configured" rather than
+  crash-loop).
+
+- **C: probe leak note.** The local-LLM probe issues a TCP connect
+  to `127.0.0.1:11434` and `127.0.0.1:8080` on every `template init`
+  invocation. Visible to other local processes (`netstat`).
+  Documented in the man page.
+
+## Plumbing (nice to have)
+
+- **A: nix-sandbox-mcp wire compat.** If exact param names / response
+  shapes match (`env`, `code`, `session`), existing clients
+  configured for nix-sandbox-mcp can point at `mvmctl mcp` with one
+  config edit.
+
+- **A: shell-env note in threat model.** For `env=shell`, `code` *is*
+  shell. There is no in-microVM interpreter sandbox beyond the
+  microVM's own walls; note this in ADR-003.
+
+- **D: orphan cleanup invariant.** `mvmctl cache prune` (existing)
+  should reap orphaned egress proxies and stale `MVMEGRESS-*`
+  iptables chains.
+
+- **B: cross-platform CI for the example flake.** macOS CI for B
+  needs `nix flake check` to pass.
+
+- **Plan housekeeping.** `specs/plans/22-agent-sandbox-patterns.md`
+  is the research-survey predecessor of A/B. After A and B land,
+  mark 22 as `Status: Superseded by [32]`.
+
+- **ADR numbering check.** ADR-003 (Proposal A) and ADR-004 (Proposal D)
+  are the next free integers after `specs/adrs/002-microvm-security-posture.md`.
+
+---
+
+# Cross-cutting verification
+
+After all proposals land:
+
+```bash
+cargo build --workspace                  # all crates compile, including mvm-mcp
+cargo test --workspace                   # 1067+ existing + new tests green
+cargo clippy --workspace -- -D warnings  # mvm CLAUDE.md rule
+nix flake check ./nix/images/examples/llm-agent  # B's flake checks
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
+  mvmctl mcp --stdio | jq '.result.tools[0].name'  # → "run"
+mvmctl template create claude-code-vm --flake ./nix/images/examples/llm-agent \
+  --profile minimal --role agent
+mvmctl template build claude-code-vm
+# In an MCP-enabled LLM client: ask the LLM to "run python -c 'print(2+2)' in
+# the python env" → observe a microVM boot, run, return "4", tear down.
+```
+
+---
+
+# Sequence
+
+A, B, C, D are largely independent. Recommended order if done
+serially:
+
+1. **C** (smallest blast radius, ~30 LoC + tests; ~half a day).
+2. **B** (no Rust changes; flake + service.nix + docs; ~1 day).
+3. **A v1** (new crate + ADR-003; ~3 days). B's `claude-code-vm`
+   becomes the canonical demo env in A's docs.
+4. **D** (egress policy + ADR-004; ~1 sprint). Updates B to default
+   to `AllowDomainsStrict` + Anthropic-only allowlist.
+5. **A.2** (MCP session semantics; additive within `mvm-mcp`; ~2-3
+   days). Composes with D so sessions inherit egress policy.
+
+Hosted-MCP transport is filed as plan 33 — an mvmd cross-repo task —
+not sequenced here.

--- a/specs/plans/33-hosted-mcp-transport.md
+++ b/specs/plans/33-hosted-mcp-transport.md
@@ -1,0 +1,123 @@
+---
+title: "Plan 33 — Hosted MCP transport (mvmd cross-repo)"
+status: Proposed (cross-repo handoff to mvmd)
+date: 2026-04-30
+related: ADR-002 (microVM security posture); plan 25 (microVM hardening); plan 32 (MCP + LLM-agent adoption); ADR-003 (local MCP — Proposal A)
+owner: mvmd team
+---
+
+## Status
+
+Proposed. **Implementation lives in the
+[mvmd](https://github.com/auser/mvmd) repository, not this one.** This
+document is mvm's permanent record of the boundary so the protocol
+crate stays a single source of truth.
+
+## Context
+
+Plan 32 / Proposal A (ADR-003) adds `mvmctl mcp --stdio`: a local-only
+MCP server that exposes one parameterized `run` tool, dispatching into
+transient microVMs on the developer's machine. That's the right shape
+for a single user driving a single host.
+
+Multi-tenant operation — a fleet of microVMs exposed over HTTP/SSE to
+remote LLM clients, with auth, tenant isolation, and pool routing — is
+mvmd's domain. mvmd already owns tenants, pools, instances, agents, and
+the coordinator API; a hosted MCP transport is one more surface on top
+of that orchestration layer.
+
+This plan locks in the boundary so neither repo accidentally drifts:
+
+- **mvm** owns the MCP *protocol* — wire types, tool schemas, JSON-RPC
+  framing, the single-tool design philosophy.
+- **mvmd** owns the *transport* — HTTP/SSE, auth, tenant routing,
+  per-tenant rate limits, observability.
+
+## Decision
+
+Split the local MCP work in mvm into two artifacts:
+
+1. **`mvm-mcp` crate (this repo)** — a library with two feature flags:
+   - `protocol-only` (default-off): exports protocol types
+     (`JsonRpcRequest`, `ToolSchema`, `RunParams`, `RunResult`) and
+     a transport-agnostic `Dispatcher` trait. No I/O.
+   - `stdio` (default-on for `mvmctl`): adds the stdio loop that
+     `mvmctl mcp --stdio` invokes.
+
+2. **mvmd's `mvmd-mcp` crate (mvmd repo)** — depends on `mvm-mcp` with
+   `protocol-only`. Implements:
+   - HTTP/SSE transport (Axum or similar; matches mvmd's existing HTTP
+     surface).
+   - Auth: API tokens scoped per tenant; reuses mvmd's signing key
+     infrastructure.
+   - `run` tool whose `env` parameter is mvmd-shaped:
+     `tenant/pool/template@revision`. Resolves to a microVM in mvmd's
+     instance pool.
+   - Per-tenant rate limits and quota tracking via mvmd's existing
+     metering.
+
+## Threat model (additive over ADR-002)
+
+mvmd's hosted transport adds two adversaries beyond ADR-002:
+
+1. **A remote LLM client.** Untrusted by default. Authenticated via
+   tenant-scoped API tokens. Cannot escape its tenant's pool. The
+   `run` tool's `env` parameter is validated against the tenant's
+   allowed templates; an attacker forging a different tenant's
+   template name returns 403.
+
+2. **A compromised tenant.** A tenant whose API token is leaked must
+   not be able to read another tenant's data, exhaust shared
+   resources, or pivot to mvmd's coordinator. Per-tenant pools (mvmd
+   already isolates these) plus per-tenant rate limits are the
+   defenses.
+
+Out of scope (named explicitly):
+
+- Cross-tenant code execution. mvmd doesn't multiplex tenants onto a
+  single microVM.
+- BYO-cloud / customer-VPC hosting. Future work for mvmd.
+
+## Wire compatibility
+
+The `run` tool's schema is owned by `mvm-mcp`. mvmd's hosted variant
+extends only the `env` parameter's *value space* (it accepts
+`tenant/pool/template@revision` strings); the schema itself is
+unchanged. This guarantees a Claude Code client that talks to local
+`mvmctl mcp` can talk to a hosted mvmd MCP endpoint with the same
+protocol code path — only the env strings differ.
+
+## Cross-repo workflow
+
+- mvm bumps `mvm-mcp` versions and publishes Cargo metadata.
+- mvmd pins to a specific `mvm-mcp` version and integrates new tool
+  fields via the `protocol-only` feature.
+- Breaking changes to the wire format require coordinated releases:
+  mvm publishes first (with the new field optional), mvmd consumes
+  next.
+
+## Tracking
+
+- Issue in mvmd: "Hosted MCP transport over the coordinator API"
+  (referencing this plan and ADR-003).
+- mvm-side checkpoint: `mvm-mcp` crate ships with the `protocol-only`
+  feature flag and a public `Dispatcher` trait from day one of plan
+  32 / Proposal A v1. Without that, mvmd cannot consume the crate
+  cleanly later.
+
+## Verification (mvm side only)
+
+- `cargo build -p mvm-mcp --no-default-features --features protocol-only`
+  succeeds and produces no I/O symbols (`std::io::stdin`, etc).
+  Asserted via `nm` symbol grep in CI.
+- `cargo test -p mvm-mcp --no-default-features --features protocol-only`
+  green.
+- Public API exports stable: enforced via `cargo-semver-checks` in CI.
+
+mvmd-side verification lives in mvmd's repo.
+
+## Reversal cost
+
+If mvmd later decides hosted MCP isn't a fit, the `protocol-only`
+feature in mvm is harmless — it's a thin set of types. Removing it
+costs one minor version bump.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -860,6 +860,13 @@ fn test_template_init_preset_unknown_shows_error() {
 fn test_template_init_prompt_generates_metadata_and_infers_preset() {
     let dir = tempfile::tempdir().expect("temp dir");
     mvm()
+        // Plan 32 / Proposal C added a loopback probe in `auto` mode that picks
+        // up Ollama / LocalAI on `:11434` / `:8080`. CI / dev hosts running one
+        // of those would otherwise route this prompt at a real model. Force
+        // heuristic fallback so the test stays deterministic.
+        .env("MVM_TEMPLATE_NO_LOCAL_PROBE", "1")
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("MVM_TEMPLATE_LOCAL_BASE_URL")
         .args([
             "template",
             "init",
@@ -910,6 +917,10 @@ fn test_template_init_prompt_uses_openai_when_configured() {
     let (base_url, request_capture) = spawn_fake_openai_response_server(response_body);
     let dir = tempfile::tempdir().expect("temp dir");
     mvm()
+        // Disable the loopback Ollama / LocalAI probe (Proposal C) so the
+        // OPENAI_API_KEY path is taken even on hosts running a local model.
+        .env("MVM_TEMPLATE_NO_LOCAL_PROBE", "1")
+        .env_remove("MVM_TEMPLATE_LOCAL_BASE_URL")
         .env("OPENAI_API_KEY", "test-key")
         .env("MVM_TEMPLATE_OPENAI_BASE_URL", base_url)
         .args([


### PR DESCRIPTION
## Summary

- **A v1 — `mvmctl mcp stdio`** — new `mvm-mcp` crate (protocol-only + stdio features) exposes mvmctl as a Model Context Protocol surface. Single parameterized `run` tool dispatches into transient microVMs via `crate::exec::run_captured`. Audit logging, 64 KiB stdout/stderr cap, `MVM_MCP_MAX_INFLIGHT` / `MVM_MCP_MEM_CEILING_MIB`, `[1, 600]` timeout clamp. ADR-003 documents the threat model.
- **A.2 schema-ready** — `RunParams.session` + `close` accepted by the wire schema; clients can adopt the session lifecycle ahead of the server. Server-side warm-VM map + reaper deferred.
- **B — `nix/images/examples/llm-agent/`** — showcase flake builds claude-code inside a microVM. Per-service uid, seccomp=`network`, secrets at `/run/mvm-secrets/claude-code/`, graceful first-run when API key missing. Pulls claude-code from `numtide/llm-agents.nix` (binary cache).
- **C — local-LLM probe** — `mvmctl template init --prompt` flips local-first; probes Ollama @ `:11434` / LocalAI @ `:8080` with `MVM_TEMPLATE_NO_LOCAL_PROBE=1` escape hatch.
- **D v1 (L3) — `NetworkPreset::Agent`** — Anthropic + OpenAI + GitHub allowlist (strictly smaller than `dev` — no package registries). ADR-004 documents the full three-layer model with L7 HTTPS-proxy + DNS-answer pinning honestly deferred.
- **Plan 33** — cross-repo handoff doc for hosted MCP transport (HTTP/SSE) — implementation lives in mvmd; mvm-mcp's `protocol-only` feature ships day one so mvmd can consume the wire schema cleanly.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` all green (mvm-mcp 19, mvm-core network_policy +3 agent-preset, mvm-cli template_cmd +2 probe, plus +1 close-field schema test)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo build -p mvm-mcp --no-default-features --features protocol-only` clean (mvmd-ready)
- [x] `nix flake check` on `nix/images/examples/llm-agent` clean (x86_64-linux + aarch64-linux)
- [x] End-to-end JSON-RPC: `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | mvmctl mcp stdio` returns the single `run` tool
- [ ] Live smoke against a dev microVM (deferred — Linux/KVM only, see #3)
- [ ] L7 + DNS-pinning enforcement integration test (deferred — covered by next branch when L7 lands)

## Files of interest

- `specs/plans/32-mcp-agent-adoption.md` — master plan (5 proposals + cross-cutting considerations)
- `specs/plans/33-hosted-mcp-transport.md` — mvmd handoff
- `specs/adrs/003-local-mcp-server.md` — local MCP threat model
- `specs/adrs/004-hypervisor-egress-policy.md` — three-layer egress model

🤖 Generated with [Claude Code](https://claude.com/claude-code)