### PR TITLE
feat(policy,runtime): L7 egress proxy foundation + plan 34

### DIFF
--- a/crates/mvm-core/src/policy/network_policy.rs
+++ b/crates/mvm-core/src/policy/network_policy.rs
@@ -120,6 +120,66 @@ impl fmt::Display for NetworkPreset {
     }
 }
 
+/// Egress enforcement layer (plan 32 / Proposal D / ADR-004).
+///
+/// The three-layer model lives in ADR-004; this enum lets callers
+/// pick which layers apply. v1 (D shipped) wires only L3; v2
+/// (plan 34, deferred) adds the L7 SNI/Host proxy + DNS pinning.
+///
+/// `Open` is the implicit mode for any `NetworkPolicy` that resolves
+/// to an unrestricted preset. `L3Only` and `L3PlusL7` apply when
+/// the policy resolves to a non-empty allowlist.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EgressMode {
+    /// No filtering — guest gets full outbound. Implied by an
+    /// unrestricted policy.
+    #[default]
+    Open,
+    /// L3 only: iptables `FORWARD` allowlist on the bridge. Catches
+    /// raw-IP exfil; doesn't catch DNS rotation or SNI/Host abuse
+    /// over a permitted destination.
+    L3Only,
+    /// L3 + L7 stack: iptables allowlist plus an HTTPS proxy on the
+    /// host that enforces SNI for HTTPS (CONNECT) and Host header
+    /// for HTTP. Plan 34 / ADR-004 §"L7" covers the runtime impl;
+    /// today this variant returns "egress proxy not implemented" at
+    /// `tap_create` time so callers see a clear error rather than a
+    /// silent downgrade.
+    L3PlusL7,
+}
+
+impl EgressMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::L3Only => "l3-only",
+            Self::L3PlusL7 => "l3-plus-l7",
+        }
+    }
+}
+
+impl FromStr for EgressMode {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "open" => Ok(Self::Open),
+            "l3-only" | "l3" => Ok(Self::L3Only),
+            "l3-plus-l7" | "l3+l7" | "l7" => Ok(Self::L3PlusL7),
+            other => anyhow::bail!(
+                "unknown egress mode {:?} (expected: open, l3-only, l3-plus-l7)",
+                other
+            ),
+        }
+    }
+}
+
+impl fmt::Display for EgressMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Network policy for a microVM, controlling outbound traffic.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -421,6 +481,50 @@ mod tests {
         assert!(!hosts.contains(&"registry.npmjs.org"));
         assert!(!hosts.contains(&"crates.io"));
         assert!(!hosts.contains(&"pypi.org"));
+    }
+
+    #[test]
+    fn egress_mode_default_is_open() {
+        assert_eq!(EgressMode::default(), EgressMode::Open);
+    }
+
+    #[test]
+    fn egress_mode_parse_canonical() {
+        assert_eq!("open".parse::<EgressMode>().unwrap(), EgressMode::Open);
+        assert_eq!("l3-only".parse::<EgressMode>().unwrap(), EgressMode::L3Only);
+        assert_eq!(
+            "l3-plus-l7".parse::<EgressMode>().unwrap(),
+            EgressMode::L3PlusL7
+        );
+    }
+
+    #[test]
+    fn egress_mode_parse_aliases() {
+        assert_eq!("l3".parse::<EgressMode>().unwrap(), EgressMode::L3Only);
+        assert_eq!("l7".parse::<EgressMode>().unwrap(), EgressMode::L3PlusL7);
+        assert_eq!("l3+l7".parse::<EgressMode>().unwrap(), EgressMode::L3PlusL7);
+    }
+
+    #[test]
+    fn egress_mode_parse_unknown_errors() {
+        assert!("bogus".parse::<EgressMode>().is_err());
+    }
+
+    #[test]
+    fn egress_mode_display_roundtrip() {
+        for mode in [EgressMode::Open, EgressMode::L3Only, EgressMode::L3PlusL7] {
+            let s = mode.to_string();
+            assert_eq!(s.parse::<EgressMode>().unwrap(), mode);
+        }
+    }
+
+    #[test]
+    fn egress_mode_serde_roundtrip() {
+        for mode in [EgressMode::Open, EgressMode::L3Only, EgressMode::L3PlusL7] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let parsed: EgressMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, mode);
+        }
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/egress_proxy.rs
+++ b/crates/mvm-runtime/src/vm/egress_proxy.rs
@@ -1,0 +1,149 @@
+//! Hypervisor-level L7 egress proxy supervision (plan 32 / Proposal D / ADR-004).
+//!
+//! Today (this branch): stub. The L3 tier of egress enforcement
+//! (`apply_network_policy` / `cleanup_network_policy` in `vm/network.rs`)
+//! is shipped via `NetworkPreset::Agent` and friends. The L7 tier
+//! (HTTPS-proxy + DNS-pinning) lands in the follow-up plan
+//! `specs/plans/34-egress-l7-proxy.md`. This module exists so callers
+//! that opt into `EgressMode::L3PlusL7` get a clear "not implemented
+//! yet" error from the runtime instead of a silent downgrade to L3.
+//!
+//! The trait surface here is the integration point: when plan 34
+//! implements the mitmdump supervisor, it implements `EgressProxy`
+//! and `tap_create` calls `start_for_vm` after the L3 rules are
+//! installed. See `EgressProxy::start_for_vm` for the contract.
+
+use std::fmt;
+
+use mvm_core::network_policy::{EgressMode, NetworkPolicy};
+
+/// Per-VM proxy handle. Returned by [`EgressProxy::start_for_vm`]
+/// and consumed by [`EgressProxy::stop_for_vm`]. Plan 34 fills in
+/// the actual fields (PID, listening port, allowlist hash).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxyHandle {
+    pub vm_name: String,
+    pub listen_port: u16,
+}
+
+/// Errors from the L7 supervisor. Stable across the v1 stub and the
+/// plan-34 real implementation so callers don't have to re-match.
+#[derive(Debug)]
+pub enum EgressProxyError {
+    /// `EgressMode::L3PlusL7` was requested but the runtime backing
+    /// the proxy isn't implemented yet (plan 34). Callers should
+    /// fall back to `EgressMode::L3Only` or surface the error.
+    NotImplemented,
+    /// Unrelated runtime failure (process spawn, port allocation,
+    /// CA cert load).
+    Other(anyhow::Error),
+}
+
+impl fmt::Display for EgressProxyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotImplemented => write!(
+                f,
+                "L7 egress proxy is not implemented yet (plan 34). Use EgressMode::L3Only \
+                 or wait for the L7 follow-up. ADR-004 §\"L7\" documents the design."
+            ),
+            Self::Other(e) => write!(f, "egress proxy: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for EgressProxyError {}
+
+impl From<anyhow::Error> for EgressProxyError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Other(e)
+    }
+}
+
+/// L7 egress supervisor. The trait is the integration point with
+/// `vm/network.rs`; plan 34 wires it up.
+///
+/// Contract:
+/// - `start_for_vm`: spawn / configure the proxy for a single VM.
+///   Idempotent — calling twice for the same `vm_name` returns the
+///   existing handle. The L3 rules must already be in place;
+///   the proxy installs additional `iptables` rules to redirect
+///   HTTPS/HTTP from the VM to itself.
+/// - `stop_for_vm`: stop the proxy and remove its iptables rules.
+///   Idempotent — safe to call for a vm_name that was never started.
+pub trait EgressProxy: Send + Sync {
+    fn start_for_vm(
+        &self,
+        vm_name: &str,
+        policy: &NetworkPolicy,
+    ) -> Result<ProxyHandle, EgressProxyError>;
+    fn stop_for_vm(&self, handle: &ProxyHandle) -> Result<(), EgressProxyError>;
+}
+
+/// Stub supervisor used when no real backing is configured. Returns
+/// `NotImplemented` for every operation. Plan 34 will replace this
+/// with a `MitmdumpSupervisor` that wraps `mitmdump` from nixpkgs.
+pub struct StubEgressProxy;
+
+impl EgressProxy for StubEgressProxy {
+    fn start_for_vm(
+        &self,
+        _vm_name: &str,
+        _policy: &NetworkPolicy,
+    ) -> Result<ProxyHandle, EgressProxyError> {
+        Err(EgressProxyError::NotImplemented)
+    }
+    fn stop_for_vm(&self, _handle: &ProxyHandle) -> Result<(), EgressProxyError> {
+        // stop on a stub is a no-op rather than NotImplemented — the
+        // teardown path runs unconditionally and we don't want to
+        // bubble errors when there's nothing to clean up.
+        Ok(())
+    }
+}
+
+/// Decide whether a policy + mode combination requires the L7
+/// supervisor at all. Used by the network setup path so it can skip
+/// proxy spawn for `L3Only` and `Open` policies.
+pub fn requires_l7(mode: EgressMode) -> bool {
+    matches!(mode, EgressMode::L3PlusL7)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::network_policy::{HostPort, NetworkPolicy};
+
+    #[test]
+    fn stub_start_returns_not_implemented() {
+        let stub = StubEgressProxy;
+        let policy = NetworkPolicy::allow_list(vec![HostPort::new("api.anthropic.com", 443)]);
+        let err = stub.start_for_vm("vm-1", &policy).unwrap_err();
+        assert!(matches!(err, EgressProxyError::NotImplemented));
+    }
+
+    #[test]
+    fn stub_stop_is_noop() {
+        let stub = StubEgressProxy;
+        let handle = ProxyHandle {
+            vm_name: "vm-1".to_string(),
+            listen_port: 0,
+        };
+        assert!(stub.stop_for_vm(&handle).is_ok());
+    }
+
+    #[test]
+    fn requires_l7_only_for_l3_plus_l7() {
+        assert!(!requires_l7(EgressMode::Open));
+        assert!(!requires_l7(EgressMode::L3Only));
+        assert!(requires_l7(EgressMode::L3PlusL7));
+    }
+
+    #[test]
+    fn error_display_mentions_plan_34() {
+        let s = EgressProxyError::NotImplemented.to_string();
+        assert!(
+            s.contains("plan 34"),
+            "error message must point at follow-up plan, got: {s}"
+        );
+    }
+}

--- a/crates/mvm-runtime/src/vm/mod.rs
+++ b/crates/mvm-runtime/src/vm/mod.rs
@@ -2,6 +2,7 @@
 pub mod apple_container;
 pub mod backend;
 pub mod docker;
+pub mod egress_proxy;
 pub mod firecracker;
 pub mod image;
 pub mod lima;

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -259,21 +259,75 @@ W1 is shipped. W2–W6 are independent and can land in any order; W3
   the hypervisor, GC roots, and private build keys.
 - Multi-tenant guests. One guest = one workload.
 - TPM/SEV/hardware attestation. Out of scope for v1.
-- Hypervisor-level egress policy enforcement (beyond NAT/tap choice).
-  *Scoped for the next sprint as plan 32 / Proposal D —
-  [`plans/32-mcp-agent-adoption.md`](plans/32-mcp-agent-adoption.md).
-  Remains a non-goal for Sprint 42.*
+- Hypervisor-level egress policy enforcement L7 / DNS-pinning. The
+  L3 tier shipped via plan 32 / Proposal D + `NetworkPreset::Agent`
+  (PR #20). The L7 tier (mitmdump-based HTTPS proxy + DNS-answer
+  pinning) is scoped in
+  [`plans/34-egress-l7-proxy.md`](plans/34-egress-l7-proxy.md);
+  PR #23 ships the foundation (`EgressMode::L3PlusL7`,
+  `EgressProxy` trait, `StubEgressProxy`). Runtime backing remains
+  a non-goal for Sprint 42.
 
-## Up next (Sprint 43 preview)
+## Sprint 43 — Nix-agent ecosystem adoption (in flight)
 
-[`plans/32-mcp-agent-adoption.md`](plans/32-mcp-agent-adoption.md) is
-the approved master plan for the next sprint:
+Master plan: [`plans/32-mcp-agent-adoption.md`](plans/32-mcp-agent-adoption.md).
+Five proposals (A, A.2, B, C, D) plus cross-repo handoff plan 33.
 
-- **A** — `mvmctl mcp` server (single-tool MCP surface, ADR-003).
-- **A.2** — MCP session semantics (snapshot-resumed VMs).
-- **B** — `nix/images/examples/llm-agent/` showcase flake.
-- **C** — local-LLM-default flip for `mvmctl template init --prompt`.
-- **D** — hypervisor egress policy with domain-pinning (ADR-004).
+### Shipped (PRs open, awaiting review)
+
+- **PR #20** [`feat/mcp-agent-adoption`](https://github.com/tinylabscom/mvm/pull/20) ←
+  `main` — plan 32 base. New `mvm-mcp` crate (protocol-only +
+  stdio), A v1 stdio MCP server, B `nix/images/examples/llm-agent/`
+  showcase flake, C local-LLM probe defaults, D v1
+  `NetworkPreset::Agent` (L3-only). New ADRs 003 / 004; new plans
+  32 / 33.
+- **PR #21** [`feat/mcp-session-semantics`](https://github.com/tinylabscom/mvm/pull/21) ← #20 —
+  A.2 v1 (session bookkeeping). `SessionMap` + `Reaper` trait +
+  audit kinds + 30 s-tick reaper thread + Drop drain.
+- **PR #22** [`feat/mcp-session-warm-vm`](https://github.com/tinylabscom/mvm/pull/22) ← #21 —
+  A.2 v2 (warm-VM materialisation). `boot_session_vm` /
+  `dispatch_in_session` / `tear_down_session_vm` exec primitives;
+  per-session `Arc<Mutex<SessionVm>>` map; boot-race handling;
+  reaper actually tears VMs down.
+- **PR #23** [`feat/egress-l7-proxy`](https://github.com/tinylabscom/mvm/pull/23) ← #22 —
+  L7 egress foundation. `EgressMode` enum (`Open` / `L3Only` /
+  `L3PlusL7`), `EgressProxy` trait + `StubEgressProxy`, plan 34
+  scoped.
+
+All four PRs: `cargo build --workspace` clean, `cargo test --workspace`
+green (mvm-mcp 31 tests including session lifecycle, mvm-core +6
+EgressMode tests + 3 agent-preset tests, mvm-cli +2 probe tests),
+`cargo clippy --workspace --all-targets -- -D warnings` clean,
+`cargo build -p mvm-mcp --no-default-features --features
+protocol-only` clean (mvmd-ready per plan 33).
+
+### Deferred — concrete follow-ups
+
+| Item | Plan | Why deferred | Estimated size |
+|---|---|---|---|
+| **L7 egress runtime backing** (mitmdump supervisor + CA cert tooling + optional DNS-pinning + `apply_network_policy` wire-up + `mvmctl egress init-ca` + `mvmctl cache prune` orphan handling + llm-agent README update) | [`plans/34-egress-l7-proxy.md`](plans/34-egress-l7-proxy.md) — 7 tiers fully specified | Heavyweight runtime dep (mitmdump pulls Python + cryptography, ~80 MiB closure); CA cert generation has corner cases (rotation, expiry, per-host vs per-VM); DNS pinning needs IPv6 + CNAME-chain handling. Live-KVM integration testing is mandatory. | ~1 sprint |
+| **A.2 v2 live-KVM smoke** (cold-boot vs warm-VM latency comparison on `claude-code-vm`; race-condition test for parallel first-calls in same session; snapshot-resume against the Anthropic-allowlisted agent VM) | Plan 32 §"Proposal A.2" | Hardware not available in the dev environment; needs a Linux/KVM host with a real Firecracker stack. | ~1 day |
+| **Hosted MCP transport (HTTP/SSE)** | [`plans/33-hosted-mcp-transport.md`](plans/33-hosted-mcp-transport.md) | Cross-repo: implementation lives in [mvmd](https://github.com/auser/mvmd). mvm-mcp's `protocol-only` feature is already shipped (PR #20) so mvmd can consume the wire schema unchanged. | mvmd owns sizing |
+| **Per-template `default_network_policy`** | ADR-004 §"Decisions" 6 (named as ergonomic follow-up) | Requires `TemplateSpec` schema bump + migration; orthogonal to the L7 work. Lets `claude-code-vm` ship with the agent preset baked in instead of needing `--network-preset agent` per `mvmctl up`. | ~1 day |
+| **CI lane `mcp-server-smoke`** (real JSON-RPC roundtrip via `scripts/test-mcp-roundtrip.sh`) | Plan 32 §"Proposal A — CI gate" | The unit tests cover protocol shape; the missing piece is a CI lane that spawns `mvmctl mcp stdio` and asserts a real `tools/list` response. Small, can land any time. | ~½ day |
+
+### Sprint 43 success criteria
+
+By sprint close, the project should be able to claim:
+
+1. *LLM clients drive mvmctl as an MCP sandbox* (PR #20 — shipped).
+2. *Sessions persist warm VMs across calls with idle/max reaping* (PRs #21 + #22 — shipped, live-KVM smoke deferred).
+3. *Hardened LLM-agent VM exists as a worked example* (PR #20 / Proposal B — shipped).
+4. *Local-LLM-first scaffolding* (PR #20 / Proposal C — shipped).
+5. *L3 hypervisor egress allowlist with an `agent` preset* (PR #20 / Proposal D — shipped).
+6. *L7 HTTPS proxy + SNI/Host enforcement* (foundation in PR #23, runtime in plan 34 — deferred).
+7. *mvmd-ready protocol crate* (PR #20's `protocol-only` feature — shipped; mvmd consumption is plan 33's job).
+
+5 of 7 are fully shipped on `feat/egress-l7-proxy`; 1 has its
+foundation in place; 1 is cross-repo work. The sprint can close on
+review approval of PRs #20–#23 — claim 6 is honestly stated as
+"foundation shipped; runtime in plan 34" and that's the right
+boundary given the runtime dep weight.
 
 Cross-repo handoff for hosted MCP transport (HTTP/SSE) is documented
 in [`plans/33-hosted-mcp-transport.md`](plans/33-hosted-mcp-transport.md);

--- a/specs/adrs/004-hypervisor-egress-policy.md
+++ b/specs/adrs/004-hypervisor-egress-policy.md
@@ -1,8 +1,8 @@
 ---
 title: "ADR-004: hypervisor-level egress policy with domain-pinning"
-status: Proposed (v1 = L3 only; L7 + DNS-pinning deferred)
+status: Proposed (v1 = L3 shipped; L7 + DNS-pinning scoped in plan 34)
 date: 2026-04-30
-related: ADR-002 (microVM security posture); ADR-003 (local MCP server); plan 32 (MCP + LLM-agent adoption); plan 25 (microVM hardening)
+related: ADR-002 (microVM security posture); ADR-003 (local MCP server); plan 32 (MCP + LLM-agent adoption); plan 34 (L7 egress proxy follow-up); plan 25 (microVM hardening)
 ---
 
 ## Status

--- a/specs/plans/34-egress-l7-proxy.md
+++ b/specs/plans/34-egress-l7-proxy.md
@@ -1,0 +1,228 @@
+---
+title: "Plan 34 — L7 egress proxy + DNS-answer pinning (plan 32 / Proposal D follow-up)"
+status: Proposed
+date: 2026-04-30
+related: ADR-002 (microVM security posture); ADR-004 (hypervisor egress policy); plan 32 (MCP + LLM-agent adoption); plan 25 (microVM hardening)
+---
+
+## Status
+
+Proposed. Plan 32 / Proposal D shipped the L3 tier (`NetworkPreset::Agent`
++ existing `apply_network_policy` iptables machinery). ADR-004 named
+the L7 HTTPS-proxy + DNS-pinning layers as the next stage and
+documented why they're deferred. This plan turns those deferrals into
+concrete implementation work.
+
+## Why
+
+ADR-004 §"The three-layer model" makes the case explicit: the L3
+allowlist catches raw-IP exfil but not DNS rotation (CDN-fronted
+hosts where the authorised answer changes between rule-install and
+connect) or SNI/Host-header abuse over a permitted destination.
+For LLM-agent workloads (`nix/images/examples/llm-agent/`'s
+`claude-code-vm`) talking to high-stakes endpoints like
+`api.anthropic.com`, those gaps matter — an exfil that uses
+DNS-rotation tricks to reach a CDN-fronted host the L3 tier
+authorised yesterday is exactly the kind of attack the LLM-agent
+posture is supposed to defend against.
+
+Plan 32 / `feat/egress-l7-proxy` shipped the foundation:
+
+- `mvm_core::policy::network_policy::EgressMode` enum
+  (`Open` / `L3Only` / `L3PlusL7`).
+- `mvm_runtime::vm::egress_proxy` module with the `EgressProxy`
+  trait, `ProxyHandle`, `EgressProxyError` (with a
+  `NotImplemented` variant pointing here), and a `StubEgressProxy`.
+- 4 unit tests cover the stub's "not implemented" surface.
+
+This plan implements the runtime backing.
+
+## Threat model (additive over ADR-004)
+
+L7 closes two gaps in L3:
+
+1. **DNS rotation.** The L3 ruleset resolves the allowlist's
+   hostnames once at TAP attach. A guest that DNS-resolves
+   `cdn.example.com` later may get a different IP than what was
+   authorised — the L3 ruleset still says "drop" because that IP
+   isn't in the table. The L7 proxy enforces by SNI/Host instead of
+   IP, so the destination's IP can rotate freely.
+2. **SNI/Host abuse.** A guest that opens TLS to a permitted SNI
+   then sends an HTTP/1.1 `Host: evil.example.com` header is
+   blocked at L7 (the proxy rejects the Host) but invisible to L3.
+
+L7 does NOT close:
+
+- **TLS-pinning bypass.** A client that ignores the proxy's CA
+  cert (e.g. statically-pinned cert in a malicious binary) can't
+  be intercepted; CONNECT to a permitted SNI lets the bytes
+  through unchanged. L7 catches "agent uses default trust store"
+  cases; not "malicious binary ships its own roots."
+- **Tunnels over allowed protocols.** Anything HTTPS-shaped to a
+  permitted destination is permitted. WebSocket/HTTP/2 to
+  api.anthropic.com is fine; if the agent is malicious-by-design
+  and uses Anthropic as a relay, that's outside this plan.
+- **Non-HTTP egress.** Raw TCP / UDP to permitted ports falls
+  back to the L3 layer.
+
+## Implementation
+
+### Tier 1 — `mitmdump` per-VM supervisor
+
+**File:** `crates/mvm-runtime/src/vm/egress_proxy.rs` (extend the
+stub).
+
+`MitmdumpSupervisor` implements `EgressProxy`:
+
+- `start_for_vm(vm_name, policy) -> ProxyHandle`:
+  - Allocate a free TCP port from `MVM_EGRESS_PROXY_PORT_BASE`
+    (default 18000) onwards. Port allocator lives in a
+    `Mutex<BTreeMap<u16, String>>` shared across calls so
+    concurrent VMs don't collide.
+  - Generate a per-VM `mitmdump` filter script that allows
+    SNI/Host matches against the policy's allowlist and rejects
+    everything else with HTTP 403. Script lives in
+    `~/.mvm/egress/<vm_name>/filter.py`.
+  - Spawn `mitmdump --mode regular@<port> -s <filter.py>
+    --set block_global=true` as a child process owned by the
+    supervisor.
+  - Wait for the proxy to start listening (TCP probe with a 3 s
+    timeout). Fail with `EgressProxyError::Other` if not up.
+  - Install iptables `nat OUTPUT/PREROUTING` rules that REDIRECT
+    the guest's `:443` and `:80` traffic to the proxy port.
+    Rules live in `MVMEGRESS-L7-<vm_name>` chain; cleanup
+    flushes that chain.
+  - Return `ProxyHandle { vm_name, listen_port }`.
+
+- `stop_for_vm(handle)`:
+  - Flush `MVMEGRESS-L7-<vm_name>` chain.
+  - Send SIGTERM to the child process; wait up to 3 s; SIGKILL.
+  - Remove `~/.mvm/egress/<vm_name>/`.
+  - Free the port allocation.
+
+**Cross-platform:** matches existing `apply_network_policy`
+pattern. The supervisor dispatches through `shell::run_in_vm` on
+macOS (Lima) and runs natively on Linux.
+
+### Tier 2 — Per-host CA cert
+
+**File:** `crates/mvm-cli/src/commands/ops/egress.rs` (new).
+
+`mvmctl egress init-ca` generates an ed25519 CA at
+`~/.mvm/egress/ca.pem` + `ca.key` (owner-readable only, mode 0400),
+valid for 5 years. `mvmctl doctor` reports its presence/expiry.
+
+`mitmdump` is configured to use this CA via `--set
+ca_certs=~/.mvm/egress/ca.pem`. The same cert path is mounted
+read-only into every guest at `/etc/ssl/certs/mvm-egress.crt` via
+mvm-runtime's existing config-files plumbing (no new `secret_files`
+needed — cert is non-sensitive once distributed).
+
+Guest-side rootfs init (in `nix/lib/minimal-init/`) copies
+`/etc/ssl/certs/mvm-egress.crt` into the system trust store at boot
+when the file is present.
+
+### Tier 3 — DNS-answer pinning (optional, per-policy)
+
+**File:** `crates/mvm-runtime/src/vm/dns_pin.rs` (new).
+
+`dnsmasq` stub resolver on the host (or inside Lima on macOS) bound
+to a private CIDR the guest reaches. The stub:
+
+- Accepts only allowlisted domains; SERVFAIL for everything else.
+- Forwards permitted queries upstream.
+- Hooks into the iptables `MVMEGRESS-L3-<vm>` chain so resolved IPs
+  are pinned with their TTL — when the TTL expires, the pin
+  re-resolves and updates the chain.
+
+Optional because L7 catches most of DNS rotation's attack value
+(SNI is checked at the proxy, not by IP). Operators who want the
+extra defence enable it via
+`network_policy.dns_pinning = true` (new field, defaults false).
+
+### Tier 4 — Wire it up
+
+**Files:**
+- `crates/mvm-runtime/src/vm/network.rs` — `apply_network_policy`
+  takes an `EgressMode` parameter and a `&dyn EgressProxy`. When
+  `EgressMode::L3PlusL7`, it calls `proxy.start_for_vm` after the
+  L3 rules. `cleanup_network_policy` calls `proxy.stop_for_vm`.
+- `crates/mvm-cli/src/commands/vm/up.rs` — new flag
+  `--egress-mode <open|l3-only|l3-plus-l7>` (default depends on
+  policy: unrestricted → open, allowlist → l3-only, agent preset
+  → l3-plus-l7 if CA cert is initialised, else l3-only with a
+  warning).
+- `crates/mvm-cli/src/commands/env/doctor.rs` — probe for
+  mitmdump on PATH (or in nixpkgs closure), CA cert presence/
+  expiry, dnsmasq if dns-pinning is on.
+
+### Tier 5 — Tests
+
+- Unit: port allocator (concurrency), filter-script generation,
+  iptables-rule generation. All pure code — runs in CI.
+- Integration (live KVM): boot `claude-code-vm` with
+  `--egress-mode l3-plus-l7`, `curl https://api.anthropic.com/`
+  → 200, `curl https://google.com/` → 403 from proxy with
+  "egress: domain not on allowlist" body. Live-KVM only.
+- Cleanup-on-crash: SIGKILL the mvmctl parent, verify the
+  supervisor's child mitmdump dies (process group), verify
+  iptables rules are flushed by `mvmctl cache prune`.
+
+### Tier 6 — `mvmctl cache prune` orphan cleanup
+
+**File:** `crates/mvm-cli/src/commands/ops/cache.rs`.
+
+Walk `~/.mvm/egress/<vm_name>/` directories whose `vm_name` isn't
+in the running VM list; flush the corresponding iptables chain;
+remove the directory.
+
+### Tier 7 — `nix/images/examples/llm-agent/` README
+
+Recommend `--egress-mode l3-plus-l7` once the CA is set up. Show
+the L3-only fallback as the alternative for users who don't want
+to inject the CA.
+
+## Files (summary)
+
+| File | Change |
+|---|---|
+| `crates/mvm-runtime/src/vm/egress_proxy.rs` | Replace `StubEgressProxy` with `MitmdumpSupervisor` |
+| `crates/mvm-runtime/src/vm/dns_pin.rs` | new — dnsmasq supervisor |
+| `crates/mvm-runtime/src/vm/network.rs` | wire `apply_network_policy` to call the proxy |
+| `crates/mvm-cli/src/commands/ops/egress.rs` | new — `mvmctl egress init-ca` |
+| `crates/mvm-cli/src/commands/vm/up.rs` | new `--egress-mode` flag |
+| `crates/mvm-cli/src/commands/env/doctor.rs` | report mitmdump availability |
+| `crates/mvm-cli/src/commands/ops/cache.rs` | orphan-cleanup pass |
+| `nix/lib/minimal-init/lib/04-etc-and-users.sh.in` | install CA cert at boot |
+| `nix/images/examples/llm-agent/README.md` | recommend `--egress-mode l3-plus-l7` |
+
+## Sequence
+
+Roughly one sprint:
+
+- Day 1-2: port allocator + mitmdump supervisor + filter-script
+  generation. Unit tests.
+- Day 3: CA-cert tooling (`mvmctl egress init-ca`, doctor probe).
+- Day 4: wire-up in `apply_network_policy` + `up.rs` flag. Live
+  KVM smoke against `claude-code-vm`.
+- Day 5: `mvmctl cache prune` orphan handling. README updates.
+- Day 6 (stretch): DNS pinning via dnsmasq.
+
+## Reversal cost
+
+- Drop `MitmdumpSupervisor` → fall back to `StubEgressProxy` (current
+  state of plan 34's foundation branch). The schema change
+  (`EgressMode::L3PlusL7`) stays — clients setting it just get the
+  `NotImplemented` error.
+- `mvmctl egress init-ca` is a separate subcommand; removing it is
+  contained.
+- DNS-pinning (tier 3) is independent of the L7 proxy; can land
+  separately or roll back without affecting L3 / L7.
+
+## References
+
+- ADR-004: `specs/adrs/004-hypervisor-egress-policy.md`
+- ADR-002: `specs/adrs/002-microvm-security-posture.md`
+- Plan 32: `specs/plans/32-mcp-agent-adoption.md`
+- Inspiration: archie-judd/agent-sandbox.nix's domain-allowlist
+  proxy, mitmproxy upstream docs.


### PR DESCRIPTION
## Summary

Lays the foundation for the L7 HTTPS-proxy + DNS-pinning tier of ADR-004 — schema + integration trait. Runtime backing (mitmdump supervisor) is scoped in the new plan 34. This branch ships the type-level work today so callers that opt into L7 mode get a clear "not implemented" error from the runtime instead of a silent downgrade to L3.

Stacked on #22 (A.2 v2). Final piece of the plan-32 series.

## What's in

**Schema (mvm-core):**
- `EgressMode` enum (`Open` / `L3Only` / `L3PlusL7`). Default = `Open`. Parses canonical + aliases (`l3`, `l7`, `l3+l7`). Display + Serde roundtrip + 6 unit tests.

**Runtime (mvm-runtime):**
- New `mvm_runtime::vm::egress_proxy` module:
  - `pub trait EgressProxy { start_for_vm, stop_for_vm }` — integration point plan 34's `MitmdumpSupervisor` will implement.
  - `pub struct ProxyHandle { vm_name, listen_port }`.
  - `pub enum EgressProxyError { NotImplemented, Other }` — stable across stub + plan-34 real impl. Display message points at plan 34 by name (asserted by test).
  - `pub struct StubEgressProxy` returns `NotImplemented` from start; stop is no-op so cleanup paths don't error spuriously.
  - `pub fn requires_l7(EgressMode) -> bool` lets callers skip proxy spawn for `Open`/`L3Only`.
  - 4 unit tests cover stub semantics + error message contract.

**Documentation:**
- `specs/plans/34-egress-l7-proxy.md` (new) sizes the L7 work into 7 tiers (mitmdump supervisor, CA cert tooling, optional dnsmasq DNS-pinning, wire-up, doctor probe, `mvmctl cache prune` orphan handling, README update). ~1 sprint.
- ADR-004 status updated to point at plan 34.

## Why this is a useful intermediate stop

- mvmd's hosted variant (plan 33) can already type-check against `EgressMode::L3PlusL7` without needing a wildcard match.
- llm-agent flake README can mention `l3-plus-l7` as the future recommended posture, with an explicit "not implemented yet" link to plan 34.
- The runtime caller in `vm/network.rs` will plug the supervisor into a stable trait, instead of refactoring the call site too when plan 34 lands.
- Reversal cost is trivial: drop `MitmdumpSupervisor` → `StubEgressProxy` (current state).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` all green (mvm-core 332→338 with 6 new EgressMode tests, mvm-runtime +4 egress_proxy tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Live integration test: `--egress-mode l3-plus-l7` against `claude-code-vm` (deferred — needs plan 34 implementation + live KVM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)