### PR TITLE
chore: worktree workflow policy + dev env wrapper

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,5 @@
+# Optional convenience for direnv users.
+# If you have direnv installed:
+#   cp .envrc.example .envrc
+#   direnv allow
+source_env scripts/dev-env.sh

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ keys
 !crates/mvm-cli/src/commands/build/
 !crates/mvm-cli/src/commands/build/**
 
+# Worktree-local dev env (use .envrc.example as template)
+/.envrc
+/.mvm-test/
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,60 @@ Examples:
 
 **Important:** `mvmctl` (via `cargo run`) commands like `template build`, `run`, `stop`, `logs`, and `status` must be run inside the Lima VM — they talk to Firecracker which only runs inside Linux. `cargo test`, `cargo clippy`, and `cargo check` must also run inside the Lima VM to ensure correct Linux-target compilation and test execution. The `cargo run -- dev` bootstrap command is the only one that runs on the macOS host directly.
 
+## Worktree Workflow for Features
+
+Every feature, refactor, or non-trivial bug fix MUST be developed in a git worktree, never on the main checkout. This isolates in-flight work from the main checkout's `~/.mvm` registry, build cache, and dev VM state.
+
+### Creating the worktree
+
+```bash
+git worktree add ../mvm-<feature-slug> -b feat/<feature-slug>
+cd ../mvm-<feature-slug>
+```
+
+Branch names follow the existing pattern (`feat/<slug>`, `fix/<slug>`, `chore/<slug>`).
+
+### Isolating mutable state
+
+Worktrees share `~/.mvm`, `~/.cache/mvm`, the Lima VM, and any pushed registries with the main checkout. Use the `bin/dev` wrapper or the `just dev-*` recipes for any `mvmctl` invocation in a worktree — they source `scripts/dev-env.sh`, which redirects `mvmctl`'s data dir into the worktree (`MVM_DATA_DIR="$PWD/.mvm-test"`) and silences the legacy-banner.
+
+Examples:
+
+```bash
+bin/dev template build              # equivalent to: cargo run --quiet -- template build
+just dev-test                       # cargo test --workspace with the dev env
+just dev-clippy                     # cargo clippy with the dev env
+```
+
+The dev env files are committed; new contributors get the right behaviour with no setup.
+
+### Lima VM sharing
+
+The Lima VM (`mvm-builder`) is shared across worktrees by design — it's expensive to boot and Nix builds benefit from a warm store. The data-dir override above keeps `mvmctl`'s per-feature state isolated; Nix store reuse is intentional.
+
+### Optional: direnv
+
+Users who already have direnv installed can opt in:
+
+```bash
+cp .envrc.example .envrc
+direnv allow
+```
+
+This is a convenience, not a requirement. The wrapper script path (`bin/dev` / `just dev-*`) works for everyone with no additional tools.
+
+### Cleaning up
+
+After the feature merges:
+
+```bash
+git worktree remove ../mvm-<feature-slug>
+```
+
+### When NOT to use a worktree
+
+Trivial single-line changes (typo fixes, doc word swaps, dependency bumps) can land directly on a topic branch in the main checkout. The worktree rule applies to anything that touches code, runtime state, or the registry.
+
 ## Definition of Done
 
 No task is complete without tests. Every feature, bug fix, or refactor must include:

--- a/Justfile
+++ b/Justfile
@@ -24,6 +24,22 @@ check:
 run *ARGS:
     cargo run -- {{ARGS}}
 
+# Run mvmctl with the dev env set (worktree-local MVM_DATA_DIR).
+dev *ARGS:
+    bin/dev {{ARGS}}
+
+# Run cargo test --workspace with the dev env.
+dev-test:
+    bash -c 'source scripts/dev-env.sh && cargo test --workspace'
+
+# Run clippy with the dev env.
+dev-clippy:
+    bash -c 'source scripts/dev-env.sh && cargo clippy --workspace -- -D warnings'
+
+# Run cargo check with the dev env.
+dev-check:
+    bash -c 'source scripts/dev-env.sh && cargo check --workspace'
+
 # ── Testing (nextest) ────────────────────────────────────────────────────
 
 # Run all tests

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$SCRIPT_DIR"
+# shellcheck source=scripts/dev-env.sh
+source scripts/dev-env.sh
+exec cargo run --quiet -- "$@"

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Source this to enter the dev env for a worktree.
+# Sets MVM_DATA_DIR to a worktree-local directory so mvmctl's
+# registry/cache writes don't stomp on the main checkout.
+export MVM_DATA_DIR="${MVM_DATA_DIR:-$PWD/.mvm-test}"
+export MVM_NO_LEGACY_BANNER=1


### PR DESCRIPTION
## Summary

- Adds a **Worktree Workflow for Features** section to `AGENTS.md` requiring features/refactors/non-trivial bug fixes to be developed in isolated git worktrees, so in-flight work doesn't stomp on the main checkout's `~/.mvm` registry, build cache, or dev VM state.
- Ships the supporting tooling: `bin/dev` wrapper, `scripts/dev-env.sh` (sets `MVM_DATA_DIR=\$PWD/.mvm-test` + `MVM_NO_LEGACY_BANNER=1`), `just dev`/`dev-test`/`dev-clippy`/`dev-check` recipes, an optional `.envrc.example` for direnv users, and `.gitignore` entries for `/.envrc` and `/.mvm-test/`.
- The Lima VM (`mvm-builder`) and Nix store remain shared across worktrees by design — only `mvmctl`'s data dir is redirected.

Verified `MVM_DATA_DIR` is the actual env var consumed by `mvm_core::config::mvm_data_dir()` (`crates/mvm-core/src/config.rs:63`).

## Test plan

- [x] \`bash -n bin/dev\` and \`bash -n scripts/dev-env.sh\` parse cleanly
- [x] \`just --list\` shows the new dev / dev-test / dev-clippy / dev-check recipes
- [x] Pre-commit hook (cargo fmt + clippy -D warnings + nextest 1137 tests) passed on commit
- [ ] Manual smoke: in a fresh worktree, run \`bin/dev --help\` and confirm \`\$MVM_DATA_DIR\` resolves to the worktree-local \`.mvm-test\` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)