### PR TITLE
feat(mvm-policy): scaffold PolicyBundle + SignedPolicyBundle — plan 37 Wave 1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,6 +2403,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-policy"
+version = "0.13.0"
+dependencies = [
+ "chrono",
+ "ed25519-dalek",
+ "mvm-core",
+ "mvm-plan",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "mvm-runtime"
 version = "0.13.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/mvm-core",
     "crates/mvm-security",
     "crates/mvm-plan",
+    "crates/mvm-policy",
     "crates/mvm-runtime",
     "crates/mvm-build",
     "crates/mvm-guest",
@@ -102,6 +103,7 @@ mvm-build = { path = "crates/mvm-build", version = "0.13.0" }
 mvm-runtime = { path = "crates/mvm-runtime", version = "0.13.0" }
 mvm-security = { path = "crates/mvm-security", version = "0.13.0" }
 mvm-plan = { path = "crates/mvm-plan", version = "0.13.0" }
+mvm-policy = { path = "crates/mvm-policy", version = "0.13.0" }
 mvm-cli = { path = "crates/mvm-cli", version = "0.13.0" }
 mvm-mcp = { path = "crates/mvm-mcp", version = "0.13.0" }
 mvm-apple-container = { path = "crates/mvm-apple-container", version = "0.7.0" }

--- a/crates/mvm-plan/src/types.rs
+++ b/crates/mvm-plan/src/types.rs
@@ -13,22 +13,22 @@ use serde::{Deserialize, Serialize};
 /// specifies a ULID; we keep the type opaque so the constructor can
 /// switch generators (UUIDv7, snowflake, etc.) without touching the
 /// wire format. Audit entries reference this id verbatim.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct PlanId(pub String);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TenantId(pub String);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct WorkloadId(pub String);
 
 /// Reference to a runtime profile (Firecracker / Apple Container /
 /// MicrovmNix / Lima / containerd). Plan 37 §3.1's open
 /// `BackendRegistry` resolves the name to a backend factory.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct RuntimeProfileRef(pub String);
 
@@ -73,11 +73,11 @@ pub struct TimeoutSpec {
 /// `mvm-policy::PolicyBundle` resolver; until then this is a name
 /// the supervisor's `Noop` resolver maps to a default-deny / open
 /// stance per its bundle.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct PolicyRef(pub String);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct FsPolicyRef(pub String);
 

--- a/crates/mvm-policy/Cargo.toml
+++ b/crates/mvm-policy/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mvm-policy"
+description = "PolicyBundle: signed network/egress/pii/tool/artifact/key/audit policy bundle. Plan 37 §10."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[dependencies]
+mvm-core.workspace = true
+mvm-plan.workspace = true
+chrono.workspace = true
+ed25519-dalek.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror = "1"
+
+[dev-dependencies]
+rand.workspace = true

--- a/crates/mvm-policy/src/bundle.rs
+++ b/crates/mvm-policy/src/bundle.rs
@@ -1,0 +1,61 @@
+//! `PolicyBundle` — the policy half of plan 37 §10.
+
+use std::collections::BTreeMap;
+
+use mvm_plan::TenantId;
+use serde::{Deserialize, Serialize};
+
+use crate::policies::{
+    ArtifactPolicy, AuditPolicy, EgressPolicy, KeyPolicy, NetworkPolicy, PiiPolicy, ToolPolicy,
+};
+
+/// Wire-format version. Same fail-closed semantics as
+/// `mvm-plan::SCHEMA_VERSION` — older verifiers reject unknown
+/// future bundle versions before any per-field deserialisation.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Stable identifier for a `PolicyBundle`. Audit entries reference
+/// `(bundle_id, bundle_version)` alongside the plan's
+/// `(plan_id, plan_version)` so a runbook can answer "which policy
+/// was in force when this audit entry was written?" in O(1).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PolicyId(pub String);
+
+/// A bundle of every policy a workload boots under. Resolved from a
+/// `PolicyRef` on `ExecutionPlan`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyBundle {
+    pub schema_version: u32,
+    pub bundle_id: PolicyId,
+    /// Monotonic per-`bundle_id` revision counter.
+    pub bundle_version: u32,
+
+    pub network: NetworkPolicy,
+    pub egress: EgressPolicy,
+    pub pii: PiiPolicy,
+    pub tool: ToolPolicy,
+    pub artifact: ArtifactPolicy,
+    pub keys: KeyPolicy,
+    pub audit: AuditPolicy,
+
+    /// Per-tenant overlays. Resolved by composing the bundle's
+    /// base policy with the matching tenant overlay (overlay wins
+    /// on conflict). Empty map means no per-tenant variation.
+    pub tenant_overlays: BTreeMap<TenantId, TenantOverlay>,
+}
+
+/// Per-tenant overlay. Each field is optional — `None` means
+/// "inherit from the bundle base"; `Some(_)` overrides.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TenantOverlay {
+    pub network: Option<NetworkPolicy>,
+    pub egress: Option<EgressPolicy>,
+    pub pii: Option<PiiPolicy>,
+    pub tool: Option<ToolPolicy>,
+    pub artifact: Option<ArtifactPolicy>,
+    pub keys: Option<KeyPolicy>,
+    pub audit: Option<AuditPolicy>,
+}

--- a/crates/mvm-policy/src/lib.rs
+++ b/crates/mvm-policy/src/lib.rs
@@ -1,0 +1,31 @@
+//! mvm-policy — signed `PolicyBundle` carrying network, egress, PII,
+//! tool, artifact, key, and audit policies referenced by an
+//! `ExecutionPlan`.
+//!
+//! Plan 37 §10. Every executable artifact (image, kernel, policy
+//! bundle) is signed and verified at admission. Plan 36 closed the
+//! image side (cosign-keyless on the dev/builder image manifest);
+//! this crate closes the policy-bundle side using the same Ed25519
+//! envelope shape `mvm-plan` introduced for `SignedExecutionPlan`.
+//!
+//! Wave 1.2 of plan 37 lands the bundle type + signed envelope. The
+//! sub-policies (NetworkPolicy, EgressPolicy, PiiPolicy, ToolPolicy,
+//! ArtifactPolicy, KeyPolicy, AuditPolicy) are scaffolded as minimal
+//! placeholders here — each gets its real shape in subsequent
+//! waves. The bundle wire format ships before substance so consumers
+//! can land their resolver hooks against a stable type.
+//!
+//! Structure:
+//! - `bundle` — `PolicyBundle` + `SCHEMA_VERSION`.
+//! - `policies` — sub-policy stubs (NetworkPolicy, EgressPolicy, ...).
+//! - `signing` — `SignedPolicyBundle` envelope + sign/verify.
+
+pub mod bundle;
+pub mod policies;
+pub mod signing;
+
+pub use bundle::{PolicyBundle, PolicyId, SCHEMA_VERSION, TenantOverlay};
+pub use policies::{
+    ArtifactPolicy, AuditPolicy, EgressPolicy, KeyPolicy, NetworkPolicy, PiiPolicy, ToolPolicy,
+};
+pub use signing::{BundleVerifyError, SignedPolicyBundle, sign_bundle, verify_bundle};

--- a/crates/mvm-policy/src/policies.rs
+++ b/crates/mvm-policy/src/policies.rs
@@ -1,0 +1,99 @@
+//! Sub-policy types referenced by `PolicyBundle`.
+//!
+//! Plan 37 Wave 1.2 lands the *shape* of each sub-policy as a
+//! minimal placeholder. Real enforcement contracts arrive in later
+//! waves:
+//!
+//! - Wave 2 fills `EgressPolicy` (L7 rules), `PiiPolicy` (detect /
+//!   redact / refuse modes), and `ToolPolicy` (RPC allowlist).
+//! - Wave 3 fills `KeyPolicy` (per-run secret grants) and
+//!   `AuditPolicy` (chain signing, per-tenant streams).
+//! - Wave 4 fills `NetworkPolicy` (per-tenant netns) and
+//!   `ArtifactPolicy` retention sweeps.
+//!
+//! Every type uses `#[serde(deny_unknown_fields)]` so a future
+//! field addition is a fail-closed schema bump for older verifiers,
+//! and every type derives `Default` so `TenantOverlay`'s
+//! `Option<T>` semantics ("None inherits from base") compose
+//! cleanly with the bundle's resolution algorithm.
+
+use serde::{Deserialize, Serialize};
+
+/// Network policy. Wave 4 introduces per-tenant netns + bridge
+/// allocation. Today: name-only stub matching the existing
+/// `mvm-core::policy::network_policy` shape.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkPolicy {
+    /// Name of the network preset
+    /// (`open` / `agent` / `tenant-isolated` / etc.). Stub.
+    pub preset: Option<String>,
+}
+
+/// L7 egress policy. Plan 37 §15 differentiator. Wave 2 fills:
+///   - inspector chain (SecretsScanner, SsrfGuard, InjectionGuard,
+///     DestinationPolicy)
+///   - AiProviderRouter
+///   - allowed destinations / SNI pin set
+///
+/// Today: a stub flag indicating whether the egress proxy is on at
+/// all. The proxy itself is plan 32 / PR #23 (foundation only).
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EgressPolicy {
+    /// `open` — no proxy. `l3` — drop-on-deny IP allowlist (plan 32).
+    /// `l3_plus_l7` — Wave 2 differentiator. Stub today.
+    pub mode: Option<String>,
+}
+
+/// PII redaction policy. Plan 37 §15.1.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PiiPolicy {
+    /// `disabled` / `detect` / `redact` / `refuse`. Stub.
+    pub mode: Option<String>,
+    /// Categories to act on (`email`, `cc_number`, `ssn`, ...).
+    /// Empty means all categories the redactor knows about.
+    pub categories: Vec<String>,
+}
+
+/// Tool-call allowlist. Plan 37 §2.2. Wave 2 wires the supervisor's
+/// vsock RPC `ToolGate`.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ToolPolicy {
+    /// Names of tools the workload is allowed to invoke. Stub.
+    pub allowed: Vec<String>,
+}
+
+/// Artifact policy. Distinct from `mvm-plan::ArtifactPolicy` —
+/// the plan field is a per-run snapshot; this is the bundle-side
+/// source of truth that the supervisor's `ArtifactCollector` (Wave 3)
+/// consults at workload exit.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactPolicy {
+    pub capture_paths: Vec<String>,
+    pub retention_days: u32,
+}
+
+/// Key policy. Plan 37 §12. Wave 3 wires `KeystoreReleaser`.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KeyPolicy {
+    /// 0 = no rotation; supervisor warns but accepts.
+    pub rotation_interval_days: u32,
+}
+
+/// Audit policy. Plan 37 §22. Wave 3 wires chain signing + per-tenant
+/// streams.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditPolicy {
+    /// Whether the supervisor should chain-sign each entry into the
+    /// previous's hash for tamper-evidence.
+    pub chain_signing: bool,
+    /// Per-tenant audit-stream destinations. Resolved by
+    /// `AuditSigner` per Wave 3.
+    pub stream_destinations: Vec<String>,
+}

--- a/crates/mvm-policy/src/signing.rs
+++ b/crates/mvm-policy/src/signing.rs
@@ -1,0 +1,235 @@
+//! `SignedPolicyBundle` — Ed25519-signed envelope around a
+//! `PolicyBundle`. Same shape `mvm-plan` uses for
+//! `SignedExecutionPlan`.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use mvm_core::protocol::signing::SignedPayload;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::bundle::{PolicyBundle, SCHEMA_VERSION};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SignedPolicyBundle(pub SignedPayload);
+
+#[derive(Debug, Error)]
+pub enum BundleVerifyError {
+    #[error("signature verification failed: {0}")]
+    SignatureInvalid(String),
+
+    #[error("bundle parse failed: {0}")]
+    Parse(String),
+
+    #[error("schema version {found} is newer than this build supports ({supported})")]
+    UnsupportedSchema { found: u32, supported: u32 },
+
+    #[error("no trusted key matched signer_id {signer_id}")]
+    UnknownSigner { signer_id: String },
+}
+
+pub fn sign_bundle(bundle: &PolicyBundle, key: &SigningKey, signer_id: &str) -> SignedPolicyBundle {
+    let payload = serde_json::to_vec(bundle).expect("PolicyBundle must serialise to JSON");
+    let signature: Signature = key.sign(&payload);
+    SignedPolicyBundle(SignedPayload {
+        payload,
+        signature: signature.to_bytes().to_vec(),
+        signer_id: signer_id.to_string(),
+    })
+}
+
+/// Same verification order as `mvm-plan::verify_plan`: signature →
+/// schema version → JSON parse. Fail-closed on unknown signer
+/// before exposing the payload bytes.
+pub fn verify_bundle(
+    signed: &SignedPolicyBundle,
+    trusted_keys: &[(&str, &VerifyingKey)],
+) -> Result<PolicyBundle, BundleVerifyError> {
+    let envelope = &signed.0;
+
+    let key = trusted_keys
+        .iter()
+        .find_map(|(id, k)| (*id == envelope.signer_id).then_some(*k))
+        .ok_or_else(|| BundleVerifyError::UnknownSigner {
+            signer_id: envelope.signer_id.clone(),
+        })?;
+
+    let signature = Signature::from_slice(&envelope.signature).map_err(|e| {
+        BundleVerifyError::SignatureInvalid(format!("malformed signature bytes: {e}"))
+    })?;
+
+    key.verify(&envelope.payload, &signature)
+        .map_err(|e| BundleVerifyError::SignatureInvalid(e.to_string()))?;
+
+    #[derive(Deserialize)]
+    struct VersionProbe {
+        schema_version: u32,
+    }
+    let probe: VersionProbe = serde_json::from_slice(&envelope.payload)
+        .map_err(|e| BundleVerifyError::Parse(format!("schema_version probe failed: {e}")))?;
+    if probe.schema_version > SCHEMA_VERSION {
+        return Err(BundleVerifyError::UnsupportedSchema {
+            found: probe.schema_version,
+            supported: SCHEMA_VERSION,
+        });
+    }
+
+    let bundle: PolicyBundle = serde_json::from_slice(&envelope.payload)
+        .map_err(|e| BundleVerifyError::Parse(e.to_string()))?;
+    Ok(bundle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bundle::{PolicyId, TenantOverlay};
+    use crate::policies::*;
+    use ed25519_dalek::SigningKey;
+    use mvm_plan::TenantId;
+    use rand::rngs::OsRng;
+    use std::collections::BTreeMap;
+
+    fn sample_bundle() -> PolicyBundle {
+        PolicyBundle {
+            schema_version: SCHEMA_VERSION,
+            bundle_id: PolicyId("01HXBUNDLE0000000000000000".to_string()),
+            bundle_version: 1,
+            network: NetworkPolicy {
+                preset: Some("agent".to_string()),
+            },
+            egress: EgressPolicy {
+                mode: Some("l3_plus_l7".to_string()),
+            },
+            pii: PiiPolicy {
+                mode: Some("redact".to_string()),
+                categories: vec!["email".to_string(), "cc_number".to_string()],
+            },
+            tool: ToolPolicy {
+                allowed: vec!["read_file".to_string()],
+            },
+            artifact: ArtifactPolicy {
+                capture_paths: vec!["/artifacts".to_string()],
+                retention_days: 30,
+            },
+            keys: KeyPolicy {
+                rotation_interval_days: 7,
+            },
+            audit: AuditPolicy {
+                chain_signing: true,
+                stream_destinations: vec!["audit://tenant-a".to_string()],
+            },
+            tenant_overlays: BTreeMap::from([(
+                TenantId("tenant-a".to_string()),
+                TenantOverlay {
+                    pii: Some(PiiPolicy {
+                        mode: Some("refuse".to_string()),
+                        categories: vec![],
+                    }),
+                    ..Default::default()
+                },
+            )]),
+        }
+    }
+
+    fn fresh_key() -> (SigningKey, VerifyingKey) {
+        let sk = SigningKey::generate(&mut OsRng);
+        let vk = sk.verifying_key();
+        (sk, vk)
+    }
+
+    #[test]
+    fn bundle_serde_roundtrip() {
+        let b = sample_bundle();
+        let bytes = serde_json::to_vec(&b).unwrap();
+        let parsed: PolicyBundle = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed, b);
+    }
+
+    #[test]
+    fn signed_bundle_roundtrip() {
+        let b = sample_bundle();
+        let (sk, vk) = fresh_key();
+        let signed = sign_bundle(&b, &sk, "test");
+        let recovered = verify_bundle(&signed, &[("test", &vk)]).unwrap();
+        assert_eq!(recovered, b);
+    }
+
+    #[test]
+    fn tampered_payload_fails_signature() {
+        let b = sample_bundle();
+        let (sk, vk) = fresh_key();
+        let mut signed = sign_bundle(&b, &sk, "test");
+        signed.0.payload[0] ^= 0x01;
+        match verify_bundle(&signed, &[("test", &vk)]) {
+            Err(BundleVerifyError::SignatureInvalid(_)) => {}
+            other => panic!("expected SignatureInvalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_signer_fails() {
+        let b = sample_bundle();
+        let (sk, _vk) = fresh_key();
+        let signed = sign_bundle(&b, &sk, "alice");
+        let (_sk2, vk2) = fresh_key();
+        match verify_bundle(&signed, &[("bob", &vk2)]) {
+            Err(BundleVerifyError::UnknownSigner { signer_id }) => assert_eq!(signer_id, "alice"),
+            other => panic!("expected UnknownSigner, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unsupported_schema_fails_closed() {
+        let mut b = sample_bundle();
+        b.schema_version = SCHEMA_VERSION + 1;
+        let (sk, vk) = fresh_key();
+        let signed = sign_bundle(&b, &sk, "test");
+        match verify_bundle(&signed, &[("test", &vk)]) {
+            Err(BundleVerifyError::UnsupportedSchema { found, supported }) => {
+                assert_eq!(found, SCHEMA_VERSION + 1);
+                assert_eq!(supported, SCHEMA_VERSION);
+            }
+            other => panic!("expected UnsupportedSchema, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_field_in_bundle_rejected() {
+        let mut value: serde_json::Value = serde_json::to_value(sample_bundle()).unwrap();
+        value["new_future_field"] = serde_json::json!("hi");
+        let bytes = serde_json::to_vec(&value).unwrap();
+        assert!(serde_json::from_slice::<PolicyBundle>(&bytes).is_err());
+    }
+
+    #[test]
+    fn empty_trusted_set_fails() {
+        let b = sample_bundle();
+        let (sk, _vk) = fresh_key();
+        let signed = sign_bundle(&b, &sk, "alice");
+        match verify_bundle(&signed, &[]) {
+            Err(BundleVerifyError::UnknownSigner { .. }) => {}
+            other => panic!("expected UnknownSigner, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tenant_overlay_resolution_shape() {
+        // Sanity: a tenant overlay with only `pii: Some(_)` leaves
+        // every other field as None (inherit-from-base semantics).
+        // The actual base+overlay merge function lives in
+        // mvm-runtime's PolicyResolver (Wave 2); here we only assert
+        // that the wire format is what the resolver will read.
+        let b = sample_bundle();
+        let overlay = b
+            .tenant_overlays
+            .get(&TenantId("tenant-a".to_string()))
+            .unwrap();
+        assert!(overlay.pii.is_some());
+        assert!(overlay.network.is_none());
+        assert!(overlay.egress.is_none());
+        assert!(overlay.tool.is_none());
+        assert!(overlay.artifact.is_none());
+        assert!(overlay.keys.is_none());
+        assert!(overlay.audit.is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Re-creation of PR #28 after Wave 1.1's squash-merge invalidated the
prior base branch. Identical content; rebased onto fresh main so
the only commit ahead is Wave 1.2's PolicyBundle scaffold.

Adds the `mvm-policy` crate with `PolicyBundle` wrapping every
policy a workload boots under (network, egress, PII, tool, artifact,
key, audit) plus per-tenant overlays, signed with the same Ed25519
envelope shape Wave 1.1 introduced for `SignedExecutionPlan`.

## What lands

- `mvm-policy::bundle::PolicyBundle` — schema_version + bundle_id +
  bundle_version + the seven sub-policies + tenant_overlays.
- `mvm-policy::policies` — sub-policy stubs (NetworkPolicy,
  EgressPolicy, PiiPolicy, ToolPolicy, ArtifactPolicy, KeyPolicy,
  AuditPolicy) each with `#[serde(deny_unknown_fields)]` + `Default`.
- `mvm-policy::bundle::TenantOverlay` — every field optional;
  per-tenant overrides without copying the entire bundle.
- `mvm-policy::signing::{SignedPolicyBundle, sign_bundle, verify_bundle}` —
  same Ed25519 shape from Wave 1.1.
- Typed `BundleVerifyError`: `SignatureInvalid` / `Parse` /
  `UnsupportedSchema` / `UnknownSigner`.

## Test plan

- [x] `cargo test -p mvm-policy` — 8 tests passing
- [x] Rebased clean onto main (single commit ahead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)