### PR TITLE
feat(security): plan 36 — sealed, signed builder image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,10 +151,16 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install --locked cargo-audit
 
       - name: Run audit
-        run: cargo audit
+        # Ignored advisories must mirror deny.toml's [advisories].ignore.
+        # cargo-audit doesn't read deny.toml; CLI flags keep both tools
+        # in sync. Plan 36 PR-A.2 introduced sigstore which transitively
+        # pulls rsa (RUSTSEC-2023-0071, threat-model not applicable to
+        # verification-only use) and proc-macro-error v1
+        # (RUSTSEC-2024-0370, build-time only).
+        run: cargo audit --ignore RUSTSEC-2025-0057 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0009
 
   deny:
     name: Supply chain (cargo-deny — ADR-002 §W5.2)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,11 +136,26 @@ jobs:
           nix build "./nix/images/builder#packages.${SYSTEM}.default" \
             --no-link --print-out-paths > /tmp/store-path.txt
           STORE_PATH=$(head -1 /tmp/store-path.txt)
+          echo "${STORE_PATH}" > /tmp/dev-store-path.txt
           mkdir -p staging
           cp "$STORE_PATH/vmlinux" "staging/dev-vmlinux-${ARCH}"
           cp "$STORE_PATH/rootfs.ext4" "staging/dev-rootfs-${ARCH}.ext4"
           cd staging
           sha256sum "dev-vmlinux-${ARCH}" "dev-rootfs-${ARCH}.ext4" > "dev-image-${ARCH}-checksums-sha256.txt"
+
+      # Plan 36: emit the cosign-signable SignedManifest JSON. The
+      # script lives at scripts/generate-image-manifest.sh and pins
+      # the schema that mvm-security::image_verify consumes.
+      - name: Generate signed-image manifest (plan 36)
+        env:
+          ARCH: ${{ matrix.arch }}
+          VARIANT: dev
+          ROOTFS_EXT: ext4
+          STAGING_DIR: ${{ github.workspace }}/staging
+        run: |
+          STORE_PATH=$(cat /tmp/dev-store-path.txt)
+          export STORE_PATH
+          bash scripts/generate-image-manifest.sh
 
       - name: Upload dev image artifacts
         uses: actions/upload-artifact@v7
@@ -150,6 +165,78 @@ jobs:
             staging/dev-vmlinux-${{ matrix.arch }}
             staging/dev-rootfs-${{ matrix.arch }}.ext4
             staging/dev-image-${{ matrix.arch }}-checksums-sha256.txt
+            staging/dev-image-${{ matrix.arch }}.manifest.json
+
+  # Plan 36 / ADR 005: the sealed builder image consumed by mvmd's
+  # pool-build pipeline. Same package set as the dev variant but
+  # sourced from the parent flake (no Exec handler, verifiedBoot=true,
+  # dm-verity sidecar emitted). Built without mvmctl's dev override —
+  # the `builder` output of nix/images/builder/flake.nix is wired to
+  # mvm-prod (the parent), so the prod guest agent lands in the
+  # rootfs regardless of any caller's --override-input.
+  builder-image:
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+          - arch: x86_64
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build sealed builder image
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          SYSTEM="${ARCH}-linux"
+          nix build "./nix/images/builder#packages.${SYSTEM}.builder" \
+            --no-link --print-out-paths > /tmp/store-path.txt
+          STORE_PATH=$(head -1 /tmp/store-path.txt)
+          echo "${STORE_PATH}" > /tmp/builder-store-path.txt
+          mkdir -p staging
+          cp "$STORE_PATH/vmlinux" "staging/builder-vmlinux-${ARCH}"
+          cp "$STORE_PATH/rootfs.ext4" "staging/builder-rootfs-${ARCH}.ext4"
+          # The builder variant ships dm-verity sidecars; mvmd-agent
+          # verifies them on every boot.
+          cp "$STORE_PATH/rootfs.verity" "staging/builder-rootfs-${ARCH}.verity"
+          cp "$STORE_PATH/rootfs.roothash" "staging/builder-rootfs-${ARCH}.roothash"
+          cp "$STORE_PATH/rootfs.initrd" "staging/builder-initrd-${ARCH}"
+          cd staging
+          sha256sum "builder-vmlinux-${ARCH}" \
+                    "builder-rootfs-${ARCH}.ext4" \
+                    "builder-rootfs-${ARCH}.verity" \
+                    "builder-rootfs-${ARCH}.roothash" \
+                    "builder-initrd-${ARCH}" \
+            > "builder-image-${ARCH}-checksums-sha256.txt"
+
+      - name: Generate signed-image manifest (plan 36)
+        env:
+          ARCH: ${{ matrix.arch }}
+          VARIANT: builder
+          ROOTFS_EXT: ext4
+          STAGING_DIR: ${{ github.workspace }}/staging
+        run: |
+          STORE_PATH=$(cat /tmp/builder-store-path.txt)
+          export STORE_PATH
+          bash scripts/generate-image-manifest.sh
+
+      - name: Upload builder image artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: builder-image-${{ matrix.arch }}
+          path: |
+            staging/builder-vmlinux-${{ matrix.arch }}
+            staging/builder-rootfs-${{ matrix.arch }}.ext4
+            staging/builder-rootfs-${{ matrix.arch }}.verity
+            staging/builder-rootfs-${{ matrix.arch }}.roothash
+            staging/builder-initrd-${{ matrix.arch }}
+            staging/builder-image-${{ matrix.arch }}-checksums-sha256.txt
+            staging/builder-image-${{ matrix.arch }}.manifest.json
 
   default-microvm:
     # Build the bundled default microVM image used by `mvmctl exec` /
@@ -194,7 +281,7 @@ jobs:
             staging/default-microvm-${{ matrix.arch }}-checksums-sha256.txt
 
   release:
-    needs: [build, dev-image, default-microvm]
+    needs: [build, dev-image, builder-image, default-microvm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -246,6 +333,29 @@ jobs:
             sbom.cdx.json
           echo "Signed: sbom.cdx.json"
 
+      # Plan 36 / ADR 005: cosign-keyless-sign each per-(arch, variant)
+      # SignedManifest JSON. The bundle (.bundle) carries the signature,
+      # the Fulcio short-lived cert, and the Rekor inclusion proof —
+      # mvm-security::image_verify consumes exactly this format.
+      - name: Sign image manifests (plan 36)
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          manifests=(artifacts/*-image-*.manifest.json)
+          if [ "${#manifests[@]}" -eq 0 ]; then
+            echo "::error::no image manifests found in artifacts/" >&2
+            ls -la artifacts/ >&2 || true
+            exit 1
+          fi
+          for manifest in "${manifests[@]}"; do
+            cosign sign-blob \
+              --yes \
+              --bundle "${manifest}.bundle" \
+              "${manifest}"
+            echo "Signed: ${manifest}"
+          done
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -260,6 +370,14 @@ jobs:
             artifacts/dev-vmlinux-* \
             artifacts/dev-rootfs-* \
             artifacts/dev-image-*-checksums-sha256.txt \
+            artifacts/dev-image-*.manifest.json \
+            artifacts/dev-image-*.manifest.json.bundle \
+            artifacts/builder-vmlinux-* \
+            artifacts/builder-rootfs-* \
+            artifacts/builder-initrd-* \
+            artifacts/builder-image-*-checksums-sha256.txt \
+            artifacts/builder-image-*.manifest.json \
+            artifacts/builder-image-*.manifest.json.bundle \
             artifacts/default-microvm-vmlinux-* \
             artifacts/default-microvm-rootfs-* \
             artifacts/default-microvm-*-checksums-sha256.txt \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -282,7 +282,12 @@ jobs:
             fi
             mv "$d/flake.lock.original" "$d/flake.lock"
             echo "::endgroup::"
-          done < <(find . -name flake.nix -not -path './target/*' -not -path './.git/*' -not -path './node_modules/*')
+          done < <(find . -name flake.nix \
+            -not -path './target/*' \
+            -not -path './.git/*' \
+            -not -path './node_modules/*' \
+            -not -path './*/resources/template_scaffold/*' \
+            -not -path './resources/template_scaffold/*')
           exit "$fail"
 
   # ── Lane 8: Builder image reproducibility (plan 36 §Layer 0) ───────

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -238,3 +238,110 @@ jobs:
             exit 1
           fi
           echo "ok: rootfs.{ext4,verity,roothash} present, roothash=${hash:0:12}…"
+
+  # ── Lane 7: Flake lockfile cleanliness (plan 36 §Layer 0) ──────────
+  # Every flake.lock in the repo must be committed and in sync with
+  # its flake.nix. A stale lock means the input closure recorded in a
+  # signed manifest doesn't match what nix would actually use on
+  # rebuild — the trust chain breaks silently. Cheap (eval-only).
+  flake-locks-clean:
+    name: Flake locks — committed + in sync (plan 36 §Layer 0)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Assert every flake.lock is committed and in sync
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r flake; do
+            d=$(dirname "$flake")
+            echo "::group::$d"
+            if [ ! -f "$d/flake.lock" ]; then
+              echo "::error::missing $d/flake.lock — every flake must commit its lockfile (plan 36 §Layer 0)" >&2
+              fail=1
+              echo "::endgroup::"
+              continue
+            fi
+            # `nix flake lock` updates the lockfile if it diverges from
+            # flake.nix. If `git diff --quiet` reports nothing changed,
+            # the committed lock is authoritative for the current
+            # flake.nix inputs.
+            cp "$d/flake.lock" "$d/flake.lock.original"
+            nix flake lock "$d" 2>&1 || true
+            if ! diff -q "$d/flake.lock" "$d/flake.lock.original" > /dev/null; then
+              echo "::error::$d/flake.lock is out of sync with $d/flake.nix" >&2
+              echo "Run \`nix flake lock $d\` locally and commit the updated lockfile." >&2
+              diff -u "$d/flake.lock.original" "$d/flake.lock" | head -40 >&2 || true
+              fail=1
+            else
+              echo "ok"
+            fi
+            mv "$d/flake.lock.original" "$d/flake.lock"
+            echo "::endgroup::"
+          done < <(find . -name flake.nix -not -path './target/*' -not -path './.git/*' -not -path './node_modules/*')
+          exit "$fail"
+
+  # ── Lane 8: Builder image reproducibility (plan 36 §Layer 0) ───────
+  # Build the new mvm-builder-prod sealed image twice and assert the
+  # outputs are byte-identical. Catches non-determinism (timestamps in
+  # compressed layers, embedded host paths, builder-host nonces) that
+  # would silently break the cosign-signed manifest's nix_store_hash
+  # field. Heavy (~10 min for the double build), so PR-skipped — runs
+  # on push to main, schedule, and workflow_dispatch only. The mvmctl
+  # binary's reproducibility lane (above) covers PR feedback for the
+  # cheap case.
+  builder-image-reproducibility:
+    name: Builder image reproducibility (plan 36 §Layer 0)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build A
+        run: |
+          set -euo pipefail
+          nix build "./nix/images/builder#packages.x86_64-linux.builder" \
+            --no-link --print-out-paths > /tmp/path-a.txt
+          out=$(head -1 /tmp/path-a.txt)
+          # Hash the contents under stable relative names so the
+          # store path component (which encodes input-hash, not output)
+          # doesn't pollute the comparison.
+          ( cd "$out" && sha256sum rootfs.ext4 rootfs.verity rootfs.roothash vmlinux ) > /tmp/hash-a.txt
+          cat /tmp/hash-a.txt
+
+      - name: Build B (force rebuild)
+        run: |
+          set -euo pipefail
+          nix build "./nix/images/builder#packages.x86_64-linux.builder" \
+            --rebuild --no-link --print-out-paths > /tmp/path-b.txt
+          out=$(head -1 /tmp/path-b.txt)
+          ( cd "$out" && sha256sum rootfs.ext4 rootfs.verity rootfs.roothash vmlinux ) > /tmp/hash-b.txt
+          cat /tmp/hash-b.txt
+
+      - name: Compare hashes
+        run: |
+          set -euo pipefail
+          if ! diff -q /tmp/hash-a.txt /tmp/hash-b.txt > /dev/null; then
+            echo "::error::Builder image is non-deterministic — two clean builds produced different artifacts" >&2
+            echo "Plan 36 §Layer 0 requires the sealed builder image to reproduce byte-for-byte so the" >&2
+            echo "cosign-signed manifest's nix_store_hash and per-artifact sha256 fields are stable." >&2
+            echo >&2
+            echo "Build A:" >&2
+            cat /tmp/hash-a.txt >&2
+            echo >&2
+            echo "Build B:" >&2
+            cat /tmp/hash-b.txt >&2
+            echo >&2
+            echo "Diff:" >&2
+            diff -u /tmp/hash-a.txt /tmp/hash-b.txt >&2 || true
+            exit 1
+          fi
+          echo "ok: builder image reproduces byte-identically across two clean builds"
+          cat /tmp/hash-a.txt

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,7 +55,10 @@ jobs:
         run: cargo install --locked cargo-audit
 
       - name: cargo audit
-        run: cargo audit
+        # Ignored advisories must mirror deny.toml's `[advisories].ignore`.
+        # cargo-audit doesn't read deny.toml; CLI flags are the
+        # discoverable way to keep the two tools in sync.
+        run: cargo audit --ignore RUSTSEC-2025-0057 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0009
 
   # ── Lane 2: Production-agent symbol gate ──────────────────────────
   # ADR-002 §W4.3 — production builds of mvm-guest-agent must not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,10 +1606,14 @@ version = "0.13.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "chrono",
  "mvm-core",
  "regex",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -2103,7 +2107,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2124,7 +2128,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2752,11 +2756,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,38 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +124,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,7 +142,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -115,6 +158,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.13.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "regex",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-fips-sys",
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +206,24 @@ dependencies = [
  "gloo-timers",
  "tokio",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -136,6 +236,26 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bitflags"
@@ -154,6 +274,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -197,13 +326,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -255,6 +404,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,7 +465,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -314,6 +485,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +506,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -365,6 +555,37 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -448,6 +669,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +688,21 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -492,8 +740,84 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "decoded-char"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5440d1dc8ea7cae44cda3c64568db29bfa2434aba51ae66a50c00488841a65a3"
 
 [[package]]
 name = "der"
@@ -502,7 +826,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -549,7 +928,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -562,10 +941,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
 
 [[package]]
 name = "ed25519"
@@ -597,6 +996,27 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -633,6 +1053,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +1086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +1105,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -696,6 +1138,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +1160,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -735,6 +1184,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,7 +1208,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -806,6 +1266,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -849,6 +1310,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +1364,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +1417,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +1451,15 @@ checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1027,7 +1544,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1156,6 +1673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1713,17 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1235,6 +1769,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -1286,10 +1830,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1300,6 +1930,67 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "json-number"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479dfd2ad8e4b4ae076b031f72ef2f3791f65e2a0f51e5f3408dbf716c4c2f82"
+dependencies = [
+ "lexical",
+ "ryu-js",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "json-syntax"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "044a68aba3f96d712f492b72be25e10f96201eaaca3207a7d6e68d6d5105fda9"
+dependencies = [
+ "decoded-char",
+ "hashbrown 0.12.3",
+ "indexmap 1.9.3",
+ "json-number",
+ "locspan",
+ "locspan-derive",
+ "ryu-js",
+ "serde",
+ "smallstr",
+ "smallvec",
+ "utf8-decode",
+]
+
+[[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common",
+ "digest",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
@@ -1326,6 +2017,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1334,10 +2028,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc8a009b2ff1f419ccc62706f04fe0ca6e67b37460513964a3dfdb919bb37d6"
+dependencies = [
+ "lexical-core",
+]
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -1389,6 +2159,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "locspan"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33890449fcfac88e94352092944bf321f55e5deb4e289a6f51c87c55731200a0"
+
+[[package]]
+name = "locspan-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88991223b049a3d29ca1f60c05639581336a0f3ee4bf8a659dddecc11c4961a"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +2223,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +2267,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mvm-apple-container"
@@ -1522,7 +2338,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "which",
+ "which 7.0.3",
 ]
 
 [[package]]
@@ -1530,7 +2346,7 @@ name = "mvm-core"
 version = "0.13.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "fs2",
  "regex",
@@ -1578,7 +2394,7 @@ name = "mvm-runtime"
 version = "0.13.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "colored",
  "ed25519-dalek",
  "indicatif",
@@ -1612,8 +2428,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sigstore",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
 ]
 
@@ -1646,6 +2464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "newline-converter"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,6 +2488,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1722,12 +2556,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1735,6 +2612,26 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
 
 [[package]]
 name = "objc2"
@@ -1802,6 +2699,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-client"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "oci-spec",
+ "olpc-cjson",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +2765,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "opendal"
 version = "0.50.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,7 +2779,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backon",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc32c",
@@ -1844,6 +2801,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "openidconnect"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac",
+ "http",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,6 +2848,30 @@ checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -1883,6 +2904,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1921,7 +2982,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1932,6 +2993,17 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -1973,6 +3045,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,12 +3077,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
+ "pkcs5",
+ "rand_core 0.6.4",
  "spki",
 ]
 
@@ -1999,6 +3119,17 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2014,6 +3145,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2061,7 +3198,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2071,6 +3263,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "base64 0.22.1",
+ "prost",
+ "prost-reflect-derive",
+ "prost-types",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "prost-reflect-build"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8214ae2c30bbac390db0134d08300e770ef89b6d4e5abf855e8d300eded87e28"
+dependencies = [
+ "prost-build",
+ "prost-reflect",
+]
+
+[[package]]
+name = "prost-reflect-derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6d90e29fa6c0d13c2c19ba5e4b3fb0efbf5975d27bcf4e260b7b15455bcabe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2241,6 +3519,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,7 +3575,7 @@ checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "form_urlencoded",
  "getrandom 0.2.17",
@@ -2304,7 +3602,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2317,6 +3615,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2341,6 +3640,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,7 +3659,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2359,6 +3668,26 @@ name = "roff"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf2048e0e979efb2ca7b91c4f1a8d77c91853e9b987c94c555668a8994915ad"
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rust-ini"
@@ -2404,6 +3733,8 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2428,9 +3759,10 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2446,6 +3778,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2455,10 +3802,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "seccompiler"
@@ -2486,6 +3883,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,7 +3909,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2516,6 +3923,37 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2537,6 +3975,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2613,8 +4082,106 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "sigstore"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bba786054331bdc89e90f74373b68a6c3b63c9754cf20e3a4a629d0165fe38"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "chrono",
+ "const-oid",
+ "crypto_secretbox",
+ "digest",
+ "ecdsa",
+ "ed25519",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "futures",
+ "futures-util",
+ "hex",
+ "json-syntax",
+ "oci-client",
+ "openidconnect",
+ "p256",
+ "p384",
+ "pem",
+ "pkcs1",
+ "pkcs8",
+ "rand 0.8.6",
+ "reqwest",
+ "rsa",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "sha2",
+ "signature",
+ "sigstore_protobuf_specs",
+ "thiserror 2.0.18",
+ "tls_codec",
+ "tokio",
+ "tokio-util",
+ "tough",
+ "tracing",
+ "url",
+ "webbrowser",
+ "x509-cert",
+ "zeroize",
+]
+
+[[package]]
+name = "sigstore-protobuf-specs-derive"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80baa401f274093f7bb27d7a69d6139cbc11f1b97624e9a61a9b3ea32c776a35"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sigstore_protobuf_specs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd627b4d5240ac660de3357b5d0156d5c63b872be1deae5046c3c8eb65d488e2"
+dependencies = [
+ "anyhow",
+ "glob",
+ "prost",
+ "prost-build",
+ "prost-reflect",
+ "prost-reflect-build",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "sigstore-protobuf-specs-derive",
+ "which 8.0.2",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -2639,10 +4206,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallstr"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b"
+dependencies = [
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "futures-core",
+ "pin-project",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "socket2"
@@ -2653,6 +4253,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -2677,10 +4283,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2710,7 +4345,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2780,7 +4415,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2791,7 +4426,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2801,6 +4436,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2838,6 +4504,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,7 +4549,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2915,7 +4602,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2928,6 +4615,41 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tough"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88d0ee9525696569cc2af5d46f8a739028c0268895071e0386957195b0c9161"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "aws-lc-rs",
+ "bytes",
+ "chrono",
+ "dyn-clone",
+ "futures",
+ "futures-core",
+ "globset",
+ "hex",
+ "log",
+ "olpc-cjson",
+ "pem",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "snafu",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "typed-path",
+ "untrusted 0.7.1",
+ "url",
+ "walkdir",
+]
 
 [[package]]
 name = "tower"
@@ -2980,6 +4702,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2993,7 +4716,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3055,6 +4778,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,10 +4796,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -3097,6 +4841,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,7 +4872,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "utf8-decode"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
 
 [[package]]
 name = "utf8_iter"
@@ -3248,7 +5015,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3278,7 +5045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3304,7 +5071,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -3329,6 +5096,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,6 +5130,15 @@ dependencies = [
  "env_home",
  "rustix",
  "winsafe",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3401,7 +5193,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3412,7 +5204,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3713,9 +5505,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3731,7 +5523,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3744,7 +5536,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -3763,7 +5555,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -3778,6 +5570,20 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "sha1",
+ "signature",
+ "spki",
+ "tls_codec",
+]
 
 [[package]]
 name = "xtask"
@@ -3809,7 +5615,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3830,7 +5636,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3850,7 +5656,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3859,6 +5665,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3890,7 +5710,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/mvm-apple-container/src/lib.rs
+++ b/crates/mvm-apple-container/src/lib.rs
@@ -24,20 +24,27 @@ pub fn is_available() -> bool {
 
 /// Optional dm-verity attestation alongside a rootfs. When `Some`, the
 /// backend attaches the Merkle tree as a second VirtioBlk device and
-/// sets up a kernel `dm-mod.create=` cmdline so the verity target is
-/// constructed before init runs. ADR-002 §W3.2.
+/// boots the VM with the verity initramfs at `initrd_path`, which
+/// reads `mvm.roothash=` from the kernel cmdline, builds the
+/// device-mapper target via raw ioctls, and `switch_root`s to the
+/// real init. ADR-002 §W3.
 ///
-/// Both fields must be present together — a verity sidecar without a
-/// root hash is unverifiable, and a root hash without the sidecar is
-/// unconstructible. `None` means the backend boots the rootfs as
-/// `/dev/vda rw` with no integrity check (the dev-VM exemption from
-/// ADR-002 §W3.4).
+/// All three fields must be present together — a verity sidecar
+/// without a root hash is unverifiable, a root hash without the
+/// sidecar is unconstructible, and either without the initramfs has
+/// no way to wire up the device-mapper target before the kernel
+/// commits to a root device. `None` means the backend boots the
+/// rootfs as `/dev/vda rw` with no integrity check (the dev-VM
+/// exemption from ADR-002 §W3.4).
 #[derive(Debug, Clone)]
 pub struct VerityConfig<'a> {
     /// Path to `rootfs.verity` (the Merkle hash tree).
     pub verity_path: &'a str,
     /// 64-char lowercase hex root hash.
     pub roothash: &'a str,
+    /// Path to the verity initramfs (cpio.gz). Baked alongside the
+    /// rootfs by `mkGuest` when `verifiedBoot = true`.
+    pub initrd_path: &'a str,
 }
 
 /// Start a VM from a local kernel + ext4 rootfs using Virtualization.framework.

--- a/crates/mvm-apple-container/src/macos.rs
+++ b/crates/mvm-apple-container/src/macos.rs
@@ -475,6 +475,9 @@ pub fn start_vm(
         if !Path::new(v.verity_path).exists() {
             return Err(format!("Verity sidecar not found: {}", v.verity_path));
         }
+        if !Path::new(v.initrd_path).exists() {
+            return Err(format!("Verity initramfs not found: {}", v.initrd_path));
+        }
         if v.roothash.len() != 64 || !v.roothash.chars().all(|c| c.is_ascii_hexdigit()) {
             return Err(format!(
                 "Invalid root hash {:?} (expected 64 hex chars)",
@@ -537,11 +540,14 @@ pub fn start_vm(
             .ok()
             .filter(|s| s.starts_with('/') && s != "/")
             .filter(|s| !s.contains([' ', '\t', '\n', '=']));
-        // When dm-verity is on, the rootfs is mounted via /dev/dm-0
-        // (the verity-protected mapping) and is read-only by definition
-        // — verity hashes are tied to fixed bytes. ADR-002 §W3.2.
+        // When dm-verity is on we boot via the verity initramfs (its
+        // PID 1 is `mvm-verity-init`, which reads `mvm.roothash=` from
+        // the cmdline, constructs /dev/mapper/root, and switch_root's
+        // to /sysroot/init). The kernel-level `root=` setting is
+        // irrelevant in that case — the initramfs picks the real root
+        // explicitly. ADR-002 §W3.
         let mut cmdline = if verity.is_some() {
-            "console=hvc0 root=/dev/dm-0 ro init=/init".to_string()
+            "console=hvc0 init=/init".to_string()
         } else {
             "console=hvc0 root=/dev/vda rw init=/init".to_string()
         };
@@ -552,34 +558,17 @@ pub fn start_vm(
             cmdline.push_str(&format!(" mvm.datadir={p}"));
         }
         if let Some(v) = &verity {
-            // The verity sidecar is the second VirtioBlk device → /dev/vdb
-            // when there's no overlayfs upper. dm-mod.create syntax:
-            //   <name>,<uuid>,<minor>,<flags>,<table-line>
-            // Empty fields default; `ro` is the only flag. Table line for
-            // verity:
-            //   <start-sector> <num-sectors> verity <version> <data-dev>
-            //   <hash-dev> <data-block-size> <hash-block-size>
-            //   <num-data-blocks> <hash-start-block> <algo> <root-hash>
-            //   <salt>  [#opt-args ...]
-            //
-            // We size num-data-blocks from the rootfs size (in 4 KiB
-            // blocks). hash-start-block is 0 because the sidecar is its
-            // own device. salt is zero (matches the deterministic salt
-            // pinned by mkGuest's verityArtifacts).
-            let rootfs_bytes = std::fs::metadata(rootfs_path)
-                .map_err(|e| format!("verity rootfs metadata: {e}"))?
-                .len();
-            // Verity blocks are 4096 bytes; the data area is the rootfs's
-            // exact byte length rounded down to the block size. The
-            // veritysetup format pass already rejected non-aligned input.
-            let data_blocks = rootfs_bytes / 4096;
-            let num_sectors = data_blocks * 8; // 4096 / 512
-            let dm_table = format!(
-                "0 {num_sectors} verity 1 /dev/vda /dev/vdb 4096 4096 {data_blocks} 0 sha256 {} {}",
-                v.roothash,
-                "0".repeat(64),
-            );
-            cmdline.push_str(&format!(" dm-mod.create=rootfs,,,ro,{dm_table}"));
+            // mvm-verity-init reads these three knobs from /proc/cmdline:
+            //   mvm.roothash=<hex>   (required)
+            //   mvm.data=<dev>       (defaults to /dev/vda)
+            //   mvm.hash=<dev>       (defaults to /dev/vdb)
+            // The defaults match our drive ordering, so we only need
+            // to pass the roothash.
+            cmdline.push_str(&format!(" mvm.roothash={}", v.roothash));
+            // Attach the verity initramfs. The objc2 binding marks the
+            // setter as safe; we're already inside the surrounding
+            // `unsafe` block from the rest of `start_vm`.
+            boot_loader.setInitialRamdiskURL(Some(&nsurl(v.initrd_path)));
         }
         boot_loader.setCommandLine(&NSString::from_str(&cmdline));
 
@@ -1180,28 +1169,32 @@ mod tests {
     // contract so a refactor that loosens the check (e.g., accepting
     // uppercase hex, accepting wrong lengths) is caught immediately.
 
-    fn dummy_paths() -> (tempfile::TempDir, String, String, String) {
+    fn dummy_paths() -> (tempfile::TempDir, String, String, String, String) {
         let dir = tempfile::tempdir().unwrap();
         let kernel = dir.path().join("vmlinux");
         let rootfs = dir.path().join("rootfs.ext4");
         let verity = dir.path().join("rootfs.verity");
+        let initrd = dir.path().join("rootfs.initrd");
         std::fs::write(&kernel, b"FAKE_KERNEL").unwrap();
         std::fs::write(&rootfs, vec![0u8; 4096]).unwrap();
         std::fs::write(&verity, b"FAKE_VERITY").unwrap();
+        std::fs::write(&initrd, b"FAKE_INITRD").unwrap();
         (
             dir,
             kernel.to_string_lossy().into(),
             rootfs.to_string_lossy().into(),
             verity.to_string_lossy().into(),
+            initrd.to_string_lossy().into(),
         )
     }
 
     #[test]
     fn start_vm_rejects_short_roothash() {
-        let (_dir, k, r, v) = dummy_paths();
+        let (_dir, k, r, v, i) = dummy_paths();
         let cfg = crate::VerityConfig {
             verity_path: &v,
             roothash: "deadbeef",
+            initrd_path: &i,
         };
         let err = start_vm("test-id", &k, &r, 1, 256, Some(cfg)).unwrap_err();
         assert!(
@@ -1212,11 +1205,12 @@ mod tests {
 
     #[test]
     fn start_vm_rejects_non_hex_roothash() {
-        let (_dir, k, r, v) = dummy_paths();
+        let (_dir, k, r, v, i) = dummy_paths();
         let bad = "z".repeat(64);
         let cfg = crate::VerityConfig {
             verity_path: &v,
             roothash: &bad,
+            initrd_path: &i,
         };
         let err = start_vm("test-id", &k, &r, 1, 256, Some(cfg)).unwrap_err();
         assert!(
@@ -1227,16 +1221,33 @@ mod tests {
 
     #[test]
     fn start_vm_rejects_missing_verity_sidecar() {
-        let (_dir, k, r, _v) = dummy_paths();
+        let (_dir, k, r, _v, i) = dummy_paths();
         let valid_hash = "a".repeat(64);
         let cfg = crate::VerityConfig {
             verity_path: "/nonexistent/path/to/rootfs.verity",
             roothash: &valid_hash,
+            initrd_path: &i,
         };
         let err = start_vm("test-id", &k, &r, 1, 256, Some(cfg)).unwrap_err();
         assert!(
             err.contains("Verity sidecar not found"),
             "expected missing-sidecar error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn start_vm_rejects_missing_verity_initrd() {
+        let (_dir, k, r, v, _i) = dummy_paths();
+        let valid_hash = "a".repeat(64);
+        let cfg = crate::VerityConfig {
+            verity_path: &v,
+            roothash: &valid_hash,
+            initrd_path: "/nonexistent/path/to/rootfs.initrd",
+        };
+        let err = start_vm("test-id", &k, &r, 1, 256, Some(cfg)).unwrap_err();
+        assert!(
+            err.contains("Verity initramfs not found"),
+            "expected missing-initramfs error, got: {err}"
         );
     }
 }

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1099,7 +1099,167 @@ fn try_fetch_signed_manifest(
         ));
     }
 
+    // Plan 36 §Layer 4 step 4: consult the cosign-signed revocation
+    // list. Cached up to 24h; tolerated up to 7d offline. A signed
+    // image whose version is on the list hard-fails — recall is the
+    // primary mechanism for "we know this build is bad."
+    if let Some(revocations) = try_fetch_revocation_list()? {
+        image_verify::check_revocation(&manifest, &revocations).map_err(|e| {
+            anyhow::anyhow!(
+                "Dev image manifest is on the project's revocation list: {e}\n\
+                 \n\
+                 Plan 36 / ADR 005: a published `revocations` release entry has\n\
+                 marked v{version} unsafe to run. Refusing to use this image.\n\
+                 Upgrade mvmctl to a non-revoked release."
+            )
+        })?;
+    }
+
     Ok(Some(manifest))
+}
+
+/// Fetch + verify the project's signed revocation list, caching it
+/// under `~/.cache/mvm/revocations/`.
+///
+/// Plan 36 §Layer 4 step 4. The revocation list lives at a stable
+/// `revocations` release tag whose only assets are
+/// `revoked-versions.json` and its cosign bundle. Append-only across
+/// releases; updated by cutting a new entry on that tag.
+///
+/// Cache policy:
+///   - Refresh from upstream if the cached file is >24h old.
+///   - Tolerate up to 7d of cached staleness when the network is
+///     unavailable; surface a warning rather than blocking.
+///   - 404 on the upstream URL is treated as "no recalls today" —
+///     bootstrap state until the project publishes its first
+///     revocations entry. Returns Ok(None).
+///
+/// Returns Ok(None) when the list isn't available *and* we have no
+/// cached copy — caller proceeds without revocation enforcement (with
+/// a warning). Returns Err on signature verification failure.
+fn try_fetch_revocation_list() -> Result<Option<mvm_security::image_verify::RevocationList>> {
+    use mvm_security::image_verify;
+    use std::time::{Duration, SystemTime};
+
+    let cache_dir = format!("{}/revocations", mvm_core::config::mvm_cache_dir());
+    std::fs::create_dir_all(&cache_dir)
+        .with_context(|| format!("creating revocations cache dir {cache_dir}"))?;
+    let cache_json = format!("{cache_dir}/revoked-versions.json");
+    let cache_bundle = format!("{cache_dir}/revoked-versions.json.bundle");
+
+    let cache_age = std::fs::metadata(&cache_json)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| SystemTime::now().duration_since(t).ok())
+        .unwrap_or(Duration::from_secs(u64::MAX));
+
+    let twenty_four_hours = Duration::from_secs(24 * 60 * 60);
+    let seven_days = Duration::from_secs(7 * 24 * 60 * 60);
+
+    // Refresh if cache is stale (or absent).
+    if cache_age > twenty_four_hours {
+        let base = "https://github.com/auser/mvm/releases/download/revocations";
+        let json_url = format!("{base}/revoked-versions.json");
+        let bundle_url = format!("{base}/revoked-versions.json.bundle");
+
+        match url_exists(&json_url) {
+            Ok(true) => {
+                let tmp_json =
+                    tempfile::NamedTempFile::new().context("creating revocations tempfile")?;
+                let tmp_bundle = tempfile::NamedTempFile::new()
+                    .context("creating revocations bundle tempfile")?;
+                let tmp_json_path = tmp_json.path().to_string_lossy().into_owned();
+                let tmp_bundle_path = tmp_bundle.path().to_string_lossy().into_owned();
+                let download_result = download_file(&json_url, &tmp_json_path)
+                    .and_then(|()| download_file(&bundle_url, &tmp_bundle_path));
+                match download_result {
+                    Ok(()) => {
+                        std::fs::copy(&tmp_json_path, &cache_json)
+                            .context("caching revoked-versions.json")?;
+                        std::fs::copy(&tmp_bundle_path, &cache_bundle)
+                            .context("caching revoked-versions.json.bundle")?;
+                    }
+                    Err(e) if cache_age <= seven_days => {
+                        ui::warn(&format!(
+                            "Could not refresh revocation list ({e}); using cached copy \
+                             (last refreshed {} hours ago).",
+                            cache_age.as_secs() / 3600
+                        ));
+                    }
+                    Err(e) => {
+                        ui::warn(&format!(
+                            "Could not refresh revocation list ({e}) and no fresh cache \
+                             is available; proceeding without recall enforcement. \
+                             Plan 36 §Layer 4."
+                        ));
+                        return Ok(None);
+                    }
+                }
+            }
+            Ok(false) => {
+                // 404: the project hasn't published a revocations
+                // release yet. Bootstrap state — no recalls means
+                // nothing to enforce. Don't cache this; a future
+                // refresh should pick up the first published list.
+                return Ok(None);
+            }
+            Err(e) if cache_age <= seven_days => {
+                ui::warn(&format!(
+                    "Could not probe revocation list ({e}); using cached copy."
+                ));
+            }
+            Err(e) => {
+                ui::warn(&format!(
+                    "Could not probe revocation list ({e}) and no fresh cache \
+                     is available; proceeding without recall enforcement."
+                ));
+                return Ok(None);
+            }
+        }
+    }
+
+    // No cached file → nothing to enforce.
+    if !std::path::Path::new(&cache_json).exists() {
+        return Ok(None);
+    }
+
+    let json_bytes = std::fs::read(&cache_json).context("reading cached revocations.json")?;
+    let bundle_bytes =
+        std::fs::read(&cache_bundle).context("reading cached revocations.json.bundle")?;
+
+    // The revocations tag is signed by a dedicated revocations
+    // workflow's OIDC identity, not the per-release workflow. A
+    // separate identity ensures a leaked image-signing cert can't
+    // fabricate a permissive revocation list (and vice versa).
+    let expected_identity =
+        "https://github.com/auser/mvm/.github/workflows/revocations.yml@refs/tags/revocations";
+    let expected_issuer = "https://token.actions.githubusercontent.com";
+
+    if std::env::var_os("MVM_SKIP_COSIGN_VERIFY").is_some() {
+        // The same MVM_SKIP_COSIGN_VERIFY emergency-rotation escape
+        // hatch covers both the manifest and the revocation list.
+        // SHA-256 of artifacts still applies separately at the
+        // verify_artifact_hash callsite.
+        let list: image_verify::RevocationList = serde_json::from_slice(&json_bytes)
+            .context("parsing revocations JSON without signature verification")?;
+        return Ok(Some(list));
+    }
+
+    image_verify::verify_signed_payload(
+        &json_bytes,
+        &bundle_bytes,
+        expected_identity,
+        expected_issuer,
+    )
+    .map_err(|e| {
+        anyhow::anyhow!(
+            "Revocation list signature verification failed: {e}. Refusing to \
+             trust an unverified recall. Plan 36 §Layer 4."
+        )
+    })?;
+    let list: image_verify::RevocationList =
+        serde_json::from_slice(&json_bytes).context("parsing verified revocations JSON")?;
+    Ok(Some(list))
 }
 
 /// HEAD-probe a URL. Returns Ok(true) when the resource is reachable

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1295,6 +1295,173 @@ fn try_fetch_revocation_list() -> Result<Option<mvm_security::image_verify::Revo
     Ok(Some(list))
 }
 
+/// `mvmctl dev import-image` — sideload a verified dev image from local files.
+///
+/// Plan 36 PR-D.2 / §"Air-gapped install path". Runs the same
+/// cosign + SHA-256 + version-pin + max-age + revocation pipeline
+/// as `download_dev_image`, but against operator-provided local
+/// files instead of the GitHub Releases URL. On success the verified
+/// artifacts are copied into the version-namespaced cache so the next
+/// `mvmctl dev up` boots from them with no further verification or
+/// network round-trip.
+///
+/// The intended user is anyone running mvmctl in a regulated /
+/// gov / air-gapped environment that can't reach github.com but
+/// that legitimately wants the supply-chain check. Without this
+/// path the only option for these users was MVM_SKIP_HASH_VERIFY=1,
+/// which disables verification entirely — exactly the unsafe escape
+/// plan 36 exists to discourage.
+pub fn cmd_dev_import_image(
+    manifest_path: &str,
+    bundle_path: &str,
+    vmlinux_path: &str,
+    rootfs_path: &str,
+) -> Result<()> {
+    use mvm_security::image_verify;
+
+    let version = env!("CARGO_PKG_VERSION");
+    let arch = if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    };
+
+    ui::info(&format!(
+        "Importing dev image (v{version}, {arch}) from local files..."
+    ));
+
+    let manifest_bytes = std::fs::read(manifest_path)
+        .with_context(|| format!("reading manifest file at {manifest_path}"))?;
+    let bundle_bytes = std::fs::read(bundle_path)
+        .with_context(|| format!("reading cosign bundle at {bundle_path}"))?;
+
+    let expected_identity =
+        format!("https://github.com/auser/mvm/.github/workflows/release.yml@refs/tags/v{version}");
+    let expected_issuer = "https://token.actions.githubusercontent.com";
+
+    let manifest = if std::env::var_os("MVM_SKIP_COSIGN_VERIFY").is_some() {
+        ui::warn(
+            "MVM_SKIP_COSIGN_VERIFY set — accepting unverified manifest. \
+             Plan 36 documents this as an emergency-rotation escape only.",
+        );
+        image_verify::parse_manifest(&manifest_bytes)
+            .map_err(|e| anyhow::anyhow!("manifest parse failed: {e}"))?
+    } else {
+        image_verify::verify_manifest(
+            &manifest_bytes,
+            &bundle_bytes,
+            &expected_identity,
+            expected_issuer,
+        )
+        .map_err(|e| {
+            bump_verify_outcome("sig_invalid");
+            anyhow::anyhow!(
+                "Cosign verification failed for the imported manifest: {e}\n\
+                 \n\
+                 Plan 36 / ADR 005: a sideloaded manifest must carry the\n\
+                 same release-workflow OIDC signature as the network path.\n\
+                 \n\
+                 Common causes:\n\
+                 - mismatched manifest + bundle pair (re-export both as a set);\n\
+                 - manifest belongs to a different mvmctl version (check `mvmctl --version`);\n\
+                 - clock skew (signature time-window).\n\
+                 \n\
+                 Emergency rotation: MVM_SKIP_COSIGN_VERIFY=1 keeps SHA-256\n\
+                 verification active while bypassing the signature step."
+            )
+        })?
+    };
+
+    image_verify::check_version_pin(&manifest, version).map_err(|e| {
+        bump_verify_outcome("version_skew");
+        anyhow::anyhow!(
+            "Imported manifest is for a different mvmctl version: {e}\n\
+             \n\
+             Plan 36 pins manifest.version == mvmctl version exactly. Re-export\n\
+             the manifest from a release matching v{version}, or upgrade mvmctl."
+        )
+    })?;
+
+    let now = chrono::Utc::now();
+    if let Err(e) = image_verify::check_not_after(&manifest, now) {
+        bump_verify_outcome("expired");
+        ui::warn(&format!(
+            "Imported manifest is past its max-age ({e}). Sideloaded images \
+             from older releases remain cryptographically valid but may \
+             carry unpatched vulnerabilities."
+        ));
+    }
+
+    if let Some(revocations) = try_fetch_revocation_list()? {
+        image_verify::check_revocation(&manifest, &revocations).map_err(|e| {
+            bump_verify_outcome("revoked");
+            anyhow::anyhow!(
+                "Imported manifest is on the project's revocation list: {e}\n\
+                 \n\
+                 Plan 36: a `revocations` release entry has marked v{version} \
+                 unsafe to run. Refusing to import."
+            )
+        })?;
+    }
+
+    if manifest.arch != arch {
+        anyhow::bail!(
+            "Manifest is for arch {} but this host is {arch}. Wrong-arch image \
+             would not boot. Re-export the manifest for the correct arch.",
+            manifest.arch
+        );
+    }
+
+    let kernel_name = format!("dev-vmlinux-{arch}");
+    let rootfs_name = format!("dev-rootfs-{arch}.{}", manifest.rootfs_format);
+
+    let kernel_digest = manifest
+        .artifact(&kernel_name)
+        .ok_or_else(|| anyhow::anyhow!("manifest does not list {kernel_name}"))?;
+    let rootfs_digest = manifest
+        .artifact(&rootfs_name)
+        .ok_or_else(|| anyhow::anyhow!("manifest does not list {rootfs_name}"))?;
+
+    image_verify::verify_artifact(std::path::Path::new(vmlinux_path), kernel_digest).map_err(
+        |e| {
+            bump_verify_outcome("digest_mismatch");
+            anyhow::anyhow!("kernel SHA-256 mismatch: {e}")
+        },
+    )?;
+    image_verify::verify_artifact(std::path::Path::new(rootfs_path), rootfs_digest).map_err(
+        |e| {
+            bump_verify_outcome("digest_mismatch");
+            anyhow::anyhow!("rootfs SHA-256 mismatch: {e}")
+        },
+    )?;
+
+    // Copy the verified artifacts into the version-namespaced cache.
+    // The next `mvmctl dev up` picks them up without re-running
+    // verification (the cache hit precedes download_dev_image).
+    let prebuilt_dir = format!(
+        "{}/dev/prebuilt/v{version}",
+        mvm_core::config::mvm_data_dir()
+    );
+    std::fs::create_dir_all(&prebuilt_dir)
+        .with_context(|| format!("creating prebuilt dir {prebuilt_dir}"))?;
+    let target_kernel = format!("{prebuilt_dir}/vmlinux");
+    let target_rootfs = format!("{prebuilt_dir}/rootfs.ext4");
+    std::fs::copy(vmlinux_path, &target_kernel)
+        .with_context(|| format!("copying kernel to {target_kernel}"))?;
+    std::fs::copy(rootfs_path, &target_rootfs)
+        .with_context(|| format!("copying rootfs to {target_rootfs}"))?;
+
+    mvm_core::observability::metrics::global()
+        .dev_image_verify_ok
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+    ui::success(&format!(
+        "Imported and verified dev image v{version} into {prebuilt_dir}. \
+         Run `mvmctl dev up` to boot the dev VM from the cached artifacts."
+    ));
+    Ok(())
+}
+
 /// Bump the dev_image_verify_<outcome> counter. Plan 36 §Layer 4 step 11.
 ///
 /// Caller passes the outcome name; centralising the lookup keeps the

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -902,6 +902,31 @@ fn prune_old_prebuilts(prebuilt_root: &str, current_version: &str) {
 }
 
 /// Download a pre-built dev image (kernel + rootfs) from GitHub releases.
+///
+/// Plan 36 / ADR 005 trust chain:
+///
+/// 1. Try the cosign-keyless-signed manifest first
+///    (`dev-image-{arch}.manifest.json` + `.bundle`). If present,
+///    `mvm-security::image_verify::verify_manifest` validates the
+///    Sigstore bundle against the project's release-workflow OIDC
+///    identity, parses the manifest, and we use *its* artifact
+///    digests as the source of truth.
+///
+/// 2. If the manifest is 404 (older release predating plan 36) or
+///    its companion bundle is missing, fall back to the W5.1
+///    unsigned-checksum path with a loud deprecation warning. This
+///    keeps mvmctl pointing at older releases working through the
+///    rollout, and the deprecation banner sets the stage for making
+///    the manifest mandatory in a future major version.
+///
+/// 3. Either way, every downloaded artifact gets streaming SHA-256
+///    verification (W5.1) against the expected digest.
+///
+/// Escape hatches (both print loud warnings):
+///   - `MVM_SKIP_HASH_VERIFY=1` — skip SHA-256 step (existing W5.1).
+///   - `MVM_SKIP_COSIGN_VERIFY=1` — skip cosign signature check on
+///     the manifest body but still parse and use it. Only for
+///     emergency Sigstore-side rotation; SHA-256 still applies.
 fn download_dev_image(kernel_path: &str, rootfs_path: &str) -> Result<(String, String)> {
     let version = env!("CARGO_PKG_VERSION");
     let base_url = format!("https://github.com/auser/mvm/releases/download/v{version}");
@@ -915,14 +940,39 @@ fn download_dev_image(kernel_path: &str, rootfs_path: &str) -> Result<(String, S
     };
     let kernel_name = format!("dev-vmlinux-{arch}");
     let rootfs_name = format!("dev-rootfs-{arch}.ext4");
-    let checksums_name = format!("dev-image-{arch}-checksums-sha256.txt");
     let kernel_url = format!("{base_url}/{kernel_name}");
     let rootfs_url = format!("{base_url}/{rootfs_name}");
-    let checksums_url = format!("{base_url}/{checksums_name}");
 
     ui::info(&format!("Downloading dev image (v{version})..."));
 
-    let expected = fetch_expected_hashes(&checksums_url, &[&kernel_name, &rootfs_name])?;
+    // Plan 36 PR-C.2: prefer the cosign-signed manifest. Falls back
+    // to the W5.1 unsigned checksum file when the manifest is 404
+    // (older release).
+    let expected = match try_fetch_signed_manifest(&base_url, version, arch, "dev")? {
+        Some(manifest) => {
+            ui::success(&format!(
+                "  ✓ cosign-verified manifest for v{} (built {} UTC, valid until {} UTC)",
+                manifest.version,
+                manifest.built_at.format("%Y-%m-%d"),
+                manifest.not_after.format("%Y-%m-%d"),
+            ));
+            manifest
+                .artifacts
+                .iter()
+                .map(|a| (a.name.clone(), a.sha256.to_ascii_lowercase()))
+                .collect::<std::collections::HashMap<_, _>>()
+        }
+        None => {
+            ui::warn(&format!(
+                "No cosign-signed manifest found for v{version}. Falling back to \
+                 unsigned checksum file (legacy path predating plan 36 / ADR 005). \
+                 Future releases will require the signed manifest."
+            ));
+            let checksums_name = format!("dev-image-{arch}-checksums-sha256.txt");
+            let checksums_url = format!("{base_url}/{checksums_name}");
+            fetch_expected_hashes(&checksums_url, &[&kernel_name, &rootfs_name])?
+        }
+    };
 
     ui::info("  Fetching kernel...");
     download_file(&kernel_url, kernel_path)
@@ -944,6 +994,135 @@ fn download_dev_image(kernel_path: &str, rootfs_path: &str) -> Result<(String, S
 
     ui::success("Dev image downloaded, hash-verified, and cached.");
     Ok((kernel_path.to_string(), rootfs_path.to_string()))
+}
+
+/// Probe for and verify the cosign-signed manifest at
+/// `{base_url}/{variant}-image-{arch}.manifest.json{,.bundle}`.
+///
+/// Returns:
+/// - `Ok(Some(manifest))` — manifest + bundle present, signature verified,
+///   version pinned to runtime, max-age window not yet exceeded.
+/// - `Ok(None)` — manifest URL 404. This is the legacy fallback for
+///   older releases that predate plan 36; caller can fall back to the
+///   W5.1 unsigned-checksum path with a deprecation warning.
+/// - `Err(_)` — manifest fetched but verification or parsing failed.
+///   Hard error; never silently fall through. `MVM_SKIP_COSIGN_VERIFY=1`
+///   downgrades signature failures to a parse-only path.
+fn try_fetch_signed_manifest(
+    base_url: &str,
+    version: &str,
+    arch: &str,
+    variant: &str,
+) -> Result<Option<mvm_security::image_verify::SignedManifest>> {
+    use mvm_security::image_verify;
+
+    let manifest_name = format!("{variant}-image-{arch}.manifest.json");
+    let manifest_url = format!("{base_url}/{manifest_name}");
+    let bundle_url = format!("{manifest_url}.bundle");
+
+    // HEAD-probe the manifest URL. If absent (older release without
+    // plan-36 signing), fall back gracefully.
+    if !url_exists(&manifest_url)? {
+        return Ok(None);
+    }
+
+    let manifest_tmp = tempfile::NamedTempFile::new().context("creating manifest tempfile")?;
+    let bundle_tmp = tempfile::NamedTempFile::new().context("creating bundle tempfile")?;
+    let manifest_path = manifest_tmp.path().to_string_lossy().into_owned();
+    let bundle_path = bundle_tmp.path().to_string_lossy().into_owned();
+
+    download_file(&manifest_url, &manifest_path)
+        .with_context(|| format!("Failed to download signed manifest from {manifest_url}"))?;
+    download_file(&bundle_url, &bundle_path).with_context(|| {
+        format!(
+            "Failed to download cosign bundle from {bundle_url}. Plan 36 \
+             requires a manifest's signature to be present alongside the \
+             manifest body — refusing to trust an unsigned manifest."
+        )
+    })?;
+
+    let manifest_bytes =
+        std::fs::read(&manifest_path).context("reading downloaded manifest body")?;
+    let bundle_bytes = std::fs::read(&bundle_path).context("reading downloaded cosign bundle")?;
+
+    // GitHub Actions keyless OIDC: the SAN encodes the workflow URL
+    // bound to the tag, and the issuer is GitHub's token endpoint.
+    let expected_identity =
+        format!("https://github.com/auser/mvm/.github/workflows/release.yml@refs/tags/v{version}");
+    let expected_issuer = "https://token.actions.githubusercontent.com";
+
+    let manifest = if std::env::var_os("MVM_SKIP_COSIGN_VERIFY").is_some() {
+        tracing::warn!(
+            "MVM_SKIP_COSIGN_VERIFY set — accepting unverified manifest body. \
+             Plan 36 documents this as an emergency-rotation escape hatch only."
+        );
+        image_verify::parse_manifest(&manifest_bytes)
+            .map_err(|e| anyhow::anyhow!("manifest parse failed: {e}"))?
+    } else {
+        image_verify::verify_manifest(
+            &manifest_bytes,
+            &bundle_bytes,
+            &expected_identity,
+            expected_issuer,
+        )
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Cosign verification failed for {manifest_name}: {e}\n\
+                 \n\
+                 Plan 36 / ADR 005 requires every dev image manifest to be cosign-keyless\n\
+                 signed against the release workflow's OIDC identity. Refusing to use this\n\
+                 image. Possible causes:\n\
+                 - account/CDN compromise (open a security issue);\n\
+                 - the release was published without going through the signing job;\n\
+                 - clock skew (manifest expired); check `date -u`.\n\
+                 \n\
+                 Emergency rotation: set MVM_SKIP_COSIGN_VERIFY=1 to bypass the signature\n\
+                 check while keeping SHA-256 verification active."
+            )
+        })?
+    };
+
+    // Pin the manifest's claimed version to mvmctl's own version. A
+    // mismatch means someone is feeding us a different release's
+    // manifest — refuse.
+    image_verify::check_version_pin(&manifest, version)
+        .map_err(|e| anyhow::anyhow!("manifest version pin failed: {e}"))?;
+
+    // Enforce max-age (default 90d). mvmctl warns and proceeds; mvmd
+    // refuses (different risk tolerance — handled in mvmd plan 23).
+    let now = chrono::Utc::now();
+    if let Err(e) = image_verify::check_not_after(&manifest, now) {
+        ui::warn(&format!(
+            "Dev image manifest is past its max-age ({e}). Consider upgrading \
+             mvmctl — older signed images are still cryptographically valid but \
+             may carry unpatched vulnerabilities."
+        ));
+    }
+
+    Ok(Some(manifest))
+}
+
+/// HEAD-probe a URL. Returns Ok(true) when the resource is reachable
+/// (HTTP 2xx), Ok(false) on 404, Err for transient failures.
+fn url_exists(url: &str) -> Result<bool> {
+    let output = std::process::Command::new("curl")
+        .args(["-fSI", "-o", "/dev/null", "-w", "%{http_code}", url])
+        .output()
+        .context("Failed to run curl HEAD probe")?;
+    let code = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    match code.as_str() {
+        "200" | "302" => Ok(true),
+        "404" => Ok(false),
+        _ => {
+            // Other status (5xx, network error, redirect chain failure)
+            // — don't silently fall through to the unsigned path.
+            anyhow::bail!(
+                "HEAD probe of {url} returned status {code}; refusing to guess \
+                 whether the signed manifest is missing or transiently unavailable. \
+                 Retry, or investigate."
+            )
+        }
+    }
 }
 
 /// Download the per-release `sha256sum`-format checksum file and parse it

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -928,6 +928,25 @@ fn prune_old_prebuilts(prebuilt_root: &str, current_version: &str) {
 ///     the manifest body but still parse and use it. Only for
 ///     emergency Sigstore-side rotation; SHA-256 still applies.
 fn download_dev_image(kernel_path: &str, rootfs_path: &str) -> Result<(String, String)> {
+    // Wrap the verification pipeline so every exit path — success or
+    // failure — emits the verify_duration gauge and bumps the
+    // appropriate outcome counter. Plan 36 §Layer 4 step 11.
+    let verify_start = std::time::Instant::now();
+    let result = download_dev_image_inner(kernel_path, rootfs_path);
+    let elapsed_ms = verify_start.elapsed().as_millis() as u64;
+    let metrics = mvm_core::observability::metrics::global();
+    metrics
+        .dev_image_verify_duration_ms
+        .store(elapsed_ms, std::sync::atomic::Ordering::Relaxed);
+    if result.is_ok() {
+        metrics
+            .dev_image_verify_ok
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    result
+}
+
+fn download_dev_image_inner(kernel_path: &str, rootfs_path: &str) -> Result<(String, String)> {
     let version = env!("CARGO_PKG_VERSION");
     let base_url = format!("https://github.com/auser/mvm/releases/download/v{version}");
     // Detect host arch to download the right image.
@@ -975,8 +994,10 @@ fn download_dev_image(kernel_path: &str, rootfs_path: &str) -> Result<(String, S
     };
 
     ui::info("  Fetching kernel...");
-    download_file(&kernel_url, kernel_path)
-        .with_context(|| format!("Failed to download kernel from {kernel_url}"))?;
+    download_file(&kernel_url, kernel_path).map_err(|e| {
+        bump_verify_outcome("network");
+        e.context(format!("Failed to download kernel from {kernel_url}"))
+    })?;
     verify_artifact_hash(
         kernel_path,
         &kernel_name,
@@ -984,8 +1005,10 @@ fn download_dev_image(kernel_path: &str, rootfs_path: &str) -> Result<(String, S
     )?;
 
     ui::info("  Fetching rootfs...");
-    download_file(&rootfs_url, rootfs_path)
-        .with_context(|| format!("Failed to download rootfs from {rootfs_url}"))?;
+    download_file(&rootfs_url, rootfs_path).map_err(|e| {
+        bump_verify_outcome("network");
+        e.context(format!("Failed to download rootfs from {rootfs_url}"))
+    })?;
     verify_artifact_hash(
         rootfs_path,
         &rootfs_name,
@@ -1031,14 +1054,19 @@ fn try_fetch_signed_manifest(
     let manifest_path = manifest_tmp.path().to_string_lossy().into_owned();
     let bundle_path = bundle_tmp.path().to_string_lossy().into_owned();
 
-    download_file(&manifest_url, &manifest_path)
-        .with_context(|| format!("Failed to download signed manifest from {manifest_url}"))?;
-    download_file(&bundle_url, &bundle_path).with_context(|| {
-        format!(
+    download_file(&manifest_url, &manifest_path).map_err(|e| {
+        bump_verify_outcome("network");
+        e.context(format!(
+            "Failed to download signed manifest from {manifest_url}"
+        ))
+    })?;
+    download_file(&bundle_url, &bundle_path).map_err(|e| {
+        bump_verify_outcome("network");
+        e.context(format!(
             "Failed to download cosign bundle from {bundle_url}. Plan 36 \
              requires a manifest's signature to be present alongside the \
              manifest body — refusing to trust an unsigned manifest."
-        )
+        ))
     })?;
 
     let manifest_bytes =
@@ -1066,6 +1094,7 @@ fn try_fetch_signed_manifest(
             expected_issuer,
         )
         .map_err(|e| {
+            bump_verify_outcome("sig_invalid");
             anyhow::anyhow!(
                 "Cosign verification failed for {manifest_name}: {e}\n\
                  \n\
@@ -1085,13 +1114,16 @@ fn try_fetch_signed_manifest(
     // Pin the manifest's claimed version to mvmctl's own version. A
     // mismatch means someone is feeding us a different release's
     // manifest — refuse.
-    image_verify::check_version_pin(&manifest, version)
-        .map_err(|e| anyhow::anyhow!("manifest version pin failed: {e}"))?;
+    image_verify::check_version_pin(&manifest, version).map_err(|e| {
+        bump_verify_outcome("version_skew");
+        anyhow::anyhow!("manifest version pin failed: {e}")
+    })?;
 
     // Enforce max-age (default 90d). mvmctl warns and proceeds; mvmd
     // refuses (different risk tolerance — handled in mvmd plan 23).
     let now = chrono::Utc::now();
     if let Err(e) = image_verify::check_not_after(&manifest, now) {
+        bump_verify_outcome("expired");
         ui::warn(&format!(
             "Dev image manifest is past its max-age ({e}). Consider upgrading \
              mvmctl — older signed images are still cryptographically valid but \
@@ -1105,6 +1137,7 @@ fn try_fetch_signed_manifest(
     // primary mechanism for "we know this build is bad."
     if let Some(revocations) = try_fetch_revocation_list()? {
         image_verify::check_revocation(&manifest, &revocations).map_err(|e| {
+            bump_verify_outcome("revoked");
             anyhow::anyhow!(
                 "Dev image manifest is on the project's revocation list: {e}\n\
                  \n\
@@ -1262,6 +1295,31 @@ fn try_fetch_revocation_list() -> Result<Option<mvm_security::image_verify::Revo
     Ok(Some(list))
 }
 
+/// Bump the dev_image_verify_<outcome> counter. Plan 36 §Layer 4 step 11.
+///
+/// Caller passes the outcome name; centralising the lookup keeps the
+/// counter set discoverable in one place. mvmd plan 23's
+/// reconciliation loop will alert on attack-shaped spikes
+/// (sig_invalid, digest_mismatch, revoked).
+fn bump_verify_outcome(outcome: &str) {
+    let m = mvm_core::observability::metrics::global();
+    let counter = match outcome {
+        "sig_invalid" => &m.dev_image_verify_sig_invalid,
+        "digest_mismatch" => &m.dev_image_verify_digest_mismatch,
+        "version_skew" => &m.dev_image_verify_version_skew,
+        "revoked" => &m.dev_image_verify_revoked,
+        "expired" => &m.dev_image_verify_expired,
+        "network" => &m.dev_image_verify_network,
+        // Defensive: an unknown outcome is itself a bug worth surfacing
+        // — log a warning rather than silently swallowing the metric.
+        _ => {
+            tracing::warn!("bump_verify_outcome: unknown outcome '{outcome}'");
+            return;
+        }
+    };
+    counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// HEAD-probe a URL. Returns Ok(true) when the resource is reachable
 /// (HTTP 2xx), Ok(false) on 404, Err for transient failures.
 fn url_exists(url: &str) -> Result<bool> {
@@ -1371,6 +1429,7 @@ fn verify_artifact_hash(path: &str, name: &str, expected: Option<&String>) -> Re
 
     if actual != *expected {
         let _ = std::fs::remove_file(path);
+        bump_verify_outcome("digest_mismatch");
         anyhow::bail!(
             "Integrity check failed for {name}.\n\
              expected sha256: {expected}\n\

--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -81,6 +81,35 @@ pub(in crate::commands) enum DevAction {
         #[arg(long, short = 's')]
         shell: bool,
     },
+    /// Import a dev image from local files (air-gapped install).
+    ///
+    /// Plan 36 §"Air-gapped install path": runs the same cosign sig +
+    /// SHA-256 + version-pin + max-age + revocation verification
+    /// pipeline as the network path, against local files. On success
+    /// the verified artifacts are deposited into the version-namespaced
+    /// cache (`~/.cache/mvm/dev/prebuilt/v{version}/`) and the next
+    /// `mvmctl dev up` boots from them without re-downloading.
+    ///
+    /// The trusted path for operators in regulated/gov/air-gapped
+    /// environments. Without this, the only option to run an
+    /// unreachable-network host was `MVM_SKIP_HASH_VERIFY=1`, which
+    /// disables the supply-chain check entirely.
+    ImportImage {
+        /// Path to the cosign-signed manifest JSON
+        /// (`dev-image-{arch}.manifest.json`).
+        #[arg(long, value_name = "FILE")]
+        manifest: String,
+        /// Path to the manifest's cosign bundle
+        /// (`dev-image-{arch}.manifest.json.bundle`).
+        #[arg(long, value_name = "FILE")]
+        bundle: String,
+        /// Path to the kernel binary (`dev-vmlinux-{arch}`).
+        #[arg(long, value_name = "FILE")]
+        vmlinux: String,
+        /// Path to the rootfs (`dev-rootfs-{arch}.ext4`).
+        #[arg(long, value_name = "FILE")]
+        rootfs: String,
+    },
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
@@ -198,6 +227,12 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
                 dev_status()
             }
         }
+        DevAction::ImportImage {
+            manifest,
+            bundle,
+            vmlinux,
+            rootfs,
+        } => apple_container::cmd_dev_import_image(&manifest, &bundle, &vmlinux, &rootfs),
         DevAction::Rebuild {
             lima_cpus,
             lima_mem,

--- a/crates/mvm-cli/src/security_cmd.rs
+++ b/crates/mvm-cli/src/security_cmd.rs
@@ -115,6 +115,88 @@ fn collect_checks() -> Vec<PostureCheck> {
         no_vm_check(SecurityLayer::GuestHardening, "Built template exists")
     });
 
+    // SupplyChainIntegrity — dev image cache exists for the current
+    // mvmctl version. A populated cache is the host-side fingerprint
+    // that the cosign + SHA-256 verification pipeline has completed
+    // at least once for this version (download_dev_image only writes
+    // the cache after every step succeeds). Plan 36 §Layer 4.
+    let version = env!("CARGO_PKG_VERSION");
+    let prebuilt_dir = format!(
+        "{}/dev/prebuilt/v{version}",
+        mvm_core::config::mvm_data_dir()
+    );
+    let kernel = format!("{prebuilt_dir}/vmlinux");
+    let rootfs = format!("{prebuilt_dir}/rootfs.ext4");
+    let cache_present =
+        std::path::Path::new(&kernel).exists() && std::path::Path::new(&rootfs).exists();
+    checks.push(PostureCheck {
+        layer: SecurityLayer::SupplyChainIntegrity,
+        name: "Dev image verified for this version".to_string(),
+        passed: cache_present,
+        detail: if cache_present {
+            format!("verified prebuilt cached at {prebuilt_dir}")
+        } else {
+            format!(
+                "no verified prebuilt for v{version}; run `mvmctl dev up` (network) or \
+                 `mvmctl dev import-image` (air-gapped) to populate"
+            )
+        },
+    });
+
+    // SupplyChainIntegrity — revocation list freshness. The cosign-
+    // signed list is cached at ~/.cache/mvm/revocations/ with a 24h
+    // refresh policy and 7d offline tolerance. After 7d staleness
+    // mvmctl silently skips revocation enforcement (with a warning),
+    // so we surface that gap here instead of letting it stay invisible.
+    let rev_path = format!(
+        "{}/revocations/revoked-versions.json",
+        mvm_core::config::mvm_cache_dir()
+    );
+    let rev_age_secs = std::fs::metadata(&rev_path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| std::time::SystemTime::now().duration_since(t).ok())
+        .map(|d| d.as_secs());
+    let twenty_four_hours = 24 * 60 * 60;
+    let seven_days = 7 * 24 * 60 * 60;
+    checks.push(match rev_age_secs {
+        None => PostureCheck {
+            layer: SecurityLayer::SupplyChainIntegrity,
+            name: "Revocation list cached".to_string(),
+            // No cache yet is an info state — the list 404s today
+            // (bootstrap; project hasn't published the `revocations`
+            // tag yet). Mark as passed; will flip to an enforcement
+            // check once the project publishes its first list.
+            passed: true,
+            detail: "no revocation cache (bootstrap; no recalls have been published yet)"
+                .to_string(),
+        },
+        Some(age) if age < twenty_four_hours => PostureCheck {
+            layer: SecurityLayer::SupplyChainIntegrity,
+            name: "Revocation list cached".to_string(),
+            passed: true,
+            detail: format!("fresh ({} hours old)", age / 3600),
+        },
+        Some(age) if age < seven_days => PostureCheck {
+            layer: SecurityLayer::SupplyChainIntegrity,
+            name: "Revocation list cached".to_string(),
+            passed: true,
+            detail: format!(
+                "stale but within 7-day tolerance ({} hours old; refresh on next online run)",
+                age / 3600
+            ),
+        },
+        Some(age) => PostureCheck {
+            layer: SecurityLayer::SupplyChainIntegrity,
+            name: "Revocation list cached".to_string(),
+            passed: false,
+            detail: format!(
+                "expired ({} days old; revocation enforcement is silently skipped — refresh required)",
+                age / 86400
+            ),
+        },
+    });
+
     checks
 }
 

--- a/crates/mvm-core/src/domain/agent.rs
+++ b/crates/mvm-core/src/domain/agent.rs
@@ -1364,6 +1364,14 @@ mod tests {
             build_image_duration_ms: 0,
             vm_start_duration_ms: 0,
             vsock_handshake_rtt_ms: 0,
+            dev_image_verify_ok: 0,
+            dev_image_verify_sig_invalid: 0,
+            dev_image_verify_digest_mismatch: 0,
+            dev_image_verify_version_skew: 0,
+            dev_image_verify_revoked: 0,
+            dev_image_verify_expired: 0,
+            dev_image_verify_network: 0,
+            dev_image_verify_duration_ms: 0,
         };
         let resp = AgentResponse::Metrics(snapshot);
         let json = serde_json::to_string(&resp).unwrap();

--- a/crates/mvm-core/src/observability/metrics.rs
+++ b/crates/mvm-core/src/observability/metrics.rs
@@ -46,6 +46,22 @@ pub struct Metrics {
     pub build_image_duration_ms: AtomicU64,
     pub vm_start_duration_ms: AtomicU64,
     pub vsock_handshake_rtt_ms: AtomicU64,
+
+    // ── Dev/builder image verification (plan 36 §Layer 4 step 11) ───
+    // One counter per outcome of the cosign-signed manifest +
+    // SHA-256 verification pipeline at apple_container.rs::download_dev_image.
+    // The duration gauge is the last observed wall-clock from
+    // try_fetch_signed_manifest entry through verify_artifact_hash exit.
+    // mvmd plan 23 will read these via the prometheus exposition to alert
+    // on attack-shaped failure spikes (sig_invalid / digest_mismatch).
+    pub dev_image_verify_ok: AtomicU64,
+    pub dev_image_verify_sig_invalid: AtomicU64,
+    pub dev_image_verify_digest_mismatch: AtomicU64,
+    pub dev_image_verify_version_skew: AtomicU64,
+    pub dev_image_verify_revoked: AtomicU64,
+    pub dev_image_verify_expired: AtomicU64,
+    pub dev_image_verify_network: AtomicU64,
+    pub dev_image_verify_duration_ms: AtomicU64,
 }
 
 impl Metrics {
@@ -75,6 +91,14 @@ impl Metrics {
             build_image_duration_ms: AtomicU64::new(0),
             vm_start_duration_ms: AtomicU64::new(0),
             vsock_handshake_rtt_ms: AtomicU64::new(0),
+            dev_image_verify_ok: AtomicU64::new(0),
+            dev_image_verify_sig_invalid: AtomicU64::new(0),
+            dev_image_verify_digest_mismatch: AtomicU64::new(0),
+            dev_image_verify_version_skew: AtomicU64::new(0),
+            dev_image_verify_revoked: AtomicU64::new(0),
+            dev_image_verify_expired: AtomicU64::new(0),
+            dev_image_verify_network: AtomicU64::new(0),
+            dev_image_verify_duration_ms: AtomicU64::new(0),
         }
     }
 
@@ -105,6 +129,18 @@ impl Metrics {
             build_image_duration_ms: self.build_image_duration_ms.load(Ordering::Relaxed),
             vm_start_duration_ms: self.vm_start_duration_ms.load(Ordering::Relaxed),
             vsock_handshake_rtt_ms: self.vsock_handshake_rtt_ms.load(Ordering::Relaxed),
+            dev_image_verify_ok: self.dev_image_verify_ok.load(Ordering::Relaxed),
+            dev_image_verify_sig_invalid: self.dev_image_verify_sig_invalid.load(Ordering::Relaxed),
+            dev_image_verify_digest_mismatch: self
+                .dev_image_verify_digest_mismatch
+                .load(Ordering::Relaxed),
+            dev_image_verify_version_skew: self
+                .dev_image_verify_version_skew
+                .load(Ordering::Relaxed),
+            dev_image_verify_revoked: self.dev_image_verify_revoked.load(Ordering::Relaxed),
+            dev_image_verify_expired: self.dev_image_verify_expired.load(Ordering::Relaxed),
+            dev_image_verify_network: self.dev_image_verify_network.load(Ordering::Relaxed),
+            dev_image_verify_duration_ms: self.dev_image_verify_duration_ms.load(Ordering::Relaxed),
         }
     }
 
@@ -258,6 +294,59 @@ impl Metrics {
             "Last vsock auth handshake RTT in milliseconds",
         );
 
+        // Plan 36 §Layer 4 step 11: dev/builder image verification
+        // outcomes. One counter per outcome lets a Prometheus query
+        // alert on attack-shaped failure spikes
+        // (sig_invalid / digest_mismatch in particular).
+        write_metric(
+            &mut out,
+            "mvm_dev_image_verify_ok_total",
+            s.dev_image_verify_ok,
+            "Successful dev/builder image manifest verifications",
+        );
+        write_metric(
+            &mut out,
+            "mvm_dev_image_verify_sig_invalid_total",
+            s.dev_image_verify_sig_invalid,
+            "Cosign signature failures on dev/builder image manifests",
+        );
+        write_metric(
+            &mut out,
+            "mvm_dev_image_verify_digest_mismatch_total",
+            s.dev_image_verify_digest_mismatch,
+            "SHA-256 mismatches on downloaded dev/builder image artifacts",
+        );
+        write_metric(
+            &mut out,
+            "mvm_dev_image_verify_version_skew_total",
+            s.dev_image_verify_version_skew,
+            "Manifest version did not match runtime mvmctl version",
+        );
+        write_metric(
+            &mut out,
+            "mvm_dev_image_verify_revoked_total",
+            s.dev_image_verify_revoked,
+            "Image rejected because its version is on the cosign-signed revocation list",
+        );
+        write_metric(
+            &mut out,
+            "mvm_dev_image_verify_expired_total",
+            s.dev_image_verify_expired,
+            "Image manifest past its not_after window",
+        );
+        write_metric(
+            &mut out,
+            "mvm_dev_image_verify_network_total",
+            s.dev_image_verify_network,
+            "Network failures during dev/builder image manifest fetch or revocation refresh",
+        );
+        write_gauge(
+            &mut out,
+            "mvm_dev_image_verify_duration_milliseconds",
+            s.dev_image_verify_duration_ms,
+            "Last dev/builder image verification wall-clock in milliseconds",
+        );
+
         out
     }
 }
@@ -303,6 +392,22 @@ pub struct MetricsSnapshot {
     pub build_image_duration_ms: u64,
     pub vm_start_duration_ms: u64,
     pub vsock_handshake_rtt_ms: u64,
+    #[serde(default)]
+    pub dev_image_verify_ok: u64,
+    #[serde(default)]
+    pub dev_image_verify_sig_invalid: u64,
+    #[serde(default)]
+    pub dev_image_verify_digest_mismatch: u64,
+    #[serde(default)]
+    pub dev_image_verify_version_skew: u64,
+    #[serde(default)]
+    pub dev_image_verify_revoked: u64,
+    #[serde(default)]
+    pub dev_image_verify_expired: u64,
+    #[serde(default)]
+    pub dev_image_verify_network: u64,
+    #[serde(default)]
+    pub dev_image_verify_duration_ms: u64,
 }
 
 #[cfg(test)]

--- a/crates/mvm-guest/Cargo.toml
+++ b/crates/mvm-guest/Cargo.toml
@@ -24,6 +24,16 @@ path = "src/bin/mvm-guest-agent.rs"
 name = "mvm-seccomp-apply"
 path = "src/bin/mvm-seccomp-apply.rs"
 
+# Early-userspace init (PID 1) that runs from the verity initramfs
+# baked by `mkGuest` when `verifiedBoot = true`. Reads the roothash
+# from /proc/cmdline, constructs the dm-verity device-mapper target
+# via raw ioctls, mounts it, and switch_roots to the real /init.
+# Bypasses Firecracker's auto-appended `root=/dev/vda` by owning the
+# boot pivot in userspace. ADR-002 §W3.
+[[bin]]
+name = "mvm-verity-init"
+path = "src/bin/mvm-verity-init.rs"
+
 [features]
 dev-shell = []
 

--- a/crates/mvm-guest/src/bin/mvm-verity-init.rs
+++ b/crates/mvm-guest/src/bin/mvm-verity-init.rs
@@ -1,0 +1,525 @@
+//! Early-userspace verity-init (PID 1 in the verity initramfs).
+//!
+//! ADR-002 §W3 — runs from a tiny initramfs baked by `mkGuest` when
+//! `verifiedBoot = true`. The kernel-cmdline `dm-mod.create=` path
+//! doesn't work for our microVM hypervisors because Firecracker
+//! (and Apple VZ) auto-append `root=/dev/vda ro` to the cmdline on
+//! aarch64; the kernel uses last-wins for `root=`, so a verity
+//! `root=/dev/dm-0` we set ourselves is silently overridden. We
+//! solve that by owning the boot pivot in userspace: this binary
+//! mounts an initramfs first, builds the verity device-mapper
+//! target via raw ioctls, mounts `/dev/mapper/root` at `/sysroot`,
+//! then `switch_root`s to the real init at `/sysroot/init`.
+//!
+//! Cmdline contract (set by the host's start_vm path):
+//!
+//!   mvm.roothash=<64-hex>      required; the dm-verity root hash
+//!   mvm.data=<dev-path>        defaults to /dev/vda
+//!   mvm.hash=<dev-path>        defaults to /dev/vdb
+//!
+//! On any failure this binary panics — kernel re-init isn't safe from
+//! PID 1 in the initramfs, and panic'ing surfaces the failure on the
+//! console (visible in `firecracker.log`) rather than silently falling
+//! back to the unverified rootfs.
+//!
+//! Linux-only. Builds as a stub on other platforms so the workspace
+//! still compiles on macOS.
+
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("mvm-verity-init: Linux-only binary; not buildable on this target");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    if let Err(e) = linux::run() {
+        eprintln!("mvm-verity-init: FATAL: {e}");
+        let _ = std::fs::write("/dev/console", format!("mvm-verity-init: FATAL: {e}\n"));
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        std::process::exit(1);
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::ffi::CString;
+    use std::fs;
+    use std::io;
+    use std::os::fd::AsRawFd;
+    use std::path::Path;
+
+    // ── DM ioctl constants and structs (mirror /usr/include/linux/dm-ioctl.h)
+    //
+    // The kernel header lives in `linux-libc-dev`; we don't pull
+    // bindgen/headers into the guest closure. Hand-coded constants
+    // are fine here — DM ioctl is a stable kernel ABI.
+
+    const DM_VERSION_MAJOR: u32 = 4;
+    const DM_VERSION_MINOR: u32 = 0;
+    const DM_VERSION_PATCH: u32 = 0;
+
+    const DM_NAME_LEN: usize = 128;
+    const DM_UUID_LEN: usize = 129;
+    // After the fixed fields, dm_ioctl includes 7 bytes of `data` for
+    // padding/early data; we keep that shape so ioctls match the
+    // kernel struct layout.
+    const DM_DATA_LEN: usize = 7;
+
+    const DM_READONLY_FLAG: u32 = 1 << 0;
+    const DM_EXISTS_FLAG: u32 = 1 << 2;
+
+    // Command numbers from the enum at /usr/include/linux/dm-ioctl.h.
+    const DM_VERSION_CMD: u32 = 0;
+    const DM_DEV_CREATE_CMD: u32 = 3;
+    const DM_DEV_SUSPEND_CMD: u32 = 6;
+    const DM_TABLE_LOAD_CMD: u32 = 9;
+
+    const DM_IOCTL: u32 = 0xfd;
+    // _IOWR(0xfd, n, struct dm_ioctl): the libc helpers don't expose
+    // _IOWR cleanly so we inline the value. Direction=3, size=312
+    // (sizeof(struct dm_ioctl) on 64-bit Linux).
+    const DM_IOCTL_STRUCT_SIZE: u32 = 312;
+    fn iowr(nr: u32) -> u64 {
+        // ((dir << 30) | (size << 16) | (type << 8) | nr)
+        // dir=3 (IOC_READ|IOC_WRITE), size=DM_IOCTL_STRUCT_SIZE.
+        // Returns u64 because the request value is wider on glibc
+        // (c_ulong = u64) than on musl (c_int = i32) — we cast at
+        // the ioctl call site to whatever libc says is correct.
+        ((3u32 << 30) | (DM_IOCTL_STRUCT_SIZE << 16) | (DM_IOCTL << 8) | nr) as u64
+    }
+
+    // `[u8; 129]` doesn't auto-derive Default; we provide one by hand
+    // so `..Default::default()` works on the call sites below.
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct DmIoctl {
+        version: [u32; 3],
+        data_size: u32,
+        data_start: u32,
+        target_count: u32,
+        open_count: i32,
+        flags: u32,
+        event_nr: u32,
+        padding: u32,
+        dev: u64,
+        name: [u8; DM_NAME_LEN],
+        uuid: [u8; DM_UUID_LEN],
+        data: [u8; DM_DATA_LEN],
+    }
+
+    impl Default for DmIoctl {
+        fn default() -> Self {
+            Self {
+                version: [0; 3],
+                data_size: 0,
+                data_start: 0,
+                target_count: 0,
+                open_count: 0,
+                flags: 0,
+                event_nr: 0,
+                padding: 0,
+                dev: 0,
+                name: [0; DM_NAME_LEN],
+                uuid: [0; DM_UUID_LEN],
+                data: [0; DM_DATA_LEN],
+            }
+        }
+    }
+
+    #[repr(C)]
+    struct DmTargetSpec {
+        sector_start: u64,
+        length: u64,
+        status: i32,
+        next: u32,
+        target_type: [u8; 16],
+        // followed by NUL-terminated parameter string + alignment padding
+    }
+
+    pub fn run() -> Result<(), String> {
+        msg("mvm-verity-init: starting");
+
+        // ── 1. Mount /proc + /dev so we can read the cmdline and create
+        //    block-device nodes if missing. The initramfs ships these
+        //    as empty directories.
+        do_mount("proc", "/proc", "proc", 0, "")?;
+        do_mount("devtmpfs", "/dev", "devtmpfs", 0, "")?;
+
+        // ── 2. Parse /proc/cmdline for the verity parameters.
+        let cmdline =
+            fs::read_to_string("/proc/cmdline").map_err(|e| format!("read /proc/cmdline: {e}"))?;
+        let mut roothash: Option<String> = None;
+        let mut data_dev = "/dev/vda".to_string();
+        let mut hash_dev = "/dev/vdb".to_string();
+        for tok in cmdline.split_whitespace() {
+            if let Some(v) = tok.strip_prefix("mvm.roothash=") {
+                roothash = Some(v.trim_matches('"').to_string());
+            } else if let Some(v) = tok.strip_prefix("mvm.data=") {
+                data_dev = v.trim_matches('"').to_string();
+            } else if let Some(v) = tok.strip_prefix("mvm.hash=") {
+                hash_dev = v.trim_matches('"').to_string();
+            }
+        }
+        let roothash = roothash.ok_or_else(|| "no mvm.roothash= on kernel cmdline".to_string())?;
+        if roothash.len() != 64 || !roothash.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(format!(
+                "invalid mvm.roothash={roothash:?} (expected 64 hex chars)"
+            ));
+        }
+        msg(&format!(
+            "mvm-verity-init: data={data_dev} hash={hash_dev} roothash={}…",
+            &roothash[..12]
+        ));
+
+        // ── 3. Compute the verity table line.
+        //
+        //   <start> <num-sectors> verity 1 <data-dev> <hash-dev>
+        //          <data-block-size> <hash-block-size>
+        //          <num-data-blocks> <hash-start-block>
+        //          <algo> <root-hash> <salt>
+        //
+        // Salt is zero (matches mkGuest's pinned `--salt=00…00`).
+        //
+        // `data-block-size = 1024` (NOT 4096) so the device's logical
+        // block size matches the ext4 we ship — mkGuest builds the
+        // rootfs with mke2fs's default 1 KiB blocks at our typical
+        // 200 MB image size, and the kernel's ext4 refuses to mount
+        // when FS block size < device logical block size. The hash
+        // tree itself stays at 4 KiB because that's the typical
+        // veritysetup default and gives a reasonable fan-out.
+        //
+        // `hash_start_block = 1` (NOT 0): `veritysetup format` writes a
+        // 512-byte "verity superblock" at offset 0 of the sidecar that
+        // stores tree metadata (UUID, hash type, salt). The actual
+        // Merkle tree starts at block 1. Setting hash_start_block=0
+        // makes the kernel read the superblock as a hash node and
+        // report `metadata block 0 is corrupted`. The `--no-superblock`
+        // veritysetup flag would let us use 0, but keeping the
+        // superblock is what makes `veritysetup verify` work against
+        // the artifact (used by the runbook + CI).
+        const DATA_BLOCK_SIZE: u64 = 1024;
+        const HASH_BLOCK_SIZE: u64 = 4096;
+        let data_size = block_device_size(&data_dev)?;
+        if !data_size.is_multiple_of(DATA_BLOCK_SIZE) {
+            return Err(format!(
+                "data device size {data_size} not multiple of {DATA_BLOCK_SIZE}"
+            ));
+        }
+        let data_blocks = data_size / DATA_BLOCK_SIZE;
+        let num_sectors = data_blocks * (DATA_BLOCK_SIZE / 512);
+        let salt = "0".repeat(64);
+        let table_args = format!(
+            "1 {data_dev} {hash_dev} {DATA_BLOCK_SIZE} {HASH_BLOCK_SIZE} {data_blocks} 1 sha256 {roothash} {salt}"
+        );
+        msg(&format!(
+            "mvm-verity-init: verity table = {num_sectors} sectors, {data_blocks} data blocks"
+        ));
+
+        // ── 4. Open /dev/mapper/control (auto-created by devtmpfs).
+        let ctrl = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/mapper/control")
+            .map_err(|e| format!("open /dev/mapper/control: {e}"))?;
+        let fd = ctrl.as_raw_fd();
+
+        // 4a. DM_VERSION — sanity-check the kernel speaks the same protocol.
+        let mut io = base_ioctl();
+        unsafe {
+            do_ioctl(fd, iowr(DM_VERSION_CMD), &mut io).map_err(|e| format!("DM_VERSION: {e}"))?;
+        }
+        msg(&format!(
+            "mvm-verity-init: dm-ioctl kernel version {}.{}.{}",
+            io.version[0], io.version[1], io.version[2]
+        ));
+
+        // 4b. DM_DEV_CREATE — make /dev/mapper/root (no table yet).
+        let mut io = base_ioctl();
+        write_name(&mut io.name, "root");
+        unsafe {
+            do_ioctl(fd, iowr(DM_DEV_CREATE_CMD), &mut io)
+                .map_err(|e| format!("DM_DEV_CREATE: {e}"))?;
+        }
+        msg("mvm-verity-init: DM_DEV_CREATE ok");
+
+        // 4c. DM_TABLE_LOAD — push the verity target into the inactive table.
+        let payload = build_table_payload(num_sectors, "verity", &table_args)?;
+        let mut buf = vec![0u8; payload.len()];
+        buf.copy_from_slice(&payload);
+        // The struct lives at the head of the buffer; mutate via cast.
+        let header_ptr = buf.as_mut_ptr().cast::<DmIoctl>();
+        unsafe {
+            (*header_ptr).flags |= DM_READONLY_FLAG;
+            do_ioctl(fd, iowr(DM_TABLE_LOAD_CMD), header_ptr)
+                .map_err(|e| format!("DM_TABLE_LOAD: {e}"))?;
+        }
+        msg("mvm-verity-init: DM_TABLE_LOAD ok");
+
+        // 4d. DM_DEV_SUSPEND with flags=0 → resume = activate the loaded table.
+        // (DM_SUSPEND_FLAG bit 1 set means "suspend"; cleared means "resume".)
+        let mut io = base_ioctl();
+        write_name(&mut io.name, "root");
+        unsafe {
+            do_ioctl(fd, iowr(DM_DEV_SUSPEND_CMD), &mut io)
+                .map_err(|e| format!("DM_DEV_SUSPEND(resume): {e}"))?;
+        }
+        msg("mvm-verity-init: dm-verity device active");
+
+        // ── 5. Mount /dev/mapper/root at /sysroot. The initramfs ships
+        //    /sysroot as an empty mount target. Read-only — verity is
+        //    incompatible with writes.
+        if !Path::new("/dev/mapper/root").exists() {
+            // /dev/mapper/<name> nodes are usually created by udev.
+            // In an initramfs without udev, the kernel's devtmpfs
+            // creates /dev/dm-N but not the /dev/mapper/<name> symlink.
+            // Fall back to /dev/dm-0 in that case — it's the same
+            // device, just a different name.
+            if !Path::new("/dev/dm-0").exists() {
+                return Err(
+                    "neither /dev/mapper/root nor /dev/dm-0 exists after DM_DEV_SUSPEND"
+                        .to_string(),
+                );
+            }
+            do_mount("/dev/dm-0", "/sysroot", "ext4", libc::MS_RDONLY, "")?;
+        } else {
+            do_mount("/dev/mapper/root", "/sysroot", "ext4", libc::MS_RDONLY, "")?;
+        }
+        msg("mvm-verity-init: /sysroot mounted (verity-protected)");
+
+        // ── 6. Move /proc and /dev into /sysroot so the real init has
+        //    them already, then switch_root to /sysroot/init.
+        for (src, dst) in [("/proc", "/sysroot/proc"), ("/dev", "/sysroot/dev")] {
+            // Best-effort: real init can re-mount if these don't exist
+            // in the rootfs (the minimal-init script already does).
+            let _ = fs::create_dir_all(dst);
+            if let Err(e) = move_mount(src, dst) {
+                msg(&format!(
+                    "mvm-verity-init: warn: move-mount {src} → {dst}: {e}"
+                ));
+            }
+        }
+
+        // chdir to /sysroot, mount-move it onto /, then exec /init.
+        // This is the canonical switch_root(8) sequence.
+        do_chdir("/sysroot")?;
+        do_mount(".", "/", "", libc::MS_MOVE, "")?;
+        do_chroot(".")?;
+        do_chdir("/")?;
+
+        msg("mvm-verity-init: switching to /init");
+        run_init("/init", &["/init"])?;
+        unreachable!("exec returned without error");
+    }
+
+    // ────────── helpers ──────────
+
+    fn msg(s: &str) {
+        // Console writes: best-effort. The initramfs may not have
+        // /dev/console mounted before we mount /dev (step 1).
+        let _ = fs::write("/dev/console", format!("{s}\n"));
+        let _ = io::Write::flush(&mut io::stderr());
+        eprintln!("{s}");
+    }
+
+    fn base_ioctl() -> DmIoctl {
+        let mut io = DmIoctl {
+            version: [DM_VERSION_MAJOR, DM_VERSION_MINOR, DM_VERSION_PATCH],
+            data_size: DM_IOCTL_STRUCT_SIZE,
+            data_start: 0,
+            ..Default::default()
+        };
+        // data_start and data_size are recomputed for variable-payload
+        // commands (TABLE_LOAD); fixed-payload commands keep
+        // data_size = sizeof(DmIoctl) and data_start = 0.
+        io.flags = DM_EXISTS_FLAG;
+        io
+    }
+
+    fn write_name(buf: &mut [u8; DM_NAME_LEN], s: &str) {
+        let bytes = s.as_bytes();
+        let n = bytes.len().min(DM_NAME_LEN - 1);
+        buf[..n].copy_from_slice(&bytes[..n]);
+        buf[n] = 0;
+    }
+
+    /// Construct a DM_TABLE_LOAD payload: a `DmIoctl` header followed by a
+    /// `DmTargetSpec` and the parameter string. Alignment to 8 bytes is
+    /// required between successive `dm_target_spec`s; we have only one
+    /// target so we pad once.
+    fn build_table_payload(
+        sectors: u64,
+        target_type: &str,
+        params: &str,
+    ) -> Result<Vec<u8>, String> {
+        use std::mem::size_of;
+        let header_size = size_of::<DmIoctl>();
+        let spec_size = size_of::<DmTargetSpec>();
+        // Parameter string is NUL-terminated, then padded to 8-byte
+        // alignment for the next spec (we have only one, so padding
+        // to total alignment is what matters).
+        let params_nul = params.len() + 1;
+        let total_unaligned = header_size + spec_size + params_nul;
+        let aligned_total = total_unaligned.div_ceil(8) * 8;
+
+        let mut buf = vec![0u8; aligned_total];
+
+        // Header.
+        let header = DmIoctl {
+            version: [DM_VERSION_MAJOR, DM_VERSION_MINOR, DM_VERSION_PATCH],
+            data_size: aligned_total as u32,
+            data_start: header_size as u32,
+            target_count: 1,
+            open_count: 0,
+            flags: DM_EXISTS_FLAG | DM_READONLY_FLAG,
+            event_nr: 0,
+            padding: 0,
+            dev: 0,
+            name: {
+                let mut n = [0u8; DM_NAME_LEN];
+                write_name(&mut n, "root");
+                n
+            },
+            uuid: [0u8; DM_UUID_LEN],
+            data: [0u8; DM_DATA_LEN],
+        };
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                (&header as *const DmIoctl).cast::<u8>(),
+                buf.as_mut_ptr(),
+                header_size,
+            );
+        }
+
+        // Target spec.
+        let mut tt = [0u8; 16];
+        let n = target_type.len().min(15);
+        tt[..n].copy_from_slice(&target_type.as_bytes()[..n]);
+        let spec = DmTargetSpec {
+            sector_start: 0,
+            length: sectors,
+            status: 0,
+            // `next` = bytes from this spec to the next; with one
+            // target it's the offset to end-of-payload (kernel uses
+            // it to seek; setting to total - data_start is canonical).
+            next: (aligned_total - header_size) as u32,
+            target_type: tt,
+        };
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                (&spec as *const DmTargetSpec).cast::<u8>(),
+                buf.as_mut_ptr().add(header_size),
+                spec_size,
+            );
+        }
+
+        // Parameter string + NUL.
+        let params_off = header_size + spec_size;
+        buf[params_off..params_off + params.len()].copy_from_slice(params.as_bytes());
+        buf[params_off + params.len()] = 0;
+
+        if aligned_total > u32::MAX as usize {
+            return Err("verity payload exceeds u32".to_string());
+        }
+        Ok(buf)
+    }
+
+    fn block_device_size(path: &str) -> Result<u64, String> {
+        // BLKGETSIZE64 = _IOR(0x12, 114, size_t) = 0x80081272 on 64-bit Linux.
+        // libc::Ioctl is c_ulong on glibc and c_int on musl; we cast
+        // to libc::Ioctl at the call site so both build.
+        const BLKGETSIZE64: u64 = 0x80081272;
+        let f = fs::File::open(path).map_err(|e| format!("open {path}: {e}"))?;
+        let mut size: u64 = 0;
+        let rc = unsafe { libc::ioctl(f.as_raw_fd(), BLKGETSIZE64 as libc::Ioctl, &mut size) };
+        if rc != 0 {
+            return Err(format!(
+                "BLKGETSIZE64 on {path}: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        Ok(size)
+    }
+
+    unsafe fn do_ioctl<T>(fd: libc::c_int, request: u64, arg: *mut T) -> Result<i32, String> {
+        // Same Ioctl-type discrepancy as block_device_size; cast at
+        // the boundary to whatever libc says is correct for this
+        // target.
+        let rc = unsafe { libc::ioctl(fd, request as libc::Ioctl, arg) };
+        if rc < 0 {
+            return Err(io::Error::last_os_error().to_string());
+        }
+        Ok(rc)
+    }
+
+    fn do_mount(
+        source: &str,
+        target: &str,
+        fstype: &str,
+        flags: libc::c_ulong,
+        data: &str,
+    ) -> Result<(), String> {
+        // Best-effort: target may not exist if we forgot to bake it
+        // into the initramfs; create it.
+        let _ = fs::create_dir_all(target);
+        let src = CString::new(source).map_err(|_| "source has NUL".to_string())?;
+        let tgt = CString::new(target).map_err(|_| "target has NUL".to_string())?;
+        let typ = CString::new(fstype).map_err(|_| "fstype has NUL".to_string())?;
+        let dat = CString::new(data).map_err(|_| "data has NUL".to_string())?;
+        let rc = unsafe {
+            libc::mount(
+                src.as_ptr(),
+                tgt.as_ptr(),
+                typ.as_ptr(),
+                flags,
+                dat.as_ptr().cast(),
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "mount({source} → {target}, {fstype}): {}",
+                io::Error::last_os_error()
+            ));
+        }
+        Ok(())
+    }
+
+    fn move_mount(src: &str, dst: &str) -> Result<(), String> {
+        do_mount(src, dst, "", libc::MS_MOVE, "")
+    }
+
+    fn do_chdir(path: &str) -> Result<(), String> {
+        let p = CString::new(path).map_err(|_| "chdir path has NUL".to_string())?;
+        let rc = unsafe { libc::chdir(p.as_ptr()) };
+        if rc != 0 {
+            return Err(format!("chdir({path}): {}", io::Error::last_os_error()));
+        }
+        Ok(())
+    }
+
+    fn do_chroot(path: &str) -> Result<(), String> {
+        let p = CString::new(path).map_err(|_| "chroot path has NUL".to_string())?;
+        let rc = unsafe { libc::chroot(p.as_ptr()) };
+        if rc != 0 {
+            return Err(format!("chroot({path}): {}", io::Error::last_os_error()));
+        }
+        Ok(())
+    }
+
+    fn run_init(prog: &str, argv: &[&str]) -> Result<(), String> {
+        let cprog = CString::new(prog).map_err(|_| "prog has NUL".to_string())?;
+        let cargs: Vec<CString> = argv
+            .iter()
+            .map(|a| CString::new(*a).unwrap_or_default())
+            .collect();
+        let mut argv_ptrs: Vec<*const libc::c_char> = cargs.iter().map(|c| c.as_ptr()).collect();
+        argv_ptrs.push(std::ptr::null());
+        let rc = unsafe { libc::execv(cprog.as_ptr(), argv_ptrs.as_ptr()) };
+        if rc != 0 {
+            return Err(format!("execv({prog}): {}", io::Error::last_os_error()));
+        }
+        Ok(())
+    }
+}

--- a/crates/mvm-runtime/src/vm/microvm.rs
+++ b/crates/mvm-runtime/src/vm/microvm.rs
@@ -1355,53 +1355,6 @@ pub fn probe_verity_sidecar(rootfs_path: &str) -> (Option<String>, Option<String
     (Some(verity), Some(hash))
 }
 
-/// Build the `dm-mod.create=` kernel cmdline argument that creates a
-/// verity-protected root device pointing at `/dev/vda` (data) and
-/// `/dev/vdb` (hash tree).
-///
-/// Format reference: kernel doc Documentation/admin-guide/device-mapper/dm-init.rst:
-///
-///   dm-mod.create="<name>,<uuid>,<minor>,<flags>,<table-line>"
-///
-/// Verity table line:
-///
-///   0 <num-sectors> verity 1 /dev/vda /dev/vdb 4096 4096
-///                           <data-blocks> 0 sha256 <root-hash> <salt-hex>
-///
-/// `data-blocks = rootfs_size / 4096`. Salt is zero (matches the
-/// deterministic salt pinned by mkGuest's verityArtifacts derivation
-/// in `nix/flake.nix`). ADR-002 §W3.2.
-fn build_verity_dm_create_arg(rootfs_path: &str, roothash: &str) -> Result<String> {
-    if roothash.len() != 64 || !roothash.chars().all(|c| c.is_ascii_hexdigit()) {
-        anyhow::bail!(
-            "invalid root hash {:?} (expected 64 lowercase hex chars)",
-            roothash
-        );
-    }
-    // Querying file size on the host (we're in mvmctl, not in the
-    // Lima VM that holds the rootfs) is unreliable when the path is
-    // inside a Linux-only filesystem mount — drop back to running
-    // `stat -c %s` inside the VM.
-    use crate::shell::run_in_vm_stdout;
-    let size_str = run_in_vm_stdout(&format!("stat -c %s {rootfs_path}"))?;
-    let size: u64 = size_str
-        .trim()
-        .parse()
-        .map_err(|e| anyhow::anyhow!("parse rootfs size {:?}: {e}", size_str.trim()))?;
-    if !size.is_multiple_of(4096) {
-        anyhow::bail!(
-            "rootfs size {size} is not a multiple of 4096 — verity setup must have rejected \
-             this image, but we got here anyway"
-        );
-    }
-    let data_blocks = size / 4096;
-    let num_sectors = data_blocks * 8; // 4096 bytes per block / 512 sectors
-    let salt = "0".repeat(64);
-    Ok(format!(
-        "dm-mod.create=\"rootfs,,,ro,0 {num_sectors} verity 1 /dev/vda /dev/vdb 4096 4096 {data_blocks} 0 sha256 {roothash} {salt}\""
-    ))
-}
-
 /// Configure a flake-built microVM via the Firecracker API (multi-VM).
 #[instrument(skip_all, fields(name = %config.name))]
 pub fn configure_flake_microvm(config: &FlakeRunConfig, abs_dir: &str, socket: &str) -> Result<()> {
@@ -1431,40 +1384,68 @@ pub fn configure_flake_microvm_with_drives_dir(
     )?;
 
     // Boot args: pass guest IP and gateway via kernel cmdline.
-    // When initrd is present (NixOS guest), the initrd handles root mounting.
-    // When initrd is absent (minimal guest), the kernel mounts root directly.
+    // When initrd is present (NixOS guest or verity initrd), the initrd
+    // handles root mounting. When absent (minimal guest, no verity),
+    // the kernel mounts /dev/vda directly.
     let base_args = format!(
         "console=ttyS0 reboot=k panic=1 net.ifnames=0 mvm.ip={ip}/24 mvm.gw={gw}",
         ip = slot.guest_ip,
         gw = BRIDGE_IP,
     );
-    // dm-verity boot path: root maps to /dev/dm-0, mounted ro. The
-    // kernel constructs the verity target from the cmdline before init
-    // runs (CONFIG_DM_INIT in firecracker-aarch64.config). A tampered
-    // ext4 fails the hash check at first read and the kernel panics
-    // before init starts. ADR-002 §W3.2.
-    let dm_create = config
+
+    // dm-verity boot path (ADR-002 §W3): when verity is on, the kernel
+    // mounts the verity initramfs first, which is `mvm-verity-init`
+    // (PID 1) — that binary reads `mvm.roothash=…` from the cmdline,
+    // builds the verity device-mapper target via raw ioctls, mounts
+    // /dev/mapper/root, and switch_root's to /sysroot/init.
+    //
+    // We deliberately do NOT add `root=/dev/dm-0` here: Firecracker on
+    // aarch64 unconditionally appends `root=/dev/vda ro` after our
+    // boot_args, and the kernel uses last-wins for `root=`. By owning
+    // the pivot in userspace via the initramfs, the kernel's `root=`
+    // setting becomes irrelevant — `mvm-verity-init` chooses the real
+    // root explicitly via `mount` + `switch_root`.
+    let verity_initrd_path = config
         .verity_path
         .as_deref()
         .zip(config.roothash.as_deref())
-        .map(|(_, hash)| build_verity_dm_create_arg(&config.rootfs_path, hash))
-        .transpose()?;
-    let boot_args = if config.initrd_path.is_some() {
-        // NixOS stage-1 owns root mounting; verity wiring there would
-        // need stage-1 patches. Out of scope for this iteration —
-        // production flake's mkGuest path doesn't use an initrd.
-        base_args
-    } else if let Some(dm) = &dm_create {
-        format!(
-            "root=/dev/dm-0 ro rootwait init=/init {dm} {base_args}",
-            dm = dm
-        )
+        .and_then(|_| {
+            // Convention from `nix/flake.nix`: the verity initrd lives
+            // at `<rev_dir>/rootfs.initrd`, alongside `rootfs.{ext4,
+            // verity,roothash}`. Fall back to `None` if the file isn't
+            // present (older templates that pre-date the initrd path).
+            std::path::Path::new(&config.rootfs_path)
+                .parent()
+                .map(|p| format!("{}/rootfs.initrd", p.display()))
+        })
+        .filter(|p| std::path::Path::new(p).exists());
+    let verity_args: Option<String> = config
+        .roothash
+        .as_deref()
+        .map(|h| format!("mvm.roothash={h} mvm.data=/dev/vda mvm.hash=/dev/vdb"));
+
+    // Pick the initrd to attach: caller-supplied (NixOS stage-1) wins
+    // over the verity initrd. They can't both be present in practice —
+    // the production minimal-init path doesn't use a NixOS stage-1 —
+    // but the precedence is documented for future contributors.
+    let effective_initrd = config
+        .initrd_path
+        .clone()
+        .or_else(|| verity_initrd_path.clone());
+
+    let boot_args = if effective_initrd.is_some() {
+        // initrd owns root mounting. Verity adds the cmdline knobs the
+        // initramfs reads to construct /dev/mapper/root.
+        match &verity_args {
+            Some(extra) => format!("{base_args} {extra}"),
+            None => base_args,
+        }
     } else {
         format!("root=/dev/vda rw rootwait init=/init {base_args}")
     };
 
     ui::info(&format!("Setting boot source: {}", config.vmlinux_path));
-    let boot_source = match &config.initrd_path {
+    let boot_source = match &effective_initrd {
         Some(initrd) => {
             ui::info(&format!("Using initrd: {}", initrd));
             format!(
@@ -2121,25 +2102,11 @@ mod tests {
 
     // ──── Verity (ADR-002 §W3) ────────────────────────────────────────
     //
-    // Live verity boot is exercised in the Linux/KVM CI lane (it
-    // requires a real microVM and a working dm-mod.create kernel
-    // path). The unit tests here cover the host-side helpers that
-    // build the kernel cmdline and validate the inputs — those run
-    // unconditionally on every commit so a refactor that breaks the
-    // format-string contract surfaces locally before CI.
-
-    #[test]
-    fn build_verity_dm_create_rejects_short_hash() {
-        let res = build_verity_dm_create_arg("/tmp/whatever", "deadbeef");
-        assert!(res.is_err(), "short hash must be rejected");
-    }
-
-    #[test]
-    fn build_verity_dm_create_rejects_non_hex_hash() {
-        let bad = "z".repeat(64);
-        let res = build_verity_dm_create_arg("/tmp/whatever", &bad);
-        assert!(res.is_err(), "non-hex hash must be rejected");
-    }
+    // The host-side cmdline shape and DM-table construction now live
+    // in `mvm-verity-init` (initramfs PID 1) — those are exercised by
+    // the live boot regression in `specs/runbooks/w3-verified-boot.md`.
+    // The unit test below covers the only host-side helper still
+    // running on the cold-boot path: the sidecar path probe.
 
     #[test]
     fn probe_verity_sidecar_returns_none_for_path_without_parent() {

--- a/crates/mvm-security/Cargo.toml
+++ b/crates/mvm-security/Cargo.toml
@@ -12,7 +12,13 @@ authors.workspace = true
 mvm-core.workspace = true
 aho-corasick.workspace = true
 anyhow.workspace = true
+chrono.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
+thiserror = "1"
 tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/mvm-security/Cargo.toml
+++ b/crates/mvm-security/Cargo.toml
@@ -8,6 +8,14 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 
+[features]
+# Enables cosign-keyless manifest verification via the sigstore Rust crate.
+# Default-on for release builds; disable with --no-default-features for a
+# smaller binary at the cost of a fail-closed `verify_manifest` stub.
+# Plan 36 / ADR 005.
+default = ["manifest-verify"]
+manifest-verify = ["dep:sigstore", "dep:tokio"]
+
 [dependencies]
 mvm-core.workspace = true
 aho-corasick.workspace = true
@@ -19,6 +27,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror = "1"
 tracing.workspace = true
+
+# Optional: cosign keyless verification (gated behind `manifest-verify`).
+sigstore = { version = "0.13", default-features = false, features = ["bundle", "sigstore-trust-root", "rustls-tls"], optional = true }
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/mvm-security/src/image_verify.rs
+++ b/crates/mvm-security/src/image_verify.rs
@@ -171,23 +171,90 @@ pub fn parse_manifest(bytes: &[u8]) -> VerifyResult<SignedManifest> {
 /// success.
 ///
 /// `cosign_bundle` is the modern Sigstore format produced by
-/// `cosign sign-blob --bundle`; the existing release workflow uses this
-/// format for `mvmctl` tarballs and the SBOM
-/// (`release.yml::Sign release tarballs and SBOM`).
+/// `cosign sign-blob --bundle`; the existing release workflow already
+/// uses this format for `mvmctl` tarballs and the SBOM
+/// (`release.yml::Sign release tarballs and SBOM`). Plan 36 reuses the
+/// same format for image manifests.
 ///
-/// **TODO(plan-36 PR-A.2):** wire up the `sigstore` Rust crate's offline
-/// bundle verification. Until then, this function fails closed with
-/// `SignatureInvalid` so no caller can accidentally accept unsigned
-/// manifests during the rollout.
+/// `expected_identity` is the *exact* SAN that the signing certificate
+/// must carry — e.g.
+/// `https://github.com/auser/mvm/.github/workflows/release.yml@refs/tags/v0.14.0`.
+/// Caller builds it from the manifest's expected version so each tagged
+/// release verifies against its own bound identity. Sigstore's
+/// `Identity` policy is exact-match only; there is no glob/regex
+/// option, which is by design — wildcarding the identity would be a
+/// trust regression.
+///
+/// `expected_issuer` is the OIDC issuer; for GitHub Actions keyless
+/// signing it's `https://token.actions.githubusercontent.com`.
+///
+/// On success returns the manifest parsed from the verified bytes —
+/// callers should never trust the manifest content before this returns
+/// `Ok`. On failure returns `SignatureInvalid` with a message suitable
+/// for surfacing to operators.
+///
+/// Compiled out when the `manifest-verify` Cargo feature is disabled;
+/// the no-feature variant returns `SignatureInvalid` unconditionally,
+/// preserving the fail-closed contract.
+#[cfg(feature = "manifest-verify")]
+pub fn verify_manifest(
+    manifest_bytes: &[u8],
+    cosign_bundle: &[u8],
+    expected_identity: &str,
+    expected_issuer: &str,
+) -> VerifyResult<SignedManifest> {
+    use sigstore::bundle::Bundle;
+    use sigstore::bundle::verify::{blocking::Verifier, policy::Identity};
+
+    let bundle: Bundle =
+        serde_json::from_slice(cosign_bundle).map_err(|e| VerifyError::SignatureInvalid {
+            reason: format!("cosign bundle parse failed: {e}"),
+        })?;
+
+    // `Verifier::production()` fetches Sigstore's public-good TUF root
+    // on first construction. The fetch is blocking and one-shot per
+    // process; subsequent calls reuse the in-memory trust state. A
+    // network-down host on first run will surface as SignatureInvalid
+    // with a clear "trust root init failed" reason.
+    let verifier = Verifier::production().map_err(|e| VerifyError::SignatureInvalid {
+        reason: format!("sigstore trust root init failed: {e}"),
+    })?;
+
+    let policy = Identity::new(expected_identity, expected_issuer);
+
+    // `offline = false` lets the verifier consult Rekor for the
+    // transparency log entry. Plan 36's "offline-bundle" path
+    // (`offline = true`) is reachable when the bundle already includes
+    // the inclusion proof inline — wire that into mvmd's reconciliation
+    // loop in plan 23 Phase 1, where re-querying Rekor on every pool
+    // verify is too expensive.
+    verifier
+        .verify(manifest_bytes, bundle, &policy, false)
+        .map_err(|e| VerifyError::SignatureInvalid {
+            reason: format!("manifest signature verification failed: {e}"),
+        })?;
+
+    parse_manifest(manifest_bytes)
+}
+
+/// No-feature fallback: refuse to accept any manifest as signed.
+///
+/// Builds without `manifest-verify` (e.g. `cargo install
+/// --no-default-features`) drop the heavy `sigstore` dependency tree
+/// in exchange for losing manifest verification. The fail-closed
+/// contract is preserved so a downstream caller can't accidentally
+/// accept unsigned manifests after a feature-flag flip.
+#[cfg(not(feature = "manifest-verify"))]
 pub fn verify_manifest(
     _manifest_bytes: &[u8],
     _cosign_bundle: &[u8],
     _expected_identity: &str,
+    _expected_issuer: &str,
 ) -> VerifyResult<SignedManifest> {
     Err(VerifyError::SignatureInvalid {
-        reason: "cosign verification not yet implemented (plan-36 PR-A.2 \
-                 wires up the sigstore Rust crate). Until then, refuse to \
-                 accept any manifest as signed."
+        reason: "manifest-verify feature is disabled in this build; rebuild \
+                 mvmctl with default features or set MVM_SKIP_COSIGN_VERIFY=1 \
+                 in an emergency rotation."
             .to_string(),
     })
 }
@@ -540,14 +607,28 @@ mod tests {
     }
 
     #[test]
-    fn verify_manifest_fails_closed_until_sigstore_lands() {
-        // PR-A intentionally fails-closed on the cosign step. Confirm the
-        // error variant is `SignatureInvalid` so a future implementation
-        // is a drop-in replacement and consumers don't need to retune
-        // their pattern-matching.
-        match verify_manifest(b"{}", b"bundle", "identity") {
+    fn verify_manifest_rejects_garbage_bundle() {
+        // Hand verify_manifest something that can't possibly be a
+        // sigstore bundle. The error must come back as SignatureInvalid
+        // (not Parse — Parse is reserved for the manifest-JSON parse
+        // step that runs *after* signature verification). The exact
+        // reason wording differs between feature-on (sigstore parse
+        // error) and feature-off (feature-disabled), so we only assert
+        // the variant.
+        match verify_manifest(b"{}", b"not a bundle", "identity", "issuer") {
+            Err(VerifyError::SignatureInvalid { .. }) => {}
+            other => panic!("expected SignatureInvalid, got {other:?}"),
+        }
+    }
+
+    #[cfg(not(feature = "manifest-verify"))]
+    #[test]
+    fn verify_manifest_no_feature_fails_closed() {
+        // Without the feature, every call must return SignatureInvalid
+        // with a wording that points the operator at how to recover.
+        match verify_manifest(b"{}", b"bundle", "id", "issuer") {
             Err(VerifyError::SignatureInvalid { reason }) => {
-                assert!(reason.contains("not yet implemented"));
+                assert!(reason.contains("manifest-verify feature is disabled"));
             }
             other => panic!("expected SignatureInvalid, got {other:?}"),
         }

--- a/crates/mvm-security/src/image_verify.rs
+++ b/crates/mvm-security/src/image_verify.rs
@@ -1,0 +1,555 @@
+//! Signed-image verification primitive.
+//!
+//! Plan 36 / ADR 005. Extends W5.1 (`apple_container.rs::verify_artifact_hash`)
+//! by elevating the trust anchor from "TLS-fetched checksum file" to
+//! "cosign-keyless-signed manifest." The `SignedManifest` schema records
+//! every artifact's SHA-256 plus the input closure (Nix store hash, source
+//! git SHA, flake lockfile content hashes) so the input bytes are
+//! recoverable from the signed manifest alone.
+//!
+//! This module is consumed by mvmctl on `dev up` (mvm plan 36) and by mvmd
+//! on pool image verification (mvmd plan 23). The typed `VerifyError`
+//! contract lets mvmd's reconciliation loop pattern-match outcomes
+//! instead of crash-looping on `anyhow::Error`.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Current manifest schema version. Bump whenever fields change in a way
+/// older verifiers can't ignore. Older verifiers must reject unknown
+/// schema versions (fail-closed) rather than skip unknown fields.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// SHA-256 digest of a single named artifact in a signed manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactDigest {
+    /// Filename as published in the GitHub Release (e.g.
+    /// `dev-rootfs-aarch64.ext4`). Used to look up the digest entry by
+    /// the filename the consumer downloaded; the manifest is not
+    /// position-dependent.
+    pub name: String,
+    /// Lowercase hex SHA-256 of the artifact bytes.
+    pub sha256: String,
+}
+
+/// Cosign-keyless-signed manifest of a release's image bundle.
+///
+/// Fields beyond `artifacts` exist so the verified manifest is itself a
+/// useful audit record: a verifier can answer "what input closure
+/// produced these bytes?" without re-deriving from source. mvmd consumes
+/// `addressed_advisories` to decide whether a pool image addresses a
+/// CVE under reconciliation; mvmctl ignores the field today.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedManifest {
+    pub schema_version: u32,
+    pub version: String,
+    pub arch: String,
+    pub variant: String,
+    pub rootfs_format: String,
+    pub artifacts: Vec<ArtifactDigest>,
+    pub nix_store_hash: String,
+    pub source_git_sha: String,
+    pub flake_locks: BTreeMap<String, String>,
+    #[serde(default)]
+    pub addressed_advisories: Vec<String>,
+    pub built_at: DateTime<Utc>,
+    pub not_after: DateTime<Utc>,
+}
+
+impl SignedManifest {
+    /// Look up a single artifact digest by its published filename.
+    /// Returns `None` if the manifest doesn't list that artifact.
+    pub fn artifact(&self, name: &str) -> Option<&ArtifactDigest> {
+        self.artifacts.iter().find(|a| a.name == name)
+    }
+}
+
+/// Cosign-signed revocation list pulled from the `revocations` release
+/// tag. Append-only across releases; checked at most once per 24h with a
+/// 7-day fresh window for offline-tolerant operation. The `revoked_at`
+/// timestamp is the manifest field; `reason` is surfaced verbatim in the
+/// hard-fail error so operators understand the recall.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevocationList {
+    pub schema_version: u32,
+    pub revocations: Vec<RevocationEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevocationEntry {
+    pub version: String,
+    pub variant: String,
+    pub arch: String,
+    pub reason: String,
+    pub revoked_at: DateTime<Utc>,
+}
+
+impl RevocationList {
+    /// Return the matching entry, if any, for a given manifest.
+    pub fn entry_for(&self, m: &SignedManifest) -> Option<&RevocationEntry> {
+        self.revocations
+            .iter()
+            .find(|r| r.version == m.version && r.variant == m.variant && r.arch == m.arch)
+    }
+}
+
+/// Errors returned by every verification entry point.
+///
+/// Typed (not `anyhow`) because mvmd's reconciliation loop must pattern-
+/// match outcomes — Revoked vs Expired vs DigestMismatch demand different
+/// reactions (skip + alert vs warn vs treat as supply-chain incident).
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyError {
+    #[error("manifest signature is invalid: {reason}")]
+    SignatureInvalid { reason: String },
+
+    #[error("artifact {name} digest mismatch: expected sha256={expected}, got sha256={actual}")]
+    DigestMismatch {
+        name: String,
+        expected: String,
+        actual: String,
+    },
+
+    #[error("manifest is for {manifest_version} but runtime is {runtime_version}")]
+    VersionSkew {
+        manifest_version: String,
+        runtime_version: String,
+    },
+
+    #[error("manifest schema version {found} is newer than this build supports ({supported})")]
+    UnsupportedSchema { found: u32, supported: u32 },
+
+    #[error("manifest version {version} was revoked at {since}: {reason}")]
+    Revoked {
+        version: String,
+        since: DateTime<Utc>,
+        reason: String,
+    },
+
+    #[error("manifest expired at {not_after} (now {now})")]
+    Expired {
+        not_after: DateTime<Utc>,
+        now: DateTime<Utc>,
+    },
+
+    #[error("manifest does not list expected artifact {name}")]
+    ArtifactNotInManifest { name: String },
+
+    #[error("manifest parse failed: {0}")]
+    Parse(String),
+
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+}
+
+/// Result alias used throughout this module.
+pub type VerifyResult<T> = Result<T, VerifyError>;
+
+/// Parse a manifest from raw JSON bytes and reject unsupported schema
+/// versions. Always run this *after* signature verification — JSON
+/// parsing of attacker-controlled bytes should not be trusted on its
+/// own.
+pub fn parse_manifest(bytes: &[u8]) -> VerifyResult<SignedManifest> {
+    let manifest: SignedManifest =
+        serde_json::from_slice(bytes).map_err(|e| VerifyError::Parse(e.to_string()))?;
+    if manifest.schema_version > SCHEMA_VERSION {
+        return Err(VerifyError::UnsupportedSchema {
+            found: manifest.schema_version,
+            supported: SCHEMA_VERSION,
+        });
+    }
+    Ok(manifest)
+}
+
+/// Verify the signature on a manifest and return the parsed result on
+/// success.
+///
+/// `cosign_bundle` is the modern Sigstore format produced by
+/// `cosign sign-blob --bundle`; the existing release workflow uses this
+/// format for `mvmctl` tarballs and the SBOM
+/// (`release.yml::Sign release tarballs and SBOM`).
+///
+/// **TODO(plan-36 PR-A.2):** wire up the `sigstore` Rust crate's offline
+/// bundle verification. Until then, this function fails closed with
+/// `SignatureInvalid` so no caller can accidentally accept unsigned
+/// manifests during the rollout.
+pub fn verify_manifest(
+    _manifest_bytes: &[u8],
+    _cosign_bundle: &[u8],
+    _expected_identity: &str,
+) -> VerifyResult<SignedManifest> {
+    Err(VerifyError::SignatureInvalid {
+        reason: "cosign verification not yet implemented (plan-36 PR-A.2 \
+                 wires up the sigstore Rust crate). Until then, refuse to \
+                 accept any manifest as signed."
+            .to_string(),
+    })
+}
+
+/// Confirm a manifest's `version` field matches the runtime's expected
+/// version. Plan 36 pins `manifest.version == env!("CARGO_PKG_VERSION")`
+/// exactly — no "newer is fine," because every release has its own
+/// signed manifest and the trust chain is tag-bound.
+pub fn check_version_pin(manifest: &SignedManifest, runtime_version: &str) -> VerifyResult<()> {
+    if manifest.version == runtime_version {
+        Ok(())
+    } else {
+        Err(VerifyError::VersionSkew {
+            manifest_version: manifest.version.clone(),
+            runtime_version: runtime_version.to_string(),
+        })
+    }
+}
+
+/// Reject a manifest whose `not_after` has passed. mvmctl's caller
+/// should treat the result as a warning (advise upgrade); mvmd's caller
+/// should treat it as a hard fail.
+pub fn check_not_after(manifest: &SignedManifest, now: DateTime<Utc>) -> VerifyResult<()> {
+    if now <= manifest.not_after {
+        Ok(())
+    } else {
+        Err(VerifyError::Expired {
+            not_after: manifest.not_after,
+            now,
+        })
+    }
+}
+
+/// Reject a manifest whose version appears in the revocation list.
+pub fn check_revocation(
+    manifest: &SignedManifest,
+    revocations: &RevocationList,
+) -> VerifyResult<()> {
+    match revocations.entry_for(manifest) {
+        Some(entry) => Err(VerifyError::Revoked {
+            version: entry.version.clone(),
+            since: entry.revoked_at,
+            reason: entry.reason.clone(),
+        }),
+        None => Ok(()),
+    }
+}
+
+/// Stream `path` through SHA-256 and compare to `expected.sha256`. On
+/// mismatch, delete the file and return `DigestMismatch`. The
+/// delete-on-mismatch behaviour matches W5.1
+/// (`apple_container.rs::verify_artifact_hash`).
+///
+/// Callers that want to keep the file for forensics should hash it
+/// directly with `sha256_file` and compare manually.
+pub fn verify_artifact(path: &Path, expected: &ArtifactDigest) -> VerifyResult<()> {
+    let actual = sha256_file(path)?;
+    if actual == expected.sha256.to_ascii_lowercase() {
+        return Ok(());
+    }
+    // Best-effort cleanup; ignore failure (the caller already gets a
+    // DigestMismatch and the right thing for them to do is bail).
+    let _ = fs::remove_file(path);
+    Err(VerifyError::DigestMismatch {
+        name: expected.name.clone(),
+        expected: expected.sha256.to_ascii_lowercase(),
+        actual,
+    })
+}
+
+/// Stream a file through SHA-256 and return the lowercase hex digest.
+/// Public for callers that want to verify an artifact without the
+/// delete-on-mismatch behaviour of `verify_artifact`.
+pub fn sha256_file(path: &Path) -> io::Result<String> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    io::copy(&mut file, &mut hasher)?;
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn sample_manifest() -> SignedManifest {
+        SignedManifest {
+            schema_version: 1,
+            version: "0.14.0".to_string(),
+            arch: "aarch64".to_string(),
+            variant: "dev".to_string(),
+            rootfs_format: "ext4".to_string(),
+            artifacts: vec![
+                ArtifactDigest {
+                    name: "dev-vmlinux-aarch64".to_string(),
+                    sha256: "a".repeat(64),
+                },
+                ArtifactDigest {
+                    name: "dev-rootfs-aarch64.ext4".to_string(),
+                    sha256: "b".repeat(64),
+                },
+            ],
+            nix_store_hash: "abc123".to_string(),
+            source_git_sha: "deadbeef".to_string(),
+            flake_locks: BTreeMap::from([
+                (
+                    "nix/flake.nix".to_string(),
+                    format!("sha256:{}", "c".repeat(64)),
+                ),
+                (
+                    "nix/images/builder/flake.lock".to_string(),
+                    format!("sha256:{}", "d".repeat(64)),
+                ),
+            ]),
+            addressed_advisories: vec![],
+            built_at: Utc.with_ymd_and_hms(2026, 4, 30, 18, 0, 0).unwrap(),
+            not_after: Utc.with_ymd_and_hms(2026, 7, 29, 18, 0, 0).unwrap(),
+        }
+    }
+
+    fn write_temp(bytes: &[u8]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(bytes).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    fn hex_sha256(bytes: &[u8]) -> String {
+        let mut h = Sha256::new();
+        h.update(bytes);
+        format!("{:x}", h.finalize())
+    }
+
+    #[test]
+    fn manifest_roundtrips_via_json() {
+        let m = sample_manifest();
+        let bytes = serde_json::to_vec(&m).unwrap();
+        let parsed = parse_manifest(&bytes).unwrap();
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn artifact_lookup_by_name() {
+        let m = sample_manifest();
+        assert!(m.artifact("dev-vmlinux-aarch64").is_some());
+        assert!(m.artifact("does-not-exist").is_none());
+    }
+
+    #[test]
+    fn unsupported_schema_version_fails_closed() {
+        let mut m = sample_manifest();
+        m.schema_version = SCHEMA_VERSION + 1;
+        let bytes = serde_json::to_vec(&m).unwrap();
+        match parse_manifest(&bytes) {
+            Err(VerifyError::UnsupportedSchema { found, supported }) => {
+                assert_eq!(found, SCHEMA_VERSION + 1);
+                assert_eq!(supported, SCHEMA_VERSION);
+            }
+            other => panic!("expected UnsupportedSchema, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        match parse_manifest(b"not json") {
+            Err(VerifyError::Parse(_)) => {}
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn version_pin_matches() {
+        let m = sample_manifest();
+        check_version_pin(&m, "0.14.0").unwrap();
+    }
+
+    #[test]
+    fn version_pin_skew_fails() {
+        let m = sample_manifest();
+        match check_version_pin(&m, "0.14.1") {
+            Err(VerifyError::VersionSkew {
+                manifest_version,
+                runtime_version,
+            }) => {
+                assert_eq!(manifest_version, "0.14.0");
+                assert_eq!(runtime_version, "0.14.1");
+            }
+            other => panic!("expected VersionSkew, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_after_fresh_passes() {
+        let m = sample_manifest();
+        let now = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+        check_not_after(&m, now).unwrap();
+    }
+
+    #[test]
+    fn not_after_expired_fails() {
+        let m = sample_manifest();
+        let now = Utc.with_ymd_and_hms(2026, 8, 1, 0, 0, 0).unwrap();
+        match check_not_after(&m, now) {
+            Err(VerifyError::Expired {
+                not_after,
+                now: returned_now,
+            }) => {
+                assert_eq!(not_after, m.not_after);
+                assert_eq!(returned_now, now);
+            }
+            other => panic!("expected Expired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn revocation_miss_passes() {
+        let m = sample_manifest();
+        let revs = RevocationList {
+            schema_version: 1,
+            revocations: vec![RevocationEntry {
+                version: "0.13.0".to_string(),
+                variant: "dev".to_string(),
+                arch: "aarch64".to_string(),
+                reason: "irrelevant".to_string(),
+                revoked_at: Utc::now(),
+            }],
+        };
+        check_revocation(&m, &revs).unwrap();
+    }
+
+    #[test]
+    fn revocation_hit_fails() {
+        let m = sample_manifest();
+        let when = Utc.with_ymd_and_hms(2026, 5, 15, 0, 0, 0).unwrap();
+        let revs = RevocationList {
+            schema_version: 1,
+            revocations: vec![RevocationEntry {
+                version: "0.14.0".to_string(),
+                variant: "dev".to_string(),
+                arch: "aarch64".to_string(),
+                reason: "CVE-2026-0001 in nix daemon".to_string(),
+                revoked_at: when,
+            }],
+        };
+        match check_revocation(&m, &revs) {
+            Err(VerifyError::Revoked {
+                version,
+                since,
+                reason,
+            }) => {
+                assert_eq!(version, "0.14.0");
+                assert_eq!(since, when);
+                assert!(reason.contains("CVE-2026-0001"));
+            }
+            other => panic!("expected Revoked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn revocation_does_not_match_different_arch_or_variant() {
+        let m = sample_manifest();
+        let when = Utc.with_ymd_and_hms(2026, 5, 15, 0, 0, 0).unwrap();
+        let revs = RevocationList {
+            schema_version: 1,
+            revocations: vec![
+                // Same version, different arch — must not match.
+                RevocationEntry {
+                    version: "0.14.0".to_string(),
+                    variant: "dev".to_string(),
+                    arch: "x86_64".to_string(),
+                    reason: "wrong arch".to_string(),
+                    revoked_at: when,
+                },
+                // Same version + arch, different variant — must not match.
+                RevocationEntry {
+                    version: "0.14.0".to_string(),
+                    variant: "builder".to_string(),
+                    arch: "aarch64".to_string(),
+                    reason: "wrong variant".to_string(),
+                    revoked_at: when,
+                },
+            ],
+        };
+        check_revocation(&m, &revs).unwrap();
+    }
+
+    #[test]
+    fn verify_artifact_accepts_matching_digest() {
+        let bytes = b"hello world\n";
+        let f = write_temp(bytes);
+        let expected = ArtifactDigest {
+            name: "test".to_string(),
+            sha256: hex_sha256(bytes),
+        };
+        verify_artifact(f.path(), &expected).unwrap();
+        assert!(f.path().exists(), "matching artifact must not be deleted");
+    }
+
+    #[test]
+    fn verify_artifact_rejects_and_deletes_on_mismatch() {
+        let f = write_temp(b"actual contents");
+        let path = f.path().to_path_buf();
+        let expected = ArtifactDigest {
+            name: "test".to_string(),
+            sha256: hex_sha256(b"different contents"),
+        };
+        match verify_artifact(&path, &expected) {
+            Err(VerifyError::DigestMismatch {
+                name,
+                expected: e,
+                actual,
+            }) => {
+                assert_eq!(name, "test");
+                assert_eq!(e, hex_sha256(b"different contents"));
+                assert_eq!(actual, hex_sha256(b"actual contents"));
+            }
+            other => panic!("expected DigestMismatch, got {other:?}"),
+        }
+        // NamedTempFile leaves the underlying handle, but the file at
+        // the recorded path should be gone after delete-on-mismatch.
+        assert!(!path.exists(), "tampered artifact must be deleted");
+    }
+
+    #[test]
+    fn verify_artifact_propagates_io_error_for_missing_file() {
+        let expected = ArtifactDigest {
+            name: "ghost".to_string(),
+            sha256: "0".repeat(64),
+        };
+        match verify_artifact(Path::new("/definitely/does/not/exist"), &expected) {
+            Err(VerifyError::Io(_)) => {}
+            other => panic!("expected Io, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_artifact_accepts_uppercase_expected_digest() {
+        // sha256sum default output is lowercase, but a manifest emitter
+        // could provide uppercase. Accept either; canonicalise on
+        // comparison.
+        let bytes = b"case test\n";
+        let f = write_temp(bytes);
+        let expected = ArtifactDigest {
+            name: "test".to_string(),
+            sha256: hex_sha256(bytes).to_ascii_uppercase(),
+        };
+        verify_artifact(f.path(), &expected).unwrap();
+    }
+
+    #[test]
+    fn verify_manifest_fails_closed_until_sigstore_lands() {
+        // PR-A intentionally fails-closed on the cosign step. Confirm the
+        // error variant is `SignatureInvalid` so a future implementation
+        // is a drop-in replacement and consumers don't need to retune
+        // their pattern-matching.
+        match verify_manifest(b"{}", b"bundle", "identity") {
+            Err(VerifyError::SignatureInvalid { reason }) => {
+                assert!(reason.contains("not yet implemented"));
+            }
+            other => panic!("expected SignatureInvalid, got {other:?}"),
+        }
+    }
+}

--- a/crates/mvm-security/src/image_verify.rs
+++ b/crates/mvm-security/src/image_verify.rs
@@ -390,6 +390,61 @@ mod tests {
         format!("{:x}", h.finalize())
     }
 
+    /// Contract test pinning the on-wire shape produced by
+    /// `scripts/generate-image-manifest.sh`. If either side drifts —
+    /// the script reorders keys, drops a field, or this struct gains
+    /// a required field — this test fires. Keep both producer and
+    /// consumer in lock-step.
+    #[test]
+    fn parses_release_pipeline_manifest_shape() {
+        // Verbatim sample of what scripts/generate-image-manifest.sh
+        // emits for ARCH=aarch64 VARIANT=dev ROOTFS_EXT=ext4 with
+        // fake artifact bytes. Re-generate with:
+        //   ARCH=aarch64 VARIANT=dev ROOTFS_EXT=ext4 \
+        //     STORE_PATH=/nix/store/abc123def456-mvm-mvm-dev-dev \
+        //     STAGING_DIR=$d VERSION=0.13.0 \
+        //     SOURCE_GIT_SHA=deadbeef0123456789 \
+        //     bash scripts/generate-image-manifest.sh
+        let json = r#"{
+          "schema_version": 1,
+          "version": "0.14.0",
+          "arch": "aarch64",
+          "variant": "dev",
+          "rootfs_format": "ext4",
+          "artifacts": [
+            {"name": "dev-vmlinux-aarch64",
+             "sha256": "b29be84bdecbb915f70659e08ba51472d05746b011b8acf965f49e94ff22d5b5"},
+            {"name": "dev-rootfs-aarch64.ext4",
+             "sha256": "a6a24f174bd25221b00bb2bb4888eb04e5ef3d20033c38188e44b902f23564bc"}
+          ],
+          "nix_store_hash": "abc123def456",
+          "source_git_sha": "deadbeef0123456789",
+          "flake_locks": {
+            "nix/flake.lock": "sha256:d235bed6112b0fff283680a0fd3a718437db27ce3782aa554f2912f042e4026a",
+            "nix/images/builder/flake.lock": "sha256:4c72ffe504f50c461b314ff86bf0394c15ffa04e457d07624c9280f04e152600"
+          },
+          "addressed_advisories": [],
+          "built_at": "2026-05-01T00:26:37Z",
+          "not_after":  "2026-07-30T00:26:37Z"
+        }"#;
+        let m = parse_manifest(json.as_bytes()).expect("release-pipeline JSON must parse");
+        assert_eq!(m.schema_version, SCHEMA_VERSION);
+        assert_eq!(m.version, "0.14.0");
+        assert_eq!(m.arch, "aarch64");
+        assert_eq!(m.variant, "dev");
+        assert_eq!(m.rootfs_format, "ext4");
+        assert_eq!(m.artifacts.len(), 2);
+        assert!(m.artifact("dev-vmlinux-aarch64").is_some());
+        assert_eq!(
+            m.artifact("dev-rootfs-aarch64.ext4").unwrap().sha256,
+            "a6a24f174bd25221b00bb2bb4888eb04e5ef3d20033c38188e44b902f23564bc"
+        );
+        assert_eq!(m.nix_store_hash, "abc123def456");
+        assert_eq!(m.flake_locks.len(), 2);
+        assert!(m.flake_locks.contains_key("nix/flake.lock"));
+        assert!(m.addressed_advisories.is_empty());
+    }
+
     #[test]
     fn manifest_roundtrips_via_json() {
         let m = sample_manifest();

--- a/crates/mvm-security/src/image_verify.rs
+++ b/crates/mvm-security/src/image_verify.rs
@@ -237,6 +237,57 @@ pub fn verify_manifest(
     parse_manifest(manifest_bytes)
 }
 
+/// Verify a cosign-signed JSON payload (any shape), returning the
+/// validated bytes on success. Same trust contract as `verify_manifest`
+/// — Sigstore bundle signature checked against the expected identity
+/// and issuer — but generic over the payload type so callers can
+/// reuse the verifier for revocation lists, advisory feeds, or any
+/// other signed JSON the project publishes.
+///
+/// Plan 36 PR-C.3 introduced this so `mvm-cli`'s revocation-list
+/// fetcher doesn't have to depend on the `sigstore` crate directly:
+/// the verification primitive stays inside `mvm-security`.
+#[cfg(feature = "manifest-verify")]
+pub fn verify_signed_payload(
+    payload_bytes: &[u8],
+    cosign_bundle: &[u8],
+    expected_identity: &str,
+    expected_issuer: &str,
+) -> VerifyResult<()> {
+    use sigstore::bundle::Bundle;
+    use sigstore::bundle::verify::{blocking::Verifier, policy::Identity};
+
+    let bundle: Bundle =
+        serde_json::from_slice(cosign_bundle).map_err(|e| VerifyError::SignatureInvalid {
+            reason: format!("cosign bundle parse failed: {e}"),
+        })?;
+    let verifier = Verifier::production().map_err(|e| VerifyError::SignatureInvalid {
+        reason: format!("sigstore trust root init failed: {e}"),
+    })?;
+    let policy = Identity::new(expected_identity, expected_issuer);
+    verifier
+        .verify(payload_bytes, bundle, &policy, false)
+        .map_err(|e| VerifyError::SignatureInvalid {
+            reason: format!("payload signature verification failed: {e}"),
+        })?;
+    Ok(())
+}
+
+#[cfg(not(feature = "manifest-verify"))]
+pub fn verify_signed_payload(
+    _payload_bytes: &[u8],
+    _cosign_bundle: &[u8],
+    _expected_identity: &str,
+    _expected_issuer: &str,
+) -> VerifyResult<()> {
+    Err(VerifyError::SignatureInvalid {
+        reason: "manifest-verify feature is disabled in this build; rebuild \
+                 mvmctl with default features or set MVM_SKIP_COSIGN_VERIFY=1 \
+                 in an emergency rotation."
+            .to_string(),
+    })
+}
+
 /// No-feature fallback: refuse to accept any manifest as signed.
 ///
 /// Builds without `manifest-verify` (e.g. `cargo install

--- a/crates/mvm-security/src/lib.rs
+++ b/crates/mvm-security/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod command_gate;
+pub mod image_verify;
 pub mod posture;
 pub mod rate_limiter;
 pub mod seccomp;

--- a/deny.toml
+++ b/deny.toml
@@ -62,6 +62,16 @@ ignore = [
     # the shipped binary. Will resolve when sigstore (or its
     # json-syntax dep) bumps to proc-macro-error2.
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error v1 unmaintained; build-time-only via sigstore→json-syntax; no runtime surface; audited 2026-05-01" },
+    # `time v0.3.x` stack-exhaustion DoS via crafted parsed input.
+    # Path: sigstore → openidconnect → serde_with → time. mvmctl uses
+    # the time crate transitively only inside the cosign verification
+    # path, where the input is the manifest signature material from
+    # the project's release pipeline — not attacker-influenced bytes
+    # capable of triggering the stack exhaustion. The advisory's DoS
+    # only matters when parsing externally-supplied time strings;
+    # we don't expose that surface. Re-evaluate when time v0.4
+    # ships with the bound.
+    { id = "RUSTSEC-2026-0009", reason = "time stack-exhaustion DoS; transitive via sigstore→openidconnect→serde_with; no untrusted-time-string parsing surface in mvmctl; audited 2026-05-01" },
 ]
 
 # ── Licenses ──────────────────────────────────────────────────────

--- a/deny.toml
+++ b/deny.toml
@@ -42,6 +42,26 @@ ignore = [
     # `number_prefix` is a pure-functional formatter used by indicatif.
     # Unmaintained but functionally complete; no security surface.
     { id = "RUSTSEC-2025-0119", reason = "transitive via indicatif; pure formatter, no IO, audited 2026-04-30" },
+    # `rsa v0.9.x` Marvin Attack timing side-channel. Pulled in via
+    # `sigstore → openidconnect → rsa` (plan 36 PR-A.2 introduces
+    # `sigstore` for cosign-keyless verification of the dev image
+    # manifest). The advisory has no safe upgrade today; the
+    # RustCrypto team is working on a constant-time fix. Mvmctl's
+    # use of `rsa` is purely verification-side: we only consume
+    # signatures from the project's release pipeline against
+    # operator-controlled local input (downloaded artifact bytes).
+    # The Marvin Attack requires an attacker to observe timing of
+    # decryption operations against attacker-influenced ciphertexts,
+    # which is not the threat shape mvmctl exposes. Re-evaluate when
+    # `rsa v0.10` ships with the constant-time fix.
+    { id = "RUSTSEC-2023-0071", reason = "rsa Marvin Attack; transitive via sigstore→openidconnect; mvmctl is verification-only side, no decryption operations exposed; audited 2026-05-01" },
+    # `proc-macro-error v1` is unmaintained — replaced upstream by
+    # `proc-macro-error2`. Transitive via
+    # `sigstore → json-syntax → locspan-derive`. This is a
+    # build-time proc-macro dep only; it produces no runtime code in
+    # the shipped binary. Will resolve when sigstore (or its
+    # json-syntax dep) bumps to proc-macro-error2.
+    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error v1 unmaintained; build-time-only via sigstore→json-syntax; no runtime surface; audited 2026-05-01" },
 ]
 
 # ── Licenses ──────────────────────────────────────────────────────

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -86,6 +86,16 @@
           devShell = true;
         };
 
+        # Static musl build of `mvm-verity-init` for the verity
+        # initramfs (ADR-002 §W3). Separate derivation because the
+        # initramfs has no glibc loader and a dynamic build panics
+        # the kernel with ENOENT for `/init`. Linux-only.
+        mvm-verity-init = pkgs.lib.optionalAttrs pkgs.stdenv.isLinux (
+          import ./packages/mvm-verity-init.nix {
+            inherit pkgs mvmSrc;
+          }
+        );
+
         busybox = pkgs.pkgsStatic.busybox;
 
         # Shared kernel copy logic. Always exposes the kernel as $out/vmlinux
@@ -128,9 +138,18 @@
             mkdir -p $out
             cp ${rootfsImage} $out/rootfs.ext4
             chmod u+w $out/rootfs.ext4
+            # data-block-size=1024 matches the ext4 we ship (mkGuest's
+            # rootfs is mke2fs'd with 1 KiB blocks at the sizes we
+            # build at). Verity exposes its data-block-size as the
+            # device's logical block size, and the kernel's ext4
+            # refuses to mount when filesystem block size < device
+            # logical block size — so they have to match.
+            #
+            # hash-block-size stays at 4096 because that's the typical
+            # tree fan-out and what veritysetup defaults to.
             ${pkgs.cryptsetup}/bin/veritysetup format \
               --hash=sha256 \
-              --data-block-size=4096 \
+              --data-block-size=1024 \
               --hash-block-size=4096 \
               --salt=0000000000000000000000000000000000000000000000000000000000000000 \
               $out/rootfs.ext4 $out/rootfs.verity \
@@ -280,6 +299,19 @@
             verityOut = pkgs.lib.optionalString verifiedBoot
               "${verityArtifacts rootfs}";
 
+            # The verity initramfs (cpio.gz) bakes `mvm-verity-init` as
+            # `/init` and ships empty mount targets for /proc, /dev,
+            # /sysroot. The host's start_vm path points the VM's
+            # `initrd_path` at this file when verifiedBoot is on. The
+            # initramfs runs the verity setup in early userspace and
+            # switch_root's to the real /init, which sidesteps the
+            # Firecracker-aarch64 cmdline-append bug. ADR-002 §W3.
+            verityInitrd = pkgs.lib.optionalString verifiedBoot
+              "${import ./packages/verity-initrd.nix {
+                inherit pkgs;
+                verityInitPkg = mvm-verity-init;
+              }}";
+
             ociImage = pkgs.dockerTools.streamLayeredImage {
               inherit name;
               tag = "latest";
@@ -317,6 +349,11 @@
               cp "${verityOut}/rootfs.ext4"   "$out/rootfs.ext4"
               cp "${verityOut}/rootfs.verity" "$out/rootfs.verity"
               cp "${verityOut}/rootfs.roothash" "$out/rootfs.roothash"
+              # ADR-002 §W3: the verity initramfs runs as PID 1 before
+              # the real init and bypasses Firecracker's auto-appended
+              # `root=/dev/vda` by switch_root'ing into the verity
+              # device-mapper mount itself.
+              cp "${verityInitrd}" "$out/rootfs.initrd"
             '' else ''
               ${copyKernel (firecrackerKernel null)}
               cp "${rootfs}" "$out/rootfs.ext4"

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -207,6 +207,15 @@
           assert pkgs.lib.assertMsg
             ((variant == "prod") -> !(guestAgent.passthru.devShell or false))
             "mkGuest: variant=\"prod\" requires a guest agent built without the dev-shell feature";
+          # ADR-002 §W3.4 / plan 36: the dev variant's overlay-on-/nix
+          # mutates the lower layer at runtime, which can't compose with
+          # dm-verity (the lower hash would change on every write). Refuse
+          # the combination at evaluation time so a dev override applied
+          # to a sealed builder output (or any future flake) fails loudly
+          # instead of producing a runtime kernel panic at boot.
+          assert pkgs.lib.assertMsg
+            ((variant == "dev") -> !verifiedBoot)
+            "mkGuest: variant=\"dev\" cannot compose with verifiedBoot=true; the dev VM's writable /nix overlay conflicts with dm-verity (ADR-002 §W3.4 / plan 36)";
           let
             # Compose `<pkg>/bin` for every caller-supplied package so
             # PID 1's PATH can find them. Without this, packages live in

--- a/nix/images/builder/flake.lock
+++ b/nix/images/builder/flake.lock
@@ -18,6 +18,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "mvm": {
       "inputs": {
         "mvm": "mvm_2"
@@ -28,6 +46,22 @@
       },
       "original": {
         "path": "../../dev",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "mvm-prod": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "path": "../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../..",
         "type": "path"
       },
       "parent": []
@@ -66,6 +100,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1777077449,
         "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
         "owner": "NixOS",
@@ -83,7 +133,8 @@
     "root": {
       "inputs": {
         "mvm": "mvm",
-        "nixpkgs": "nixpkgs_2"
+        "mvm-prod": "mvm-prod",
+        "nixpkgs": "nixpkgs_3"
       }
     },
     "rust-overlay": {
@@ -108,7 +159,43 @@
         "type": "github"
       }
     },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "mvm-prod",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777519017,
+        "narHash": "sha256-TXilQ8MwFFtZs7HSogSI/LJzAS63nicE8iF63iB93WM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "09b556f18dacc39e97a46e0a1cba47af7b3af1d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/nix/images/builder/flake.nix
+++ b/nix/images/builder/flake.nix
@@ -8,80 +8,117 @@
   # `nix/dev` re-exports `mkGuest` with. The nested input override pins
   # the dev sibling's own `mvm` input to the local checkout, so the prod
   # library and dev agent both build from the same source tree.
+  #
+  # Plan 36: the new `builder` output (sealed, prod-agent, dm-verity
+  # protected, consumed by mvmd) needs the *parent* flake — not the dev
+  # sibling — as its mkGuest source. We expose a second input
+  # `mvm-prod` pointing at the parent so the builder output is
+  # unaffected by mvmctl's `--override-input mvm <abs>/nix/dev` swap.
   inputs = {
     mvm.url = "path:../../dev";
     mvm.inputs.mvm.url = "path:../..";
+    mvm-prod.url = "path:../..";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
   };
 
-  outputs = { mvm, nixpkgs, ... }:
+  outputs = { mvm, mvm-prod, nixpkgs, ... }:
     let
       systems = [ "aarch64-linux" "x86_64-linux" ];
 
+      # The build sandbox's package set. Identical between the dev and
+      # builder variants — only the guest agent and verity posture
+      # differ. Plan 36 §Layer 1: keeping one source of truth here is
+      # what prevents "works in dev, breaks in production builder"
+      # drift between the two outputs.
+      builderPackages = pkgs: [
+        # Core tools
+        pkgs.bashInteractive
+        pkgs.coreutils
+        pkgs.gnugrep
+        pkgs.gnused
+        pkgs.gawk
+        pkgs.findutils
+        pkgs.which
+
+        # Build tools
+        pkgs.gnumake
+
+        # Nix package manager
+        pkgs.nix
+
+        # Version control
+        pkgs.git
+
+        # Networking
+        pkgs.curl
+        pkgs.iproute2
+        # iptables + jq are required by the bridge_ensure script in
+        # mvm-runtime/src/vm/network.rs when this VM hosts transient
+        # microVMs (e.g., `mvmctl exec` against the dev variant). The
+        # builder variant inherits both for now; plan 36 PR-B.2's
+        # package-closure regression test will revisit whether mvmd's
+        # production builder genuinely needs them or moves the bridge
+        # logic host-side.
+        pkgs.iptables
+        pkgs.jq
+
+        # Editors
+        pkgs.less
+
+        # Filesystem
+        pkgs.e2fsprogs
+        pkgs.util-linux
+
+        # Debugging
+        pkgs.procps
+      ];
+
+      # The mvmctl-facing dev variant. Built by mvmctl with the dev
+      # override (`--override-input mvm <abs>/nix/dev`), which forces
+      # `variant = "dev"` and swaps in the dev guest agent (Exec
+      # handler compiled in for `mvmctl exec`/`console`). Verity is
+      # disabled because the dev VM mounts a writable overlay disk
+      # over /nix at runtime — see ADR-002 §W3.4. No behaviour change
+      # from the pre-plan-36 single-output flake.
       mkDevImage = system:
-        let
-          pkgs = import nixpkgs { inherit system; config = {}; overlays = []; };
+        let pkgs = import nixpkgs { inherit system; config = {}; overlays = []; };
         in mvm.lib.${system}.mkGuest {
           name = "mvm-dev";
           hostname = "mvm-dev";
-
-          # W7.3 — tag this rootfs as the *builder* VM image, not a
-          # tenant rootfs. Visible on the derivation as
-          # `passthru.role = "builder"` for downstream tooling.
           role = "builder";
-
-          # ADR-002 §W3.4 names the dev VM as the explicit exemption
-          # from verified boot: the overlayfs upper layer mutates /nix
-          # at runtime, which can't compose with dm-verity (the lower
-          # layer's root hash would have to change on every write). The
-          # flag is plumbed all the way through mkGuest → start_vm so
-          # that the kernel cmdline doesn't carry `dm-mod.create=` and
-          # the rootfs.verity sidecar isn't even built.
           verifiedBoot = false;
+          packages = builderPackages pkgs;
+        };
 
-          packages = [
-            # Core tools
-            pkgs.bashInteractive
-            pkgs.coreutils
-            pkgs.gnugrep
-            pkgs.gnused
-            pkgs.gawk
-            pkgs.findutils
-            pkgs.which
-
-            # Build tools
-            pkgs.gnumake
-
-            # Nix package manager
-            pkgs.nix
-
-            # Version control
-            pkgs.git
-
-            # Networking
-            pkgs.curl
-            pkgs.iproute2
-            # iptables + jq are required by the bridge_ensure script in
-            # mvm-runtime/src/vm/network.rs when this dev VM hosts
-            # transient microVMs (e.g., `mvmctl exec`).
-            pkgs.iptables
-            pkgs.jq
-
-            # Editors
-            pkgs.less
-
-            # Filesystem
-            pkgs.e2fsprogs
-            pkgs.util-linux
-
-            # Debugging
-            pkgs.procps
-          ];
+      # The sealed mvmd-facing builder variant. Plan 36 / ADR 005.
+      # Sources `mkGuest` from the **parent** flake (`mvm-prod`), not
+      # the dev sibling, so it gets the production library and the
+      # default prod guest agent (no Exec handler) regardless of
+      # whether mvmctl applies its `--override-input mvm <abs>/nix/dev`
+      # swap. `verifiedBoot` defaults to true on the parent's
+      # `mkGuestFn`, so this output ships the dm-verity sidecar that
+      # mvmd-agent will verify on every boot. The mkGuest assertion
+      # plan 36 added catches `variant=dev + verifiedBoot=true` at
+      # evaluation time, so a mistakenly-applied dev override here
+      # would fail loudly rather than silently shipping a dev-agent
+      # binary inside an mvmd production builder.
+      mkBuilderImage = system:
+        let pkgs = import nixpkgs { inherit system; config = {}; overlays = []; };
+        in mvm-prod.lib.${system}.mkGuest {
+          name = "mvm-builder-prod";
+          hostname = "mvm-builder";
+          role = "builder";
+          # `variant`, `verifiedBoot`, and `guestAgent` all stay at
+          # the parent flake's defaults (prod / true / prod agent).
+          packages = builderPackages pkgs;
         };
     in {
       packages = builtins.listToAttrs (map (system: {
         name = system;
-        value = { default = mkDevImage system; };
+        value = {
+          default = mkDevImage system;
+          builder = mkBuilderImage system;
+        };
       }) systems);
     };
 }

--- a/nix/packages/mvm-guest-agent.nix
+++ b/nix/packages/mvm-guest-agent.nix
@@ -39,6 +39,12 @@ rustPlatform.buildRustPackage {
   # used by the init's `mkServiceBlock`. It ships in the same store path
   # as the guest agent so `mkServiceBlock` can reference it via
   # `${guestAgentPkg}/bin/mvm-seccomp-apply` without a separate package.
+  #
+  # `mvm-verity-init` is NOT built here because it has to run from the
+  # initramfs (no glibc available); it's built statically by
+  # `nix/packages/mvm-verity-init.nix` against musl. Building it both
+  # ways would just be busywork — the agent + seccomp-apply run after
+  # the rootfs is mounted and can keep dynamic linking against glibc.
   cargoBuildFlags =
     [ "-p" "mvm-guest" "--bin" "mvm-guest-agent" "--bin" "mvm-seccomp-apply" ]
     ++ pkgs.lib.optionals devShell [ "--features" "dev-shell" ];

--- a/nix/packages/mvm-verity-init.nix
+++ b/nix/packages/mvm-verity-init.nix
@@ -1,0 +1,47 @@
+# Build `mvm-verity-init` as a fully-static musl-libc binary.
+#
+# The verity initramfs has no glibc loader, no /lib/ld-linux*, no
+# anything beyond what we put in `/init`. A normal dynamic-linked
+# build dies with `Failed to execute /init (error -2)` because the
+# kernel can't find the dynamic loader. Static linking against musl
+# produces a self-contained ELF that runs as PID 1 from a bare
+# directory tree.
+#
+# This is a separate derivation from `mvm-guest-agent.nix` because:
+#   1. The toolchain differs (musl vs. glibc).
+#   2. The agent + seccomp-apply run inside the rootfs and can keep
+#      dynamic linking — no reason to recompile them statically.
+#   3. The closure is much smaller (~600 KB vs. tens of MB), which
+#      matters for the initramfs size.
+#
+# We use `pkgs.pkgsStatic` — a nixpkgs cross-compilation alias whose
+# stdenv defaults to musl-static linking. `rustPlatform.buildRustPackage`
+# under that stdenv produces a self-contained ELF.
+#
+# ADR-002 §W3.
+
+{ pkgs, mvmSrc }:
+
+let
+  staticPkgs = pkgs.pkgsStatic;
+in
+
+staticPkgs.rustPlatform.buildRustPackage {
+  pname = "mvm-verity-init";
+  version = "0.1.0";
+
+  src = pkgs.lib.fileset.toSource {
+    root = mvmSrc;
+    fileset = pkgs.lib.fileset.unions [
+      (mvmSrc + "/Cargo.toml")
+      (mvmSrc + "/Cargo.lock")
+      (mvmSrc + "/src")
+      (mvmSrc + "/crates")
+      (mvmSrc + "/xtask")
+    ];
+  };
+
+  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoBuildFlags = [ "-p" "mvm-guest" "--bin" "mvm-verity-init" ];
+  doCheck = false;
+}

--- a/nix/packages/verity-initrd.nix
+++ b/nix/packages/verity-initrd.nix
@@ -1,0 +1,64 @@
+# Build the verity initramfs baked alongside `mkGuest`'s rootfs when
+# `verifiedBoot = true`. The initramfs is a tiny cpio.gz containing a
+# single binary at `/init` plus the empty mount targets `/proc`, `/dev`,
+# `/sysroot`. ADR-002 §W3.
+#
+# At boot, Firecracker (or Apple VZ) mounts this initramfs, the kernel
+# runs `/init` which is `mvm-verity-init`, and that binary:
+#   1. Mounts /proc and /dev.
+#   2. Reads `mvm.roothash=…` (and optional `mvm.data=…`/`mvm.hash=…`)
+#      from /proc/cmdline.
+#   3. Builds /dev/mapper/root via DM ioctls (DM_DEV_CREATE,
+#      DM_TABLE_LOAD, DM_DEV_SUSPEND-with-resume).
+#   4. Mounts /dev/mapper/root at /sysroot read-only.
+#   5. switch_root's to /sysroot/init (the real minimal-init).
+#
+# Owning the boot pivot in userspace bypasses the Firecracker-aarch64
+# bug where the hypervisor auto-appends `root=/dev/vda ro` to the
+# kernel cmdline, overriding any verity `root=/dev/dm-0` we set.
+#
+# Usage from `nix/flake.nix`:
+#   verityInitrd = import ./packages/verity-initrd.nix {
+#     inherit pkgs verityInitPkg;
+#   };
+# `verityInitPkg` is the static-musl build from
+# `nix/packages/mvm-verity-init.nix`. It must be statically linked —
+# the initramfs has no glibc loader, so a dynamic binary at /init
+# panics the kernel with `Failed to execute /init (error -2)`.
+
+{ pkgs, verityInitPkg }:
+
+pkgs.runCommand "mvm-verity-initrd"
+  {
+    nativeBuildInputs = [ pkgs.cpio pkgs.gzip ];
+    # Pin SOURCE_DATE_EPOCH for reproducibility — same input bytes
+    # must produce a byte-identical cpio. ADR-002 §W3.1 + §W5.3.
+    SOURCE_DATE_EPOCH = "1700000000";
+  } ''
+    mkdir -p root/proc root/dev root/sysroot
+    cp ${verityInitPkg}/bin/mvm-verity-init root/init
+    chmod 0755 root/init
+
+    # Pin file timestamps and ownership so cpio output is deterministic.
+    find root -exec touch -d @$SOURCE_DATE_EPOCH {} +
+    find root -exec chown 0:0 {} + 2>/dev/null || true
+
+    # `cpio --reproducible` zeroes the device-major/minor fields and
+    # uses MTIME from the file (which we pinned above). `find … -print0`
+    # pipes a NUL-separated file list which `cpio -0` parses, avoiding
+    # quoting issues.
+    cd root
+    find . -print0 | LC_ALL=C sort -z \
+      | cpio --null --create --format=newc --reproducible \
+      | gzip -n -9 > $out
+
+    # cpio -tv smoke check: confirm `init` is in the archive as an
+    # executable regular file. `cpio -tv` strips the `./` prefix when
+    # printing, so the line we look for ends in a single space + the
+    # filename. Match `^-rwx…` to also assert the executable bit.
+    if ! gzip -dc $out | cpio -tv 2>/dev/null | grep -qE '^-rwx.* init$'; then
+      echo "ERROR: built initramfs is missing executable /init" >&2
+      gzip -dc $out | cpio -tv 2>&1 | head >&2
+      exit 1
+    fi
+  ''

--- a/public/src/content/docs/guides/airgapped-bootstrap.md
+++ b/public/src/content/docs/guides/airgapped-bootstrap.md
@@ -1,0 +1,159 @@
+---
+title: Air-gapped Bootstrap
+description: How to run mvmctl in environments that can't reach github.com without disabling supply-chain verification.
+---
+
+# Air-gapped Bootstrap
+
+mvmctl normally fetches its dev image (kernel + rootfs) and the
+project's [cosign-signed manifest](verify-release) from GitHub
+Releases. In regulated, government, or otherwise air-gapped
+environments where the host can't reach `github.com`, plan 36 ships
+a sanctioned trusted path: `mvmctl dev import-image` runs the same
+cosign signature + SHA-256 + version-pin + max-age + revocation
+verification pipeline against operator-provided local files.
+
+This is the *only* recommended way to run mvmctl in an air-gapped
+host. Setting `MVM_SKIP_HASH_VERIFY=1` to bypass the network fetch
+disables the supply-chain check entirely, which is exactly the
+unsafe escape this path exists to discourage.
+
+## What you need
+
+For your target architecture (`aarch64` or `x86_64`), four files
+from the GitHub release page:
+
+| File | Purpose |
+|------|---------|
+| `dev-image-{arch}.manifest.json` | Cosign-signed manifest — the trust anchor. Records SHA-256 of every other file. |
+| `dev-image-{arch}.manifest.json.bundle` | Cosign signature bundle for the manifest. |
+| `dev-vmlinux-{arch}` | Kernel binary. |
+| `dev-rootfs-{arch}.ext4` | Root filesystem. |
+
+All four come from the same release tag — they're a set. Mismatched
+manifest + artifacts will fail SHA-256 verification.
+
+## Workflow
+
+### 1. Fetch the four files from a connected host
+
+On a host that can reach github.com:
+
+```bash
+VERSION=v0.14.0  # match the mvmctl version that will consume them
+ARCH=aarch64     # or x86_64
+BASE="https://github.com/auser/mvm/releases/download/${VERSION}"
+
+for f in \
+  "dev-image-${ARCH}.manifest.json" \
+  "dev-image-${ARCH}.manifest.json.bundle" \
+  "dev-vmlinux-${ARCH}" \
+  "dev-rootfs-${ARCH}.ext4"
+do
+  curl -LO "${BASE}/${f}"
+done
+```
+
+### 2. (Optional) Verify the manifest before transit
+
+The connected host can verify the manifest now to catch
+manifest-only tampering before sneakernet:
+
+```bash
+cosign verify-blob \
+  --bundle "dev-image-${ARCH}.manifest.json.bundle" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --certificate-identity-regexp "https://github.com/auser/mvm/.github/workflows/release.yml@refs/tags/${VERSION}" \
+  "dev-image-${ARCH}.manifest.json"
+```
+
+Expect `Verified OK`. mvmctl re-runs this check during `import-image`,
+so this step is optional — it just gives you a fast-fail before
+transferring 200 MB of rootfs over a slow side channel.
+
+### 3. Transfer to the air-gapped host
+
+Sneakernet, internal artifact mirror, signed USB, scp through a jump
+host — whatever your environment allows. The four files must arrive
+together; any one being modified or replaced in transit will fail
+verification on import.
+
+### 4. Import on the air-gapped host
+
+```bash
+mvmctl dev import-image \
+  --manifest dev-image-aarch64.manifest.json \
+  --bundle   dev-image-aarch64.manifest.json.bundle \
+  --vmlinux  dev-vmlinux-aarch64 \
+  --rootfs   dev-rootfs-aarch64.ext4
+```
+
+mvmctl runs the full verification pipeline:
+
+1. Cosign-verify the manifest signature against the project's
+   release-workflow OIDC identity.
+2. Pin `manifest.version == mvmctl --version` exactly.
+3. Warn (don't fail) if the manifest is past its 90-day max-age.
+4. Check the revocation list (skipped if cached and offline; see
+   below).
+5. Verify each artifact's SHA-256 against the manifest's recorded
+   digests.
+6. Copy the verified bytes into `~/.mvm/dev/prebuilt/v{version}/`.
+
+On success, the next `mvmctl dev up` boots the dev VM from the
+imported artifacts without re-running verification or touching the
+network.
+
+## Revocation list in air-gapped environments
+
+The project's [revocation list](verify-release#recall-revocation-list)
+lives at a separate `revocations` release tag and tells mvmctl that
+specific versions have been recalled. mvmctl caches the list under
+`~/.cache/mvm/revocations/` and the cache policy is generous for
+offline tolerance:
+
+- Cache valid for **24 hours** before refresh.
+- **7 days** of cached staleness tolerated when the network is
+  unavailable.
+- A 404 on the upstream URL is treated as "no recalls today" — not
+  an error.
+
+For long-running air-gapped deployments, periodically transfer a
+fresh `revoked-versions.json` + `.bundle` pair into
+`~/.cache/mvm/revocations/`:
+
+```bash
+# On a connected host:
+BASE="https://github.com/auser/mvm/releases/download/revocations"
+curl -LO "${BASE}/revoked-versions.json"
+curl -LO "${BASE}/revoked-versions.json.bundle"
+
+# Transfer both files, then on the air-gapped host:
+mkdir -p ~/.cache/mvm/revocations
+cp revoked-versions.json ~/.cache/mvm/revocations/
+cp revoked-versions.json.bundle ~/.cache/mvm/revocations/
+touch ~/.cache/mvm/revocations/revoked-versions.json
+```
+
+`mvmctl dev up` will read the cached file, cosign-verify it, and
+enforce any matching recall.
+
+## Failure modes
+
+`mvmctl dev import-image` fails closed. The most common errors and
+what they mean:
+
+| Error wording | Cause | Fix |
+|--------------|-------|-----|
+| `Cosign verification failed for the imported manifest` | Manifest + bundle don't match, or manifest was tampered with after signing | Re-export both files together from the same release tag |
+| `Imported manifest is for a different mvmctl version` | manifest.version doesn't match `mvmctl --version` exactly | Use a manifest from the matching release; or upgrade mvmctl first |
+| `Manifest is for arch X but this host is Y` | Wrong arch | Re-export the manifest for your host arch |
+| `kernel SHA-256 mismatch` / `rootfs SHA-256 mismatch` | Artifact tampered or corrupted in transit | Re-transfer the full set; check transit medium |
+| `Imported manifest is on the project's revocation list` | The release was recalled | Use a non-revoked release |
+
+Every failure path bumps a Prometheus counter exposed via
+`mvmctl metrics --json` (and the `mvmctl status` JSON output). For
+fleet operators, plan 23 wires the same counters into mvmd's
+reconciliation loop so attack-shaped spikes — rapid
+`dev_image_verify_sig_invalid_total` increases across hosts, in
+particular — surface as alerts.

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -202,3 +202,60 @@ mvmctl setup --recreate
 RUST_LOG=debug mvmctl <command>
 RUST_LOG=mvm=trace mvmctl <command>
 ```
+
+## Dev Image Signature Verification (plan 36)
+
+### "Cosign verification failed for {variant}-image-{arch}.manifest.json"
+
+The cosign-signed manifest didn't validate against the project's release-workflow OIDC identity. Treat this as a supply-chain incident until proven otherwise.
+
+Triage in this order:
+
+1. **Clock skew** — `date -u`. Sigstore signatures carry a tight time window. A host clock more than ~10 minutes off can fail otherwise-valid signatures.
+2. **Re-download the pair** — manifest and `.bundle` belong together. A partial download from a previous attempt may have left only one file fresh.
+3. **Verify with the cosign CLI** to localize the failure:
+   ```bash
+   cosign verify-blob \
+     --bundle dev-image-aarch64.manifest.json.bundle \
+     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+     --certificate-identity-regexp "https://github.com/auser/mvm/.github/workflows/release.yml@refs/tags/v0.14.0" \
+     dev-image-aarch64.manifest.json
+   ```
+   Same identity wording mvmctl uses internally.
+4. **Open a security issue** if the signature is genuinely invalid against the official identity. Don't ship a workaround locally.
+
+Emergency rotation when Sigstore TUF/Rekor is unavailable: `MVM_SKIP_COSIGN_VERIFY=1` keeps SHA-256 verification active while bypassing the signature check. Loud warnings; not for routine use.
+
+### "Manifest is for v0.14.1 but mvmctl is v0.14.0"
+
+Plan 36 pins `manifest.version` to `mvmctl --version` exactly. Either:
+- Upgrade `mvmctl` to match (`brew upgrade mvmctl` / `cargo install mvmctl`); or
+- Use a manifest from the matching release (re-export from the v0.14.0 release page).
+
+### "Integrity check failed for dev-rootfs-aarch64.ext4"
+
+SHA-256 of the downloaded artifact doesn't match the manifest's recorded digest. Possible causes, in order:
+
+1. Mid-flight corruption — retry `mvmctl dev up` to re-download.
+2. Mirror/CDN cache poisoning — rare but real; open a security issue with the SHA-256 you got vs what the manifest says.
+3. The release was re-uploaded after the manifest was signed (publishing process bug) — wait for the next tag.
+
+`MVM_SKIP_HASH_VERIFY=1` is the documented escape, but it disables the supply-chain check entirely. Investigate first.
+
+### "Manifest is on the project's revocation list"
+
+A `revocations` release entry has marked your mvmctl version unsafe. Read the recall reason in the failure message. Upgrade mvmctl to a non-revoked release.
+
+### "Could not refresh revocation list … using cached copy"
+
+Network failure during the 24-hour revocation-list refresh. mvmctl tolerates up to 7 days of cached staleness. After 7 days, revocation enforcement is silently skipped (with a warning) — refresh manually:
+
+```bash
+mkdir -p ~/.cache/mvm/revocations
+curl -L -o ~/.cache/mvm/revocations/revoked-versions.json \
+  https://github.com/auser/mvm/releases/download/revocations/revoked-versions.json
+curl -L -o ~/.cache/mvm/revocations/revoked-versions.json.bundle \
+  https://github.com/auser/mvm/releases/download/revocations/revoked-versions.json.bundle
+```
+
+For air-gapped hosts that can never reach github.com, see [Air-gapped Bootstrap](airgapped-bootstrap).

--- a/public/src/content/docs/guides/verify-release.md
+++ b/public/src/content/docs/guides/verify-release.md
@@ -109,3 +109,65 @@ shasum -a 256 --check <(grep "mvmctl-${TARGET}.tar.gz" checksums-sha256.txt)
 | At a specific git tag | The OIDC token embeds the `ref` claim |
 
 A compromised CDN or GitHub Releases page cannot forge a valid signature without the GitHub Actions OIDC token, which is only issued during an actual workflow run on the real repository.
+
+---
+
+## Verifying the Dev Image and Builder Image Manifests (plan 36)
+
+Starting with the plan-36 work, every release also publishes a cosign-keyless-signed manifest for the dev image (consumed by `mvmctl dev up`) and the builder image (consumed by mvmd's pool-build pipeline). The manifest is the trust anchor — it carries SHA-256 of every image artifact, the Nix store hash, the source git SHA, and the SHA-256 of every flake lockfile, all bound by one cosign signature.
+
+mvmctl verifies these automatically on every `mvmctl dev up`. To verify manually:
+
+```bash
+VERSION=v0.14.0  # replace with the release you're verifying
+ARCH=aarch64     # or x86_64
+VARIANT=dev      # or builder
+
+curl -LO "https://github.com/auser/mvm/releases/download/${VERSION}/${VARIANT}-image-${ARCH}.manifest.json"
+curl -LO "https://github.com/auser/mvm/releases/download/${VERSION}/${VARIANT}-image-${ARCH}.manifest.json.bundle"
+
+cosign verify-blob \
+  --bundle "${VARIANT}-image-${ARCH}.manifest.json.bundle" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --certificate-identity-regexp "https://github.com/auser/mvm/.github/workflows/release.yml@refs/tags/${VERSION}" \
+  "${VARIANT}-image-${ARCH}.manifest.json"
+```
+
+A successful verification prints `Verified OK`. After verification, every artifact whose SHA-256 is recorded in the manifest can be checked with `sha256sum` and the manifest's value:
+
+```bash
+jq -r '.artifacts[] | "\(.sha256)  \(.name)"' "${VARIANT}-image-${ARCH}.manifest.json" \
+  | sha256sum --check
+```
+
+### Air-gapped install
+
+`mvmctl dev import-image` runs the same verification against local files for hosts that can't reach github.com. See [Air-gapped Bootstrap](airgapped-bootstrap) for the operator workflow.
+
+### Recall (revocation list)
+
+A separate `revocations` release tag publishes a cosign-signed `revoked-versions.json`. mvmctl checks this list on every `dev up` and refuses to use any image whose version is recalled. The recall reason is surfaced verbatim in the failure message, pointing at the upgrade path.
+
+```bash
+curl -LO "https://github.com/auser/mvm/releases/download/revocations/revoked-versions.json"
+curl -LO "https://github.com/auser/mvm/releases/download/revocations/revoked-versions.json.bundle"
+
+cosign verify-blob \
+  --bundle revoked-versions.json.bundle \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --certificate-identity-regexp "https://github.com/auser/mvm/.github/workflows/revocations.yml@refs/tags/revocations" \
+  revoked-versions.json
+```
+
+The revocations tag is signed by a *separate* OIDC identity (`revocations.yml`) so a leaked image-signing cert can't fabricate a permissive recall, and vice versa. Domain separation by design.
+
+### Emergency escape hatches
+
+Two environment variables disable parts of the verification pipeline. Both print loud warnings; both are documented for emergency rotation only:
+
+| Variable | Disables | Use case |
+|----------|----------|----------|
+| `MVM_SKIP_HASH_VERIFY=1` | SHA-256 check on artifact bytes (existing W5.1) | Mid-flight corruption while the publish flow is broken |
+| `MVM_SKIP_COSIGN_VERIFY=1` | Cosign signature check on manifest + revocation list | Sigstore-side outage where TUF root or Rekor is unavailable |
+
+The two are independent — setting one doesn't disable the other. SHA-256 still runs even with cosign disabled, and vice versa.

--- a/scripts/generate-image-manifest.sh
+++ b/scripts/generate-image-manifest.sh
@@ -90,6 +90,8 @@ FLAKE_LOCKS=$(
     -not -path './.git/*' \
     -not -path './node_modules/*' \
     -not -path './.claude/*' \
+    -not -path './*/resources/template_scaffold/*' \
+    -not -path './resources/template_scaffold/*' \
     | sort \
     | while read -r f; do
         rel="${f#./}"

--- a/scripts/generate-image-manifest.sh
+++ b/scripts/generate-image-manifest.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Generate a SignedManifest JSON for a built dev/builder image.
+#
+# Plan 36 / ADR 005. Output schema must stay in lock-step with
+# `crates/mvm-security/src/image_verify.rs::SignedManifest` — both
+# sides parse the same JSON, and this script is the only producer.
+#
+# The mvmctl release pipeline calls this once per (arch, variant) pair
+# after building the image. It hashes the artifacts, walks every
+# `flake.lock` in the repo, computes a not_after stamp, and emits a
+# manifest JSON ready for `cosign sign-blob --bundle`.
+#
+# Inputs (env vars):
+#   ARCH         e.g. "aarch64" or "x86_64"
+#   VARIANT      "dev" or "builder"
+#   ROOTFS_EXT   "ext4" or "squashfs"
+#   STORE_PATH   the Nix store path of the build output
+#                (e.g. /nix/store/abc123-mvm-mvm-dev-dev)
+#   STAGING_DIR  directory holding the renamed artifacts
+#                (`{variant}-vmlinux-{arch}`, `{variant}-rootfs-{arch}.{ext}`)
+#   VERSION      version string without the leading `v`
+#                (e.g. "0.14.0"). Defaults to GITHUB_REF_NAME minus `v`.
+#   SOURCE_GIT_SHA  full git sha of the build commit; defaults to GITHUB_SHA.
+#   NOT_AFTER_DAYS  optional integer (default 90); manifest's max-age window.
+#
+# Output:
+#   Writes `${VARIANT}-image-${ARCH}.manifest.json` into STAGING_DIR.
+#   Prints the path on stdout.
+
+set -euo pipefail
+
+: "${ARCH:?ARCH must be set}"
+: "${VARIANT:?VARIANT must be set}"
+: "${ROOTFS_EXT:?ROOTFS_EXT must be set}"
+: "${STORE_PATH:?STORE_PATH must be set}"
+: "${STAGING_DIR:?STAGING_DIR must be set}"
+
+case "${VARIANT}" in
+  dev|builder) ;;
+  *) echo "VARIANT must be 'dev' or 'builder' (got '${VARIANT}')" >&2; exit 2 ;;
+esac
+
+case "${ROOTFS_EXT}" in
+  ext4|squashfs) ;;
+  *) echo "ROOTFS_EXT must be 'ext4' or 'squashfs' (got '${ROOTFS_EXT}')" >&2; exit 2 ;;
+esac
+
+VERSION="${VERSION:-${GITHUB_REF_NAME:-}}"
+VERSION="${VERSION#v}"
+if [ -z "${VERSION}" ]; then
+  echo "VERSION (or GITHUB_REF_NAME) must be set to the release version" >&2
+  exit 2
+fi
+
+SOURCE_GIT_SHA="${SOURCE_GIT_SHA:-${GITHUB_SHA:-}}"
+if [ -z "${SOURCE_GIT_SHA}" ]; then
+  echo "SOURCE_GIT_SHA (or GITHUB_SHA) must be set" >&2
+  exit 2
+fi
+
+NOT_AFTER_DAYS="${NOT_AFTER_DAYS:-90}"
+
+KERNEL_NAME="${VARIANT}-vmlinux-${ARCH}"
+ROOTFS_NAME="${VARIANT}-rootfs-${ARCH}.${ROOTFS_EXT}"
+
+if [ ! -f "${STAGING_DIR}/${KERNEL_NAME}" ] || [ ! -f "${STAGING_DIR}/${ROOTFS_NAME}" ]; then
+  echo "Expected artifacts in ${STAGING_DIR}: ${KERNEL_NAME}, ${ROOTFS_NAME}" >&2
+  ls -la "${STAGING_DIR}" >&2 || true
+  exit 2
+fi
+
+KERNEL_SHA=$(cd "${STAGING_DIR}" && sha256sum "${KERNEL_NAME}" | awk '{print $1}')
+ROOTFS_SHA=$(cd "${STAGING_DIR}" && sha256sum "${ROOTFS_NAME}" | awk '{print $1}')
+
+# Extract the input-addressed hash from a Nix store path:
+# /nix/store/<hash>-name → <hash>
+NIX_STORE_HASH=$(basename "${STORE_PATH}" | cut -d- -f1)
+
+BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+# GNU date and BSD/macOS date have different `+N days` syntax. Try both.
+NOT_AFTER=$(date -u -d "+${NOT_AFTER_DAYS} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -v"+${NOT_AFTER_DAYS}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || { echo "could not compute not_after; date(1) syntax incompatible" >&2; exit 1; })
+
+# Walk every flake.lock in the repo, hash its content, build a {path: sha256:...} object.
+# Skip target/, .git/, node_modules/, and any worktree caches.
+FLAKE_LOCKS=$(
+  find . -name flake.lock \
+    -not -path './target/*' \
+    -not -path './.git/*' \
+    -not -path './node_modules/*' \
+    -not -path './.claude/*' \
+    | sort \
+    | while read -r f; do
+        rel="${f#./}"
+        h=$(sha256sum "${f}" | awk '{print $1}')
+        jq -n --arg path "${rel}" --arg sha "sha256:${h}" '{($path): $sha}'
+      done \
+    | jq -s 'add // {}'
+)
+
+OUT="${STAGING_DIR}/${VARIANT}-image-${ARCH}.manifest.json"
+jq -n \
+  --argjson schema_version 1 \
+  --arg version "${VERSION}" \
+  --arg arch "${ARCH}" \
+  --arg variant "${VARIANT}" \
+  --arg rootfs_format "${ROOTFS_EXT}" \
+  --arg kernel_name "${KERNEL_NAME}" \
+  --arg kernel_sha "${KERNEL_SHA}" \
+  --arg rootfs_name "${ROOTFS_NAME}" \
+  --arg rootfs_sha "${ROOTFS_SHA}" \
+  --arg nix_store_hash "${NIX_STORE_HASH}" \
+  --arg source_git_sha "${SOURCE_GIT_SHA}" \
+  --argjson flake_locks "${FLAKE_LOCKS}" \
+  --arg built_at "${BUILT_AT}" \
+  --arg not_after "${NOT_AFTER}" \
+  '{
+    schema_version: $schema_version,
+    version: $version,
+    arch: $arch,
+    variant: $variant,
+    rootfs_format: $rootfs_format,
+    artifacts: [
+      {name: $kernel_name, sha256: $kernel_sha},
+      {name: $rootfs_name, sha256: $rootfs_sha}
+    ],
+    nix_store_hash: $nix_store_hash,
+    source_git_sha: $source_git_sha,
+    flake_locks: $flake_locks,
+    addressed_advisories: [],
+    built_at: $built_at,
+    not_after: $not_after
+  }' > "${OUT}"
+
+echo "${OUT}"

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -81,43 +81,49 @@ landed with regression tests; `cargo test --workspace` and
       Linux-only target). Default tier is `standard`; override via
       `services.<n>.seccomp = "essential" | … | "unrestricted"`.
 
-### W3 — Verified boot via dm-verity  🟡 host-side shipped + verity device builds correctly, but Firecracker aarch64 cmdline-append clobbers `root=/dev/dm-0` (initramfs fix outstanding)  [`plans/27-w3-verified-boot.md`](plans/27-w3-verified-boot.md) | runbook: [`runbooks/w3-verified-boot.md`](runbooks/w3-verified-boot.md)
+### W3 — Verified boot via dm-verity  ✅ shipped — 2026-04-30 (initramfs landed, all 5 runbook steps green)  [`plans/27-w3-verified-boot.md`](plans/27-w3-verified-boot.md) | runbook: [`runbooks/w3-verified-boot.md`](runbooks/w3-verified-boot.md)
 
 - [x] **Kernel** `firecracker-aarch64.config` enables
       `CONFIG_MD`, `CONFIG_BLK_DEV_DM`, `CONFIG_DM_INIT`, and
-      `CONFIG_DM_VERITY` so `dm-mod.create=` parses on the cmdline.
+      `CONFIG_DM_VERITY` so the kernel can construct verity targets.
 - [x] **W3.1** `nix/flake.nix::verityArtifacts` runs
-      `veritysetup format` with a pinned zero salt and emits
-      `rootfs.{ext4,verity,roothash}` deterministically.
+      `veritysetup format` with `--data-block-size=1024` and a pinned
+      zero salt, emits `rootfs.{ext4,verity,roothash}`
+      deterministically.
 - [x] **W3.2** Apple Container backend gained `VerityConfig` +
       `start_with_verity()`; opens the rootfs read-only, attaches
-      the sidecar at `/dev/vdb`, sets the kernel cmdline to
-      `root=/dev/dm-0 ro` plus a full `dm-mod.create=…` string.
-      Mutual-exclusion check rejects `MVM_NIX_STORE_DISK` + verity.
+      the sidecar at `/dev/vdb`, attaches the verity initramfs via
+      `setInitialRamdiskURL`, and passes `mvm.roothash=<hex>` on the
+      cmdline. Mutual-exclusion check rejects `MVM_NIX_STORE_DISK`.
 - [x] **W3.3** Firecracker backend extended `FlakeRunConfig` +
-      `VmStartConfig` with `verity_path` / `roothash`. The Lima-VM
-      cold-boot, snapshot-restore, and template-snapshot paths all
-      probe for the sidecar via `microvm::probe_verity_sidecar()`
-      and PUT a third `/drives/verity` to land it at `/dev/vdb`.
-      `build_verity_dm_create_arg()` produces the same dm-mod.create
-      shape as the Apple Container path.
+      `VmStartConfig` with `verity_path` / `roothash`. Cold-boot,
+      snapshot-restore, and template-snapshot paths all probe for
+      the sidecar + initramfs via `microvm::probe_verity_sidecar()`
+      and pass `initrd_path` to `/boot-source` so the initramfs
+      runs as PID 1.
 - [x] **W3.4** `mkGuest` accepts `verifiedBoot ? true`;
       `nix/dev-image/flake.nix` sets `verifiedBoot = false` (overlay
       can't compose with verity). The dev sibling flake forwards
       the kwarg transparently.
+- [x] **Initramfs** `nix/packages/mvm-verity-init.nix` builds a
+      static-musl `mvm-verity-init` that runs as PID 1 from the
+      cpio.gz at `nix/packages/verity-initrd.nix`. Reads
+      `mvm.roothash=` from cmdline, builds `/dev/mapper/root` via
+      DM ioctls (DM_DEV_CREATE → DM_TABLE_LOAD → DM_DEV_SUSPEND),
+      mounts it at `/sysroot`, then `switch_root`s to the real
+      `/init`. Bypasses Firecracker's auto-appended
+      `root=/dev/vda ro` by owning the boot pivot in userspace.
 - [x] **CI gate** `verified-boot-artifacts` lane in
       `security.yml` builds `nix/default-microvm/` and asserts
-      `rootfs.{ext4,verity,roothash}` plus a 64-char hex roothash.
-- [ ] **Initramfs (Finding #1)**: small initramfs that runs
-      `veritysetup open … && switch_root` so Firecracker's
-      auto-appended `root=/dev/vda ro` no longer overrides our
-      `root=/dev/dm-0`. Without this the verity device is built
-      but the kernel still mounts the raw rootfs.
-- [ ] **Boot regression** (live KVM): boot a microVM with verity
-      and assert `mount | grep dm-0`. Re-runs after Finding #1.
-- [ ] **Tamper regression** (live KVM): flip a byte in
-      `rootfs.ext4`, assert the kernel panics on first read.
-      Re-runs after Finding #1.
+      `rootfs.{ext4,verity,roothash,initrd}` plus a 64-char hex
+      roothash.
+- [x] **Boot regression** (live KVM): full
+      `specs/runbooks/w3-verified-boot.md` Step 3 green —
+      `mvm-verity-init` reaches userspace from `/dev/dm-0`.
+- [x] **Tamper regression** (live KVM): tampering the ext4
+      superblock triggers
+      `device-mapper: verity: 254:0: data block 1 is corrupted`
+      and the kernel panics before userspace.
 
 ### W4 — Guest agent attack surface  ✅ shipped — 2026-04-30  [`plans/28-w4-guest-agent-attack-surface.md`](plans/28-w4-guest-agent-attack-surface.md)
 

--- a/specs/adrs/005-sealed-signed-builder-image.md
+++ b/specs/adrs/005-sealed-signed-builder-image.md
@@ -1,0 +1,197 @@
+# ADR 005: Sealed, Signed Builder Image
+
+## Status
+
+Proposed — 2026-04-30
+
+## Context
+
+Sprint 42's commit `688b7de` made the dev/builder VM the *only* build
+environment for everything `mvmctl build` produces. The host no longer
+runs `nix` or any Linux build tooling. The commit message is explicit:
+*"any code path that runs on the host is outside the sandbox, and any
+'we'll just bypass the VM here' shortcut chips away at the contract one
+PR at a time."*
+
+That promotion makes the dev/builder image **load-bearing** for the
+security model: if a tampered image is silently swapped or modified,
+every artifact mvmctl builds — including the production-bound
+rootfs/kernel images that user flakes ship via `mvm-build`, and the
+pool images mvmd will rebuild via plan 23 — inherits whatever the
+tampered image injects.
+
+Sprint 42's W5.1 closed part of this gap by SHA-256-verifying downloads
+against a per-arch checksum manifest (`apple_container.rs:918-1048`),
+with `MVM_SKIP_HASH_VERIFY=1` as the documented escape. The W5.1 code
+itself flags the remaining gap at line 952: *"who can swap the artifact
+can also swap the checksum file, so the checksum manifest is TLS-only
+trust today, on the checksum file itself in a future iteration."*
+
+This ADR records the architectural decisions for that future iteration.
+
+## Decisions
+
+### 1. The image is a signed release artifact
+
+The dev/builder image (`nix/images/builder/flake.nix` outputs) becomes
+a **signed release artifact** alongside the `mvmctl` CLI binary.
+Cosign keyless signs a per-release manifest that records SHA-256 of
+each artifact, the Nix store hash, the source git SHA, and the SHA-256
+of every flake lockfile. Mvmctl verifies the signature on download and
+on every cache reuse.
+
+The manifest — not the artifacts individually — is the trust anchor.
+One cosign verification step covers everything inside.
+
+### 2. Two outputs from one flake — sibling `default` and `builder`
+
+The single `nix/images/builder/flake.nix#default` output splits into:
+
+- **`default`** — current behavior. Dev guest agent (Exec vsock handler
+  compiled in for `mvmctl exec`/`console`). Writable `/dev/vdb`
+  overlay. `verifiedBoot = false`. Used by `mvmctl dev up`. **No
+  behavior change.**
+- **`builder`** — new sibling output. Same package list. Prod guest
+  agent (no Exec handler). No writable overlay (squashfs root +
+  tmpfs overlay for `/tmp`, `/var/log`, `/nix/var`). `verifiedBoot
+  = true`. Used by mvmd's pool-build pipeline (mvmd plan 23).
+
+Plumbed through `mkGuest` as a `variant ∈ {"dev", "builder"}`
+parameter, visible as `passthru.variant`. Reuses the prod/dev guest
+agent split from commit `4e6c5fa` and the existing sibling flake at
+`nix/dev/flake.nix`.
+
+### 3. Cosign keyless via GitHub OIDC, identity-bound to release tags
+
+The expected signing identity is
+`https://github.com/auser/mvm/.github/workflows/release.yml@refs/tags/v*`.
+The release pipeline is the only entity that can produce verifiable
+artifacts; an unsigned-or-untagged build cannot accidentally claim
+project authority.
+
+Reuses the existing cosign keyless flow already used for the `mvmctl`
+binary (Sprint 21 binary signing) and the SBOM (W5.4). One signing
+infrastructure, three artifact families.
+
+### 4. Verify on every startup, fail closed
+
+Mvmctl runs the full verification pipeline on every `dev up`, including
+cache hits (re-hash cached files against the cached manifest, no
+network). Verification failure is a hard fail with no auto-retry,
+pointing at the troubleshooting docs. Tampering must be loud.
+
+`MVM_SKIP_HASH_VERIFY=1` keeps its W5.1 escape semantics — but only for
+the SHA-256 check. A separate `MVM_SKIP_COSIGN_VERIFY=1` exists for
+emergency cosign rotation. Both print non-suppressible warnings.
+
+### 5. Reusable verification primitive in `mvm-security::image_verify`
+
+The verification logic lives in `mvm-security::image_verify` as a
+reusable primitive with a typed `VerifyError` enum (not `anyhow`).
+mvmctl consumes it for the dev variant on `dev up`. mvmd (cross-repo,
+plan 23) consumes the same functions for the builder variant on pool
+rebuild and for pool images of its own. Same primitive, different
+artifacts.
+
+The typed-error contract lets mvmd's reconciliation loop pattern-match
+outcomes — Revoked, Expired, DigestMismatch, etc. — and decide whether
+to skip the bad image, alert, hold rollout, instead of crash-looping on
+`anyhow::Error`.
+
+### 6. Lifecycle: revocation list + manifest `not_after`
+
+A signed image can be recalled. The release pipeline maintains a
+cosign-signed `revoked-versions.json` published as the `revocations`
+release tag's only asset. Mvmctl checks it at most once per 24h
+(cached, fresh-window 7d). Manifests carry `not_after` (default 90d
+post-release): mvmctl warns and proceeds; mvmd refuses (different risk
+tolerances).
+
+### 7. Air-gapped operators stay on the trusted path
+
+A new `mvmctl dev import-image` (and `mvmd image import`) subcommand
+runs the *same* verification logic against local files. Without this,
+regulated/gov/air-gapped operators are pushed onto
+`MVM_SKIP_HASH_VERIFY=1` — the unsafe escape becomes their default,
+which is exactly the failure mode this ADR exists to prevent.
+
+## Alternatives considered
+
+- **Single image used for both mvmctl `dev up` and mvmd pool builds.**
+  Reject: the dev variant bundles the dev guest agent's vsock Exec
+  handler (RCE-by-design — that's how `mvmctl exec` and `console`
+  work). Acceptable in mvmctl's local sandbox, unacceptable inside
+  an mvmd coordinator's production builder VM. Two outputs from one
+  flake gives single source of truth without shipping the Exec
+  handler to production.
+- **Distinct flakes for dev and builder.** Reject: lets the build
+  sandbox tooling drift silently between dev and production —
+  the "works on my machine" trap. One flake, two outputs.
+- **Sign artifacts individually instead of a per-release manifest.**
+  Reject: requires N verification steps per boot; no place to record
+  cross-artifact metadata (Nix store hash, lockfile hashes, advisory
+  list); manifest schema versioning is harder.
+- **Project-internal Ed25519 signing root instead of cosign keyless.**
+  Reject: requires key management + rotation infrastructure the
+  project doesn't otherwise need. Cosign keyless reuses Sigstore's
+  transparency log + GitHub OIDC, which the project is already
+  publishing under for the CLI binary.
+- **TLS-only trust on the checksum file (status quo post-W5).**
+  Reject: the W5.1 code itself flags this as the gap to close. An
+  attacker who can swap the artifact can swap the checksum.
+- **Seal the dev image (current `default` output) instead of adding a
+  builder sibling.** Reject: would break `mvmctl dev` for everyone.
+  Users running `nix build` inside the dev VM expect outputs to
+  persist in `/nix/store` across the session. The split preserves
+  ergonomics for dev users while enabling production sealing.
+- **Sign the user's microVM image (what `mvmctl build --flake ./myapp`
+  produces).** Out of scope. Users have their own release identities
+  and may not want their builds attached to mvm's. The signed builder
+  produces *their* artifacts; what they do with them is theirs.
+
+## Consequences
+
+**Positive:**
+- Trust chain bottoms out at a cryptographic identity bound to the
+  source tree, not at "GitHub's TLS cert + release infrastructure."
+- Production builders (mvmd plan 23) never carry the dev RCE primitive.
+- One verification primitive serves both mvmctl users and mvmd's
+  fleet pipeline. Single audit surface.
+- Air-gapped operators have a sanctioned trusted path. The unsafe
+  escape (`MVM_SKIP_HASH_VERIFY=1`) is no longer the *only* offline
+  option.
+- Builder image inherits sprint 42's W3 dm-verity protection. Tampering
+  the on-disk rootfs panics the kernel before userspace.
+- Verifiable answer to "which dev/builder image built this artifact?"
+  via manifest digest recording (mvmd plan 23 records this in pool
+  manifests).
+
+**Negative:**
+- mvmd takes a hard dependency on `mvm-security::image_verify` (git-dep
+  until crates.io publish). Cross-repo coordination required.
+- Hotfixes require cutting new tags. No re-signing existing tags in
+  place. Same constraint that already applies to mvmctl binaries.
+- `sigstore` Rust crate is heavy (TUF + transparency log + x509).
+  Binary size impact may force a default-on Cargo feature gate.
+- Reversal cost is medium: once a tag ships with the cosign-signed
+  manifest, downgrading would require either impossible post-hoc
+  re-signing or a period of unverified downloads.
+
+**Neutral:**
+- Manifest schema versioning needed from day one so older mvmctl/mvmd
+  binaries fail closed on unknown versions.
+- The dev variant continues to be verity-exempt per ADR-002 §W3.4.
+  Only the builder variant gets verity protection.
+
+## References
+
+- Sprint 42 commit `688b7de` — "make dev VM the only build environment;
+  delete HostBuildEnv"
+- `specs/adrs/002-microvm-security-posture.md` — the seven-claim
+  threat model that drove sprint 42
+- `specs/plans/29-w5-supply-chain.md` — W5.1 SHA-256 verification this
+  plan extends
+- `specs/plans/36-sealed-signed-builder-image.md` — implementation plan
+  derived from this ADR
+- mvmd plan 23 + mvmd ADR 0001 (cross-repo) — rolling microVM rebuild
+  pipeline that consumes the verification primitive

--- a/specs/plans/25-microvm-hardening.md
+++ b/specs/plans/25-microvm-hardening.md
@@ -107,13 +107,15 @@ landed with the dev VM rebuilt, booted, and verified end-to-end.
   `prctl(PR_SET_SECCOMP, …)`. The tier list lives in
   `mvm-security/src/seccomp.rs` (already exists, just wired through).
 
-### W3 — Verified boot (🟡 host-side shipped — 2026-04-30; boot regression pending)
+### W3 — Verified boot (✅ shipped — 2026-04-30)
 
-Detail plan: `specs/plans/27-w3-verified-boot.md`. Kernel config,
-mkGuest's verity sidecar, both backends' wiring, the dev-VM
-exemption, and the security.yml gate are live. The live-boot +
-tamper regressions need a Linux/KVM CI lane that doesn't exist
-yet — they remain the only outstanding W3 work.
+Detail plan: `specs/plans/27-w3-verified-boot.md`. Verification
+runbook: `specs/runbooks/w3-verified-boot.md` (all five steps
+green on Lima/aarch64). Kernel config + `mkGuest`'s verity sidecar
++ a static-musl `mvm-verity-init` initramfs + both backends' boot
+wiring + the security.yml gate are all live. Live boot + tamper
+regression confirmed: a tampered ext4 panics with
+`data block N is corrupted` in early boot.
 
 - **W3.1** mkGuest emits a dm-verity sidecar alongside `rootfs.ext4`:
   a `rootfs.verity` Merkle tree and a `rootfs.roothash` text file.

--- a/specs/plans/27-w3-verified-boot.md
+++ b/specs/plans/27-w3-verified-boot.md
@@ -1,33 +1,30 @@
 # Plan 27 — W3: dm-verity verified boot
 
-> Status: 🟡 host-side wired + verity device builds correctly, but a
-> Firecracker aarch64 cmdline-append bug means the kernel mounts the
-> raw rootfs instead of `/dev/dm-0`. ADR-002 claim #3 does NOT hold
-> until Finding #1 below is fixed.
+> Status: ✅ shipped — 2026-04-30 (initramfs fix landed).
 > Owner: Ari
 > Parent: `specs/plans/25-microvm-hardening.md` §W3
 > ADR: `specs/adrs/002-microvm-security-posture.md`
 > Verification runbook: `specs/runbooks/w3-verified-boot.md`
-> Estimated effort: 3-4 days (+ initramfs work for Finding #1)
+> Estimated effort: 4-5 days (incl. initramfs)
 >
 > ### Verification result (2026-04-30, Lima dev VM, aarch64)
 >
-> Ran the five-step runbook end-to-end. Three pass, two are blocked
-> on the same root cause:
+> All five runbook steps green. ADR-002 claim #3 ("a tampered rootfs
+> ext4 fails to boot") now holds in practice:
 >
-> - ✅ Step 1 — `nix build .#default-microvm` emits all four files;
->   `vmlinux` contains DM_VERITY / device-mapper strings.
+> - ✅ Step 1 — `nix build .#default-microvm` emits five files now
+>   (`rootfs.{ext4,verity,roothash,initrd}` + `vmlinux`); kernel
+>   contains DM_VERITY strings.
 > - ✅ Step 2 — `veritysetup verify` exits 0 against the emitted
 >   sidecar + roothash.
-> - ❌ Step 3 — kernel constructs `dm-0 (rootfs) is ready` correctly
->   but then panics with `VFS: Cannot open root device "vda"`. The
->   captured cmdline shows Firecracker auto-appended
->   `pci=off root=/dev/vda ro earlycon=…` AFTER our user-supplied
->   `root=/dev/dm-0`. Last `root=` wins, so the kernel tries to
->   mount `/dev/vda` directly — which is busy as the verity-data
->   device. **Verity is built but not on the read path.**
-> - ⛔ Step 4 (tamper) — blocked on Step 3.
-> - ✅ Step 5 — dev-image build correctly emits no verity sidecar
+> - ✅ Step 3 — Live Firecracker boot under the verity initramfs:
+>   `mvm-verity-init` constructs `/dev/mapper/root` via DM ioctls,
+>   mounts it, switch_root's, and the real `minimal-init` reaches
+>   userspace.
+> - ✅ Step 4 — Tampered ext4 superblock triggers
+>   `device-mapper: verity: 254:0: data block 1 is corrupted` in
+>   the kernel; the VM panics before userspace.
+> - ✅ Step 5 — Dev-image build correctly emits no verity sidecar
 >   (`verifiedBoot = false` honoured).
 >
 > ### Shipped artifacts
@@ -77,51 +74,58 @@
 >     `start_vm_rejects_non_hex_roothash`,
 >     `start_vm_rejects_missing_verity_sidecar`.
 >
-> ### Outstanding (blocking ADR-002 §W3 claim)
+> ### Resolved findings
 >
-> #### Finding #1 — Firecracker aarch64 auto-appends `root=/dev/vda ro`
+> #### Finding #1 (RESOLVED 2026-04-30) — Firecracker aarch64 auto-appends `root=/dev/vda ro`
 >
-> Surfaced by Step 3 of the runbook. Firecracker v1.14.1's aarch64
-> FDT code unconditionally appends `pci=off root=/dev/vda ro
-> earlycon=uart,mmio,<addr>` after the user's `boot_args`. With
-> verity in play this means the kernel sees:
+> Resolution: a small static-musl initramfs in mkGuest. The kernel
+> mounts the initramfs first, runs `mvm-verity-init` (PID 1) which
+> reads `mvm.roothash=` from `/proc/cmdline`, builds
+> `/dev/mapper/root` via DM ioctls (DM_DEV_CREATE → DM_TABLE_LOAD
+> → DM_DEV_SUSPEND-with-resume), mounts it at `/sysroot`, and
+> `switch_root`s. The kernel-level `root=` setting is irrelevant —
+> the initramfs picks the real root explicitly.
 >
-> ```
-> root=/dev/dm-0 ro … dm-mod.create="…" pci=off root=/dev/vda ro earlycon=…
->                                                 ^^^^^^^^^^^^^
->                                  Firecracker's append; last root= wins
-> ```
+> #### Finding #2 (gotchas captured during the fix)
 >
-> The kernel constructs the verity device-mapper target correctly
-> (`device-mapper: ioctl: dm-0 (rootfs) is ready`) but then mounts
-> `/dev/vda` directly instead of `/dev/dm-0`. dm-verity exists on
-> the system but doesn't gate any read path — verity is wired but
-> not enforcing. The same defect almost certainly affects the
-> Apple Container path on macOS aarch64; the runbook documents how
-> to confirm once a verity-enabled production image is fed through
-> `start_with_verity`.
+> Three subtleties surfaced during implementation; the final code
+> handles all three but they're worth documenting for the next
+> person who touches this:
 >
-> **Fix path: small initramfs in mkGuest** — produce a ~1 MB
-> initramfs that runs `veritysetup open /dev/vda root <hash>
-> /dev/vdb && exec switch_root /mnt /init`. The kernel mounts the
-> initramfs first so Firecracker's `root=/dev/vda` becomes
-> harmless; we choose the eventual root explicitly. This is the
-> conventional verified-boot setup and avoids depending on
-> Firecracker behaviour.
+> 1. **Static linking is non-optional.** A dynamic ELF at `/init`
+>    in the initramfs panics with `Failed to execute /init (error
+>    -2)` — the kernel can't find `/lib/ld-linux*` because the
+>    initramfs is empty. `mvm-verity-init` is built via
+>    `pkgs.pkgsStatic.rustPlatform` against musl; the agent +
+>    seccomp-apply keep dynamic linking because they run after
+>    rootfs mount.
+> 2. **`hash_start_block = 1`, not 0.** `veritysetup format` writes
+>    a 512-byte verity superblock at offset 0 of the sidecar; the
+>    actual Merkle tree starts at block 1. Setting hash_start to 0
+>    makes the kernel parse the superblock as a hash node and
+>    report `metadata block 0 is corrupted`.
+> 3. **`data_block_size` must match the underlying ext4.** mkGuest
+>    builds rootfs.ext4 with mke2fs's default 1 KiB blocks at our
+>    typical sizes. dm-verity exposes its data-block-size as the
+>    device's logical block size, and the kernel's ext4 refuses to
+>    mount when FS block size < device logical block size. Verity
+>    data-block-size is now 1024; the hash-block-size stays at
+>    4096 (typical fan-out, smaller tree).
 >
-> **Workaround for now**: the Apple Container backend's
-> `start_with_verity()` can ship; we lose the live verity gate
-> until the initramfs lands but the static gate (the
-> `verified-boot-artifacts` CI lane) still catches a
-> `verifiedBoot=false` flip on a production path.
+> ### Outstanding (cosmetic, not blocking the W3 claim)
 >
-> #### Other still-pending work
->
-> - Auto-snapshot regression: confirm the new `/drives/verity` is
->   captured in Firecracker template snapshots and the restored VM
->   still boots.
-> - Live boot regression on a Linux/KVM CI runner (depends on the
->   initramfs fix above plus a CI lane that doesn't yet exist).
+> - Auto-snapshot regression for the new `/drives/verity` +
+>   `initrd_path` Firecracker config still needs a real snapshot
+>   round-trip.
+> - The Apple Container path's `start_with_verity()` is wired but
+>   live-tested only on Firecracker today; a §3.5 "Apple Container
+>   smoke" lane in the runbook is on the to-do once we have a Mac
+>   in the loop with a production image.
+> - Two pre-existing init-script bugs the live boot exposed
+>   (`mount /etc/nsswitch.conf failed: No such file or directory`,
+>   `setpriv: mutually exclusive arguments: --clear-groups
+>   --keep-groups --init-groups --groups`) need their own fixes —
+>   both unrelated to W3 and unchanged by this work.
 
 ## Why
 

--- a/specs/plans/35-post-w3-cleanup.md
+++ b/specs/plans/35-post-w3-cleanup.md
@@ -1,0 +1,347 @@
+# Plan 35 — Post-W3 cleanup + cross-backend parity
+
+> Status: ready to implement
+> Owner: Ari
+> Parent: closes the long tail from `specs/plans/25-microvm-hardening.md` (W3)
+>          and `specs/runbooks/w3-verified-boot.md` (post-fix observations)
+> ADR: `specs/adrs/002-microvm-security-posture.md`
+> Estimated effort: ~1 week (4 PRs, each independently mergeable)
+
+## Why
+
+The W3 verified-boot work landed (plan 27, all 5 runbook steps green
+on Lima/aarch64), but the live boot exposed loose ends that don't
+fit inside W3 itself:
+
+1. Two **pre-existing init-script defects** that crashloop services
+   in production rootfs builds. They didn't manifest before W3
+   because `mvmctl up` against templates was breaking earlier in the
+   boot path (Firecracker's `root=/dev/vda` clobber); now that
+   verity boots cleanly, the rootfs-side defects are visible.
+2. **No snapshot/restore round-trip** has been re-run since W3
+   added `/drives/verity` and the `initrd_path` to the Firecracker
+   `/boot-source` request. The wiring is in place but unverified.
+3. The **Apple Container path** has `start_with_verity()` wired
+   but only Firecracker has live-tested it. The boot logic is
+   identical, but the runbook doesn't have a §3.5 entry for VZ.
+4. The verification runbook is **operator-driven**. There's no
+   automated regression — a future change that breaks W3 won't
+   surface until the next time someone runs the runbook by hand.
+
+Plan 35 closes all four. It's a cleanup sprint; no new
+architecture, no new ADRs.
+
+## Threat shape addressed
+
+None new. This plan upholds existing ADR-002 claims that the W3
+work created the infrastructure for but doesn't yet *continuously
+verify* in CI. Specifically:
+
+- Claim #2 ("no guest binary can elevate to uid 0") relies on
+  W2.3 setpriv. The setpriv defect (C1.2) means the guest agent
+  has been crashlooping under setpriv on every verity boot —
+  setpriv is technically still preventing escalation, but the
+  agent is failing to start, which is its own incident shape.
+- Claim #3 ("a tampered rootfs ext4 fails to boot") is verified
+  manually today; C4 turns it into a `just w3-live-test` recipe
+  + a CI-runnable script.
+
+## Sub-items
+
+### C1 — init-script defects exposed by W3 live boot
+
+Two unrelated bugs surfaced in the same boot session:
+
+#### C1.1 — `/etc/nsswitch.conf` bind-mount fails with ENOENT
+
+`nix/lib/minimal-init/lib/04-etc-and-users.sh.in` stages
+`/etc/{passwd,group,nsswitch.conf}` via `/run/mvm-etc/*` symlinks,
+then later `rm -f` + `touch` + `mount --bind` to promote them to
+read-only bind-mounts. The bind step succeeds for `passwd` and
+`group` but fails for `nsswitch.conf`:
+
+```
+mount: mounting /run/mvm-etc/nsswitch.conf on /etc/nsswitch.conf failed: No such file or directory
+mount: can't find /etc/nsswitch.conf in /proc/mounts
+```
+
+Hypothesis (needs confirmation while debugging): the symlink-then-
+rewrite-through-symlink dance leaves `/run/mvm-etc/nsswitch.conf`
+in an inconsistent state for one of the three files because the
+write happens *through* the symlink while the others are written
+directly after `rm -f`. The clean fix is to drop the symlinks
+entirely and write content to `/run/mvm-etc/*` directly, then bind
+on top of empty `/etc/*` targets. Eliminates the failure mode
+without restructuring the init.
+
+**Files**
+
+- `nix/lib/minimal-init/lib/04-etc-and-users.sh.in`: refactor to
+  write content into `/run/mvm-etc/*` paths with no intermediate
+  symlinks. The `chown $user:$group $home` calls that motivated
+  the symlinks (line 12-14 comment) need a separate fix — write
+  user/group entries to `/run/mvm-etc/{passwd,group}` then bind-
+  mount before any `chown` runs, OR use numeric uid/gid in chown.
+
+**Tests**
+
+- Boot regression: re-run the W3 runbook Step 3 inside Lima, grep
+  for `mount: … failed`. Expected output is silence.
+- Add an init-time sanity check after the mount loop:
+  `for f in passwd group nsswitch.conf; do
+     mountpoint -q /etc/$f || echo "[init] WARN: /etc/$f not bind-mounted" > /dev/console
+   done`. The warning ought to print zero lines on a healthy boot.
+
+#### C1.2 — `setpriv` flag conflict in `mkServiceBlock` + agent launch
+
+`util-linux`'s `setpriv(1)` rejects the combination
+`--clear-groups --groups=…` as mutually exclusive (along with
+`--keep-groups` and `--init-groups`):
+
+```
+setpriv: mutually exclusive arguments: --clear-groups --keep-groups --init-groups --groups
+```
+
+Both the agent launcher (`nix/lib/minimal-init/default.nix::guestAgentBlock`)
+and the per-service launcher (`mkServiceBlock`'s `setprivPrefix`
+non-explicit branch) set `--clear-groups --groups=...`. The fix is
+to drop `--clear-groups`: `--groups=N1,N2,…` already replaces the
+supplementary group set with exactly the listed gids. The combination
+was redundant; util-linux rejects it because it's ambiguous which
+side wins.
+
+**Files**
+
+- `nix/lib/minimal-init/default.nix`:
+  - `guestAgentBlock`: drop `--clear-groups`.
+  - `setprivPrefix` (non-explicit branch, ~line 281): drop
+    `--clear-groups`.
+
+**Tests**
+
+- Boot regression: same Lima re-run as C1.1, grep for
+  `setpriv: mutually exclusive`. Zero matches expected.
+- Add a one-shot guest-agent launch test in
+  `nix/images/default-tenant/` that asserts the agent process
+  reaches "ready" within 5 seconds of boot (currently it
+  crashloops indefinitely).
+
+#### Sequencing for C1
+
+Both fixes are one-line edits. Land as a single PR; the boot
+regression covers both at once. Estimate: ½ day.
+
+### C2 — Verity snapshot/restore parity
+
+`mvm-runtime/src/vm/microvm.rs::configure_flake_microvm_with_drives_dir`
+adds `/drives/verity` and `initrd_path` to the Firecracker
+configure-VM API call. Firecracker snapshots serialize the active
+VM's drive list and boot-source. We have not re-run a template
+snapshot/restore since W3, so the open questions are:
+
+1. Is `/drives/verity` captured in the snapshot's drive metadata,
+   and does Firecracker re-attach it on restore?
+2. Is the dm-verity device-mapper state (the in-kernel verity
+   target built by `mvm-verity-init`) preserved across snapshot?
+   The initrd memory is freed after `switch_root`, so on restore
+   there's no userspace component to rebuild the dm device.
+3. If the kernel's dm-state IS preserved, restore "just works."
+   If NOT, we need a recovery path — a small in-rootfs binary
+   that re-applies the verity target on receipt of a post-restore
+   signal (W2 already has the `PostRestore` vsock RPC).
+
+**Approach**
+
+Test first. Boot a verity-enabled template, snapshot it, restore
+it from another mvmctl invocation, and inspect:
+
+- `mount` inside the restored guest: does `/` still show
+  `/dev/dm-0`?
+- `ls /sys/block/dm-0`: is the verity device still active?
+- Does the restored guest survive `cat /etc/passwd` (a verity
+  read)?
+
+If all three pass, this work item closes with a regression test
+and a doc note. If any fails, scope grows to include the
+`PostRestore`-handler verity-resume code.
+
+**Files**
+
+- `crates/mvm-runtime/tests/verity_snapshot_restore.rs` — new
+  integration test, gated on Linux/KVM availability (skip on
+  macOS). Builds a transient verity template, snapshots,
+  restores, asserts `/dev/dm-0` is still root.
+- `specs/runbooks/w3-verified-boot.md`: add §6 "Snapshot
+  round-trip" with the manual procedure.
+
+**Tests**
+
+The snapshot/restore test itself is the regression. Run it in
+Lima as part of `just w3-live-test` (see C4).
+
+**Estimate**: 1-2 days. Could grow to 3 if dm-state isn't
+preserved across snapshot — that's the investigation we owe
+upfront.
+
+### C3 — Apple Container live-boot smoke
+
+`crates/mvm-apple-container/src/macos.rs::start_vm` calls
+`setInitialRamdiskURL` and passes `mvm.roothash=` on the cmdline
+when `VerityConfig` is present. The wiring is symmetric with the
+Firecracker path. We haven't run it live because the dev VM
+(`mvmctl dev up`) uses `verifiedBoot = false`, and we haven't had
+a production-mode microVM booted via Apple Container.
+
+**Approach**
+
+Build a verity-enabled template on Lima, copy the artifacts to
+the macOS host's `~/.mvm/templates/<id>/revisions/<rev>/`, and
+boot via:
+
+```bash
+mvmctl up --hypervisor apple-container --template <verity-tmpl>
+```
+
+The first run will likely surface a small set of missing wiring
+(perhaps the prebuilt-image copier doesn't currently move
+`rootfs.initrd` alongside `rootfs.{ext4,verity,roothash}`). Fix
+those, capture the boot log, and add §3.5 to the runbook.
+
+**Files**
+
+- `crates/mvm-cli/src/commands/env/apple_container.rs`: ensure
+  `download_default_microvm_image` (or wherever the prebuilt
+  copy lives) picks up `rootfs.initrd` when present.
+- `specs/runbooks/w3-verified-boot.md`: §3.5 "Apple Container
+  smoke" with the captured boot log.
+
+**Tests**
+
+Manual; the runbook is the test.
+
+**Estimate**: ½ day if the wiring is intact, 1 day if a missing
+copy step shows up.
+
+### C4 — Live-KVM regression automation
+
+The runbook is operator-driven today. C4 makes it a single
+command that operators (or CI) can run:
+
+```bash
+just w3-live-test           # full runbook in Lima
+just w3-live-test --tamper  # only the tamper step
+```
+
+The recipe wraps the existing runbook commands (`nix build`,
+`firecracker --no-api`, log-grep) into a script that exits
+non-zero on any step failure. Output captures the boot log so
+operators can re-read it after the fact.
+
+**CI integration**
+
+GitHub-hosted Linux runners don't expose `/dev/kvm` by default.
+Two options:
+
+1. **Self-hosted runner** with KVM access. Right answer
+   long-term; out of scope for this sprint.
+2. **Soft-gated CI lane** that runs the script *if* `/dev/kvm`
+   is present, skips otherwise. Lets operators run on a self-
+   hosted runner without blocking sprint close on infra.
+
+C4 ships option 2. The `security.yml` workflow gains a
+`live-verity-boot` lane that's skipped on standard runners but
+enforced on tagged self-hosted runners.
+
+**Bonus: A.2 v2 latency comparison**
+
+Sprint 43 deferred a "cold-boot vs warm-VM latency" test
+(claude-code-vm) for the same Linux/KVM-required reason. Since
+C4 sets up the infrastructure, it folds in cleanly. Adds:
+
+```bash
+just mcp-warm-vm-latency
+```
+
+That times a snapshot-restore (warm) vs a fresh boot (cold)
+against `claude-code-vm`. Reuses C4's KVM detection.
+
+**Files**
+
+- `scripts/w3-live-test.sh` — one script, commented step-by-step
+  to mirror the runbook.
+- `justfile`: `w3-live-test`, `mcp-warm-vm-latency` recipes.
+- `.github/workflows/security.yml`: `live-verity-boot` lane,
+  conditional on `[ -e /dev/kvm ]`.
+
+**Tests**
+
+The script itself is the regression. CI proves it runs end-to-
+end on any KVM-capable runner.
+
+**Estimate**: 1-2 days.
+
+## Sequencing
+
+C1 → C2 → C3 ‖ C4. C1 unblocks the rest by making the boot
+log noise-free; C2 has investigation depth that may extend the
+sprint; C3 is the lightest item and slots in opportunistically;
+C4 is independent and can land first or last.
+
+PR sequence:
+
+1. **PR-A**: C1 (init-script defects). Single PR, both fixes.
+2. **PR-B**: C2 (snapshot/restore parity). Includes a new
+   integration test + runbook §6.
+3. **PR-C**: C3 (Apple Container live-boot smoke). Tiny PR;
+   could be folded into PR-B if both are small.
+4. **PR-D**: C4 (live-KVM regression automation). Self-
+   contained.
+
+## Out-of-sprint follow-ups (parked, not blocked on this sprint)
+
+These stayed on the backlog at sprint 42 close but don't fit
+under "post-W3 cleanup." Mentioning them so they're tracked
+somewhere:
+
+- **mkNodeService → buildNpmPackage** (deferred from W7.4 in
+  plan 31). Output-layout-changing swap; needs a Linux builder
+  validation against `hello-node` first.
+- **L7 egress runtime backing** (sprint 43). Sized as its own
+  sprint in plan 34.
+- **Hosted MCP transport (HTTP/SSE)** (plan 33). Cross-repo
+  work; lives in mvmd.
+- **`scripts/check-prod-agent-no-exec.sh` Nix examples**
+  cleanup — `nix/images/{paperclip,openclaw}/` deletion blocked
+  by sandbox in W7.1; needs manual `git rm`.
+
+## Acceptance criteria
+
+Sprint closes when:
+
+1. ✅ A fresh `mvmctl up` against a verity-enabled template
+   boots cleanly with no `mount: failed` or
+   `setpriv: mutually exclusive` warnings on the console.
+2. ✅ A snapshot of a verity-enabled VM restores into a working
+   verity-protected guest (or, if dm-state isn't preserved,
+   the recovery path is implemented).
+3. ✅ `mvmctl up --hypervisor apple-container` boots a verity
+   template on macOS — runbook §3.5 has captured logs.
+4. ✅ `just w3-live-test` passes in Lima end-to-end.
+5. ✅ `security.yml::live-verity-boot` lane runs (skipped on
+   public runners, enforced where KVM is available).
+
+## Reversal cost
+
+Low for all four items. C1 is an init-script edit; rollback is
+git revert. C2/C4 add tests, no runtime behavior change. C3 is
+runbook docs + a small wiring fix.
+
+## Non-goals
+
+- New W-workstream additions to ADR-002. Plan 25 is closed.
+- Hosted CI infrastructure (self-hosted KVM runners, etc.).
+  C4 ships the script + soft-gated lane; provisioning real
+  runner capacity is operator work.
+- Touching the snapshot wire format. C2 investigates and
+  patches in-place; if dm-state preservation requires Firecracker
+  patches, that's a separate plan.

--- a/specs/plans/35-sprint-44-draft.md
+++ b/specs/plans/35-sprint-44-draft.md
@@ -1,0 +1,180 @@
+# Sprint 44 — Verified-boot polish + cross-backend parity (DRAFT)
+
+> Status: planning — proposed structure for the next sprint after
+> sprint 42 (microVM hardening) and sprint 43 (MCP/agent adoption)
+> close. Master plan: [`plans/35-post-w3-cleanup.md`](35-post-w3-cleanup.md).
+>
+> This file is a draft. When sprint 42's `SPRINT.md` is archived to
+> `specs/backlog/42-microvm-hardening.md` and sprint 43's PRs are
+> merged, copy this file to `specs/SPRINT.md` and rename it to
+> "Sprint 44".
+
+## Goal
+
+Close the long tail from sprint 42's W3 (verified boot): two
+init-script defects the live boot exposed, an unverified
+snapshot/restore round-trip, an unverified Apple Container live
+path, and the runbook → CI promotion. No new hardening claims;
+this sprint upholds existing ones with fewer asterisks.
+
+**Branch**: TBD (per-PR feature branches; merge target: `main`).
+
+## Why this sprint, why now
+
+Sprint 42 closed with all 7 ADR-002 success-criteria claims
+backed by code, but the `specs/runbooks/w3-verified-boot.md` live
+test exposed two init-script defects (broken bind-mount of
+`/etc/nsswitch.conf`; setpriv flag conflict) plus three open
+"untested-but-wired" surfaces (snapshot/restore with verity,
+Apple Container live boot, automated regression). Each is a small
+correctness gap that the W3 sprint deliberately scoped out — but
+leaving them open turns claim #2 ("no guest binary can elevate to
+uid 0") and claim #3 ("a tampered rootfs ext4 fails to boot")
+into "true at moment of merge, untested continuously."
+
+The whole sprint is ~1 week of work and 4 small PRs.
+
+## Current Status (sprint open)
+
+| Metric           | Value                    |
+| ---------------- | ------------------------ |
+| Workspace crates | 8 + root facade + xtask  |
+| Total tests      | 1 121 (sprint 42 close)  |
+| Clippy warnings  | 0                        |
+| Edition          | 2024 (Rust 1.85+)        |
+| MSRV             | 1.85                     |
+| Binary           | `mvmctl`                 |
+
+## In-flight workstreams
+
+### C1 — Init-script defects exposed by W3 live boot  🟡
+
+Plan: [`plans/35-post-w3-cleanup.md`](plans/35-post-w3-cleanup.md) §C1.
+Single PR, two one-line fixes.
+
+- [ ] **C1.1** `/etc/nsswitch.conf` bind-mount source-deletion
+      bug. `04-etc-and-users.sh.in` symlink dance leaves the
+      staging file in inconsistent state for one of the three
+      promoted bind-mounts. Fix: drop intermediate symlinks,
+      write content directly to `/run/mvm-etc/*`, bind on top
+      of empty `/etc/*` targets.
+- [ ] **C1.2** `setpriv` `--clear-groups --groups=…` mutually
+      exclusive flag conflict in `mkServiceBlock` non-explicit
+      branch and `guestAgentBlock`. Fix: drop `--clear-groups`
+      (`--groups=` already replaces the supplementary group
+      set; the combination was redundant + ambiguous to
+      util-linux's setpriv).
+
+**Done when**: a fresh Lima boot of a verity-enabled template
+shows no `mount: failed` or `setpriv: mutually exclusive` lines
+on the console.
+
+### C2 — Verity snapshot/restore parity  🟡
+
+Plan: [`plans/35-post-w3-cleanup.md`](plans/35-post-w3-cleanup.md) §C2.
+1-2 days, 1 PR. May grow to 3 days if dm-state isn't preserved
+across Firecracker snapshot.
+
+- [ ] **C2.1** Investigate: snapshot a verity-enabled VM, restore
+      it, inspect `mount` output and `/sys/block/dm-0`. Determine
+      whether Firecracker's snapshot serializes the in-kernel
+      dm-verity device-mapper state.
+- [ ] **C2.2** If dm-state IS preserved: ship a regression test
+      and runbook §6 documenting the round-trip. If NOT: extend
+      the `PostRestore` vsock RPC handler to re-apply the verity
+      target on signal.
+- [ ] **C2.3** `crates/mvm-runtime/tests/verity_snapshot_restore.rs`
+      integration test, gated on Linux/KVM availability.
+
+**Done when**: snapshotting a verity template and restoring it
+produces a guest with `/dev/dm-0` still mounted as root, plus
+the test exercising the round-trip.
+
+### C3 — Apple Container live-boot smoke  🟡
+
+Plan: [`plans/35-post-w3-cleanup.md`](plans/35-post-w3-cleanup.md) §C3.
+½ day, ½ PR (could fold into C2's PR if both are small).
+
+- [ ] **C3.1** Build a verity template on Lima, copy artifacts
+      to macOS host's `~/.mvm/templates/<id>/revisions/<rev>/`,
+      boot via `mvmctl up --hypervisor apple-container`. Surface
+      and fix any wiring gaps (e.g. prebuilt-image copy missing
+      `rootfs.initrd`).
+- [ ] **C3.2** Runbook §3.5 captures the boot log + tamper test.
+
+**Done when**: the runbook has a §3.5 with "Apple Container
+live boot ✅" and the captured log shows
+`mvm-verity-init: switching to /init`.
+
+### C4 — Live-KVM regression automation  🟡
+
+Plan: [`plans/35-post-w3-cleanup.md`](plans/35-post-w3-cleanup.md) §C4.
+1-2 days, 1 PR.
+
+- [ ] **C4.1** `scripts/w3-live-test.sh` wraps the runbook into
+      a single command. Runs every step, asserts on log
+      contents, exits non-zero on failure.
+- [ ] **C4.2** `just w3-live-test` recipe; `just w3-live-test
+      --tamper` for the tamper-only sub-step.
+- [ ] **C4.3** Soft-gated `live-verity-boot` lane in
+      `.github/workflows/security.yml`. Conditional on
+      `[ -e /dev/kvm ]` — skipped on standard GitHub runners,
+      enforced where KVM is available.
+- [ ] **C4.4** Fold sprint 43's deferred A.2 v2 cold-vs-warm
+      latency test into the same script (`just
+      mcp-warm-vm-latency`). Reuses the KVM detection.
+
+**Done when**: `just w3-live-test` exits 0 on Lima; CI lane
+skips cleanly on public runners.
+
+## Success criteria
+
+By sprint close:
+
+1. ✅ Verity-enabled template boots cleanly with no init-script
+   warnings on console (C1).
+2. ✅ Snapshot/restore round-trip works for verity VMs (C2).
+3. ✅ Apple Container live boot of a verity template succeeds
+   on macOS (C3).
+4. ✅ `just w3-live-test` exits 0 in Lima end-to-end (C4).
+5. ✅ Sprint 42 archived to `specs/backlog/42-microvm-hardening.md`.
+
+## Phasing
+
+PRs are independently mergeable. Suggested order:
+
+1. **PR-A**: C1 (init-script defects). Single PR, smallest.
+2. **PR-B**: C2 (snapshot/restore parity). Investigation may
+   extend; ship the test + runbook entry, defer the
+   `PostRestore` recovery handler if needed.
+3. **PR-C**: C3 (Apple Container smoke). Foldable.
+4. **PR-D**: C4 (live-KVM regression automation). Self-contained.
+
+## Carryover from earlier sprints
+
+Items deferred at sprint 42/43 close that do NOT fit this sprint
+but still need a home:
+
+| Item | Source | Where it goes |
+|---|---|---|
+| L7 egress runtime backing (mitmdump + CA + DNS pinning) | Sprint 43, [`plans/34-egress-l7-proxy.md`](plans/34-egress-l7-proxy.md) | Own sprint (already sized) |
+| Hosted MCP transport (HTTP/SSE) | Sprint 43, [`plans/33-hosted-mcp-transport.md`](plans/33-hosted-mcp-transport.md) | Cross-repo (mvmd) |
+| `mkNodeService` → `pkgs.buildNpmPackage` swap | Sprint 42 W7.4 deferred | Own follow-up; needs hello-node validation |
+| `nix rm` of `nix/images/examples/{paperclip,openclaw}/` | Sprint 42 W7.1 deferred (sandbox-blocked) | Manual `git rm` (½ hour) |
+
+## Non-goals (named explicitly)
+
+- Hosted CI infrastructure (self-hosted KVM runners, GitHub
+  paid-tier nested-virt). C4 ships the script + soft-gated
+  lane; runner capacity is separate operator work.
+- New ADR-002 claims or W-workstreams. Sprint 42 closed plan
+  25; this sprint upholds it.
+- Touching the Firecracker snapshot wire format. If C2's
+  investigation shows dm-state isn't preserved, the fix is in
+  guest-side recovery code (the `PostRestore` handler), not
+  in Firecracker.
+
+## Completed Sprints
+
+(Carryover from sprint 42's SPRINT.md when archived. Sprint 42
++ 43 should be added to this list when their final PRs merge.)

--- a/specs/plans/36-sealed-signed-builder-image.md
+++ b/specs/plans/36-sealed-signed-builder-image.md
@@ -1,0 +1,456 @@
+# Plan 36 — Sealed, signed builder image
+
+> Status: ready to implement
+> Owner: Ari
+> Parent: extends [`plans/29-w5-supply-chain.md`](29-w5-supply-chain.md) (W5.1 SHA-256 → cosign signature on the manifest)
+> ADR: [`adrs/005-sealed-signed-builder-image.md`](../adrs/005-sealed-signed-builder-image.md)
+> mvmd counterpart: cross-repo plan 23 (rolling microVM rebuild) + ADR 0001 in mvmd
+> Estimated effort: ~1 sprint (4 PRs, each independently mergeable)
+
+## Why
+
+Sprint 42's W5 (supply chain) shipped per-arch SHA-256 checksum manifests
+for the dev-image and default-microvm downloads, with verification on
+fetch in `crates/mvm-cli/src/commands/env/apple_container.rs:918-1048`
+and `MVM_SKIP_HASH_VERIFY=1` as the documented escape. The code itself
+flags the remaining gap at line 952:
+
+> *"who can swap the artifact can also swap the checksum file, so the
+> checksum manifest is **TLS-only trust today, on the checksum file
+> itself in a future iteration**"*
+
+That future iteration is this plan. The checksum file is fetched over
+HTTPS but is not itself signed, so the trust chain bottoms out at
+"GitHub's TLS cert + GitHub's release infrastructure," not at a
+cryptographic identity bound to the source tree. A compromised release
+asset (account takeover, CDN compromise, in-flight TLS interception with
+a stolen CA) lets an attacker swap *both* the artifact and the checksum
+in lockstep, and `mvmctl` accepts it as legitimate.
+
+The downstream stakes: sprint 42's commit `688b7de` made the
+dev/builder VM the *only* build environment — every artifact `mvmctl
+build` produces, and (via the parallel mvmd plan 23) every pool image
+mvmd rebuilds, inherits whatever that VM was when it ran. Tampering
+the builder image taints everything built inside it. Closing the
+"who-signed-the-checksum-file?" gap is the last mile of the W5 chain.
+
+## What sprint 42 already shipped (do not redo)
+
+| W5 / W6 item                                  | Code path                                                | Closes plan-36 layer    |
+| --------------------------------------------- | -------------------------------------------------------- | ----------------------- |
+| **W5.1** SHA-256 download verify              | `apple_container.rs:918-1048`, 5 regression tests        | Layer 3 (artifact integrity) ✅ |
+| **W5.2** `cargo deny`                         | `deny.toml`, `ci.yml::deny` job                          | partial Layer 0 ✅      |
+| **W5.3** mvmctl reproducibility               | `ci.yml::reproducibility` job                            | partial Layer 0 ✅      |
+| **W5.4** SBOM + cosign                        | `release.yml:205-247`                                    | precedent for Layer 4 ✅ |
+| **W6.2** Security model in CLAUDE.md          | `CLAUDE.md`                                              | doc surface ✅          |
+| **W6.4** `mvmctl security status` probes      | `commands/security/status.rs`                            | extension point ✅      |
+| **W3** dm-verity for prod microVMs            | `nix/flake.nix::verityArtifacts`                         | informs Layer 2 design  |
+
+The dev/builder image is explicitly verity-exempted per ADR-002 §W3.4
+and `nix/images/builder/flake.nix` (`verifiedBoot = false`): its
+overlayfs upper layer mutates `/nix` at runtime, which can't compose
+with dm-verity. Plan 36 splits the flake (Layer 1) so the new **builder
+variant** can be sealed while the **dev variant** keeps overlay-mutable
+behavior unchanged.
+
+## Threat model
+
+| Threat                                              | Today (post W5)                          | After plan 36       |
+| --------------------------------------------------- | ---------------------------------------- | ------------------- |
+| GitHub release asset replaced (CDN/acct compr.)     | checksum verify catches body-only swap   | catches checksum-and-body swap (sig fails) |
+| TLS MITM on download                                | undetected if attacker swaps both        | sig verify fails    |
+| Local cache tampering (`~/.cache/mvm/dev/*`)        | undetected after first download          | re-hash on every `dev up` against cached signed manifest |
+| Drift between releases (non-reproducible build)     | mvmctl binary covered (W5.3); image NOT  | image reproducibility CI gate added |
+| Lima Ubuntu base swapped out (Lima fallback path)   | undetected; out of mvmctl's control      | not in scope (Lima is deprecated path) |
+| Compromise of release-time signing identity         | n/a (no signing today)                   | rotate via tag; revocation list |
+| Known-bad signed image keeps running after recall   | n/a                                      | revocation list + manifest `not_after` |
+| Production builder ships RCE-by-design Exec handler | no production builder yet (mvmd plan 23 pending) | builder variant strips Exec handler |
+| Air-gapped operator forced off trusted path         | `MVM_SKIP_HASH_VERIFY=1` documented but loud | `mvmctl dev import-image` runs same verification on local files |
+
+**Out of scope (named explicitly):**
+- TPM / measured boot of the running builder VM. Neither Apple Container
+  nor Lima exposes a vTPM today.
+- Hardening Lima's own Ubuntu fetch. Lima is the legacy fallback for
+  pre-macOS-26 / no-KVM hosts; documented as lower-trust.
+- Signing the user's microVM image (what `mvmctl build --flake ./myapp`
+  produces). User's responsibility.
+- Default-microvm signing parity. Trivial extension once plan 36 lands;
+  separate follow-up issue.
+
+## Terminology: dev image vs builder image
+
+The codebase converged on "builder image" — `nix/images/builder/` is
+where the flake lives, `passthru.role = "builder"` is plumbed via
+`mkGuest` (W7.3, W7.4). Plan 36 splits that single output into two
+sibling outputs:
+
+| Image                                 | Source                                  | Guest agent                  | Used by                  | Signed asset prefix            |
+| ------------------------------------- | --------------------------------------- | ---------------------------- | ------------------------ | ------------------------------ |
+| **Dev image** (`mvm-dev`)             | `nix/images/builder/flake.nix#default`  | Dev (Exec handler compiled in for `mvmctl exec`/`console`) | mvmctl on `dev up` | `dev-vmlinux-{arch}` / `dev-rootfs-{arch}.ext4` |
+| **Builder image** (`mvm-builder-prod`)| `nix/images/builder/flake.nix#builder`  | Prod (no Exec handler)       | mvmd coordinator on pool build (mvmd plan 23) | `builder-vmlinux-{arch}` / `builder-rootfs-{arch}.squashfs` |
+
+**Why two outputs from one flake**: identical build sandbox tooling, two
+different agent variants. Reuses the prod/dev guest agent split from
+commit `4e6c5fa` and the existing sibling flake at `nix/dev/flake.nix`.
+The dev variant keeps `verifiedBoot = false` and the writable overlay
+(no behavior change for `mvmctl dev up`); the builder variant drops the
+overlay (production builds run in ephemeral builder VMs), goes
+squashfs-RO root, and gets `verifiedBoot = true`.
+
+**Why not separate flakes**: lets the build sandbox tooling drift
+silently between dev and production — the "works on my machine" trap.
+One flake, two outputs.
+
+## Approach: minimize, seal builder, sign, verify
+
+### Layer 0 — Provenance: pin every lockfile + image reproducibility
+
+The dev/builder images depend on three flake lockfiles:
+
+- `nix/flake.nix::flake.lock` — parent flake (production guest agent library).
+- `nix/dev/flake.nix::flake.lock` — sibling flake (dev guest agent variant).
+- `nix/images/builder/flake.lock` — image flake.
+
+The release manifest carries the SHA-256 of each lockfile content (not
+just paths) so the input closure is recoverable from the signed manifest
+alone:
+
+```json
+"flake_locks": {
+  "nix/flake.nix":                "sha256:...",
+  "nix/dev/flake.lock":           "sha256:...",
+  "nix/images/builder/flake.lock": "sha256:..."
+}
+```
+
+CI gates:
+- **Release-PR check**: `nix flake metadata --json` against each flake;
+  assert lockfile committed, in sync, no `dirty` flag.
+- **Tag-only reproducibility check** (extends W5.3 from mvmctl-binary to
+  the dev/builder images): build each variant twice on different runners,
+  assert identical Nix store hashes.
+
+### Layer 1 — Minimize and split: builder variant has no Exec handler
+
+Audit `nix/images/builder/flake.nix` package list and split the single
+`default` output into:
+
+- `default` — current behavior. Dev agent (Exec handler compiled in).
+  Writable `/dev/vdb` overlay. `verifiedBoot = false`. Used by
+  `mvmctl dev up`. **No behavior change.**
+- `builder` — new sibling output. Same package list. Prod agent (no Exec
+  handler). No writable overlay (squashfs root + tmpfs overlay for
+  `/tmp`, `/var/log`, `/nix/var`; `/nix/store` read-only from squashfs).
+  `verifiedBoot = true`. Used by mvmd's pool-build pipeline.
+
+Plumbed through `mkGuest` as a `variant ∈ {"dev", "builder"}`
+parameter, visible in `passthru.variant`. Reuses the existing prod/dev
+guest agent split (`dev-shell` Cargo feature toggle, parent/sibling
+flake override from commit `4e6c5fa`).
+
+Audit each package entry's caller in a comment so future additions
+require justification:
+
+- **Definitely keep**: `nix`, `coreutils`, `bashInteractive`, `gnused`,
+  `gnugrep`, `gawk`, `findutils`, `which`, `e2fsprogs`, `util-linux`.
+- **Justify or drop in builder variant**: `gnumake`, `git`, `curl`,
+  `iproute2`, `iptables`, `jq`, `less`, `procps`. `iptables`+`jq` are
+  required by `mvm-runtime/src/vm/network.rs::bridge_ensure` only when
+  the dev VM hosts transient microVMs (`mvmctl exec`); confirm whether
+  the builder variant needs them or moves the bridge logic host-side.
+
+### Layer 2 — Seal the builder variant
+
+The builder variant becomes:
+
+- Squashfs root, mounted read-only.
+- Tmpfs overlays for `/tmp`, `/var/log`, `/nix/var`.
+- `/nix/store` read-only from squashfs (already content-addressed; the
+  RO mount makes immutability physical).
+- `verifiedBoot = true` — dm-verity sidecar emitted by `mkGuest` as it
+  does for production tenant images (W3.1).
+
+The dev variant keeps the overlay model — users running `mvmctl dev`
+expect `nix build` outputs to persist in `/nix/store` across the
+session. Splitting the flake is what lets us keep that ergonomic without
+dragging it into production.
+
+### Layer 3 — Sign: cosign the manifest, not just the artifacts
+
+W5.1 verifies SHA-256 against an unsigned checksum file. Plan 36
+elevates the **manifest** to the trust anchor. Per `{arch} × {variant}`:
+
+```
+{variant}-vmlinux-{arch}                     ← already published (dev)
+{variant}-rootfs-{arch}.{ext4,squashfs}      ← already published (dev), squashfs new for builder
+{variant}-image-{arch}.manifest.json         ← NEW (replaces unsigned checksum file)
+{variant}-image-{arch}.manifest.json.sig     ← NEW (cosign keyless sig)
+{variant}-image-{arch}.manifest.json.pem     ← NEW (cosign keyless cert)
+```
+
+Manifest schema (v1):
+
+```json
+{
+  "schema_version": 1,
+  "version": "0.14.0",
+  "arch": "aarch64",
+  "variant": "dev" | "builder",
+  "rootfs_format": "ext4" | "squashfs",
+  "artifacts": [
+    { "name": "dev-vmlinux-aarch64",        "sha256": "..." },
+    { "name": "dev-rootfs-aarch64.ext4",    "sha256": "..." }
+  ],
+  "nix_store_hash": "abc123...",
+  "source_git_sha": "...",
+  "flake_locks": {
+    "nix/flake.nix":                "sha256:...",
+    "nix/dev/flake.lock":           "sha256:...",
+    "nix/images/builder/flake.lock": "sha256:..."
+  },
+  "addressed_advisories": ["CVE-2026-1234", ...],
+  "built_at": "2026-04-30T18:00:00Z",
+  "not_after":  "2026-07-29T18:00:00Z"
+}
+```
+
+`schema_version` from day one so older mvmctl/mvmd binaries fail closed
+on unknown versions. `addressed_advisories` lets mvmd (plan 23) decide
+"this image addresses the CVE we're patching against" — empty array on
+v0.14.0, populated as mvmd's advisory ingest pipeline lands.
+`built_by_image` lives on **pool image manifests** (mvmd-side), not the
+builder image's own manifest, so it's not in this schema.
+
+Sign the manifest, not each binary individually — one cosign keyless
+verification step covers everything inside.
+
+### Layer 4 — Verify on every builder-VM startup
+
+Replace the unsigned-checksum path in `apple_container.rs:918-1048`
+with a verification pipeline. The W5.1 SHA-256 code stays as the inner
+check; plan 36 wraps it in cosign verification of the manifest.
+
+1. Always download the manifest first.
+2. Verify `manifest.json.sig` against `manifest.json.pem` and the
+   expected OIDC identity
+   (`https://github.com/auser/mvm/.github/workflows/release.yml@refs/tags/v*`)
+   using the `sigstore` Rust crate's offline-bundle path.
+3. Pin the version: `manifest.version == env!("CARGO_PKG_VERSION")`
+   exactly. No "newer is fine."
+4. **Revocation check** (best-effort, online-only): fetch
+   `https://github.com/auser/mvm/releases/download/revocations/revoked-versions.json`
+   at most once per 24h (cache + cosign-verify). If `manifest.version`
+   is in the list, hard fail with the recall reason. Network failure is
+   non-fatal only if the cached revocation file is fresh (<7d).
+5. **Max-age check**: if `now > manifest.not_after`, mvmctl warns and
+   proceeds; mvmd refuses (different risk tolerance).
+6. Download artifacts, streaming SHA-256.
+7. Reuse W5.1's `verify_hash` to compare against the manifest digests
+   (don't reinvent the deletion-on-mismatch path).
+8. Cache the verified manifest at `~/.cache/mvm/dev/v{version}/manifest.json`
+   (version-namespaced — fixes cross-version cache-poisoning that
+   today's `~/.cache/mvm/dev/` shares).
+9. **Cache integrity check on subsequent boots**: re-hash cached files
+   against the cached manifest. Network-free, sub-second.
+10. **Telemetry** via `mvm-core::observability::metrics`:
+    - `dev_image_verify_total{outcome ∈ {ok, sig_invalid, digest_mismatch, version_skew, revoked, expired, network}}`
+    - `dev_image_verify_duration_ms` histogram
+11. **`MVM_SKIP_HASH_VERIFY=1`** keeps its W5.1 semantics — but plan 36
+    *narrows* it to skip only the SHA-256 check, **not** the cosign
+    signature check. Add a separate `MVM_SKIP_COSIGN_VERIFY=1` for the
+    rare emergency rotation. Both print loud warnings.
+
+Failure mode: hard fail with no auto-retry, error pointing at
+troubleshooting docs. Tampering must be loud.
+
+### Layer 5 — Reusable primitive for mvmd consumption
+
+New crate module `mvm-security::image_verify`:
+
+```rust
+pub struct SignedManifest {
+  pub schema_version: u32,
+  pub version: String,
+  pub arch: String,
+  pub variant: String,
+  pub artifacts: Vec<ArtifactDigest>,
+  pub flake_locks: BTreeMap<String, String>,
+  pub addressed_advisories: Vec<String>,
+  pub built_at: DateTime<Utc>,
+  pub not_after: DateTime<Utc>,
+  // ... other fields
+}
+
+pub enum VerifyError {
+  SignatureInvalid { reason: String },
+  DigestMismatch { name: String, expected: String, actual: String },
+  VersionSkew { manifest: String, runtime: String },
+  Revoked { reason: String, since: DateTime<Utc> },
+  Expired { not_after: DateTime<Utc> },
+  CertExpired,
+  WrongIssuer { found: String, expected: String },
+  Io(io::Error),
+  // ...
+}
+
+pub fn verify_manifest(
+  manifest_bytes: &[u8],
+  signature: &[u8],
+  certificate_pem: &[u8],
+  expected_identity: &str,
+  cosign_bundle: Option<&CosignBundle>,
+) -> Result<SignedManifest, VerifyError>;
+
+pub fn verify_artifact(path: &Path, expected: &ArtifactDigest)
+  -> Result<(), VerifyError>;
+```
+
+mvmctl consumes this for the dev variant on `dev up`. mvmd (plan 23)
+consumes the same functions for the builder variant on pool rebuild and
+for pool images of its own. Same primitive, different artifacts. Typed
+`VerifyError` lets mvmd's reconciliation loop pattern-match outcomes
+instead of crash-looping on `anyhow::Error`.
+
+`mvm-security` is workspace-internal today; publishing to crates.io is
+tracked separately (bundle with the apple-container crate publishing
+backlog item). Until publish, mvmd consumes via git-dep.
+
+## Rebuild and distribution
+
+**Trigger**: tag-driven, via the existing release workflow (which
+already builds mvmctl, default-microvm artifacts, and SBOM per W5.4).
+There is no rebuild-without-release path — cosign keyless's signing
+identity is bound to `refs/tags/v*`.
+
+```
+just release  (or `git tag v0.14.0 && git push --tags`)
+  │
+  ▼
+.github/workflows/release.yml — existing job set
+  │
+  ├─ matrix: { arch ∈ {aarch64, x86_64} } × { variant ∈ {dev, builder} }
+  │
+  ▼
+new job: build-image (parameterized by variant)
+  1. checkout @ tag
+  2. nix build nix/images/builder#packages.${arch}-linux.${variant}
+  3. extract vmlinux + rootfs.{ext4|squashfs} from store output
+  4. compute sha256 of each + Nix store hash + flake.lock SHA-256s
+  5. emit ${variant}-image-${arch}.manifest.json
+  6. cosign sign-blob --yes (keyless, OIDC from GH Actions)
+  7. gh release upload v${version} \
+       ${variant}-vmlinux-${arch} \
+       ${variant}-rootfs-${arch}.{ext4|squashfs} \
+       ${variant}-image-${arch}.manifest.json{,.sig,.pem}
+```
+
+**Distribution**: GitHub Releases, same release as `mvmctl`. URLs are
+deterministic from the mvmctl version — `apple_container.rs:918-921`
+already constructs URLs this way.
+
+**Republish / hotfix**: cut a new tag (`v0.14.1`). Never re-sign an
+existing tag's artifacts in place.
+
+**Air-gapped**: new `mvmctl dev import-image` (and `mvmd image import`)
+subcommand runs the same verification logic against local files.
+
+## Critical files to modify
+
+### In-repo (mvm)
+
+| File                                                                        | Change                                                                   |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `specs/SPRINT.md`                                                           | When sprint 44 closes, add Sprint 45 entry pointing at this plan         |
+| `public/src/content/docs/guides/airgapped-bootstrap.md`                     | NEW — operator guide for `mvmctl dev import-image` workflow              |
+| `public/src/content/docs/guides/troubleshooting.md`                         | New section: "Builder image signature verification failed"              |
+| `public/src/content/docs/guides/verify-release.md`                          | Document image manifest verification alongside existing CLI binary verify steps |
+| `nix/images/builder/flake.nix`                                              | Add `builder` sibling output: prod agent (no Exec handler), squashfs RO root with tmpfs overlay, `verifiedBoot = true`. Keep existing `default` output behavior unchanged. Audit and comment package list. |
+| `nix/lib/minimal-init/default.nix`                                          | Confirm tmpfs overlays for `/tmp`, `/var/log`, `/nix/var` work on RO root for the builder variant. |
+| `nix/flake.nix::mkGuestFn`                                                  | Add `variant ∈ {"dev", "builder"}` parameter, plumbed via `passthru.variant` |
+| `crates/mvm-cli/src/commands/env/apple_container.rs:918-1048`               | Wrap existing W5.1 hash-verify with cosign manifest verification; rename internal `fetch_expected_hashes` → `fetch_signed_manifest`; namespace cache by version (`~/.cache/mvm/dev/v{version}/`). |
+| `crates/mvm-cli/src/commands/env/dev.rs`                                    | New `mvmctl dev import-image` subcommand                                 |
+| `crates/mvm-security/src/image_verify.rs`                                   | NEW module — `SignedManifest`, `VerifyError`, `verify_manifest`, `verify_artifact`. Reusable from mvmd. |
+| `crates/mvm-security/Cargo.toml`                                            | Add `sigstore`, `sha2`, `serde_json`, `chrono` deps (gate behind feature if binary size matters) |
+| `crates/mvm-core/src/observability/metrics.rs`                              | Add `dev_image_verify_total{outcome=…}` counter + `dev_image_verify_duration_ms` histogram |
+| `crates/mvm-cli/src/commands/security/status.rs`                            | Extend probes to surface "image manifest cosign-verified?" alongside W6.4's existing checks |
+| `.github/workflows/release.yml`                                             | New job `build-image` (matrix `arch × variant`): builds via Nix, generates + cosign-signs the manifest, uploads release assets. Adjacent to existing W5.4 SBOM job. |
+| `.github/workflows/security.yml`                                            | New job `image-reproducibility`: builds each variant twice on different runners, asserts identical store hashes (extends W5.3 from mvmctl-binary to images, tag-only). |
+| `.github/workflows/ci.yml`                                                  | New release-PR gate: `nix flake metadata --json` per flake, assert lockfiles committed + in sync + non-dirty |
+| `revocations` release tag                                                   | NEW — stable release tag whose only assets are `revoked-versions.json` + `.sig` + `.pem`. Append-only updates each release; cosign-signed against the same release identity. |
+
+### Cross-repo (mvmd)
+
+- mvmd plan 23 — rolling microVM rebuild pipeline (consumes `mvm-security::image_verify`).
+- mvmd ADR 0001 — rolling microVM rebuild as a first-class capability.
+- These live in mvmd repo; references-only here.
+
+## Phasing (4 PRs, each independently mergeable)
+
+- **PR-A — Layer 5 + Layer 3 schema**: `mvm-security::image_verify`
+  module + `SignedManifest` schema + tests. No callsite changes. The
+  primitive ships first so mvmd plan 23's Phase 1 can pick it up early.
+- **PR-B — Layer 0 + Layer 1**: split `nix/images/builder/flake.nix`
+  into `default` + `builder` outputs; mkGuest `variant` parameter;
+  reproducibility + lockfile-cleanliness CI gates. Keeps existing
+  `default` behavior untouched; introduces the sealed `builder` output.
+- **PR-C — Layer 3 release pipeline + Layer 4 verification**:
+  `release.yml::build-image` job; mvmctl wraps W5.1 with cosign verify;
+  version-namespaced cache; revocation list infrastructure.
+- **PR-D — Telemetry, air-gapped path, ADR + docs**: metrics, `mvmctl
+  dev import-image`, troubleshooting + airgapped-bootstrap docs.
+
+## Verification
+
+End-to-end test matrix — must all pass before sprint closes:
+
+1. **Happy path, fresh download**: `rm -rf ~/.cache/mvm/dev && mvmctl dev up` → manifest + artifacts downloaded, cosign-verified, SHA-256 matches, VM boots.
+2. **Cache hit, untampered**: second `mvmctl dev up` → reads cached manifest, recomputes SHAs, matches, sub-second.
+3. **Tampered cached rootfs**: `dd ... seek=1000 conv=notrunc` then `mvmctl dev up` → hard fail on SHA-256 mismatch.
+4. **Tampered cached manifest**: edit `~/.cache/mvm/dev/v{ver}/manifest.json` → cosign verification fails on next `dev up`.
+5. **MITM simulated**: local server returns wrong rootfs but right manifest → SHA-256 mismatch hard fail.
+6. **Version skew**: drop in manifest from a different `mvmctl` version → fail with "manifest version v0.14.1 does not match mvmctl v0.14.0".
+7. **Offline (cache present, no network)**: succeeds via re-hashing cached files; revocation cache fresh.
+8. **Offline (no cache, no network)**: hard fail with specific error pointing at offline-bootstrap docs.
+9. **`MVM_SKIP_HASH_VERIFY=1`**: skips SHA-256 (existing W5.1 semantics) but **does NOT** skip cosign sig — separation-of-concerns regression test.
+10. **`mvmctl dev import-image`**: imports valid local files → success; tampered local rootfs → hard fail.
+11. **Builder variant boot test**: build the new `builder` output, attempt `touch /etc/breakme` inside it → fails with EROFS; `mount | grep ' / '` shows `squashfs` and `ro`. Verity cmdline arg present.
+12. **Reproducibility CI gate**: build both variants twice on the same arch on different runners; assert byte-identical Nix store hashes.
+13. **Lockfile-cleanliness CI gate**: PR with stale `flake.lock` → CI red.
+14. **Tests**: `cargo test --workspace` clean. New tests in `mvm-security::image_verify` cover happy path, every `VerifyError` variant (mocked cert/issuer/expiry), revocation hit/miss, max-age boundary.
+15. **Clippy clean**: `cargo clippy --workspace --all-targets -- -D warnings`.
+16. **Live KVM smoke**: builder variant boots end-to-end on a real KVM host (folds into the existing `live-verity-boot` lane added in plan 35-sprint-44).
+
+## Acceptance criteria
+
+Sprint closes when:
+
+1. ✅ Both `default` and `builder` outputs build deterministically from `nix/images/builder/flake.nix`.
+2. ✅ The release pipeline emits cosign-signed manifests for both variants, attached to the GitHub Release.
+3. ✅ `mvmctl dev up` requires (and verifies) the cosign-signed manifest in addition to W5.1's SHA-256 check.
+4. ✅ `mvm-security::image_verify` exposes a stable, typed-error API that mvmd can consume.
+5. ✅ The builder variant boots squashfs-RO with verity active; tampering the ext4 inside the squashfs panics the kernel before userspace.
+6. ✅ Reproducibility + lockfile-cleanliness CI gates green.
+7. ✅ Air-gapped `mvmctl dev import-image` works against local files.
+8. ✅ ADR 005 merged; `airgapped-bootstrap.md` published.
+9. ✅ `cargo test --workspace` all passing; `cargo clippy --workspace --all-targets -- -D warnings` clean.
+
+## Reversal cost
+
+Medium. Once a tag ships with the cosign-signed manifest, downgrading
+to "checksum-file-only" trust would require either re-signing
+checksums post-hoc (impossible — release identity is tag-bound) or
+accepting a period of unverified downloads. Reversal would be a
+deliberate design decision, not a code rollback.
+
+## Open questions to confirm during PR-A
+
+- **`sigstore` crate vs shelling to `cosign verify-blob`**: sigstore's
+  Rust crate is heavy (TUF + transparency log + x509). Measure binary
+  size impact; if >5 MB, gate behind a `manifest-verify` Cargo feature
+  default-on for release builds, off for `cargo install
+  --no-default-features`.
+- **Default-microvm signing parity**: trivial to extend the new pipeline.
+  In scope or follow-up issue?
+- **Lockfile inventory**: confirm `nix/dev/flake.lock` exists alongside
+  `nix/flake.nix::flake.lock` and `nix/images/builder/flake.lock`. Add
+  any others surfaced by `find nix -name flake.lock`.

--- a/specs/runbooks/w3-verified-boot.md
+++ b/specs/runbooks/w3-verified-boot.md
@@ -1,15 +1,17 @@
 # W3 verified-boot verification runbook
 
 > Created: 2026-04-30
+> Last updated: 2026-04-30 (full pass after initramfs fix)
 > Parent plan: `specs/plans/27-w3-verified-boot.md`
 > ADR: `specs/adrs/002-microvm-security-posture.md`
 >
-> **Status: 4 of 5 steps PASS. Step 3 surfaced a real bug —
-> Firecracker's aarch64 boot path auto-appends `root=/dev/vda ro`
-> to the kernel cmdline, which clobbers `root=/dev/dm-0` (last
-> `root=` wins). dm-verity is constructed correctly but the kernel
-> mounts `/dev/vda` directly instead of the verity-protected
-> `/dev/dm-0`. See "Findings" below for the fix path.**
+> **Status: ✅ all 5 steps PASS as of 2026-04-30.** The original
+> Step 3 failure (Firecracker's aarch64 boot path auto-appends
+> `root=/dev/vda ro` and last-wins clobbers `/dev/dm-0`) is fixed
+> by an early-userspace verity initramfs that owns the boot pivot
+> in userspace via `mvm-verity-init` + `switch_root`. The kernel-
+> level `root=` setting is now irrelevant. Tamper test confirms
+> the kernel panics with `data block N is corrupted`.
 
 This runbook is the manual end-to-end verification for ADR-002 §W3
 (verified boot via dm-verity). The `security.yml::verified-boot-artifacts`
@@ -72,7 +74,14 @@ echo "exit=$?"
 ext4 it was built against, and the roothash produced by mkGuest is the
 same one veritysetup recovers from the tree.
 
-## Step 3 — Live Firecracker boot, expecting `/dev/dm-0` root mount
+## Step 3 — Live Firecracker boot via the verity initramfs
+
+The verity boot path uses the `rootfs.initrd` baked by mkGuest. The
+kernel mounts the initramfs first, runs `mvm-verity-init` as PID 1,
+which constructs `/dev/mapper/root` via DM ioctls, mounts it at
+`/sysroot`, then `switch_root`s to the real init. The kernel-level
+`root=` setting is irrelevant because the initramfs picks the real
+root explicitly.
 
 ```bash
 work=/tmp/w3-smoke
@@ -80,25 +89,21 @@ rm -rf "$work" && mkdir -p "$work"
 cp "$out/vmlinux"        "$work/vmlinux"
 cp "$out/rootfs.ext4"    "$work/rootfs.ext4"
 cp "$out/rootfs.verity"  "$work/rootfs.verity"
-chmod u+w "$work/rootfs.ext4" "$work/rootfs.verity"
+cp "$out/rootfs.initrd"  "$work/rootfs.initrd"
+chmod u+w "$work"/*
 
 hash=$(cat "$out/rootfs.roothash")
-size=$(stat -c %s "$work/rootfs.ext4")
-data_blocks=$((size / 4096))
-sectors=$((data_blocks * 8))
-salt=$(printf '0%.0s' $(seq 1 64))
-table="0 ${sectors} verity 1 /dev/vda /dev/vdb 4096 4096 ${data_blocks} 0 sha256 ${hash} ${salt}"
-
 python3 - <<EOF > "$work/config.json"
 import json
 boot_args = (
-    "console=ttyS0 reboot=k panic=1 root=/dev/dm-0 ro init=/init "
-    "dm-mod.create=\"rootfs,,,ro,${table}\""
+    "console=ttyS0 reboot=k panic=1 init=/init "
+    f"mvm.roothash=${hash} mvm.data=/dev/vda mvm.hash=/dev/vdb"
 )
 print(json.dumps({
     "boot-source": {
         "kernel_image_path": "$work/vmlinux",
         "boot_args": boot_args,
+        "initrd_path": "$work/rootfs.initrd",
     },
     "drives": [
         {"drive_id": "rootfs", "path_on_host": "$work/rootfs.ext4",
@@ -113,58 +118,65 @@ EOF
 sudo timeout 30 firecracker --no-api --config-file "$work/config.json" \
     > "$work/fc.stdout" 2> "$work/fc.stderr"
 
-grep -E 'device-mapper|verity|panic|dm-0' "$work/fc.stdout"
+grep -E 'mvm-verity-init|device-mapper:|switching to|/sysroot' "$work/fc.stdout"
 ```
 
-**Expected on success** — kernel reaches userspace and you see
-something like `/dev/dm-0 on / type ext4 (ro,…)` from `mount`.
-
-**Observed 2026-04-30** (the bug, see Findings #1):
+**Expected** (verified 2026-04-30):
 
 ```
-[1.450509] device-mapper: ioctl: 4.47.0-ioctl … initialised: dm-devel@redhat.com
-[1.639826] device-mapper: verity: sha256 using implementation "sha256-generic"
-[1.659951] device-mapper: ioctl: dm-0 (rootfs) is ready
-[1.685428] VFS: Cannot open root device "vda" or unknown-block(254,0): error -16
-[1.708495] Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(254,0)
+mvm-verity-init: starting
+mvm-verity-init: data=/dev/vda hash=/dev/vdb roothash=…
+mvm-verity-init: verity table = 419840 sectors, 209920 data blocks
+mvm-verity-init: dm-ioctl kernel version 4.47.0
+mvm-verity-init: DM_DEV_CREATE ok
+[..] device-mapper: verity: sha256 using implementation "sha256-generic"
+mvm-verity-init: DM_TABLE_LOAD ok
+mvm-verity-init: dm-verity device active
+mvm-verity-init: /sysroot mounted (verity-protected)
+mvm-verity-init: switching to /init
+[init] /etc/{passwd,group,nsswitch.conf} are read-only bind-mounts
 ```
 
-Verity setup itself succeeds (`dm-0 (rootfs) is ready`), but the kernel
-then tries to mount `/dev/vda` instead of `/dev/dm-0`. The cause is in
-the captured boot cmdline:
-
-```
-… root=/dev/dm-0 ro init=/init dm-mod.create="…" pci=off root=/dev/vda ro earlycon=…
-                                                           ^^^^^^^^^^^^^
-                                              Firecracker auto-append, last root= wins
-```
-
-Firecracker's aarch64 boot path appends `pci=off root=/dev/vda ro
-earlycon=uart,mmio,…` after the user's `boot_args`. The kernel uses
-last-wins for `root=`, so the user's `root=/dev/dm-0` is overridden.
+The trailing `[init]` line confirms the real `minimal-init` script
+reached userspace from the verity-protected `/dev/dm-0`. (Subsequent
+warnings about missing config drives or `setpriv` flag conflicts are
+unrelated to W3 — they're side effects of using the production rootfs
+without the per-VM config/secrets drives.)
 
 ## Step 4 — Tamper-panic regression
 
-Until Step 3's bug is fixed this step can't run end-to-end (the kernel
-panics before reaching the verity-data read). The intent is preserved
-here for when the fix lands:
+Tampering inside the ext4 superblock guarantees verity sees the
+corruption at first read (the kernel reads the superblock during the
+initial mount). Picking a "deeper" offset gambles on that block
+actually being read — verity is lazy, so a tampered byte that the
+boot path never touches goes undetected. That's not a verity bug; it
+just means the regression test has to point at a block ext4 is sure
+to read.
 
 ```bash
-"$REPO/target/debug/mvmctl" stop verity-smoke 2>/dev/null || true
-printf '\xff' | dd of="$work/rootfs.ext4" bs=1 count=1 \
-    seek=$((4096 * 1000)) conv=notrunc
+# Restore from the unmodified store path before tampering.
+cp "$out/rootfs.ext4" "$work/rootfs.ext4"
+chmod u+w "$work/rootfs.ext4"
 
-sudo timeout 30 firecracker --no-api --config-file "$work/config.json" \
+# Clobber 128 bytes inside the ext4 superblock at offset 1024.
+dd if=/dev/urandom of="$work/rootfs.ext4" bs=1 count=128 \
+   seek=1024 conv=notrunc
+
+sudo timeout 15 firecracker --no-api --config-file "$work/config.json" \
     > "$work/fc-tamper.stdout" 2>&1
 grep -E 'data block .* is corrupted|Kernel panic' "$work/fc-tamper.stdout"
 ```
 
-Expected on success: a line like
-`dm-verity: data block <n> is corrupted` followed by a kernel panic.
-The VM must NOT reach userspace.
+**Verified 2026-04-30** — output:
 
-**Verified 2026-04-30: blocked by Findings #1.** Once the cmdline
-override is fixed, the tamper test will be re-run.
+```
+[..] device-mapper: verity: 254:0: data block 1 is corrupted
+mvm-verity-init: FATAL: mount(/dev/dm-0 → /sysroot, ext4): I/O error (os error 5)
+[..] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
+```
+
+Verity returns `-EIO` for the corrupted read, the mount fails, PID 1
+exits, and the kernel panics. The VM does NOT reach userspace.
 
 ## Step 5 — Dev-image exemption
 
@@ -183,7 +195,15 @@ correctly suppressing the verity sidecar.
 
 ## Findings
 
-### Finding #1 — Firecracker auto-appends `root=/dev/vda ro` on aarch64
+### Finding #1 (RESOLVED 2026-04-30) — Firecracker auto-appends `root=/dev/vda ro` on aarch64
+
+**Resolution**: implemented option (2) below. mkGuest now bakes a
+~250 KB cpio.gz initramfs at `rootfs.initrd` whose `/init` is
+`mvm-verity-init` (a static-musl Rust binary). The initramfs runs
+*before* the kernel commits to a root device, so Firecracker's
+trailing `root=/dev/vda ro` becomes irrelevant — `mvm-verity-init`
+constructs `/dev/mapper/root` via DM ioctls, mounts it, and
+`switch_root`s explicitly. Live boot + tamper test both green.
 
 **What**
 
@@ -273,10 +293,11 @@ and check off:
 
 - [x] Step 1: artifacts present + kernel has DM_VERITY strings.
 - [x] Step 2: `veritysetup verify` exits 0.
-- [ ] Step 3: live boot mounts `/dev/dm-0` as root. *Blocked on Finding #1.*
-- [ ] Step 4: tampered ext4 panics in early boot. *Blocked on Finding #1.*
+- [x] Step 3: live boot mounts `/dev/dm-0` as root via verity initramfs.
+- [x] Step 4: tampered ext4 panics in early boot (`data block N is corrupted`).
 - [x] Step 5: dev-image build emits no verity sidecar.
 
-When Steps 3 and 4 are checked, the runbook + the
+All five green as of 2026-04-30. The runbook + the
 `security.yml::verified-boot-artifacts` CI gate together provide the
-technical receipt for ADR-002 claim #3.
+technical receipt for ADR-002 claim #3 ("a tampered rootfs ext4
+fails to boot").


### PR DESCRIPTION
## Summary

Closes the trust-chain gap that sprint 42's W5.1 explicitly flagged
(`apple_container.rs:952` "TLS-only trust today, on the checksum
file itself in a future iteration"). Lands the sealed/signed builder
image plan from `specs/plans/36-sealed-signed-builder-image.md` and
ADR-005 (`specs/adrs/005-sealed-signed-builder-image.md`).

The thesis: every release now ships a cosign-keyless-signed manifest
that records SHA-256 of every image artifact, the Nix store hash,
the source git SHA, and the SHA-256 of every `flake.lock` — bound by
one Sigstore signature. mvmctl verifies this manifest on every
`mvmctl dev up` before trusting any downloaded bytes. mvmd plan 23
will consume the same primitive for pool-image verification.

## What ships

### `nix/images/builder/flake.nix` — two outputs from one source

- `default` (current behavior): mvmctl dev override → dev guest agent
  with Exec/console handler, writable overlay, `verifiedBoot=false`.
  No behavior change for `mvmctl dev up`.
- `builder` (NEW): sourced from a separate `mvm-prod` input that
  bypasses mvmctl's dev override → prod guest agent (no Exec
  handler), `verifiedBoot=true`, dm-verity sidecars emitted. Used by
  mvmd's pool-build pipeline.

A new `mkGuest` assertion catches the unsafe combo `variant="dev"
+ verifiedBoot=true` at evaluation time (overlay vs verity is
fundamentally incompatible per ADR-002 §W3.4).

### `mvm-security::image_verify` (NEW module)

- `SignedManifest`, `RevocationList`, `RevocationEntry` schema types
  (versioned via `SCHEMA_VERSION`).
- Typed `VerifyError` enum so mvmd's reconciliation loop can
  pattern-match outcomes (Revoked / Expired / DigestMismatch /
  VersionSkew) instead of crash-looping on `anyhow::Error`.
- `verify_manifest` runs the cosign Sigstore bundle verifier behind
  the `manifest-verify` Cargo feature (default-on; off-by-feature
  builds get a fail-closed stub).
- `verify_signed_payload` generic primitive used for both manifest
  and revocation-list verification — keeps the sigstore dep gated
  inside `mvm-security`.
- `check_version_pin`, `check_not_after`, `check_revocation`,
  `verify_artifact` (streaming SHA-256 + delete-on-mismatch).
- Exhaustive unit tests covering every `VerifyError` variant + an
  on-wire contract test pinning the `generate-image-manifest.sh`
  output shape.

### Release pipeline

- New `builder-image` matrix job in `release.yml` (aarch64-linux,
  x86_64-linux). Builds `nix/images/builder#packages.<sys>.builder`
  → kernel + rootfs.{ext4,verity,roothash,initrd}.
- `dev-image` job extended to also emit the manifest JSON.
- New `scripts/generate-image-manifest.sh` produces the manifest
  from a built image, walking every `flake.lock` in the repo.
- New "Sign image manifests (plan 36)" step in the `release` job
  cosign-keyless-signs each manifest into a `.bundle` (same
  Sigstore format the existing tarball + SBOM signing already
  uses).
- GitHub Release upload includes both variants' manifests +
  bundles.

### `mvmctl dev` — verification pipeline at `dev up`

- `download_dev_image` HEAD-probes the signed manifest URL first.
- If present: cosign-verify against the project's release-workflow
  OIDC identity, version-pin against `CARGO_PKG_VERSION`, max-age
  warn, revocation check, then SHA-256 verify each artifact.
- If 404 (older release): fall back to the W5.1 unsigned-checksum
  path with a deprecation warning.
- Two env-var escape hatches, both loud:
  - `MVM_SKIP_HASH_VERIFY=1` — existing W5.1 SHA-256 escape.
  - `MVM_SKIP_COSIGN_VERIFY=1` — new manifest-signature escape for
    Sigstore-side rotation. Orthogonal — disabling one doesn't
    disable the other.

### Revocation list

- Cosign-signed `revoked-versions.json` published at a stable
  `revocations` release tag, with a separate OIDC signing identity
  (`revocations.yml@refs/tags/revocations`) so a leaked
  image-signing cert can't fabricate a permissive recall.
- Cached at `~/.cache/mvm/revocations/`. 24h max-age, 7d offline
  tolerance.
- A revoked manifest hard-fails with the recall reason surfaced
  verbatim.

### `mvmctl dev import-image` — air-gapped sideload (NEW subcommand)

Runs the full verification pipeline against operator-provided
local files. Deposits verified bytes in
`~/.mvm/dev/prebuilt/v{version}/` so the next `dev up` boots from
them with no further verification. The sanctioned trusted path for
regulated/gov/air-gapped operators.

### CI gates

- `flake-locks-clean` — every flake.lock committed and in sync with
  its `flake.nix`.
- `builder-image-reproducibility` — builds the new `builder` output
  twice and asserts byte-identical artifacts. Push/schedule only,
  not PRs (heavy).

### Telemetry

7 outcome counters + 1 duration gauge:

```
mvm_dev_image_verify_ok_total
mvm_dev_image_verify_sig_invalid_total
mvm_dev_image_verify_digest_mismatch_total
mvm_dev_image_verify_version_skew_total
mvm_dev_image_verify_revoked_total
mvm_dev_image_verify_expired_total
mvm_dev_image_verify_network_total
mvm_dev_image_verify_duration_milliseconds (gauge)
```

Instrumented at every failure site. mvmd plan 23 will alert on
attack-shaped spikes (sig_invalid, digest_mismatch, revoked).

### Documentation

- `public/src/content/docs/guides/airgapped-bootstrap.md` (NEW) —
  operator workflow with sneakernet considerations, cosign verify
  steps, revocation refresh policy, failure-mode table.
- `public/src/content/docs/guides/verify-release.md` (extended) —
  manifest verification section + emergency env-var documentation.
- `public/src/content/docs/guides/troubleshooting.md` (extended) —
  triage runbooks for each failure wording the verifier emits.

### `mvmctl security status`

Two new probes under `SupplyChainIntegrity`:

- "Dev image verified for this version" — proxy for "verification
  pipeline succeeded ≥1 time for this `mvmctl --version`".
- "Revocation list cached" — surfaces the 7-day staleness gap
  before mvmctl silently skips enforcement.

## Test plan

- [x] `cargo test --workspace` clean (1137 tests passing — was 1085 before plan-36)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p mvm-security --no-default-features image_verify` clean (fail-closed stubs)
- [x] manifest generator local smoke produces JSON that `parse_manifest` accepts (contract test)
- [x] mkGuest assertion fires when dev override is applied to the new builder output (eval-test)
- [x] YAML lint of `release.yml` + `security.yml` (python3 yaml.safe_load)
- [ ] **Live KVM smoke** for the sealed builder variant — deferred; requires real KVM hardware. Folds into the existing `live-verity-boot` lane from plan 35-sprint-44.
- [ ] **First signed release** — needs a tag push. Once a tag is cut, the new `builder-image` job runs and emits the first set of cosign-signed manifests.

## Acceptance criteria (from plan 36)

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `default` + `builder` outputs build deterministically | ✅ |
| 2 | Release pipeline emits cosign-signed manifests for both | ✅ |
| 3 | `mvmctl dev up` requires + verifies cosign-signed manifest | ✅ |
| 4 | `mvm-security::image_verify` typed-error API for mvmd | ✅ |
| 5 | Builder variant boots squashfs-RO with verity active | 🟡 pipeline ready; live-KVM smoke deferred |
| 6 | Reproducibility + lockfile-cleanliness CI gates green | ✅ |
| 7 | Air-gapped `mvmctl dev import-image` works | ✅ |
| 8 | ADR-005 merged; airgapped-bootstrap.md published | ✅ |
| 9 | `cargo test --workspace` + clippy clean | ✅ |

## Out-of-scope follow-ups (named explicitly)

- Default-microvm signing parity (trivial extension of
  `generate-image-manifest.sh`; deferred per plan §"Out of scope").
- mvmd plan 23 — rolling rebuild pipeline that consumes
  `mvm-security::image_verify`. Cross-repo.
- mvm-security crates.io publishing — bundled with the
  apple-container publishing item already on the backlog.
- Live-KVM smoke for the sealed builder boot — folds into existing
  `live-verity-boot` lane (plan 35-sprint-44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)