### PR TITLE
feat(mcp): MCP session bookkeeping + reaper (plan 32 / A.2 v1)

### DIFF
--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -14,12 +14,17 @@
 //! useful when pointed at dev VMs, harmless when pointed at prod ones.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::Result;
 use clap::{Args as ClapArgs, Subcommand};
 
 use mvm_core::user_config::MvmConfig;
-use mvm_mcp::{ContentBlock, Dispatcher, RunParams, ToolResult};
+use mvm_mcp::{
+    ContentBlock, Dispatcher, ReapReason, Reaper, RunParams, SessionConfig, SessionLookup,
+    SessionMap, SessionState, ToolResult,
+};
 
 use super::Cli;
 
@@ -43,6 +48,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         McpTransport::Stdio => {
             mvm_mcp::init_stderr_tracing();
             let dispatcher = ExecDispatcher::default();
+            // Spawn the session reaper. Drops out when the process exits;
+            // sessions still in the map at shutdown get drained by the
+            // dispatcher's Drop impl (RAII via Arc<Mutex<SessionMap>>
+            // + the Drop on ExecDispatcher).
+            dispatcher.spawn_reaper();
             let stdin = std::io::stdin();
             let stdout = std::io::stdout();
             mvm_mcp::run_with_dispatcher(stdin.lock(), &mut stdout.lock(), &dispatcher)
@@ -80,11 +90,27 @@ const DEFAULT_MEM_CEILING_MIB: u32 = 4096;
 const DEFAULT_VM_CPUS: u32 = 2;
 const DEFAULT_VM_MEM_MIB: u32 = 1024;
 
+/// How often the reaper sweeps the session map. Smaller intervals
+/// reap closer to the configured idle/max boundary at the cost of
+/// extra wake-ups; the default is generous because session timeouts
+/// are measured in minutes-to-hours.
+const REAPER_TICK_SECS: u64 = 30;
+
 /// Concrete dispatcher backed by [`crate::exec::run_captured`].
+///
+/// Holds the MCP session map (plan 32 / Proposal A.2). v1 ships the
+/// bookkeeping/correlation tier — sessions show up in audit logs and
+/// the reaper trims stale entries — but warm-VM materialisation is
+/// staged for A.2 v2 alongside the exec.rs refactor (see
+/// `TODO(A.2 v2)` markers below). Today every `tools/call run` still
+/// cold-boots its own VM; the session map is the wire-compatible
+/// foundation the v2 work composes against.
 struct ExecDispatcher {
     inflight: AtomicUsize,
     max_inflight: usize,
     mem_ceiling_mib: u32,
+    sessions: Arc<Mutex<SessionMap>>,
+    reaper: Arc<DispatcherReaper>,
 }
 
 impl Default for ExecDispatcher {
@@ -93,7 +119,79 @@ impl Default for ExecDispatcher {
             inflight: AtomicUsize::new(0),
             max_inflight: parse_env_usize("MVM_MCP_MAX_INFLIGHT", DEFAULT_MAX_INFLIGHT),
             mem_ceiling_mib: parse_env_u32("MVM_MCP_MEM_CEILING_MIB", DEFAULT_MEM_CEILING_MIB),
+            sessions: Arc::new(Mutex::new(SessionMap::new(SessionConfig::from_env()))),
+            reaper: Arc::new(DispatcherReaper),
         }
+    }
+}
+
+impl ExecDispatcher {
+    /// Start a background thread that sweeps the session map every
+    /// [`REAPER_TICK_SECS`]. Idempotent — safe to call once at
+    /// startup. The thread is detached: it dies with the process.
+    fn spawn_reaper(&self) {
+        let sessions = Arc::clone(&self.sessions);
+        let reaper = Arc::clone(&self.reaper);
+        std::thread::spawn(move || {
+            loop {
+                std::thread::sleep(Duration::from_secs(REAPER_TICK_SECS));
+                let n = match sessions.lock() {
+                    Ok(mut map) => map.reap_expired(reaper.as_ref()),
+                    Err(_) => return, // poisoned mutex = process is unwinding
+                };
+                if n > 0 {
+                    tracing::debug!(reaped = n, "MCP session reaper swept");
+                }
+            }
+        });
+    }
+}
+
+/// On Drop, drain the session map and audit-log every remaining
+/// session as `Shutdown`. Kicks in when the stdio loop exits cleanly.
+impl Drop for ExecDispatcher {
+    fn drop(&mut self) {
+        if let Ok(mut map) = self.sessions.lock() {
+            let n = map.drain(self.reaper.as_ref());
+            if n > 0 {
+                tracing::info!(drained = n, "MCP server shutdown drained sessions");
+            }
+        }
+    }
+}
+
+/// Reaper impl that turns map evictions into audit-log events. The
+/// trait-based design (per `mvm_mcp::session`) means mvmd's hosted
+/// variant can plug in its own reaper that also kills the per-tenant
+/// VMs without changing the map contract.
+struct DispatcherReaper;
+
+impl Reaper for DispatcherReaper {
+    fn on_reap(&self, session_id: &str, state: &SessionState, reason: ReapReason) {
+        let detail = serde_json::json!({
+            "session": session_id,
+            "env": state.env,
+            "reason": reason_str(reason),
+            "vm_name": state.vm_name,
+            "lifetime_secs": state.started_at.elapsed().as_secs(),
+        })
+        .to_string();
+        mvm_core::policy::audit::emit(
+            mvm_core::policy::audit::LocalAuditKind::McpSessionClosed,
+            state.vm_name.as_deref(),
+            Some(&detail),
+        );
+        // TODO(A.2 v2): when v2 materialises warm VMs, this is where
+        // the actual `backend.stop(VmId(state.vm_name))` call lands.
+    }
+}
+
+fn reason_str(r: ReapReason) -> &'static str {
+    match r {
+        ReapReason::Idle => "idle",
+        ReapReason::MaxLifetime => "max_lifetime",
+        ReapReason::Closed => "closed",
+        ReapReason::Shutdown => "shutdown",
     }
 }
 
@@ -113,6 +211,32 @@ impl Dispatcher for ExecDispatcher {
         // Validate env against the local template registry.
         if let Err(e) = validate_env(&params.env) {
             return error_result(format!("{e}"));
+        }
+
+        // Session bookkeeping (A.2 v1). Touch the map before the
+        // exec so audit logs see "session started" before "tools/call
+        // ran". v1 doesn't materialise a warm VM — the cold-boot path
+        // below is taken regardless of session state.
+        // TODO(A.2 v2): when warm VMs land, look the VM up here and
+        // skip the cold-boot path when present.
+        if let Some(session_id) = params.session.as_deref() {
+            let lookup = self
+                .sessions
+                .lock()
+                .map(|mut map| map.touch_or_insert(session_id, &params.env, None))
+                .unwrap_or(SessionLookup::Created);
+            if matches!(lookup, SessionLookup::Created) {
+                let detail = serde_json::json!({
+                    "session": session_id,
+                    "env": params.env,
+                })
+                .to_string();
+                mvm_core::policy::audit::emit(
+                    mvm_core::policy::audit::LocalAuditKind::McpSessionStarted,
+                    Some(&params.env),
+                    Some(&detail),
+                );
+            }
         }
 
         // Memory ceiling check: reject envs whose recorded mem_mib
@@ -147,6 +271,15 @@ impl Dispatcher for ExecDispatcher {
         let started = std::time::Instant::now();
         let result = crate::exec::run_captured(req);
         let elapsed = started.elapsed();
+
+        // After the dispatch completes (regardless of success), honour
+        // an explicit close request so the reaper has nothing left to
+        // do for this session.
+        if let (Some(session_id), Some(true)) = (params.session.as_deref(), params.close)
+            && let Ok(mut map) = self.sessions.lock()
+        {
+            map.remove(session_id, ReapReason::Closed, self.reaper.as_ref());
+        }
 
         match result {
             Ok(out) => {

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -54,6 +54,12 @@ pub enum LocalAuditKind {
     /// `tools/call run` failed before completing (orchestration error,
     /// not a non-zero guest exit code).
     McpToolsCallRunError,
+    /// MCP session opened — first call with a previously-unseen
+    /// `session=ID` parameter (plan 32 / Proposal A.2).
+    McpSessionStarted,
+    /// MCP session closed by the client (`close: true`) or reaped
+    /// by the server (idle / max-lifetime / shutdown drain).
+    McpSessionClosed,
 }
 
 /// A single local audit log entry.

--- a/crates/mvm-mcp/src/lib.rs
+++ b/crates/mvm-mcp/src/lib.rs
@@ -26,12 +26,17 @@
 
 pub mod dispatcher;
 pub mod protocol;
+pub mod session;
 pub mod tools;
 
 pub use dispatcher::Dispatcher;
 pub use protocol::{
     ContentBlock, JsonRpcError, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION, SERVER_NAME,
     SERVER_VERSION, ToolResult,
+};
+pub use session::{
+    DEFAULT_IDLE_SECS, DEFAULT_MAX_SECS, ReapReason, Reaper, SessionConfig, SessionLookup,
+    SessionMap, SessionState,
 };
 pub use tools::{RunParams, ToolSchema, all_tools, run_input_schema};
 

--- a/crates/mvm-mcp/src/session.rs
+++ b/crates/mvm-mcp/src/session.rs
@@ -1,0 +1,401 @@
+//! Session lifecycle for the MCP `run` tool.
+//!
+//! Plan 32 / Proposal A.2. v1 ships the bookkeeping layer:
+//!
+//! - [`SessionMap`] tracks `(session_id → SessionState)` with idle and
+//!   max-lifetime expiry — *protocol-only safe*, no I/O.
+//! - [`SessionConfig`] reads `MVM_MCP_SESSION_IDLE` / `MVM_MCP_SESSION_MAX`
+//!   from the environment with documented defaults.
+//! - The [`Reaper`] trait is the bridge between the pure map and the
+//!   side-effecting world (kill the VM, audit-log the close); the
+//!   stdio server and mvmd's hosted variant each plug in their own.
+//!
+//! Warm-VM materialisation (booting a long-running VM that persists
+//! across `tools/call` invocations) is deferred to A.2 v2 because the
+//! existing `crate::exec` boot/dispatch/teardown path is tightly
+//! coupled and a clean split is risky without live-KVM integration
+//! tests. The wire schema (`session`, `close`) is already in place —
+//! v1 honours the schema for bookkeeping/correlation; v2 will materialise
+//! the VM behind the bookkeeping. ADR-003 §"Decisions" 6 documents the
+//! split.
+
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+/// Default session idle timeout (seconds). Overridable via
+/// `MVM_MCP_SESSION_IDLE` env var.
+pub const DEFAULT_IDLE_SECS: u64 = 300;
+
+/// Default session max lifetime (seconds). Overridable via
+/// `MVM_MCP_SESSION_MAX` env var.
+pub const DEFAULT_MAX_SECS: u64 = 3600;
+
+/// Configuration knobs for the session map.
+#[derive(Debug, Clone, Copy)]
+pub struct SessionConfig {
+    pub idle: Duration,
+    pub max: Duration,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            idle: Duration::from_secs(DEFAULT_IDLE_SECS),
+            max: Duration::from_secs(DEFAULT_MAX_SECS),
+        }
+    }
+}
+
+impl SessionConfig {
+    /// Read idle/max from environment, falling back to defaults.
+    pub fn from_env() -> Self {
+        let idle = std::env::var("MVM_MCP_SESSION_IDLE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(DEFAULT_IDLE_SECS));
+        let max = std::env::var("MVM_MCP_SESSION_MAX")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(DEFAULT_MAX_SECS));
+        Self { idle, max }
+    }
+}
+
+/// One row in the session map.
+///
+/// `vm_name` is `Option` so v1 (bookkeeping-only) can record a
+/// session without owning a VM. v2 sets it when a warm VM is
+/// materialised. Either way the lifetime tracking is identical.
+#[derive(Debug, Clone)]
+pub struct SessionState {
+    pub env: String,
+    pub vm_name: Option<String>,
+    pub started_at: Instant,
+    pub last_used: Instant,
+}
+
+/// Outcome of [`SessionMap::touch_or_insert`]: did we hit an existing
+/// session, or did we just create it?
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionLookup {
+    /// Session existed; `last_used` was updated.
+    Existing,
+    /// Session did not exist; a fresh entry was created.
+    Created,
+}
+
+/// Reason a session was reaped — passed to [`Reaper::on_reap`] so the
+/// caller can audit-log the right kind (idle-expiry vs. max-lifetime
+/// vs. explicit close vs. server-shutdown drain).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReapReason {
+    /// `last_used + idle < now`.
+    Idle,
+    /// `started_at + max < now`.
+    MaxLifetime,
+    /// Client sent `close: true` on the most recent call.
+    Closed,
+    /// Server shutting down; reap everything still in the map.
+    Shutdown,
+}
+
+/// The bridge between the pure [`SessionMap`] and the side-effecting
+/// world. Implementors do whatever needs to happen when a session
+/// ends: kill the VM, audit-log, free per-session resources.
+pub trait Reaper: Send + Sync {
+    fn on_reap(&self, session_id: &str, state: &SessionState, reason: ReapReason);
+}
+
+/// Pure session map. All time math goes through `Instant::now()`
+/// at call time so tests can drive expiry by injecting their own
+/// "now" via [`SessionMap::touch_or_insert_at`] /
+/// [`SessionMap::reap_expired_at`].
+#[derive(Debug, Default)]
+pub struct SessionMap {
+    sessions: BTreeMap<String, SessionState>,
+    config: SessionConfig,
+}
+
+impl SessionMap {
+    pub fn new(config: SessionConfig) -> Self {
+        Self {
+            sessions: BTreeMap::new(),
+            config,
+        }
+    }
+
+    pub fn config(&self) -> SessionConfig {
+        self.config
+    }
+
+    /// Number of live sessions currently tracked.
+    pub fn len(&self) -> usize {
+        self.sessions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+
+    /// Look up an existing session or create a new one. Updates
+    /// `last_used` to `now` either way. Returns whether the session
+    /// was already present.
+    ///
+    /// `vm_name_hint` is what to record on first insert. v1 callers
+    /// pass `None` because warm VMs aren't materialised yet; v2
+    /// passes the booted VM name so the reaper has something to kill.
+    pub fn touch_or_insert(
+        &mut self,
+        session_id: &str,
+        env: &str,
+        vm_name_hint: Option<String>,
+    ) -> SessionLookup {
+        self.touch_or_insert_at(session_id, env, vm_name_hint, Instant::now())
+    }
+
+    /// Test-friendly variant that takes an explicit "now".
+    pub fn touch_or_insert_at(
+        &mut self,
+        session_id: &str,
+        env: &str,
+        vm_name_hint: Option<String>,
+        now: Instant,
+    ) -> SessionLookup {
+        if let Some(state) = self.sessions.get_mut(session_id) {
+            state.last_used = now;
+            // env mismatch on a reused session is a client bug; the
+            // map records the original env. Caller may want to surface
+            // a warning, but the map itself is permissive.
+            return SessionLookup::Existing;
+        }
+        self.sessions.insert(
+            session_id.to_string(),
+            SessionState {
+                env: env.to_string(),
+                vm_name: vm_name_hint,
+                started_at: now,
+                last_used: now,
+            },
+        );
+        SessionLookup::Created
+    }
+
+    /// Get a snapshot of a session's state (for audit logging,
+    /// inspection). Returns `None` if no such session.
+    pub fn get(&self, session_id: &str) -> Option<&SessionState> {
+        self.sessions.get(session_id)
+    }
+
+    /// Remove a session by id, calling the reaper with the given
+    /// reason. Used for explicit `close: true` and shutdown drain.
+    pub fn remove(&mut self, session_id: &str, reason: ReapReason, reaper: &dyn Reaper) -> bool {
+        if let Some(state) = self.sessions.remove(session_id) {
+            reaper.on_reap(session_id, &state, reason);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Sweep expired sessions, calling the reaper for each. Returns
+    /// the number of sessions reaped.
+    pub fn reap_expired(&mut self, reaper: &dyn Reaper) -> usize {
+        self.reap_expired_at(reaper, Instant::now())
+    }
+
+    /// Test-friendly variant that takes an explicit "now".
+    pub fn reap_expired_at(&mut self, reaper: &dyn Reaper, now: Instant) -> usize {
+        let mut to_reap: Vec<(String, ReapReason)> = Vec::new();
+        for (id, state) in &self.sessions {
+            // Max lifetime trumps idle: a session that hits both is
+            // reported as MaxLifetime so audit logs distinguish "user
+            // walked away" from "policy says enough."
+            if now.duration_since(state.started_at) >= self.config.max {
+                to_reap.push((id.clone(), ReapReason::MaxLifetime));
+            } else if now.duration_since(state.last_used) >= self.config.idle {
+                to_reap.push((id.clone(), ReapReason::Idle));
+            }
+        }
+        let n = to_reap.len();
+        for (id, reason) in to_reap {
+            if let Some(state) = self.sessions.remove(&id) {
+                reaper.on_reap(&id, &state, reason);
+            }
+        }
+        n
+    }
+
+    /// Drain the map (server shutdown). All remaining sessions are
+    /// reaped with [`ReapReason::Shutdown`].
+    pub fn drain(&mut self, reaper: &dyn Reaper) -> usize {
+        let drained: Vec<(String, SessionState)> =
+            std::mem::take(&mut self.sessions).into_iter().collect();
+        let n = drained.len();
+        for (id, state) in drained {
+            reaper.on_reap(&id, &state, ReapReason::Shutdown);
+        }
+        n
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Records every reap so tests can assert on them.
+    #[derive(Default)]
+    struct RecordingReaper {
+        calls: Mutex<Vec<(String, ReapReason)>>,
+    }
+    impl Reaper for RecordingReaper {
+        fn on_reap(&self, session_id: &str, _state: &SessionState, reason: ReapReason) {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((session_id.to_string(), reason));
+        }
+    }
+
+    fn cfg(idle_secs: u64, max_secs: u64) -> SessionConfig {
+        SessionConfig {
+            idle: Duration::from_secs(idle_secs),
+            max: Duration::from_secs(max_secs),
+        }
+    }
+
+    #[test]
+    fn touch_or_insert_creates_then_returns_existing() {
+        let mut map = SessionMap::new(cfg(300, 3600));
+        let t0 = Instant::now();
+        assert_eq!(
+            map.touch_or_insert_at("s1", "shell", None, t0),
+            SessionLookup::Created
+        );
+        assert_eq!(map.len(), 1);
+        assert_eq!(
+            map.touch_or_insert_at("s1", "shell", None, t0 + Duration::from_secs(5)),
+            SessionLookup::Existing
+        );
+        assert_eq!(map.len(), 1, "second touch must not create a new entry");
+    }
+
+    #[test]
+    fn touch_updates_last_used() {
+        let mut map = SessionMap::new(cfg(300, 3600));
+        let t0 = Instant::now();
+        map.touch_or_insert_at("s1", "shell", None, t0);
+        let t1 = t0 + Duration::from_secs(60);
+        map.touch_or_insert_at("s1", "shell", None, t1);
+        let state = map.get("s1").unwrap();
+        assert_eq!(state.last_used, t1);
+        assert_eq!(state.started_at, t0, "started_at must be sticky");
+    }
+
+    #[test]
+    fn idle_reaps_after_idle_window() {
+        let mut map = SessionMap::new(cfg(60, 3600));
+        let reaper = RecordingReaper::default();
+        let t0 = Instant::now();
+        map.touch_or_insert_at("s1", "shell", None, t0);
+
+        // 30 s later — under idle window.
+        assert_eq!(
+            map.reap_expired_at(&reaper, t0 + Duration::from_secs(30)),
+            0
+        );
+        assert_eq!(map.len(), 1);
+
+        // 60 s later — at idle window boundary, should reap.
+        assert_eq!(
+            map.reap_expired_at(&reaper, t0 + Duration::from_secs(60)),
+            1
+        );
+        assert_eq!(map.len(), 0);
+        let calls = reaper.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "s1");
+        assert_eq!(calls[0].1, ReapReason::Idle);
+    }
+
+    #[test]
+    fn max_lifetime_reaps_even_if_recently_touched() {
+        let mut map = SessionMap::new(cfg(300, 60));
+        let reaper = RecordingReaper::default();
+        let t0 = Instant::now();
+        map.touch_or_insert_at("s1", "shell", None, t0);
+
+        // 50 s later — under max but recently touched.
+        map.touch_or_insert_at("s1", "shell", None, t0 + Duration::from_secs(50));
+
+        // 60 s later — at max window. last_used was 50 s ago, idle is 300 s
+        // so idle would not fire; max should fire.
+        assert_eq!(
+            map.reap_expired_at(&reaper, t0 + Duration::from_secs(60)),
+            1
+        );
+        let calls = reaper.calls.lock().unwrap();
+        assert_eq!(calls[0].1, ReapReason::MaxLifetime);
+    }
+
+    #[test]
+    fn explicit_close_reports_reason_closed() {
+        let mut map = SessionMap::new(cfg(300, 3600));
+        let reaper = RecordingReaper::default();
+        map.touch_or_insert("s1", "shell", None);
+        assert!(map.remove("s1", ReapReason::Closed, &reaper));
+        let calls = reaper.calls.lock().unwrap();
+        assert_eq!(calls[0].1, ReapReason::Closed);
+        assert_eq!(map.len(), 0);
+    }
+
+    #[test]
+    fn remove_unknown_session_returns_false() {
+        let mut map = SessionMap::new(cfg(300, 3600));
+        let reaper = RecordingReaper::default();
+        assert!(!map.remove("nonexistent", ReapReason::Closed, &reaper));
+        assert!(reaper.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn drain_reports_reason_shutdown() {
+        let mut map = SessionMap::new(cfg(300, 3600));
+        let reaper = RecordingReaper::default();
+        map.touch_or_insert("s1", "shell", None);
+        map.touch_or_insert("s2", "python", None);
+        assert_eq!(map.drain(&reaper), 2);
+        let calls = reaper.calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert!(calls.iter().all(|(_, r)| *r == ReapReason::Shutdown));
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn config_from_env_uses_defaults_when_unset() {
+        // Don't mutate env in this test (other tests rely on defaults
+        // being readable without setup); just check the type-level
+        // defaults.
+        let c = SessionConfig::default();
+        assert_eq!(c.idle, Duration::from_secs(DEFAULT_IDLE_SECS));
+        assert_eq!(c.max, Duration::from_secs(DEFAULT_MAX_SECS));
+    }
+
+    #[test]
+    fn vm_name_hint_persists() {
+        let mut map = SessionMap::new(cfg(300, 3600));
+        map.touch_or_insert("s1", "shell", Some("mcp-session-s1".to_string()));
+        let state = map.get("s1").unwrap();
+        assert_eq!(state.vm_name.as_deref(), Some("mcp-session-s1"));
+    }
+
+    #[test]
+    fn reap_after_drain_is_no_op() {
+        let mut map = SessionMap::new(cfg(60, 3600));
+        let reaper = RecordingReaper::default();
+        map.touch_or_insert("s1", "shell", None);
+        map.drain(&reaper);
+        assert_eq!(map.reap_expired(&reaper), 0);
+    }
+}

--- a/specs/adrs/003-local-mcp-server.md
+++ b/specs/adrs/003-local-mcp-server.md
@@ -98,10 +98,17 @@ Surfaces specific to this ADR:
    cross-repo handoff. mvm owns the protocol; mvmd owns
    tenant-aware HTTP/SSE transport, auth, rate limits.
 
-6. **Session semantics deferred to A.2.** The `session` parameter
-   exists in the v1 schema but is ignored — clients can adopt the
-   field ahead of the server. The implementation (snapshot-resumed
-   warm VMs) is in plan 32 / Proposal A.2.
+6. **Session semantics split into A.2 v1 (bookkeeping, shipped) +
+   v2 (warm VMs, deferred).** v1 ships a `SessionMap` + `Reaper`
+   trait + reaper thread + idle/max/close/shutdown audit events,
+   so client correlation and policy enforcement work today. v2
+   adds the actual warm-VM materialisation (snapshot-resumed VMs
+   that persist across calls); the v1 map's `vm_name: Option<…>`
+   is the integration point. v2 requires an exec.rs refactor that
+   's risky to land without live-KVM integration tests, so it
+   stages on a separate branch. `// TODO(A.2 v2)` markers in
+   `commands/ops/mcp.rs` and the plan-32 status block document the
+   exact lines that change.
 
 ## Consequences
 

--- a/specs/plans/32-mcp-agent-adoption.md
+++ b/specs/plans/32-mcp-agent-adoption.md
@@ -437,12 +437,34 @@ D is independent of A, B, C but most useful *with* B (gives the
 
 # Proposal A.2 — MCP session semantics (mvm follow-up to A)
 
-**Status (schema-ready):** wire schema is in place — `RunParams` now
-carries both `session: Option<String>` and `close: Option<bool>`, and
-the `tools/list` JSON Schema documents both fields. v1 server still
-ignores them (clients may set them without error). Server-side
-session map + reaper thread + `run_in_existing` exec path remain
-deferred to a later branch.
+**Status (v1 shipped — bookkeeping; v2 deferred — warm-VM materialisation):**
+
+v1 (shipped on `feat/mcp-session-semantics`):
+- Wire schema in `mvm_mcp::tools` accepts `session: Option<String>`
+  and `close: Option<bool>` with full JSON-Schema descriptions.
+- `mvm_mcp::session` ships a protocol-only `SessionMap` + `Reaper`
+  trait + `SessionConfig` (idle / max from `MVM_MCP_SESSION_IDLE` /
+  `MVM_MCP_SESSION_MAX`). Pure unit tests cover create / touch /
+  idle-reap / max-lifetime / close / drain transitions.
+- `ExecDispatcher` (mvm-cli) holds the map, spawns a 30 s-tick
+  reaper thread at startup, drains on `Drop` (clean shutdown),
+  and emits `LocalAuditKind::McpSessionStarted` /
+  `McpSessionClosed` events with the close reason (`idle` /
+  `max_lifetime` / `closed` / `shutdown`).
+
+v2 (deferred):
+- The map's `vm_name: Option<String>` is always `None` in v1
+  because `crate::exec::run_captured` is still cold-boot per call.
+  v2 will refactor exec.rs to expose
+  `boot_session_vm` / `dispatch_in_session` / `tear_down_session`
+  primitives, set `vm_name = Some(...)` on first boot, and skip
+  the cold-boot path on subsequent calls in the same session. The
+  `ExecDispatcher` already holds the map under
+  `Arc<Mutex<SessionMap>>` so v2 plugs in without touching the
+  wire types or the `Reaper` trait.
+- `// TODO(A.2 v2)` markers in
+  `crates/mvm-cli/src/commands/ops/mcp.rs` flag the exact lines
+  that change.
 
 ## Why
 


### PR DESCRIPTION
## Summary

- Adds `mvm_mcp::session` — `SessionMap` + `Reaper` trait + `SessionConfig` (idle/max from `MVM_MCP_SESSION_IDLE` / `MVM_MCP_SESSION_MAX`). Pure, protocol-only, no I/O. mvmd's hosted variant (plan 33) gets the same lifecycle types.
- `LocalAuditKind::McpSessionStarted` + `McpSessionClosed` audit events with reason (`idle` / `max_lifetime` / `closed` / `shutdown`).
- `ExecDispatcher` (mvm-cli) holds the map under `Arc<Mutex<…>>`, spawns a 30 s-tick reaper thread at startup, drains on `Drop`, routes `close: true` to `SessionMap::remove`.
- 10 new unit tests in `mvm_mcp::session::tests` cover create / touch / idle-reap / max-lifetime / close / drain transitions with injected `Instant`s.

Stacked on #20 (`feat/mcp-agent-adoption`).

## Deferred (A.2 v2)

Warm-VM materialisation. The map's `vm_name: Option<String>` is `None` in v1 because `crate::exec::run_captured` is still cold-boot per call. v2 will refactor exec.rs to expose `boot_session_vm` / `dispatch_in_session` / `tear_down_session` primitives and short-circuit cold-boot on session reuse. `// TODO(A.2 v2)` markers in `commands/ops/mcp.rs` flag the integration points; the wire types and Reaper trait don't change in v2. This split is documented in:

- `specs/plans/32-mcp-agent-adoption.md` §"Proposal A.2"
- `specs/adrs/003-local-mcp-server.md` §"Decisions" 6

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` all green (mvm-mcp 19 → 29 with the 10 new session tests; +2 audit-kind variants)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo build -p mvm-mcp --no-default-features --features protocol-only` clean (mvmd-ready; session module is protocol-only safe)
- [ ] Live integration test against a real session-resumed warm VM (deferred — A.2 v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)