### PR TITLE
feat(mvm-plan): scaffold ExecutionPlan + SignedExecutionPlan — plan 37 Wave 1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,6 +2390,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-plan"
+version = "0.13.0"
+dependencies = [
+ "chrono",
+ "ed25519-dalek",
+ "mvm-core",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "mvm-runtime"
 version = "0.13.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/mvm-core",
     "crates/mvm-security",
+    "crates/mvm-plan",
     "crates/mvm-runtime",
     "crates/mvm-build",
     "crates/mvm-guest",
@@ -100,6 +101,7 @@ mvm-guest = { path = "crates/mvm-guest", version = "0.13.0" }
 mvm-build = { path = "crates/mvm-build", version = "0.13.0" }
 mvm-runtime = { path = "crates/mvm-runtime", version = "0.13.0" }
 mvm-security = { path = "crates/mvm-security", version = "0.13.0" }
+mvm-plan = { path = "crates/mvm-plan", version = "0.13.0" }
 mvm-cli = { path = "crates/mvm-cli", version = "0.13.0" }
 mvm-mcp = { path = "crates/mvm-mcp", version = "0.13.0" }
 mvm-apple-container = { path = "crates/mvm-apple-container", version = "0.7.0" }

--- a/crates/mvm-plan/Cargo.toml
+++ b/crates/mvm-plan/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mvm-plan"
+description = "ExecutionPlan: signed, typed workload contract for mvm. Plan 37 §3.3."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[dependencies]
+mvm-core.workspace = true
+chrono.workspace = true
+ed25519-dalek.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror = "1"
+
+[dev-dependencies]
+rand.workspace = true

--- a/crates/mvm-plan/src/lib.rs
+++ b/crates/mvm-plan/src/lib.rs
@@ -1,0 +1,35 @@
+//! mvm-plan — typed, signed `ExecutionPlan` contract for mvm workloads.
+//!
+//! Plan 37 §3.3 (CORNERSTONE) makes the `ExecutionPlan` the runtime
+//! contract every workload boots from: image + resources + every
+//! policy reference, signed with Ed25519, audit-bound to a stable
+//! `plan_id` so audit entries can refer back to the exact plan
+//! version a workload ran under.
+//!
+//! Wave 1.1 of plan 37 lands the type itself + the signed envelope.
+//! Resolvers for the `*Ref` fields (PolicyRef, FsPolicyRef, etc.)
+//! are scaffolded as opaque newtypes here and filled in subsequent
+//! waves (Wave 2 wires the egress + tool-gate policies, Wave 3 the
+//! attestation requirement, etc.).
+//!
+//! Structure:
+//! - `plan` — `ExecutionPlan`, `SCHEMA_VERSION`.
+//! - `types` — every `*Ref` / `*Spec` placeholder type the plan
+//!   references. Each is a thin newtype with serde + deny_unknown_fields
+//!   so older verifiers fail closed on a future field addition.
+//! - `signing` — `SignedExecutionPlan` envelope + sign/verify helpers
+//!   using ed25519_dalek directly. Reuses the `SignedPayload` shape
+//!   from `mvm-core::protocol::signing` so plan signatures fit the
+//!   existing audit + control-plane wire types.
+
+pub mod plan;
+pub mod signing;
+pub mod types;
+
+pub use plan::{ExecutionPlan, SCHEMA_VERSION};
+pub use signing::{PlanVerifyError, SignedExecutionPlan, sign_plan, verify_plan};
+pub use types::{
+    ArtifactPolicy, AttestationMode, AttestationRequirement, FsPolicyRef, KeyRotationSpec, PlanId,
+    PolicyRef, PostRunLifecycle, ReleasePin, Resources, RuntimeProfileRef, SecretBinding,
+    SecretSource, SignedImageRef, TenantId, TimeoutSpec, WorkloadId,
+};

--- a/crates/mvm-plan/src/plan.rs
+++ b/crates/mvm-plan/src/plan.rs
@@ -1,0 +1,95 @@
+//! `ExecutionPlan` — the cornerstone type of plan 37 §3.3.
+//!
+//! Every workload mvm runs is launched from one of these. The plan
+//! is signed by mvmd (or a developer key in dev mode) and the
+//! supervisor refuses unsigned plans outside dev mode. Every audit
+//! entry the supervisor emits references `(plan_id, plan_version)`
+//! so a runbook can answer "what plan was this workload running at
+//! the moment of incident?" in O(1) without re-deriving from logs.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{
+    ArtifactPolicy, AttestationRequirement, AuditLabels, FsPolicyRef, KeyRotationSpec, PlanId,
+    PolicyRef, PostRunLifecycle, ReleasePin, Resources, RuntimeProfileRef, SecretBinding,
+    SignedImageRef, TenantId, WorkloadId,
+};
+
+/// Wire-format version. Bump when fields change in a way older
+/// verifiers can't ignore. Older verifiers must fail closed on
+/// unknown schema versions rather than silently skipping unknown
+/// fields — the schema_version field is consulted before any
+/// per-field deserialisation.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Typed contract for one workload's execution.
+///
+/// Plan 37 §3.3. The fields here are the rubric — `enforce_*`
+/// in `mvm-runtime/src/enforce.rs` (Wave 1.5) walks the plan
+/// field-by-field and rejects any plan that doesn't satisfy
+/// the corresponding §5 row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutionPlan {
+    /// Wire-format version. See [`SCHEMA_VERSION`].
+    pub schema_version: u32,
+
+    /// Stable plan identifier. Audit entries reference this verbatim.
+    pub plan_id: PlanId,
+
+    /// Monotonic per-`plan_id` revision counter. Bumped each time
+    /// mvmd publishes a revised plan with the same id (eg. policy
+    /// changes). The supervisor logs both id+version on every
+    /// audit entry so "which version of the plan was running" is
+    /// answerable from audit alone.
+    pub plan_version: u32,
+
+    pub tenant: TenantId,
+    pub workload: WorkloadId,
+
+    /// Which backend / runtime profile this workload runs on.
+    /// Resolved by `BackendRegistry` (plan 37 §3.1).
+    pub runtime_profile: RuntimeProfileRef,
+
+    /// Signed image to boot. SHA-256 + cosign bundle reference;
+    /// resolved by `mvm-security::image_verify` (plan 36).
+    pub image: SignedImageRef,
+
+    pub resources: Resources,
+
+    /// Network policy reference. Wave 2 wires this to
+    /// `mvm-policy::EgressPolicy` (L7 + PII rules) via the
+    /// supervisor's `EgressProxy`.
+    pub network_policy: PolicyRef,
+
+    /// Filesystem policy reference. Resolved per Wave 2.
+    pub fs_policy: FsPolicyRef,
+
+    pub secrets: Vec<SecretBinding>,
+
+    /// L7 egress + PII rules. Wave 2 differentiator. The same kind
+    /// of `PolicyRef` as `network_policy` so the resolver is shared,
+    /// but kept separate here so an audit entry can show "egress
+    /// allowed, pii redacted" as orthogonal facts.
+    pub egress_policy: PolicyRef,
+
+    /// Tool-call policy (which tools the model is allowed to invoke
+    /// over the supervisor's vsock RPC). Wave 2.
+    pub tool_policy: PolicyRef,
+
+    pub artifact_policy: ArtifactPolicy,
+
+    /// Free-form audit labels copied verbatim into every audit entry
+    /// generated for this plan. Usually carries tenant-meaningful
+    /// metadata (`workflow_id`, `request_id`).
+    pub audit_labels: AuditLabels,
+
+    pub key_rotation: KeyRotationSpec,
+    pub attestation: AttestationRequirement,
+
+    /// Optional release pin. mvmd sets this to enforce
+    /// "this workload runs at exactly v0.X.Y of mvm/mvmd."
+    pub release_pin: Option<ReleasePin>,
+
+    pub post_run: PostRunLifecycle,
+}

--- a/crates/mvm-plan/src/signing.rs
+++ b/crates/mvm-plan/src/signing.rs
@@ -1,0 +1,282 @@
+//! `SignedExecutionPlan` — Ed25519-signed envelope around an
+//! `ExecutionPlan`.
+//!
+//! Plan 37 §3.3 requires that every plan outside dev mode arrive
+//! through a signed envelope. The supervisor verifies the signature
+//! against a trusted-keys set before parsing the plan body — the
+//! plan's content is never deserialised from attacker-controlled
+//! bytes prior to signature check.
+//!
+//! Wire format mirrors `mvm-core::protocol::signing::SignedPayload`
+//! so the same envelope shape used for control-plane messages can
+//! carry plans, keeping the audit + transport surface uniform.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use mvm_core::protocol::signing::SignedPayload;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::plan::{ExecutionPlan, SCHEMA_VERSION};
+
+/// Plan envelope. Wraps the canonical-JSON-encoded `ExecutionPlan`
+/// alongside the Ed25519 signature and a signer identifier.
+///
+/// Concretely this is a `SignedPayload` reused via newtype rather
+/// than a fresh struct so the same audit + transport code paths can
+/// carry plans without learning a second envelope shape. The newtype
+/// wrapper keeps the type system honest: a `SignedPayload` is
+/// generic, a `SignedExecutionPlan` is specifically the wrapper for
+/// `ExecutionPlan` and nothing else.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SignedExecutionPlan(pub SignedPayload);
+
+#[derive(Debug, Error)]
+pub enum PlanVerifyError {
+    #[error("signature verification failed: {0}")]
+    SignatureInvalid(String),
+
+    #[error("plan parse failed: {0}")]
+    Parse(String),
+
+    #[error("schema version {found} is newer than this build supports ({supported})")]
+    UnsupportedSchema { found: u32, supported: u32 },
+
+    #[error("no trusted key matched signer_id {signer_id}")]
+    UnknownSigner { signer_id: String },
+}
+
+/// Sign an `ExecutionPlan` with the given key.
+///
+/// The plan is serialised to canonical JSON via `serde_json` (the
+/// same encoding `verify_plan` round-trips through), signed, and
+/// wrapped in a `SignedExecutionPlan` envelope. The `signer_id` is
+/// the human-readable name of the key inside the envelope — used
+/// by the verifier to look the corresponding `VerifyingKey` up in
+/// the trusted-keys set.
+pub fn sign_plan(plan: &ExecutionPlan, key: &SigningKey, signer_id: &str) -> SignedExecutionPlan {
+    let payload = serde_json::to_vec(plan).expect("ExecutionPlan must serialise to JSON");
+    let signature: Signature = key.sign(&payload);
+    SignedExecutionPlan(SignedPayload {
+        payload,
+        signature: signature.to_bytes().to_vec(),
+        signer_id: signer_id.to_string(),
+    })
+}
+
+/// Verify a signed plan against a set of trusted keys, returning the
+/// parsed `ExecutionPlan` on success.
+///
+/// The verification order is signature → schema version → JSON
+/// parse. Older verifiers fail closed on a future schema version
+/// rather than parsing unknown bytes — the `schema_version` field
+/// is read separately *after* the signature check, before
+/// `ExecutionPlan` deserialisation, so an attacker who manages to
+/// bypass the sig check still can't smuggle in a v2 plan.
+///
+/// `trusted_keys` is a slice of `(signer_id, VerifyingKey)` pairs.
+/// The verifier picks the key whose `signer_id` matches the
+/// envelope's, then validates the signature against it. An empty
+/// `trusted_keys` slice always errors with `UnknownSigner`.
+pub fn verify_plan(
+    signed: &SignedExecutionPlan,
+    trusted_keys: &[(&str, &VerifyingKey)],
+) -> Result<ExecutionPlan, PlanVerifyError> {
+    let envelope = &signed.0;
+
+    // Pick the trusted key matching the envelope's signer_id. If
+    // none matches, the envelope is signed by an unknown party —
+    // fail before exposing the payload bytes to a verifier.
+    let key = trusted_keys
+        .iter()
+        .find_map(|(id, k)| (*id == envelope.signer_id).then_some(*k))
+        .ok_or_else(|| PlanVerifyError::UnknownSigner {
+            signer_id: envelope.signer_id.clone(),
+        })?;
+
+    let signature = Signature::from_slice(&envelope.signature).map_err(|e| {
+        PlanVerifyError::SignatureInvalid(format!("malformed signature bytes: {e}"))
+    })?;
+
+    key.verify(&envelope.payload, &signature)
+        .map_err(|e| PlanVerifyError::SignatureInvalid(e.to_string()))?;
+
+    // Schema-version sniff before full parse. We read just
+    // `{"schema_version": N, ...}` to see if the rest is something
+    // this build understands. A future v2 plan will error with
+    // UnsupportedSchema even though its signature is valid.
+    #[derive(Deserialize)]
+    struct VersionProbe {
+        schema_version: u32,
+    }
+    let probe: VersionProbe = serde_json::from_slice(&envelope.payload)
+        .map_err(|e| PlanVerifyError::Parse(format!("schema_version probe failed: {e}")))?;
+    if probe.schema_version > SCHEMA_VERSION {
+        return Err(PlanVerifyError::UnsupportedSchema {
+            found: probe.schema_version,
+            supported: SCHEMA_VERSION,
+        });
+    }
+
+    let plan: ExecutionPlan = serde_json::from_slice(&envelope.payload)
+        .map_err(|e| PlanVerifyError::Parse(e.to_string()))?;
+    Ok(plan)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::*;
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+    use std::collections::BTreeMap;
+
+    fn sample_plan() -> ExecutionPlan {
+        ExecutionPlan {
+            schema_version: SCHEMA_VERSION,
+            plan_id: PlanId("01HXTESTPLAN000000000000".to_string()),
+            plan_version: 1,
+            tenant: TenantId("tenant-a".to_string()),
+            workload: WorkloadId("workload-1".to_string()),
+            runtime_profile: RuntimeProfileRef("firecracker".to_string()),
+            image: SignedImageRef {
+                name: "tenant-worker-aarch64".to_string(),
+                sha256: "a".repeat(64),
+                cosign_bundle: None,
+            },
+            resources: Resources {
+                cpus: 2,
+                mem_mib: 1024,
+                disk_mib: 4096,
+                timeouts: TimeoutSpec {
+                    boot_secs: 30,
+                    exec_secs: 600,
+                },
+            },
+            network_policy: PolicyRef("default-deny".to_string()),
+            fs_policy: FsPolicyRef("default".to_string()),
+            secrets: vec![],
+            egress_policy: PolicyRef("agent-l7".to_string()),
+            tool_policy: PolicyRef("read-only-tools".to_string()),
+            artifact_policy: ArtifactPolicy {
+                capture_paths: vec!["/artifacts".to_string()],
+                retention_days: 30,
+            },
+            audit_labels: BTreeMap::from([("workflow".to_string(), "etl-1".to_string())]),
+            key_rotation: KeyRotationSpec { interval_days: 7 },
+            attestation: AttestationRequirement {
+                mode: AttestationMode::Noop,
+            },
+            release_pin: None,
+            post_run: PostRunLifecycle {
+                destroy_on_exit: true,
+                snapshot_on_idle: false,
+                idle_secs: 0,
+            },
+        }
+    }
+
+    fn fresh_key() -> (SigningKey, VerifyingKey) {
+        let sk = SigningKey::generate(&mut OsRng);
+        let vk = sk.verifying_key();
+        (sk, vk)
+    }
+
+    #[test]
+    fn plan_serde_roundtrip() {
+        let plan = sample_plan();
+        let bytes = serde_json::to_vec(&plan).unwrap();
+        let parsed: ExecutionPlan = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed, plan);
+    }
+
+    #[test]
+    fn signed_plan_roundtrip() {
+        let plan = sample_plan();
+        let (sk, vk) = fresh_key();
+        let signed = sign_plan(&plan, &sk, "test-signer");
+        let recovered = verify_plan(&signed, &[("test-signer", &vk)]).unwrap();
+        assert_eq!(recovered, plan);
+    }
+
+    #[test]
+    fn tampered_payload_fails_signature() {
+        let plan = sample_plan();
+        let (sk, vk) = fresh_key();
+        let mut signed = sign_plan(&plan, &sk, "test-signer");
+        // Flip a bit in the payload after signing.
+        signed.0.payload[0] ^= 0x01;
+        match verify_plan(&signed, &[("test-signer", &vk)]) {
+            Err(PlanVerifyError::SignatureInvalid(_)) => {}
+            other => panic!("expected SignatureInvalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_signer_fails() {
+        let plan = sample_plan();
+        let (sk, _vk) = fresh_key();
+        let signed = sign_plan(&plan, &sk, "alice");
+        // Trusted set knows "bob" but not "alice".
+        let (_other_sk, other_vk) = fresh_key();
+        match verify_plan(&signed, &[("bob", &other_vk)]) {
+            Err(PlanVerifyError::UnknownSigner { signer_id }) => {
+                assert_eq!(signer_id, "alice");
+            }
+            other => panic!("expected UnknownSigner, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_key_fails_signature() {
+        let plan = sample_plan();
+        let (sk, _vk) = fresh_key();
+        let (_sk2, vk2) = fresh_key();
+        let signed = sign_plan(&plan, &sk, "alice");
+        match verify_plan(&signed, &[("alice", &vk2)]) {
+            Err(PlanVerifyError::SignatureInvalid(_)) => {}
+            other => panic!("expected SignatureInvalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unsupported_schema_version_fails_closed() {
+        // Build a plan, sign it, then pretend a future build emitted
+        // a schema_version 2 plan. The verifier should refuse before
+        // the per-field deserialisation runs.
+        let mut plan = sample_plan();
+        plan.schema_version = SCHEMA_VERSION + 1;
+        let (sk, vk) = fresh_key();
+        let signed = sign_plan(&plan, &sk, "test-signer");
+        match verify_plan(&signed, &[("test-signer", &vk)]) {
+            Err(PlanVerifyError::UnsupportedSchema { found, supported }) => {
+                assert_eq!(found, SCHEMA_VERSION + 1);
+                assert_eq!(supported, SCHEMA_VERSION);
+            }
+            other => panic!("expected UnsupportedSchema, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_field_in_plan_rejected() {
+        // ExecutionPlan and its types use #[serde(deny_unknown_fields)],
+        // so a future field added to the wire format fails closed in
+        // older builds.
+        let mut value: serde_json::Value = serde_json::to_value(sample_plan()).unwrap();
+        value["new_future_field"] = serde_json::json!("hi");
+        let bytes = serde_json::to_vec(&value).unwrap();
+        let result: Result<ExecutionPlan, _> = serde_json::from_slice(&bytes);
+        assert!(result.is_err(), "deny_unknown_fields must reject");
+    }
+
+    #[test]
+    fn empty_trusted_set_fails() {
+        let plan = sample_plan();
+        let (sk, _vk) = fresh_key();
+        let signed = sign_plan(&plan, &sk, "alice");
+        match verify_plan(&signed, &[]) {
+            Err(PlanVerifyError::UnknownSigner { .. }) => {}
+            other => panic!("expected UnknownSigner, got {other:?}"),
+        }
+    }
+}

--- a/crates/mvm-plan/src/types.rs
+++ b/crates/mvm-plan/src/types.rs
@@ -1,0 +1,177 @@
+//! `*Ref` and `*Spec` types referenced from `ExecutionPlan`.
+//!
+//! Most fields here are opaque newtype wrappers so plan 37's later
+//! waves can introduce real resolvers without churning the wire
+//! format. Every type carries `#[serde(deny_unknown_fields)]` so
+//! adding a field is a fail-closed schema bump for older verifiers.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Stable identifier for an `ExecutionPlan` instance. Plan 37 §3.3
+/// specifies a ULID; we keep the type opaque so the constructor can
+/// switch generators (UUIDv7, snowflake, etc.) without touching the
+/// wire format. Audit entries reference this id verbatim.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PlanId(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TenantId(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WorkloadId(pub String);
+
+/// Reference to a runtime profile (Firecracker / Apple Container /
+/// MicrovmNix / Lima / containerd). Plan 37 §3.1's open
+/// `BackendRegistry` resolves the name to a backend factory.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RuntimeProfileRef(pub String);
+
+/// Reference to a signed image. Mirrors plan 36's `ArtifactDigest`
+/// shape: SHA-256 of the rootfs + name. The `cosign_bundle` field
+/// is the path or URL to the cosign keyless bundle that
+/// `mvm-security::image_verify` validates against; in dev mode the
+/// resolver may stub this to `None` and accept the digest alone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SignedImageRef {
+    pub name: String,
+    /// Lowercase hex SHA-256.
+    pub sha256: String,
+    /// Cosign-keyless `.bundle` reference. Path on disk or URL
+    /// resolvable by the supervisor. Stub in dev.
+    pub cosign_bundle: Option<String>,
+}
+
+/// Resource budget. Hard caps; the supervisor refuses to start a VM
+/// that would exceed the host's available capacity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Resources {
+    pub cpus: u32,
+    pub mem_mib: u64,
+    pub disk_mib: u64,
+    pub timeouts: TimeoutSpec,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimeoutSpec {
+    /// Max wall-clock for kernel boot + initramfs + minimal-init.
+    pub boot_secs: u32,
+    /// Max wall-clock for the workload itself. 0 = unbounded (only
+    /// permitted for sleep-waking instances; supervisor enforces).
+    pub exec_secs: u32,
+}
+
+/// Opaque pointer to a policy bundle. Wave 2 introduces the real
+/// `mvm-policy::PolicyBundle` resolver; until then this is a name
+/// the supervisor's `Noop` resolver maps to a default-deny / open
+/// stance per its bundle.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PolicyRef(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FsPolicyRef(pub String);
+
+/// A secret binding from a name (visible inside the guest) to its
+/// source (resolved by the supervisor's `KeystoreReleaser` per Wave 3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretBinding {
+    /// Name as the workload sees it (e.g. env var name or
+    /// /run/mvm-secrets/<name> file).
+    pub name: String,
+    pub source: SecretSource,
+}
+
+/// Where a secret comes from. Plan 37 §25 lists pluggable providers
+/// (Vault, AWS SM, GCP SM); Wave 3 adds the per-run attestation-gated
+/// release. The `Static` variant is a compile-time literal for tests
+/// only — `mvmctl plan validate --prod` rejects plans that contain it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum SecretSource {
+    /// Test-only literal. Refused by `--prod` validation.
+    Static { value: String },
+    /// Per-run release from the supervisor's keystore. The address
+    /// resolves to a SecretId at the supervisor.
+    Keystore { address: String },
+    /// External provider (Vault, AWS SM, etc.). The provider URL +
+    /// path are opaque to mvm-plan; resolved by `KeystoreReleaser`.
+    External { provider: String, path: String },
+}
+
+/// Artifact-capture policy for the run. `capture_paths` are guest-side
+/// directories the supervisor's `ArtifactCollector` (Wave 3) sweeps
+/// post-run; `retention_days` controls the cleanup sweeper.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactPolicy {
+    pub capture_paths: Vec<String>,
+    pub retention_days: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KeyRotationSpec {
+    /// 0 = no rotation required; supervisor warns but accepts.
+    pub interval_days: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AttestationRequirement {
+    pub mode: AttestationMode,
+}
+
+/// Plan 37 §14 attestation modes. Wave 3 introduces real TPM2 / SEV
+/// providers; the `Noop` mode lets every plan launch without
+/// attestation (today's behaviour) for backwards compat.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttestationMode {
+    /// No attestation. Stub. mvmctl warns; mvmd may refuse.
+    Noop,
+    /// TPM2 EK + AK quote. Supervisor's `KeystoreReleaser` gates
+    /// secret release on a successful quote.
+    Tpm2,
+    /// AMD SEV-SNP report. Provider lands in Wave 6.
+    SevSnp,
+    /// Intel TDX quote. Provider lands in Wave 6.
+    Tdx,
+}
+
+/// Plan 37 §11 release pinning: the workload runs at a specific
+/// release of mvm/mvmd. Mismatch is grounds for refusal at admission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleasePin {
+    pub release_id: String,
+}
+
+/// Plan 37 §27 lifecycle directives. The supervisor's plan state
+/// machine consults these on workload exit / idle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PostRunLifecycle {
+    /// Tear down the VM on workload exit (one-shot semantics).
+    pub destroy_on_exit: bool,
+    /// Snapshot the VM after `idle_secs` of inactivity (sleep-wake).
+    pub snapshot_on_idle: bool,
+    /// Idle window before snapshot. Ignored if `snapshot_on_idle`
+    /// is false. 0 = immediate.
+    pub idle_secs: u32,
+}
+
+/// Convenience — the audit-labels alias the type uses. Free-form
+/// `key: value` annotations the supervisor copies into every audit
+/// entry generated for this plan.
+pub type AuditLabels = BTreeMap<String, String>;

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -339,6 +339,141 @@ Cross-repo handoff for hosted MCP transport (HTTP/SSE) is documented
 in [`plans/33-hosted-mcp-transport.md`](plans/33-hosted-mcp-transport.md);
 implementation lives in mvmd, not this repo.
 
+## Sprint 44 — Whitepaper alignment (proposed)
+
+Master plan: [`plans/37-whitepaper-alignment.md`](plans/37-whitepaper-alignment.md).
+Walks the V2 whitepaper (`specs/docs/whitepaper.md`) section by section,
+identifies what `mvm` (the runtime/CLI half — not `mvmd`) is missing
+relative to its claims, and sequences the work into six waves. Includes
+ADR-004 (PII redaction lives in `mvm`, not `mvmd`) staged for creation
+at `specs/adrs/004-pii-redaction-in-mvm.md` when implementation begins.
+
+### Why this sprint
+
+The whitepaper's load-bearing AI-native claims — signed `ExecutionPlan`
+contract, Zone B runtime supervisor, L7 egress + PII redaction,
+tool-call mediation, attestation-gated key release, signed policy
+bundles, runtime artifact capture, audit binding to plan version — have
+no code path on `mvm` today. Sprint 42 closed the local-isolation
+substrate (W1–W6); Sprint 43 shipped MCP + L3 egress + the L7 proxy
+foundation (PR #23). Sprint 44 builds the rest of the whitepaper's
+runtime contract on top of that substrate.
+
+### Wave breakdown
+
+Effort labels: **XS** ≤ ½ day · **S** 1–2 days · **M** 3–5 days · **L** > 1 sprint.
+
+- **Wave 0 — Whitepaper truth fixes (XS, prereq).** Soften §3.1 backend
+  list, §14 hardware claims, §15.1 PII as design intent until built.
+  Update CLAUDE.md / MEMORY.md: W3 dm-verity is **shipped**.
+- **Wave 1 — Foundation (S+M).** New crates `mvm-plan`, `mvm-policy`,
+  `mvm-supervisor` (lifted from `mvm-hostd`). `Supervisor::launch(plan)`
+  happy path. Audit binds to plan/policy/image. Plus B6 (kill switch),
+  B8 (cosign verify cache), B15 (zeroize lint), B16 (local registry),
+  B19 (admission audit), B21 (config-change audit), C1 (supervisor
+  self-attest), C3 (anti-debug), C4 (supervisor death = fail-closed),
+  E2 (policy precedence), G4 (plan replay protection — latent bug fix).
+- **Wave 2 — Differentiator (M).** L7 egress proxy in supervisor (plan
+  34 expanded); inspector chain (SecretsScanner, SsrfGuard,
+  InjectionGuard, DestinationPolicy); AiProviderRouter + PiiRedactor
+  (detect-only first); tool-call vsock RPC + ToolGate wired. Plus B17
+  (egress audit completeness with audit-emits-before-forward CI gate),
+  B18 (tool audit), E1 (false-positive circuit breaker — ship-blocker),
+  G1 (streaming session audit), G2 (retry-storm dedup).
+- **Wave 3 — Identity & artifact closure (M).** Attestation key-release
+  gate with TPM2 provider; per-run secret grants + revoke-on-stop;
+  audit chain signing + per-tenant streams + export; artifact capture
+  path (virtiofs `/artifacts` + ArtifactCollector). Plus B7 (audit
+  buffering during mvmd outage), B9 (workload identity JWT), B10
+  (memory scrub on stop), B11 (host-published trusted time), B12 (crash
+  dump capture), B14 (snapshot integrity + plan-id binding), B20
+  (secret-grant pairing CI), B22 (audit-write health metrics), C2
+  (channel rekey), D1 (webhook inspection), D2 (RAG/retrieved-content
+  inspection), D3 (file-upload inspection), E3 (attestation clock
+  skew), E4 (disk-full audit), F1 (cost telemetry), F2 (stuck-workload
+  detection), F4 (tenant-visible audit projection), G3 (cross-plan
+  request stitching).
+- **Wave 4 — Multi-tenant + release (M).** Per-tenant netns,
+  per-tenant DEK, ReleasePin admission + two-slot policy rollback,
+  DataClass admission gate.
+- **Wave 5 — Surface & ergonomics (S+M).** Local HTTP API on supervisor
+  Unix socket, `mvm-sdk` crate, cross-backend CI matrix on §3.3 fixture
+  plan, threat-control matrix CI generator. Plus F3 (reproducible plan
+  execution).
+- **Wave 6 — Confidential & adapters (L, optional).** SEV-SNP / TDX
+  provider real impls; Lima/Incus/containerd adapters; Vault / AWS SM /
+  GCP SM secret providers.
+
+### Cornerstones
+
+Two pieces unblock everything else and should land first:
+
+1. **`mvm_core::ExecutionPlan`** (§3.3, Wave 1) — typed, signed plan
+   replacing scattered `RunParams` / `FlakeRunConfig`. Every
+   "signed/audited/policy-pinned" claim hangs off this. Including
+   `valid_from` / `valid_until` / `nonce` (G4) closes the latent
+   replay bug.
+2. **`mvm-supervisor` daemon** (§7B, Wave 1) — packages the existing
+   `mvm-hostd` skeleton plus EgressProxy, ToolGate, KeystoreReleaser,
+   AuditSigner, ArtifactCollector behind a single trusted process.
+   Owns the data path so tenant code can't bypass policy.
+
+### Differentiator
+
+L7 egress + AI-provider PII redaction (§15 + §15.1, Wave 2). The
+single most important AI-native claim in the whitepaper and currently
+zero code. Ships as **detect-only** first to safely measure detector
+quality on real traffic before transforms are enabled. **Fail-closed**
+on detector error — any inspection failure blocks the request, never
+forwards raw.
+
+### Trust boundary decision (ADR-004)
+
+PII redaction stays in `mvm`, not `mvmd`. The host running the microVM
+is the only point at which a request body is in plaintext on
+infrastructure we trust. Putting redaction in `mvmd` would collapse §8
+plane separation, expand §13 control-plane blast radius (an `mvmd`
+compromise would expose every prompt), break §19 residency, and add a
+network round-trip per AI call. `mvmd` owns policy authoring,
+signing, distribution, and fleet-aggregated reporting; `mvm` owns the
+engine on the data path. ADR-004 staged in plan 37 Addendum A.
+
+### Sprint 44 success criteria
+
+By sprint close, the project should be able to claim:
+
+1. *Workloads run from typed, signed `ExecutionPlan`s with replay
+   protection.* (Wave 1)
+2. *A trusted supervisor process owns the data path; tenant code
+   cannot bypass policy.* (Wave 1)
+3. *Every outbound egress event produces a signed, plan-bound audit
+   entry.* (Wave 2)
+4. *AI-provider requests pass through PII inspection; detector errors
+   fail closed.* (Wave 2)
+5. *Tool calls are mediated by the supervisor's `ToolGate` and
+   audited.* (Wave 2)
+6. *Attestation gates secret release; TPM2 implementation exists.*
+   (Wave 3)
+7. *Workload outputs are captured under `ArtifactPolicy` retention,
+   not destroyed on exit.* (Wave 3)
+
+Waves 4–6 are post-44 follow-ups; the sprint can close on Waves 0–3.
+
+### Non-goals (named explicitly)
+
+- **mvmd-side concerns:** fleet placement, releases / canary / rollout,
+  host registration, cross-host wake/sleep, policy distribution,
+  control-layer key rotation. Wire types live in
+  `mvm_core::mvmd_iface` so mvmd can land later without reshaping
+  `mvm`.
+- **Hardware-attested vendor trust roots beyond TPM2 in the first pass.**
+  SEV-SNP / TDX providers ship as `unimplemented!()` scaffolds.
+- **Vendor-specific PII detector beyond regex/dictionary v0.**
+  `Detector` trait is open for later additions.
+- **Workflow-engine specific SDKs beyond the generic `mvm-sdk`.**
+- **Model selection, prompt engineering, cost optimization, federated
+  learning** (plan 37 Addendum H — application concerns, not runtime).
+
 ## Completed Sprints
 
 - [01-foundation.md](sprints/01-foundation.md)


### PR DESCRIPTION
## Summary

First slice of plan 37 (whitepaper alignment) — the cornerstone item
from §3.3. Adds the new `mvm-plan` crate with the typed
`ExecutionPlan` contract every workload will boot from, plus the
Ed25519-signed envelope that gates plan acceptance outside dev mode.

This PR is **type scaffold + signed envelope only**. It doesn't yet
wire `ExecutionPlan` into `mvmctl up`/`run` — that's plan 37 Wave 1.4.
Subsequent waves connect the contract to the supervisor launch path,
the §5 enforce table, the L7 egress proxy, and the attestation
key-release gate. This PR unblocks all of them by establishing the
type and the signed wire format.

## What lands

### `mvm-plan::plan::ExecutionPlan`

The cornerstone type. Every field plan 37 §3.3 calls for:

```rust
pub struct ExecutionPlan {
    pub schema_version: u32,
    pub plan_id: PlanId,                  // ULID-style opaque
    pub plan_version: u32,                // monotonic per plan_id
    pub tenant: TenantId,
    pub workload: WorkloadId,
    pub runtime_profile: RuntimeProfileRef,
    pub image: SignedImageRef,            // sha256 + cosign bundle ref
    pub resources: Resources,
    pub network_policy: PolicyRef,
    pub fs_policy: FsPolicyRef,
    pub secrets: Vec<SecretBinding>,
    pub egress_policy: PolicyRef,
    pub tool_policy: PolicyRef,
    pub artifact_policy: ArtifactPolicy,
    pub audit_labels: BTreeMap<String, String>,
    pub key_rotation: KeyRotationSpec,
    pub attestation: AttestationRequirement,
    pub release_pin: Option<ReleasePin>,
    pub post_run: PostRunLifecycle,
}
```

Every field with `#[serde(deny_unknown_fields)]` so a future schema
bump fails closed in older verifiers. `SCHEMA_VERSION = 1` is sniffed
from the JSON before per-field deserialisation — an attacker who
manages to bypass the cosign sig check on a v2 plan still can't
smuggle one through a v1 verifier because schema version is read
separately.

### `mvm-plan::signing::SignedExecutionPlan`

Newtype around `mvm-core::protocol::signing::SignedPayload` so the
same envelope shape used for control-plane messages carries plans
too. Sign/verify uses `ed25519-dalek` directly:

```rust
pub fn sign_plan(plan: &ExecutionPlan, key: &SigningKey, signer_id: &str) -> SignedExecutionPlan;

pub fn verify_plan(
    signed: &SignedExecutionPlan,
    trusted_keys: &[(&str, &VerifyingKey)],
) -> Result<ExecutionPlan, PlanVerifyError>;
```

Verification order: signature → schema-version probe → JSON parse.
Defence in depth: an empty trusted-keys slice always errors with
`UnknownSigner` (no fallthrough to unauthenticated parse).

### Typed `PlanVerifyError`

`SignatureInvalid` / `Parse` / `UnsupportedSchema` / `UnknownSigner`.
Same shape plan 36 established for `mvm-security::image_verify::VerifyError`
so the supervisor's reconciliation loop can pattern-match outcomes
instead of crash-looping on `anyhow::Error`.

### Supporting types (`mvm-plan::types`)

Every `*Ref`/`*Spec` plan 37 enumerates, as opaque newtypes ready
for future resolvers:

- `PlanId`, `TenantId`, `WorkloadId`, `RuntimeProfileRef`,
  `PolicyRef`, `FsPolicyRef` — transparent newtype wrappers
- `SignedImageRef` — name + sha256 + optional cosign bundle ref
  (mirrors plan 36 ArtifactDigest shape so the supervisor's
  image verifier doesn't learn a second format)
- `Resources` / `TimeoutSpec` — cpus, mem, disk, boot/exec timeouts
- `SecretBinding` + `SecretSource` (Static for tests, Keystore,
  External) — Wave 3 adds the per-run attestation-gated release
- `ArtifactPolicy`, `KeyRotationSpec`, `ReleasePin`,
  `PostRunLifecycle` — straightforward
- `AttestationRequirement` + `AttestationMode` (Noop / Tpm2 /
  SevSnp / Tdx) — Wave 3 wires Tpm2; Wave 6 wires SevSnp / Tdx

## Test plan

- [x] `cargo test -p mvm-plan` — 8 tests passing:
  - `plan_serde_roundtrip`
  - `signed_plan_roundtrip` (sign → verify recovers exact plan)
  - `tampered_payload_fails_signature`
  - `unknown_signer_fails`
  - `wrong_key_fails_signature`
  - `unsupported_schema_version_fails_closed`
  - `unknown_field_in_plan_rejected` (deny_unknown_fields contract)
  - `empty_trusted_set_fails`
- [x] `cargo test --workspace` — 1145 tests, all green (was 1137)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] **Wired into mvmctl** — deferred; plan 37 Wave 1.4 lands
  `mvmctl plan validate` + Supervisor::launch happy path

## Non-goals (deferred per plan 37)

- mvmctl CLI verbs (`mvmctl plan validate`) — Wave 1.4
- Supervisor::launch wiring — Wave 1.4
- §5 enforce table — Wave 1.5
- L7 egress / tool-call gate — Wave 2
- Attestation real providers — Wave 3 / Wave 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)