### PR TITLE
chore(ci,docs): post-W7 polish — concurrency, Linux flake-check, doc audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel a previous run when a new commit lands on the same branch.
+# Without this, the PR check panel accumulates stale failed runs from
+# superseded SHAs (we hit this on PRs #17 and #18). `main` runs are
+# never cancelled because the group is keyed on workflow + ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
@@ -268,3 +276,33 @@ jobs:
 
       - name: Build mvmctl + run MCP roundtrip smoke
         run: ./scripts/test-mcp-roundtrip.sh
+
+  # ── Lane: Nix flake check (Linux eval) ────────────────────────────
+  # Catches eval-time bugs that only surface on Linux. The host-side
+  # `nix flake check` was only ever exercised on the macOS runner;
+  # Linux-only output paths (`packages.<sys>.{mvm-guest-agent,
+  # mvm-guest-agent-dev}`, `devShells.<sys>.builder`) never got
+  # evaluated in CI before. The `flake-utils.lib.eachSystem`
+  # inversion-semantics bug we almost shipped during W7 would have
+  # been caught here.
+  nix-flake-check:
+    name: Nix flake check (Linux eval)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Eval-check every flake
+        run: |
+          set -euo pipefail
+          for d in ./nix \
+                   ./nix/dev \
+                   ./nix/images/builder \
+                   ./nix/images/default-tenant \
+                   ./nix/images/examples/hello \
+                   ./nix/images/examples/hello-node \
+                   ./nix/images/examples/hello-python \
+                   ./nix/images/examples/llm-agent; do
+            echo "=== $d ==="
+            nix flake check --no-build "$d"
+          done

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,14 @@ on:
     - cron: "17 4 * * *"
   workflow_dispatch:
 
+# Cancel a previous run when a new commit lands on the same branch.
+# Same rationale as ci.yml — keep the PR check panel free of stale
+# failed runs from superseded SHAs. `main` pushes and the nightly
+# cron are never cancelled (different ref → different group).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/public/src/content/docs/guides/config-secrets.md
+++ b/public/src/content/docs/guides/config-secrets.md
@@ -86,108 +86,113 @@ The `DriveFile` type is content-agnostic — it's just `{name, content, mode}`. 
 - Adding support for new applications doesn't require code changes
 - NixOS `EnvironmentFile` can load `.env` files directly as systemd environment variables
 
-## Example: OpenClaw
+## Example: generic flake with config + secrets mounts
 
-The [OpenClaw example](/nix/examples/openclaw/) demonstrates all of these features. It ships with a default config baked into the image, but you can override it by mounting host directories.
+The pattern below works with any `mkGuest` flake that reads
+`/mnt/config/` and/or `/mnt/secrets/` at boot. See
+[`nix/images/examples/`](https://github.com/auser/mvm/tree/main/nix/images/examples)
+for concrete flakes (`hello`, `hello-node`, `hello-python`, `llm-agent`).
 
-### Running with example config
+### Running with host-mounted config and secrets
 
 ```bash
-mvmctl template build openclaw
-mvmctl up --template openclaw --name oc \
-    -v nix/examples/openclaw/config:/mnt/config \
-    -v nix/examples/openclaw/secrets:/mnt/secrets \
+mvmctl template build my-template
+mvmctl up --template my-template --name my-vm \
+    -v ./config:/mnt/config \
+    -v ./secrets:/mnt/secrets \
     -p 3000:3000
-mvmctl forward oc 3000:3000
+mvmctl forward my-vm 3000:3000
 ```
 
-The default config uses `auth.mode: "none"` — no token is required to access the Control UI. The gateway binds to loopback inside the VM with a TCP proxy forwarding external connections, so all connections appear local and are auto-approved by OpenClaw (no device pairing prompts). To enable token auth, set `"auth": { "mode": "token" }` in your config and `OPENCLAW_GATEWAY_TOKEN` in `secrets/api-keys.env`.
+Each `-v` flag mounts a host directory as an ext4 drive read-only by
+default. Secrets land at `/mnt/secrets/` (mode 0440 root:mvm by the
+init script) and are also re-staged to `/run/mvm-secrets/<svc>/`
+with mode 0400 owned by the per-service uid (ADR-002 §W2.1) so
+sibling services on the same microVM can't cross-read.
 
-### Running with custom config and API keys
+### Custom config + API keys at runtime
 
 ```bash
-# Create config directory with OpenClaw gateway settings
-mkdir -p /tmp/oc-config
-cat > /tmp/oc-config/openclaw.json << 'EOF'
-{
-  "gateway": {
-    "mode": "local",
-    "channelHealthCheckMinutes": 0,
-    "auth": { "mode": "none" },
-    "reload": { "mode": "off" },
-    "controlUi": {
-      "dangerouslyAllowHostHeaderOriginFallback": true
-    }
-  }
-}
+# Create a config directory with whatever shape your flake expects
+mkdir -p /tmp/my-config
+cat > /tmp/my-config/app.json << 'EOF'
+{ "feature_flag": "value" }
 EOF
 
-# Create secrets directory with API keys
-mkdir -p /tmp/oc-secrets
-cat > /tmp/oc-secrets/api-keys.env << 'EOF'
+# Create secrets — typically a .env file the service sources
+mkdir -p /tmp/my-secrets
+cat > /tmp/my-secrets/api-keys.env << 'EOF'
 ANTHROPIC_API_KEY=sk-ant-...
 EOF
 
-mvmctl up --template openclaw --name oc \
-    -v /tmp/oc-config:/mnt/config \
-    -v /tmp/oc-secrets:/mnt/secrets \
+mvmctl up --template my-template --name my-vm \
+    -v /tmp/my-config:/mnt/config \
+    -v /tmp/my-secrets:/mnt/secrets \
     -p 3000:3000
 ```
 
-The OpenClaw service's `preStart` script checks for `/mnt/config/openclaw.json` and uses it (with `envsubst` expansion) instead of the built-in default. The `command` script sources `/mnt/config/env.sh` and `/mnt/secrets/api-keys.env` if they exist, making environment variables available to the gateway process.
+A typical `mkGuest` service uses `preStart` to check for
+`/mnt/config/<file>` and falls back to a built-in default; the
+`command` script sources `/mnt/secrets/<env-file>` if present so
+environment variables are available to the service process.
 
 ### Using snapshots for fast startup
 
-Build the template with `--snapshot` to capture a running VM state. Subsequent runs restore from the snapshot instead of cold-booting, reducing startup time from minutes to **1-2 seconds**:
+Build the template with `--snapshot` to capture a running VM state.
+Subsequent runs restore from the snapshot instead of cold-booting,
+reducing startup time from minutes to **1-2 seconds**:
 
 ```bash
-mvmctl template build openclaw --snapshot
-mvmctl up --template openclaw --name oc \
-    -v nix/examples/openclaw/config:/mnt/config \
-    -v nix/examples/openclaw/secrets:/mnt/secrets \
+mvmctl template build my-template --snapshot
+mvmctl up --template my-template --name my-vm \
+    -v ./config:/mnt/config \
+    -v ./secrets:/mnt/secrets \
     -p 3000:3000
 ```
 
-When restoring from a snapshot with `-v` mounts, the guest agent automatically remounts config/secrets drives and restarts services with the fresh data.
+When restoring from a snapshot with `-v` mounts, the guest agent
+automatically remounts config/secrets drives and restarts services
+with the fresh data.
 
-#### Snapshots + Dynamic Mounts = Instant Boots with Flexible Config
+#### Snapshots + dynamic mounts = instant boots with flexible config
 
-**Key insight:** The snapshot stores the OS and application state (memory, running processes, compiled code caches), but **config and secrets drives are created fresh at runtime** from your host directories. This means:
+**Key insight:** the snapshot stores OS and application state
+(memory, running processes, compiled code caches), but **config and
+secrets drives are created fresh at runtime** from your host
+directories. This means:
 
-- ✅ **Same snapshot** can serve multiple instances with different configs
-- ✅ **Update configs without rebuilding** — just change the files in your host directory
-- ✅ **Instant boot + dynamic configuration** — get both benefits simultaneously
+- ✅ **Same snapshot** can serve multiple instances with different
+  configs.
+- ✅ **Update configs without rebuilding** — change the host files
+  and re-up.
+- ✅ **Instant boot + dynamic configuration** — get both benefits
+  simultaneously.
 
-Example: Run three OpenClaw instances from one snapshot with different API keys:
+Example: run three instances from one snapshot with different API
+keys:
 
 ```bash
-# Production gateway with prod Anthropic key
-mvmctl up --template openclaw --name oc-prod \
+mvmctl up --template my-template --name my-vm-prod \
     -v ./prod/config:/mnt/config \
     -v ./prod/secrets:/mnt/secrets \
     -p 3000:3000
 
-# Staging gateway with test key
-mvmctl up --template openclaw --name oc-staging \
+mvmctl up --template my-template --name my-vm-staging \
     -v ./staging/config:/mnt/config \
     -v ./staging/secrets:/mnt/secrets \
     -p 3001:3000
 
-# Dev gateway with no key (localhost-only testing)
-mvmctl up --template openclaw --name oc-dev \
+mvmctl up --template my-template --name my-vm-dev \
     -v ./dev/config:/mnt/config \
     -p 3002:3000
 ```
 
-All three VMs restore from the same snapshot (1-2 second boot) but get different configs and secrets at runtime.
+All three restore from the same snapshot (1-2 second boot) but get
+different configs and secrets at runtime.
 
 ### Monitoring the VM
 
-Check the OpenClaw gateway logs via the guest console:
-
 ```bash
-mvmctl logs oc        # view console output
-mvmctl logs oc -f     # follow in real time
+mvmctl logs my-vm        # view console output
+mvmctl logs my-vm -f     # follow in real time
 ```
-
-See [nix/examples/openclaw/](https://github.com/auser/mvm/tree/main/nix/examples/openclaw) for the full example with sample config and secrets files.

--- a/public/src/content/docs/guides/dev-image.md
+++ b/public/src/content/docs/guides/dev-image.md
@@ -10,18 +10,18 @@ The **dev image** is a minimal Linux VM image (kernel + ext4 rootfs) used by `mv
 When you run `mvmctl dev up`, the CLI:
 
 1. Checks `~/.cache/mvm/dev/` for cached `vmlinux` and `rootfs.ext4`
-2. If missing, builds the image from `nix/dev-image/flake.nix` (requires Nix with a Linux builder)
+2. If missing, builds the image from `nix/images/builder/flake.nix` (requires Nix with a Linux builder)
 3. If Nix build fails (e.g. no Linux builder on macOS), downloads a pre-built image from the matching GitHub release
 
 The dev image is built using the same `mkGuest` helper that builds all microVM images, so it follows the same conventions (busybox init, vsock communication, no SSH).
 
 ## Customizing the dev image
 
-The dev image flake lives at [`nix/dev-image/flake.nix`](https://github.com/auser/mvm/blob/main/nix/dev-image/flake.nix). It imports the parent flake at `nix/` and calls `mkGuest` with a list of packages.
+The dev image flake lives at [`nix/images/builder/flake.nix`](https://github.com/auser/mvm/blob/main/nix/images/builder/flake.nix). It imports the parent flake at `nix/` and calls `mkGuest` with a list of packages.
 
 ### Adding packages
 
-Edit the `packages` list in `nix/dev-image/flake.nix`:
+Edit the `packages` list in `nix/images/builder/flake.nix`:
 
 ```nix
 packages = [
@@ -66,11 +66,11 @@ See the [Nix Flakes guide](/guides/nix-flakes) for the full `mkGuest` API.
 
 ```bash
 # Build for the current architecture
-nix build ./nix/dev-image
+nix build ./nix/images/builder
 
 # Build for a specific architecture
-nix build ./nix/dev-image#packages.aarch64-linux.default
-nix build ./nix/dev-image#packages.x86_64-linux.default
+nix build ./nix/images/builder#packages.aarch64-linux.default
+nix build ./nix/images/builder#packages.x86_64-linux.default
 ```
 
 The output is a Nix store path containing `vmlinux` (kernel) and `rootfs.ext4` (root filesystem).
@@ -90,7 +90,7 @@ mvmctl dev up
 Or copy the built artifacts directly:
 
 ```bash
-STORE_PATH=$(nix build ./nix/dev-image --no-link --print-out-paths)
+STORE_PATH=$(nix build ./nix/images/builder --no-link --print-out-paths)
 mkdir -p ~/.cache/mvm/dev
 cp "$STORE_PATH/vmlinux" ~/.cache/mvm/dev/
 cp "$STORE_PATH/rootfs.ext4" ~/.cache/mvm/dev/
@@ -128,14 +128,22 @@ The release workflow (`.github/workflows/release.yml`) builds dev images for bot
 ```
 nix/
 ├── flake.nix                    # Parent flake — defines mkGuest (production)
-├── firecracker-kernel-pkg.nix
-├── minimal-init.nix
-├── guest-agent-pkg.nix
+├── packages/
+│   ├── firecracker-kernel.nix
+│   ├── mvm-guest-agent.nix
+│   └── mvmctl.nix
+├── lib/
+│   ├── minimal-init/            # PID 1 init script generator
+│   ├── rootfs-templates/        # populate.sh.in etc.
+│   └── kernel-configs/
 ├── dev/                         # Sibling flake — dev variant of mkGuest
 │   └── flake.nix
-└── dev-image/                   # Dev environment image
-    ├── flake.nix                # Calls mkGuest with dev tools
-    └── flake.lock
+└── images/
+    ├── builder/                 # Builder VM image (was nix/dev-image/)
+    │   ├── flake.nix            # Calls mkGuest with dev tools, role = "builder"
+    │   └── flake.lock
+    ├── default-tenant/          # Bundled fallback rootfs (was nix/default-microvm/)
+    └── examples/                # hello, hello-node, hello-python, llm-agent
 ```
 
-The dev image flake references the parent via a relative path (`mvm.url = "path:.."`), so changes to the kernel or init system are picked up automatically on the next build.
+The builder image flake references the parent via a relative path (`mvm.url = "path:../.."`), so changes to the kernel or init system are picked up automatically on the next build.

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -40,7 +40,7 @@ mvmctl exec --launch-plan ./launch.json
 If you don't pass `--template` or `--flake`, `mvmctl exec` boots the
 bundled default image:
 
-- Defined by [`nix/default-microvm/`](https://github.com/auser/mvm/tree/main/nix/default-microvm)
+- Defined by [`nix/images/default-tenant/`](https://github.com/auser/mvm/tree/main/nix/images/default-tenant)
   in the repo: a minimal `mkGuest` rootfs with busybox and the auto-included
   guest agent. No extra packages.
 - Built via Nix on first use, cached at `~/.cache/mvm/default-microvm/`

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -258,8 +258,9 @@ This applies to:
 - `mvmctl up` / `mvmctl run` / `mvmctl start` — boots a long-running microVM
   with the same image
 
-The image is built from `nix/default-microvm/` on first use and cached at
-`~/.cache/mvm/default-microvm/` (kernel + rootfs). Nix is required to build
+The image is built from `nix/images/default-tenant/` on first use and cached at
+`~/.cache/mvm/default-microvm/` (kernel + rootfs; cache directory name
+unchanged for backward compat). Nix is required to build
 it; pass `--template` or `--flake` if Nix isn't available on your host.
 
 ## Cache


### PR DESCRIPTION
## Summary

Three small post-W7 cleanups batched into one PR per the follow-up plan:

1. **CI concurrency** on both `ci.yml` and `security.yml` so the PR check panel stops accumulating stale failed runs from superseded SHAs (we hit this on PRs #17 and #18). Group is `${{ github.workflow }}-${{ github.ref }}` so `main` and nightly cron are never cancelled.
2. **Linux flake-check CI lane** — new `nix-flake-check` job in `ci.yml` evaluating every flake on `ubuntu-latest`. Catches eval-time bugs that only surface on Linux (the `flake-utils.lib.eachSystem` inversion-semantics bug we almost shipped during W7 would have been caught here).
3. **Documentation audit** — sweep `public/src/content/docs/` for old paths from before W7's layout move:
   - `nix/dev-image/` → `nix/images/builder/`
   - `nix/default-microvm/` → `nix/images/default-tenant/`
   - `firecracker-kernel-pkg.nix` / `guest-agent-pkg.nix` → `nix/packages/` tree
   - `nix/examples/openclaw/` (deleted) → generic flake example in `config-secrets.md` with links to the surviving examples

## Worktree workflow

Developed per `AGENTS.md` in a worktree at `../mvm-post-w7-polish/` on branch `chore/post-w7-polish`.

## Test plan

- [ ] CI green on all jobs including the new `nix-flake-check` lane
- [ ] PR check panel doesn't accumulate stale failed runs across pushes (visible after the next fix-up commit on any branch)
- [ ] No remaining old-path references in `public/src/content/docs/` except intentional "(was X)" historical notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)