### PR TITLE
docs(sprint-44): add §C0 housekeeping + §C5 L7 feature-gate

### DIFF
--- a/specs/plans/35-post-w3-cleanup.md
+++ b/specs/plans/35-post-w3-cleanup.md
@@ -48,6 +48,39 @@ verify* in CI. Specifically:
 
 ## Sub-items
 
+### C0 — Carryover housekeeping
+
+W7.1 from sprint 42's plan 31 left
+`nix/images/examples/{paperclip,openclaw}/` undeleted because
+the sandbox blocked `git rm` twice (recorded at sprint 42's
+SPRINT.md note for W7.1). Close it now.
+
+```bash
+git rm -r nix/images/examples/paperclip nix/images/examples/openclaw
+```
+
+Audit `nix/images/examples/flake.nix` (or per-example
+`flake.nix` files) for dangling references after the deletion;
+remove or update them so `nix flake check` stays green on the
+remaining examples.
+
+**Files**
+
+- `nix/images/examples/paperclip/` — full deletion.
+- `nix/images/examples/openclaw/` — full deletion.
+- Any aggregator flake that references these examples — drop
+  the now-dangling entries.
+
+**Tests**
+
+- `nix flake check` (in Lima) passes after deletion: no
+  dangling refs.
+- `git ls-files nix/images/examples/ | grep -E
+  '(paperclip|openclaw)'` returns nothing.
+
+**Estimate**: ½ hour. Smallest workstream in the sprint;
+slots in front of any other PR.
+
 ### C1 — init-script defects exposed by W3 live boot
 
 Two unrelated bugs surfaced in the same boot session:
@@ -183,6 +216,20 @@ Lima as part of `just w3-live-test` (see C4).
 preserved across snapshot — that's the investigation we owe
 upfront.
 
+**Investigation cap (1 day).** dm-verity-across-snapshot
+behaviour is undocumented in the firecracker-microvm spec; we
+won't know until we test. Cap the investigation at 1 day:
+
+- If dm-state IS preserved → ship the regression test +
+  runbook §6, close C2.
+- If NOT → file a follow-up plan for the in-rootfs recovery
+  handler (post-restore vsock RPC re-applies the verity
+  target), defer recovery code to sprint 45+, ship a
+  "verity-not-supported-in-snapshots-yet" doc note in the
+  same PR.
+
+Without this cap, C2 can eat the whole sprint.
+
 ### C3 — Apple Container live-boot smoke
 
 `crates/mvm-apple-container/src/macos.rs::start_vm` calls
@@ -252,6 +299,15 @@ C4 ships option 2. The `security.yml` workflow gains a
 `live-verity-boot` lane that's skipped on standard runners but
 enforced on tagged self-hosted runners.
 
+**Soft-gate acceptance note.** Until a self-hosted KVM runner
+is provisioned, the `live-verity-boot` lane skips silently on
+public GitHub-hosted runners (`[ -e /dev/kvm ]` returns false).
+W3 regressions caught only by operator-run `just w3-live-test`
+inside Lima during that window. Document this gap inline in
+the workflow's comment header so future maintainers don't
+assume the lane is enforcing — a green PR with the lane
+"skipped" is not the same as a green PR with the lane "passed."
+
 **Bonus: A.2 v2 latency comparison**
 
 Sprint 43 deferred a "cold-boot vs warm-VM latency" test
@@ -280,22 +336,67 @@ end on any KVM-capable runner.
 
 **Estimate**: 1-2 days.
 
+### C5 — L7 egress feature-gate (PR #23 follow-up)
+
+PR #23 landed `EgressMode::L3PlusL7` + `EgressProxy` trait +
+`StubEgressProxy` in `main`. The runtime that makes the
+variant actually filter traffic is plan 34, sized as its own
+future sprint. Today the variant is selectable from `mvmctl
+up --egress-mode l3-plus-l7` and silently passes through —
+`StubEgressProxy::apply_network_policy` is a no-op. A user
+who reads `--help` and picks the variant assumes filtering;
+gets none. Visible footgun.
+
+Feature-gate it. Ship now to remove the visibility without
+blocking on plan 34's runtime work.
+
+**Files**
+
+- `crates/mvm-core/Cargo.toml`: add `l7-egress` Cargo feature
+  (default off).
+- `crates/mvm-core/src/policy/network_policy.rs`: gate
+  `EgressMode::L3PlusL7`, the `EgressProxy` trait export, and
+  the `StubEgressProxy` instance behind
+  `#[cfg(feature = "l7-egress")]`.
+- `crates/mvm-cli/src/commands/vm/up.rs`: when parsing
+  `--egress-mode`, emit a clear error message (pointing at
+  plan 34) if the user passes `l3-plus-l7` and the feature
+  is off. Don't silently fall back to `l3-only`.
+- Plan 34's first PR flips the feature on.
+
+**Tests**
+
+- `cargo build -p mvm-cli` (default features): compiles, and
+  `mvmctl up --help | grep -F 'l3-plus-l7'` produces no output.
+- `cargo build -p mvm-cli --features l7-egress`: compiles,
+  and `mvmctl up --help` shows the variant.
+- CLI integration test (`crates/mvm-cli/tests/cli.rs` or
+  similar): with the default feature set, passing
+  `--egress-mode l3-plus-l7` returns an error whose message
+  contains `plan 34`.
+
+**Estimate**: ½ day.
+
 ## Sequencing
 
-C1 → C2 → C3 ‖ C4. C1 unblocks the rest by making the boot
-log noise-free; C2 has investigation depth that may extend the
-sprint; C3 is the lightest item and slots in opportunistically;
-C4 is independent and can land first or last.
+C0 → C1 → C2 → C3 ‖ C4 ‖ C5. C0 is the smallest workstream
+(½ hour) and slots in front. C1 unblocks the rest by making
+the boot log noise-free; C2 has investigation depth that may
+extend the sprint; C3 is the lightest of the verity-side
+items; C4 + C5 are independent and can land in any order
+relative to the boot-side workstreams.
 
 PR sequence:
 
-1. **PR-A**: C1 (init-script defects). Single PR, both fixes.
-2. **PR-B**: C2 (snapshot/restore parity). Includes a new
-   integration test + runbook §6.
-3. **PR-C**: C3 (Apple Container live-boot smoke). Tiny PR;
-   could be folded into PR-B if both are small.
-4. **PR-D**: C4 (live-KVM regression automation). Self-
+1. **PR-A**: C0 (housekeeping deletion). Tiny PR.
+2. **PR-B**: C1 (init-script defects). Single PR, both fixes.
+3. **PR-C**: C2 (snapshot/restore parity). New integration
+   test + runbook §6.
+4. **PR-D**: C3 (Apple Container live-boot smoke). Tiny PR;
+   could be folded into PR-C if both are small.
+5. **PR-E**: C4 (live-KVM regression automation). Self-
    contained.
+6. **PR-F**: C5 (L7 egress feature-gate). Self-contained.
 
 ## Out-of-sprint follow-ups (parked, not blocked on this sprint)
 

--- a/specs/plans/35-sprint-44-draft.md
+++ b/specs/plans/35-sprint-44-draft.md
@@ -47,6 +47,22 @@ The whole sprint is ~1 week of work and 4 small PRs.
 
 ## In-flight workstreams
 
+### C0 — Carryover housekeeping  🟡
+
+Plan: [`plans/35-post-w3-cleanup.md`](plans/35-post-w3-cleanup.md) §C0.
+½ hour, smallest PR; lands in front of everything else.
+
+- [ ] **C0.1** `git rm -r nix/images/examples/{paperclip,openclaw}/`
+      (W7.1 sandbox-blocked deletion from sprint 42's plan 31).
+- [ ] **C0.2** Audit `nix/images/examples/flake.nix` (or per-
+      example flake aggregator) for dangling references to the
+      deleted directories; remove or update so `nix flake check`
+      stays green.
+
+**Done when**: `git ls-files nix/images/examples/ | grep -E
+'(paperclip|openclaw)'` returns nothing and `nix flake check`
+on the remaining examples passes.
+
 ### C1 — Init-script defects exposed by W3 live boot  🟡
 
 Plan: [`plans/35-post-w3-cleanup.md`](plans/35-post-w3-cleanup.md) §C1.
@@ -127,28 +143,54 @@ Plan: [`plans/35-post-w3-cleanup.md`](plans/35-post-w3-cleanup.md) §C4.
 **Done when**: `just w3-live-test` exits 0 on Lima; CI lane
 skips cleanly on public runners.
 
+### C5 — L7 egress feature-gate (PR #23 follow-up)  🟡
+
+Plan: [`plans/35-post-w3-cleanup.md`](plans/35-post-w3-cleanup.md) §C5.
+½ day, 1 PR.
+
+- [ ] **C5.1** Add `l7-egress` Cargo feature to
+      `crates/mvm-core/Cargo.toml` (default off).
+- [ ] **C5.2** Gate `EgressMode::L3PlusL7` + `EgressProxy`
+      trait export + `StubEgressProxy` instance behind
+      `#[cfg(feature = "l7-egress")]`.
+- [ ] **C5.3** CLI parser in `crates/mvm-cli/src/commands/vm/up.rs`
+      rejects `--egress-mode l3-plus-l7` with a clear error
+      pointing at plan 34 when feature off.
+
+**Done when**: default `cargo build` doesn't expose
+`l3-plus-l7` in `mvmctl up --help`; `--features l7-egress`
+build does; default-build CLI rejection error contains
+"plan 34". Removes the user-visible footgun PR #23 left
+behind without blocking on plan 34's runtime backing.
+
 ## Success criteria
 
 By sprint close:
 
-1. ✅ Verity-enabled template boots cleanly with no init-script
+1. ✅ Sprint 42's W7.1 paperclip/openclaw deletion closed (C0).
+2. ✅ Verity-enabled template boots cleanly with no init-script
    warnings on console (C1).
-2. ✅ Snapshot/restore round-trip works for verity VMs (C2).
-3. ✅ Apple Container live boot of a verity template succeeds
+3. ✅ Snapshot/restore round-trip works for verity VMs (C2).
+4. ✅ Apple Container live boot of a verity template succeeds
    on macOS (C3).
-4. ✅ `just w3-live-test` exits 0 in Lima end-to-end (C4).
-5. ✅ Sprint 42 archived to `specs/backlog/42-microvm-hardening.md`.
+5. ✅ `just w3-live-test` exits 0 in Lima end-to-end (C4).
+6. ✅ L7 egress variant feature-gated; user can't silently pick
+   the no-op stub (C5).
+7. ✅ Sprint 42 archived to `specs/backlog/42-microvm-hardening.md`.
 
 ## Phasing
 
 PRs are independently mergeable. Suggested order:
 
-1. **PR-A**: C1 (init-script defects). Single PR, smallest.
-2. **PR-B**: C2 (snapshot/restore parity). Investigation may
+1. **PR-A**: C0 (housekeeping deletion). Tiny PR, lands first.
+2. **PR-B**: C1 (init-script defects). Single PR, both fixes.
+3. **PR-C**: C2 (snapshot/restore parity). Investigation may
    extend; ship the test + runbook entry, defer the
    `PostRestore` recovery handler if needed.
-3. **PR-C**: C3 (Apple Container smoke). Foldable.
-4. **PR-D**: C4 (live-KVM regression automation). Self-contained.
+4. **PR-D**: C3 (Apple Container smoke). Foldable into PR-C.
+5. **PR-E**: C4 (live-KVM regression automation).
+   Self-contained.
+6. **PR-F**: C5 (L7 egress feature-gate). Self-contained.
 
 ## Carryover from earlier sprints
 
@@ -160,7 +202,6 @@ but still need a home:
 | L7 egress runtime backing (mitmdump + CA + DNS pinning) | Sprint 43, [`plans/34-egress-l7-proxy.md`](plans/34-egress-l7-proxy.md) | Own sprint (already sized) |
 | Hosted MCP transport (HTTP/SSE) | Sprint 43, [`plans/33-hosted-mcp-transport.md`](plans/33-hosted-mcp-transport.md) | Cross-repo (mvmd) |
 | `mkNodeService` → `pkgs.buildNpmPackage` swap | Sprint 42 W7.4 deferred | Own follow-up; needs hello-node validation |
-| `nix rm` of `nix/images/examples/{paperclip,openclaw}/` | Sprint 42 W7.1 deferred (sandbox-blocked) | Manual `git rm` (½ hour) |
 
 ## Non-goals (named explicitly)
 


### PR DESCRIPTION
## Summary

Two new sprint-44 workstreams + tightening notes on two existing ones.

- **§C0** — close out W7.1's deletion of `nix/images/examples/{paperclip,openclaw}/` (sandbox-blocked twice in plan 31). One-line `git rm`, smallest sprint-44 PR.
- **§C5** — feature-gate `EgressMode::L3PlusL7` behind a default-off `l7-egress` Cargo feature in `mvm-core`. Removes the user-visible footgun PR #23 left behind: today the CLI accepts `--egress-mode l3-plus-l7` and silently routes traffic through `StubEgressProxy` (no-op). Plan 34's first PR flips the feature on alongside the runtime backing.
- **§C2** — investigation budget cap (1 day). dm-verity-across-snapshot behaviour is undocumented; if dm-state isn't preserved, ship a doc note and defer the post-restore recovery handler to sprint 45+ rather than letting C2 eat the whole sprint.
- **§C4** — soft-gate acceptance note. Documents inline that the `live-verity-boot` CI lane skips on public runners until self-hosted KVM exists; W3 regressions caught only by operator-run \`just w3-live-test\` during that window.

Sprint 44 phasing updates from 4 PRs (A-D) to 6 PRs (A-F). Carryover-table row for paperclip/openclaw removed (covered by C0).

Docs-only — no Rust, no Nix evaluation impact. \`nix flake check\` and \`cargo build\` unaffected.

## Out of scope

- The L7 runtime work (plan 34) — separate sprint.
- Two pre-existing failures on \`main\` surfaced during local verification: clippy 1.94's \`unnecessary_cast\` flags ~171 \`libc::SYS_*\` casts in \`crates/mvm-guest/src/bin/mvm-seccomp-apply.rs\`, and \`cargo test --workspace\` fails 2 download-tests in \`mvm-build::pipeline::build\`. Neither is caused by this PR; both deserve their own fix-up.

## Test plan

- [ ] \`grep -c '^### C0' specs/plans/35-post-w3-cleanup.md\` returns 1.
- [ ] \`grep -c '^### C5' specs/plans/35-post-w3-cleanup.md\` returns 1.
- [ ] Sprint-44 draft workstream list has C0 + C5 entries.
- [ ] Carryover table no longer mentions paperclip/openclaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)