### PR TITLE
chore(dev): worktree isolation tooling + lighter pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,98 +1,69 @@
 #!/bin/bash
-# Pre-commit hook for mvm
+# Pre-commit hook for mvm — light, host-runnable.
+#
+# Per AGENTS.md: this hook fires once per commit at the main checkout
+# (because git always runs from there), and it must stay fast and host-
+# friendly so it doesn't block worktree workflows. Heavy checks
+# (workspace clippy, full test suite, supply-chain gates) live in CI,
+# not here.
+#
+# What this hook does:
+#   1. Skip entirely if the staged set is empty.
+#   2. Run cargo fmt --all if any Rust files are staged (auto-fixes,
+#      re-stages). Cargo fmt works on the macOS host.
+#   3. Run nix fmt --check on the nix/ dir if any *.nix files are
+#      staged AND the nix CLI is available. Otherwise skip.
+#
+# What this hook deliberately does NOT do:
+#   - cargo check / cargo build / cargo clippy / cargo test — the
+#     workspace targets Linux-specific deps and these don't compile
+#     cleanly on the macOS host. Run them via Lima or rely on CI.
+#   - cargo-deny / cargo-audit — supply-chain gates run in CI
+#     (.github/workflows/security.yml).
+#
+# To run the heavier checks locally before pushing:
+#   limactl shell mvm-builder -- cargo clippy --workspace --all-targets -- -D warnings
+#   limactl shell mvm-builder -- cargo nextest run --workspace
+#   limactl shell mvm-builder -- cargo deny check
+#   just ci
 
 set -e
 
-echo "Running pre-commit checks..."
-echo ""
-
-# Check if there are any staged changes
+# Bail out early if nothing is staged.
 if git diff --cached --quiet; then
-    echo "No staged changes to commit"
     exit 0
 fi
 
-# Auto-fix formatting and stage changes
-echo "Auto-formatting code..."
-if ! cargo fmt; then
-    echo "Formatting failed!"
-    exit 1
-fi
+# Detect what kinds of files changed.
+staged="$(git diff --cached --name-only --diff-filter=ACMR)"
 
-if ! git diff --quiet --exit-code; then
-    echo "Auto-staging formatted files..."
-    git add -u
-fi
-echo "Code formatting applied and staged"
-echo ""
+has_rust=0
+has_nix=0
+while IFS= read -r f; do
+    case "$f" in
+        *.rs) has_rust=1 ;;
+        *.nix) has_nix=1 ;;
+    esac
+done <<< "$staged"
 
-# Run clippy (zero warnings required)
-echo "Running clippy (zero warnings required)..."
-if ! cargo clippy --all-targets -- -D warnings; then
-    echo "Clippy failed!"
-    echo "   Run 'cargo clippy --all-targets --fix --allow-dirty' to auto-fix"
-    exit 1
-fi
-echo "Clippy passed"
-echo ""
-
-# Run tests
-echo "Running tests..."
-if ! cargo test -- --color=always; then
-    echo "Tests failed!"
-    exit 1
-fi
-echo "All tests passed"
-echo ""
-
-# Supply-chain gate — ADR-002 §W5.2. cargo-deny is the load-bearing
-# tool (advisories + licenses + bans + sources); cargo-audit is a
-# narrower second opinion against the same advisory DB. Both run if
-# installed; missing tools log a notice but don't block the commit
-# (CI is the enforcement point).
-if command -v cargo-deny >/dev/null 2>&1; then
-    echo "Running cargo-deny (supply chain)..."
-    if ! cargo deny check; then
-        echo "cargo-deny failed!"
-        echo "   See deny.toml for ignore/skip syntax."
+if [ "$has_rust" -eq 1 ]; then
+    echo "pre-commit: cargo fmt --all"
+    if ! cargo fmt --all; then
+        echo "  cargo fmt failed."
         exit 1
     fi
-    echo "cargo-deny passed"
-    echo ""
-else
-    echo "(cargo-deny not installed — install with 'cargo install cargo-deny' to gate locally)"
-    echo ""
-fi
-
-if command -v cargo-audit >/dev/null 2>&1; then
-    echo "Running cargo-audit..."
-    if ! cargo audit; then
-        echo "cargo-audit failed!"
-        exit 1
+    if ! git diff --quiet --exit-code; then
+        echo "pre-commit: re-staging formatted files"
+        git add -u
     fi
-    echo "cargo-audit passed"
-    echo ""
-else
-    echo "(cargo-audit not installed — install with 'cargo install cargo-audit' to gate locally)"
-    echo ""
 fi
 
-# Nix formatter (W7.4). `nix fmt --check` runs the formatter from
-# `nix/flake.nix#formatter.${system}` (nixfmt-rfc-style) and exits
-# non-zero on drift. Skipped when nix isn't on PATH (matches cargo-deny
-# / cargo-audit gates above — CI is the enforcement point).
-if command -v nix >/dev/null 2>&1; then
-    echo "Running nix fmt --check..."
+if [ "$has_nix" -eq 1 ] && command -v nix >/dev/null 2>&1; then
+    echo "pre-commit: nix fmt --check ./nix"
     if ! nix --extra-experimental-features 'nix-command flakes' fmt -- --check ./nix; then
-        echo "nix fmt detected drift!"
-        echo "   Run 'nix fmt ./nix' to auto-format."
+        echo "  nix fmt detected drift. Run 'nix fmt ./nix' to auto-format."
         exit 1
     fi
-    echo "nix fmt clean"
-    echo ""
-else
-    echo "(nix not installed — install Nix to gate formatting locally)"
-    echo ""
 fi
 
-echo "All pre-commit checks passed!"
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,18 @@ Examples:
 
 Every feature, refactor, or non-trivial bug fix is developed in a git worktree — code edits and cargo invocations happen inside the worktree directory. Git operations (status, add, commit, stash, rebase, push, fetch, pull, hook execution) happen from the main `mvm/` checkout, with `-C` pointing at the worktree when needed. The main checkout is the single git operator; worktree directories are code+build sandboxes only.
 
+### Never commit directly to `main`
+
+`main` is updated only via merged pull requests — never by `git commit` against the local `main` branch, even from the main checkout, even for docs-only changes, even with `--no-verify`. Reasons:
+
+- **Safety against parallel agents.** Multiple agents share `.git/`. Any agent that pulls/rebases/`reset --hard origin/main` (a routine recovery move) silently discards local-only commits on main. Branches that exist on `origin` cannot be wiped this way.
+- **CI gating.** The full clippy + nextest + supply-chain + flake-check matrix only runs on PRs. A direct commit ships untested.
+- **Audit trail.** PR descriptions, CI status, review comments, and merge events form the project's history. A local commit pushed to main loses all of it.
+
+If you have changes intended for `main`, push them to a branch and open a PR — even a one-line typo fix. The repo's GitHub settings are not branch-protected, so the convention is the only thing keeping main clean.
+
+The only `git` commands that should ever target `main` directly are read-only (`git log main`, `git show main:path`) or routine sync (`git fetch origin`, `git pull --ff-only origin main`).
+
 ### Creating the worktree
 
 From the main `mvm/` checkout:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,11 @@
 
 ## Lima VM Requirement
 
-All Nix builds, Firecracker operations, `mvmctl` commands, test execution, clippy checks, and Linux-specific commands MUST be run inside the Lima VM. Use `limactl shell mvm-builder -- <command>` to execute commands inside the VM. The Lima VM name is `mvm-builder` (renamed from `mvm` in W7.2).
+All Nix builds, Firecracker operations, `mvmctl` runtime commands (anything that boots, talks to, or manages microVMs), and Linux-specific syscalls MUST be run inside the Lima VM. Use `limactl shell mvm-builder -- <command>` to execute commands inside the VM. The Lima VM name is `mvm-builder` (renamed from `mvm` in W7.2).
+
+**Run cargo on the macOS host wherever it compiles cleanly.** `cargo test`, `cargo check`, and `cargo build` should default to the host so worktrees don't deadlock on the single shared Lima VM (cargo target-dir contention, registry locks, and `.git/index` cross-mount races are real and have caused us to lose work). Tests that genuinely need Linux — vsock, jailer/seccomp, dm-verity, network namespaces, anything that pokes at `/dev/kvm` or `/proc/net` — should be gated with `#[cfg(target_os = "linux")]` and only those sub-targets are run inside Lima. Workspace-wide `cargo clippy --workspace --all-targets -- -D warnings` is still expected to pass inside Lima before merge, since clippy needs to see the Linux-gated code paths.
+
+**git always runs on the macOS host, never inside Lima.** The repo is shared with the Lima VM via 9p/virtiofs and the two sides do not share git's lock semantics — running `git` from inside Lima while another worktree is also doing git work on the host produces "unable to write new index file" deadlocks. Only cargo/nix/firecracker/mvmctl operations cross into the VM.
 
 If the Lima VM is not running, boot it with:
 
@@ -28,7 +32,7 @@ Examples:
 - `limactl shell mvm-builder -- cargo clippy --workspace -- -D warnings`
 - `limactl shell mvm-builder -- cargo check --workspace`
 
-**Important:** `mvmctl` (via `cargo run`) commands like `template build`, `run`, `stop`, `logs`, and `status` must be run inside the Lima VM — they talk to Firecracker which only runs inside Linux. `cargo test`, `cargo clippy`, and `cargo check` must also run inside the Lima VM to ensure correct Linux-target compilation and test execution. The `cargo run -- dev` bootstrap command is the only one that runs on the macOS host directly.
+**Important:** `mvmctl` (via `cargo run`) commands like `template build`, `run`, `stop`, `logs`, and `status` must be run inside the Lima VM — they talk to Firecracker which only runs inside Linux. `cargo test` / `cargo check` / `cargo build` should run on the macOS host by default (see "Run cargo on the macOS host" above); only `cargo clippy --workspace --all-targets` and tests gated on `target_os = "linux"` need Lima. `cargo run -- dev` always runs on the macOS host directly.
 
 ## Worktree Workflow for Features
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,14 +49,28 @@ Branch names follow the existing pattern (`feat/<slug>`, `fix/<slug>`, `chore/<s
 
 ### Isolating mutable state
 
-Worktrees share `~/.mvm`, `~/.cache/mvm`, the Lima VM, and any pushed registries with the main checkout. Per-worktree isolation is achieved by overriding `mvmctl`'s data dir for the duration of a command:
+Worktrees share `~/.mvm`, `~/.cache/mvm`, `~/.cargo`, `~/.rustup`, the Lima VM, the Nix store, and any pushed registries with the main checkout. Per-worktree isolation is achieved by overriding three env vars for the duration of a command:
 
 ```bash
-MVM_DATA_DIR="$PWD/.mvm-test" cargo run --quiet -- template build
-MVM_DATA_DIR="$PWD/.mvm-test" cargo test --workspace
+MVM_DATA_DIR="$PWD/.mvm-test"      \
+CARGO_TARGET_DIR="$PWD/.mvm-test/target" \
+CARGO_HOME="$PWD/.mvm-test/cargo"  \
+  cargo test --workspace
 ```
 
-A `bin/dev` wrapper, `scripts/dev-env.sh`, and `just dev-*` recipes that bake this in are planned but not yet committed — until they land, set `MVM_DATA_DIR` explicitly in worktrees.
+- `MVM_DATA_DIR` redirects mvmctl's templates, sockets, microVM registry, snapshots, and signing keys away from `~/.mvm`.
+- `CARGO_TARGET_DIR` gives the worktree its own `target/` so two worktrees compiling at once don't fight over output paths or rustc invocation locks.
+- `CARGO_HOME` gives the worktree its own cargo registry/cache and (most importantly) its own `.package-cache` lock — without this, two concurrent `cargo test` invocations across worktrees serialize on `~/.cargo/registry/.package-cache` and one will block until the other finishes downloading or resolving.
+
+A `bin/dev` wrapper, `scripts/dev-env.sh`, and `just dev-*` recipes that bake all three in are planned but not yet committed — until they land, set the env vars explicitly in worktrees, or `direnv allow` an `.envrc` that exports them.
+
+### What still collides between worktrees
+
+Even with per-worktree isolation, a few resources are shared and can cause concurrent commands to interfere:
+
+- **`.git/objects/`, `.git/packed-refs`, and the shared hooks dir.** Each `git worktree add` directory has its own index, HEAD, and refs (in `.git/worktrees/<name>/`), but the object store and packed refs are one set. Concurrent `git status` is fine (read-only); concurrent `git stash`, `git commit`, and especially `git rebase` from multiple worktrees can race on `.git/packed-refs` and the shared `.git/hooks/` invocation context. Don't run heavy hooks (full `cargo test --workspace`) on every commit — the pre-commit hook should be limited to formatting + fast checks.
+- **The Lima VM's `/var/lib/mvm/`, `br-mvm` bridge, and TAP devices.** Vary microVM and TAP names between worktrees if you need two microVMs running at the same time.
+- **The Nix store inside Lima.** This is shared by design (warm cache) and Nix's own locking handles it.
 
 ### Lima VM sharing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,12 @@ CARGO_HOME="$PWD/.mvm-test/cargo"  \
 - `CARGO_TARGET_DIR` gives the worktree its own `target/` so two worktrees compiling at once don't fight over output paths or rustc invocation locks.
 - `CARGO_HOME` gives the worktree its own cargo registry/cache and (most importantly) its own `.package-cache` lock — without this, two concurrent `cargo test` invocations across worktrees serialize on `~/.cargo/registry/.package-cache` and one will block until the other finishes downloading or resolving.
 
-A `bin/dev` wrapper, `scripts/dev-env.sh`, and `just dev-*` recipes that bake all three in are planned but not yet committed — until they land, set the env vars explicitly in worktrees, or `direnv allow` an `.envrc` that exports them.
+Three things are committed to make this convenient:
+
+- **`scripts/dev-env.sh`** exports all three vars (resolved relative to the worktree root, so it works from any subdir). Source it once at the top of a shell: `source scripts/dev-env.sh`.
+- **`bin/dev`** is a wrapper that sources `scripts/dev-env.sh` and execs `cargo run --quiet -- "$@"`. Use it for any one-off `mvmctl` call: `bin/dev template build`, `bin/dev exec ...`.
+- **`just dev-test` / `just dev-clippy` / `just dev-check`** invoke cargo with the env sourced.
+- **`.envrc.example`** sources `scripts/dev-env.sh` for direnv users (`cp .envrc.example .envrc && direnv allow`).
 
 ### What still collides between worktrees
 
@@ -114,7 +119,7 @@ cp .envrc.example .envrc
 direnv allow
 ```
 
-This is a convenience, not a requirement. Once the `bin/dev` / `just dev-*` wrappers land, those will be the default; until then, set `MVM_DATA_DIR` inline as shown above.
+This is a convenience for users who already have direnv installed; the `bin/dev` / `just dev-*` wrappers work without it.
 
 ### Cleaning up
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ All Nix builds, Firecracker operations, `mvmctl` runtime commands (anything that
 
 **Run cargo on the macOS host wherever it compiles cleanly.** `cargo test`, `cargo check`, and `cargo build` should default to the host so worktrees don't deadlock on the single shared Lima VM (cargo target-dir contention, registry locks, and `.git/index` cross-mount races are real and have caused us to lose work). Tests that genuinely need Linux — vsock, jailer/seccomp, dm-verity, network namespaces, anything that pokes at `/dev/kvm` or `/proc/net` — should be gated with `#[cfg(target_os = "linux")]` and only those sub-targets are run inside Lima. Workspace-wide `cargo clippy --workspace --all-targets -- -D warnings` is still expected to pass inside Lima before merge, since clippy needs to see the Linux-gated code paths.
 
-**git always runs on the macOS host, never inside Lima.** The repo is shared with the Lima VM via 9p/virtiofs and the two sides do not share git's lock semantics — running `git` from inside Lima while another worktree is also doing git work on the host produces "unable to write new index file" deadlocks. Only cargo/nix/firecracker/mvmctl operations cross into the VM.
+**git only runs from the main `mvm/` checkout, never from inside a worktree directory and never from inside Lima.** The main checkout is the single git operator for the whole repo. To act on a worktree's branch, use `git -C /path/to/mvm-<slug> <cmd>` from the main checkout — that drives the worktree's index/HEAD/refs while keeping the running git process anchored at the main checkout. Reasons: (1) only one git process at a time touches `.git/objects`, `.git/packed-refs`, and the shared `.git/hooks/` invocation context, eliminating the cross-worktree contention that has caused us to lose work; (2) the 9p/virtiofs share with Lima does not share git's lock semantics, so git from inside Lima deadlocks against host-side git. Cargo/nix/firecracker/mvmctl commands still run from each worktree's own directory — only `git` is centralized.
 
 If the Lima VM is not running, boot it with:
 
@@ -36,16 +36,41 @@ Examples:
 
 ## Worktree Workflow for Features
 
-Every feature, refactor, or non-trivial bug fix MUST be developed in a git worktree, never on the main checkout. This isolates in-flight work from the main checkout's `~/.mvm` registry, build cache, and dev VM state.
+Every feature, refactor, or non-trivial bug fix is developed in a git worktree — code edits and cargo invocations happen inside the worktree directory. Git operations (status, add, commit, stash, rebase, push, fetch, pull, hook execution) happen from the main `mvm/` checkout, with `-C` pointing at the worktree when needed. The main checkout is the single git operator; worktree directories are code+build sandboxes only.
 
 ### Creating the worktree
 
+From the main `mvm/` checkout:
+
 ```bash
+cd /Users/auser/work/personal/microvm/kv/mvm
 git worktree add ../mvm-<feature-slug> -b feat/<feature-slug>
+```
+
+Then switch terminals/agents into the worktree directory for code work:
+
+```bash
 cd ../mvm-<feature-slug>
+# edit code, run cargo, run mvmctl from here
 ```
 
 Branch names follow the existing pattern (`feat/<slug>`, `fix/<slug>`, `chore/<slug>`).
+
+### Doing git work for a worktree
+
+Always from the main `mvm/` checkout, with `-C` pointing at the worktree:
+
+```bash
+cd /Users/auser/work/personal/microvm/kv/mvm
+git -C ../mvm-<feature-slug> status
+git -C ../mvm-<feature-slug> add path/to/file
+git -C ../mvm-<feature-slug> commit -m "..."
+git -C ../mvm-<feature-slug> push -u origin feat/<feature-slug>
+```
+
+This serializes all git activity through one process and keeps `.git/objects`, `.git/packed-refs`, and the hooks dir from being touched by multiple agents at once. The pre-commit hook fires once per commit, in the main checkout — no concurrent-hook fan-out.
+
+Agents working inside a worktree directory should not invoke `git` directly. If you need git state, ask the operator at the main checkout, or run a read-only `git -C <main-checkout> status` if you must.
 
 ### Isolating mutable state
 
@@ -68,7 +93,7 @@ A `bin/dev` wrapper, `scripts/dev-env.sh`, and `just dev-*` recipes that bake al
 
 Even with per-worktree isolation, a few resources are shared and can cause concurrent commands to interfere:
 
-- **`.git/objects/`, `.git/packed-refs`, and the shared hooks dir.** Each `git worktree add` directory has its own index, HEAD, and refs (in `.git/worktrees/<name>/`), but the object store and packed refs are one set. Concurrent `git status` is fine (read-only); concurrent `git stash`, `git commit`, and especially `git rebase` from multiple worktrees can race on `.git/packed-refs` and the shared `.git/hooks/` invocation context. Don't run heavy hooks (full `cargo test --workspace`) on every commit — the pre-commit hook should be limited to formatting + fast checks.
+- **`.git/objects/`, `.git/packed-refs`, and the shared hooks dir.** Each `git worktree add` directory has its own index, HEAD, and refs (in `.git/worktrees/<name>/`), but the object store, packed refs, and hooks dir are one set. The "git only runs from the main checkout" rule (see the top of this doc) is what keeps these from colliding — never bypass it. Even with that rule, the pre-commit hook still gets invoked on every commit, so keep it limited to formatting + fast checks; don't run a full `cargo test --workspace` from inside a hook.
 - **The Lima VM's `/var/lib/mvm/`, `br-mvm` bridge, and TAP devices.** Vary microVM and TAP names between worktrees if you need two microVMs running at the same time.
 - **The Nix store inside Lima.** This is shared by design (warm cache) and Nix's own locking handles it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,12 +87,14 @@ CARGO_HOME="$PWD/.mvm-test/cargo"  \
 - `CARGO_TARGET_DIR` gives the worktree its own `target/` so two worktrees compiling at once don't fight over output paths or rustc invocation locks.
 - `CARGO_HOME` gives the worktree its own cargo registry/cache and (most importantly) its own `.package-cache` lock — without this, two concurrent `cargo test` invocations across worktrees serialize on `~/.cargo/registry/.package-cache` and one will block until the other finishes downloading or resolving.
 
-Three things are committed to make this convenient:
+Four things are committed to make this convenient:
 
 - **`scripts/dev-env.sh`** exports all three vars (resolved relative to the worktree root, so it works from any subdir). Source it once at the top of a shell: `source scripts/dev-env.sh`.
 - **`bin/dev`** is a wrapper that sources `scripts/dev-env.sh` and execs `cargo run --quiet -- "$@"`. Use it for any one-off `mvmctl` call: `bin/dev template build`, `bin/dev exec ...`.
 - **`just dev-test` / `just dev-clippy` / `just dev-check`** invoke cargo with the env sourced.
 - **`.envrc.example`** sources `scripts/dev-env.sh` for direnv users (`cp .envrc.example .envrc && direnv allow`).
+
+One-time per clone: run `just install-hooks` from the main checkout to point `core.hooksPath` at `.githooks/`. The committed pre-commit hook (`.githooks/pre-commit`) is intentionally light — it formats Rust code and checks Nix formatting, nothing else — so it doesn't block worktree workflows. Heavy gates (workspace clippy, full tests, supply-chain checks) run in CI.
 
 ### What still collides between worktrees
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,21 +45,22 @@ Branch names follow the existing pattern (`feat/<slug>`, `fix/<slug>`, `chore/<s
 
 ### Isolating mutable state
 
-Worktrees share `~/.mvm`, `~/.cache/mvm`, the Lima VM, and any pushed registries with the main checkout. Use the `bin/dev` wrapper or the `just dev-*` recipes for any `mvmctl` invocation in a worktree — they source `scripts/dev-env.sh`, which redirects `mvmctl`'s data dir into the worktree (`MVM_DATA_DIR="$PWD/.mvm-test"`) and silences the legacy-banner.
-
-Examples:
+Worktrees share `~/.mvm`, `~/.cache/mvm`, the Lima VM, and any pushed registries with the main checkout. Per-worktree isolation is achieved by overriding `mvmctl`'s data dir for the duration of a command:
 
 ```bash
-bin/dev template build              # equivalent to: cargo run --quiet -- template build
-just dev-test                       # cargo test --workspace with the dev env
-just dev-clippy                     # cargo clippy with the dev env
+MVM_DATA_DIR="$PWD/.mvm-test" cargo run --quiet -- template build
+MVM_DATA_DIR="$PWD/.mvm-test" cargo test --workspace
 ```
 
-The dev env files are committed; new contributors get the right behaviour with no setup.
+A `bin/dev` wrapper, `scripts/dev-env.sh`, and `just dev-*` recipes that bake this in are planned but not yet committed — until they land, set `MVM_DATA_DIR` explicitly in worktrees.
 
 ### Lima VM sharing
 
-The Lima VM (`mvm-builder`) is shared across worktrees by design — it's expensive to boot and Nix builds benefit from a warm store. The data-dir override above keeps `mvmctl`'s per-feature state isolated; Nix store reuse is intentional.
+The Lima VM (`mvm-builder`) is shared across worktrees by design — **never fork it per worktree**. It is expensive to boot, and the Nix store inside it is the warm cache that makes builds fast; a per-worktree VM would duplicate tens of GB of store, re-download the kernel/rootfs, and multiply boot time with no isolation benefit. There is also no second VM name baked into the codebase: `mvmctl`, the `Justfile`, CI, and AGENTS.md examples all hard-code `mvm-builder`, and `RuntimeBuildEnv` / `run_on_vm` route through `mvm_runtime::config::VM_NAME`.
+
+The `MVM_DATA_DIR` override is what isolates per-feature state — templates, sockets, the microVM registry, snapshots, signing keys. Anything that would otherwise land in `~/.mvm` ends up under the worktree.
+
+State that *does* live inside the shared Lima VM (`/var/lib/mvm/`, the `br-mvm` bridge, TAP devices, in-flight microVMs) is the only collision surface between worktrees. If two worktrees need to run microVMs concurrently, give them distinct microVM and TAP names — do not spin up a second Lima VM.
 
 ### Optional: direnv
 
@@ -70,7 +71,7 @@ cp .envrc.example .envrc
 direnv allow
 ```
 
-This is a convenience, not a requirement. The wrapper script path (`bin/dev` / `just dev-*`) works for everyone with no additional tools.
+This is a convenience, not a requirement. Once the `bin/dev` / `just dev-*` wrappers land, those will be the default; until then, set `MVM_DATA_DIR` inline as shown above.
 
 ### Cleaning up
 

--- a/Justfile
+++ b/Justfile
@@ -12,11 +12,11 @@ default:
 
 # ── Development ──────────────────────────────────────────────────────────
 
-# One-time setup: point git at the committed .githooks/ dir so the
-# lightweight pre-commit hook (cargo fmt + nix fmt --check) actually runs.
-# Without this, git falls back to .git/hooks/pre-commit, which may be a
-# stale local copy or the legacy heavy hook.
+# Wire core.hooksPath at .githooks/ (one-time per clone)
 install-hooks:
+    # Without this, git falls back to .git/hooks/pre-commit, which may
+    # be a stale local copy or the legacy heavy hook. .githooks/pre-commit
+    # is intentionally light (cargo fmt + nix fmt --check).
     git config core.hooksPath .githooks
     @echo "core.hooksPath -> .githooks/"
 

--- a/Justfile
+++ b/Justfile
@@ -12,6 +12,14 @@ default:
 
 # ── Development ──────────────────────────────────────────────────────────
 
+# One-time setup: point git at the committed .githooks/ dir so the
+# lightweight pre-commit hook (cargo fmt + nix fmt --check) actually runs.
+# Without this, git falls back to .git/hooks/pre-commit, which may be a
+# stale local copy or the legacy heavy hook.
+install-hooks:
+    git config core.hooksPath .githooks
+    @echo "core.hooksPath -> .githooks/"
+
 # Build all crates (debug)
 build:
     cargo build --workspace

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -1,6 +1,39 @@
 #!/usr/bin/env bash
-# Source this to enter the dev env for a worktree.
-# Sets MVM_DATA_DIR to a worktree-local directory so mvmctl's
-# registry/cache writes don't stomp on the main checkout.
-export MVM_DATA_DIR="${MVM_DATA_DIR:-$PWD/.mvm-test}"
-export MVM_NO_LEGACY_BANNER=1
+# scripts/dev-env.sh — per-worktree env for mvm.
+#
+# Source from the worktree root to isolate mvmctl + cargo state from
+# the main checkout and from other worktrees:
+#
+#   source scripts/dev-env.sh
+#
+# What it sets:
+#   MVM_DATA_DIR       mvmctl templates, sockets, microVM registry,
+#                      snapshots, signing keys land under
+#                      $WORKTREE/.mvm-test instead of ~/.mvm.
+#   CARGO_TARGET_DIR   cargo target output goes to
+#                      $WORKTREE/.mvm-test/target so two worktrees
+#                      don't fight on output paths.
+#   CARGO_HOME         cargo registry/cache + .package-cache lock are
+#                      per-worktree. Without this, concurrent
+#                      `cargo test` invocations across worktrees
+#                      serialize on ~/.cargo/registry/.package-cache
+#                      and one blocks until the other completes
+#                      dependency resolution.
+#   MVM_NO_LEGACY_BANNER silences the legacy `mvm` Lima VM warning
+#                      so worktrees don't spam it on every command.
+#
+# Wrappers (`bin/dev`) and recipes (`just dev-*`) source this file.
+# direnv users: `cp .envrc.example .envrc && direnv allow`.
+
+# Resolve the worktree root so this works regardless of caller CWD.
+__mvm_dev_env_root="${BASH_SOURCE[0]:-$0}"
+__mvm_dev_env_root="$(cd "$(dirname "$__mvm_dev_env_root")/.." && pwd)"
+
+export MVM_DATA_DIR="${MVM_DATA_DIR:-$__mvm_dev_env_root/.mvm-test}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$__mvm_dev_env_root/.mvm-test/target}"
+export CARGO_HOME="${CARGO_HOME:-$__mvm_dev_env_root/.mvm-test/cargo}"
+export MVM_NO_LEGACY_BANNER="${MVM_NO_LEGACY_BANNER:-1}"
+
+mkdir -p "$MVM_DATA_DIR" "$CARGO_TARGET_DIR" "$CARGO_HOME"
+
+unset __mvm_dev_env_root


### PR DESCRIPTION
## Summary

Two related changes that fell out of debugging a multi-worktree deadlock during today's parallel-agent work:

- **Documentation rules** (4 commits) — sharpen the worktree contract in `AGENTS.md`:
  - Lima VM is shared across worktrees by design; never fork it.
  - `cargo test` / `check` / `build` default to the macOS host (only Linux-gated tests + workspace clippy go through Lima).
  - Per-worktree isolation requires `MVM_DATA_DIR` + `CARGO_TARGET_DIR` + `CARGO_HOME`; the third is the load-bearing fix (without it, concurrent `cargo test` runs serialize on `~/.cargo/registry/.package-cache`).
  - All `git` runs from the main `mvm/` checkout (`git -C ../mvm-<slug>` to act on a worktree's branch). Centralizing git eliminates contention on `.git/objects`, `.git/packed-refs`, and the shared hooks invocation context.

- **Tooling to make the rules cheap to follow** (3 commits):
  - `scripts/dev-env.sh` now exports the full env triple (resolved relative to the worktree root). `bin/dev` and `.envrc.example` already in place from PR #29 just become useful.
  - `.githooks/pre-commit` cut from a heavy clippy + nextest + cargo-deny + cargo-audit + nix fmt run to just `cargo fmt --all` (when `*.rs` is staged) and `nix fmt --check` (when `*.nix` is staged and Nix is installed). The previous hook couldn't pass on a macOS host and amplified worktree contention. Heavy gates run in CI.
  - `just install-hooks` recipe + AGENTS.md note to wire `core.hooksPath` to `.githooks/` once per clone — without this the source-of-truth hook in `.githooks/` is dead code.

## Test plan

- [ ] CI green (workflow concurrency block from PR #32 should keep this from churning prior failed runs).
- [ ] After merge: `git config core.hooksPath` already points at `.githooks/` here; new clones run `just install-hooks` to get the same.
- [ ] After merge: try a parallel `cargo test` from two worktrees, confirm no `.package-cache` serialization and no `.git/index.lock` stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)