### PR TITLE
fix(pre-commit): point cargo-audit at separate advisory-db path

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -66,7 +66,14 @@ fi
 
 if command -v cargo-audit >/dev/null 2>&1; then
     echo "Running cargo-audit..."
-    if ! cargo audit; then
+    # cargo-deny (above) and cargo-audit both default to
+    # `~/.cargo/advisory-db`, but they store in incompatible layouts
+    # (cargo-deny uses a content-addressed `advisory-db-<hash>/`
+    # subdir; cargo-audit clones flat at the root). When cargo-deny
+    # runs first and populates the dir, cargo-audit refuses with
+    # "Refusing to initialize the non-empty directory".
+    # Point cargo-audit at its own path to break the conflict.
+    if ! cargo audit --db "$HOME/.cargo/cargo-audit-db"; then
         echo "cargo-audit failed!"
         exit 1
     fi


### PR DESCRIPTION
## Summary

Fixes a latent conflict in the pre-commit hook: `cargo-deny` and `cargo-audit` both default to `~/.cargo/advisory-db`, but they use incompatible layouts:

- **cargo-deny** clones into a content-addressed `advisory-db-<hash>/` subdir at that path.
- **cargo-audit** clones flat at the root of the path.

When the hook runs cargo-deny first (populating the dir with its subdir), cargo-audit then refuses:

```
error: couldn't fetch advisory database: git operation failed: failed to prepare clone
Caused by:
  -> Refusing to initialize the non-empty directory as '/Users/auser/.cargo/advisory-db'
cargo-audit failed!
```

Pass `--db ~/.cargo/cargo-audit-db` to cargo-audit so it owns its own path. cargo-deny keeps its existing default. Both pull from the same RustSec repo; only cost is a one-time extra clone the first time the hook runs post-merge.

## Why now

Hit this when committing an unrelated `chore/mvm-mcp-orphan-cleanup` branch — every commit was failing on the same shared-state conflict. PR follow-up #N will land the orphan cleanup once this is in.

## Worktree

Per AGENTS.md, developed at `../mvm-pre-commit-hook-fix/` on branch `chore/pre-commit-hook-advisory-db-fix`.

## --no-verify justification

The fix commit itself was made with `--no-verify` because **the hook being fixed is the broken thing we're fixing** — chicken-and-egg. Subsequent commits will run the fixed hook normally. This is the documented exception in the project rules.

## Test plan

- [ ] CI green (CI doesn't run the local pre-commit hook, so CI shouldn't be affected)
- [ ] **Local validation**: `git commit` on a follow-up branch with both `cargo-deny` and `cargo-audit` installed should run cleanly through both lanes without the directory conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)