### PR TITLE
feat(mvm-cli): mvmctl invoke — plan 41 W3

### DIFF
--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -99,6 +99,15 @@ pub(in crate::commands) enum Commands {
     /// `mvmctl exec` flags. Alternatively, pass `--launch-plan ./launch.json` to invoke an
     /// mvmforge-emitted entrypoint instead of an inline argv.
     Exec(vm::exec::Args),
+    /// Boot a microVM and call its baked entrypoint (production-safe).
+    ///
+    /// Distinct from `mvmctl exec` (dev-only, arbitrary shell). `invoke` dispatches the
+    /// `RunEntrypoint` vsock verb, which the guest agent serves only by spawning the
+    /// program named in `/etc/mvm/entrypoint`. No shell, no argv override, no env
+    /// injection beyond what the wrapper template defined at image build time. Stdin
+    /// from `--stdin <PATH>` (or `-` for mvmctl's own stdin); stdout/stderr stream back
+    /// to mvmctl's own streams. ADR-007 / plan 41.
+    Invoke(vm::invoke::Args),
     /// Speak Model Context Protocol — exposes mvmctl as a sandbox surface for LLM clients.
     ///
     /// Single parameterized `run` tool whose `env` parameter selects from `mvmctl template list`.
@@ -208,6 +217,7 @@ pub fn run() -> Result<()> {
         Commands::Cache(a) => ops::cache::run(&cli, a, &cfg),
         Commands::Init(a) => env::init::run(&cli, a, &cfg),
         Commands::Exec(a) => vm::exec::run(&cli, a, &cfg),
+        Commands::Invoke(a) => vm::invoke::run(&cli, a, &cfg),
         Commands::Mcp(a) => ops::mcp::run(&cli, a, &cfg),
     };
 

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -1,0 +1,283 @@
+//! `mvmctl invoke` — boot a microVM and call its baked entrypoint.
+//!
+//! ADR-007 / plan 41 W3.
+//!
+//! Distinct from `mvmctl exec` (dev-only, arbitrary shell). `invoke`
+//! is the production-safe call surface — it dispatches the
+//! `RunEntrypoint` vsock verb, which the guest agent serves only by
+//! spawning the program named in `/etc/mvm/entrypoint`. There is no
+//! shell, no argv override, and no env injection beyond what the
+//! wrapper template defined at image build time.
+//!
+//! v1 behaviour:
+//!   - boots a transient microVM from a registered template,
+//!   - waits for the guest agent,
+//!   - reads stdin from a file (`-` = mvmctl's own stdin, default empty),
+//!   - sends `GuestRequest::RunEntrypoint`,
+//!   - streams `EntrypointEvent::Stdout` / `Stderr` events back to
+//!     mvmctl's own stdout / stderr as they arrive,
+//!   - tears the VM down,
+//!   - exits with the wrapper's exit code (or non-zero on error).
+//!
+//! `--fresh` and `--reset` are accepted but informational in v1 — the
+//! current behaviour matches `--fresh` (no warm session reuse). When
+//! the session-pool plan lands, the default flips to "reuse warm VM"
+//! and `--fresh` becomes the opt-out for callers who need a clean
+//! VM per call.
+
+use std::io::{Read, Write};
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+use crate::ui;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Template (or pre-built manifest) to boot. Resolves the same way
+    /// as `mvmctl exec --manifest <ARG>` (registered name, manifest
+    /// path, or manifest directory). Required for v1; warm-session
+    /// reuse and arbitrary VM-name targeting come with the
+    /// session-pool plan.
+    #[arg(value_name = "MANIFEST")]
+    pub manifest: String,
+
+    /// Path to stdin payload, or `-` for mvmctl's own stdin. Default:
+    /// no stdin (the wrapper sees an empty pipe).
+    #[arg(long, value_name = "PATH")]
+    pub stdin: Option<String>,
+
+    /// Wall-clock timeout for the call, in seconds. Default 30.
+    #[arg(long, default_value = "30")]
+    pub timeout: u64,
+
+    /// vCPU count for the booted VM. Default 2.
+    #[arg(long, default_value = "2")]
+    pub cpus: u32,
+
+    /// Memory for the booted VM (MiB). Default 512.
+    #[arg(long, default_value = "512")]
+    pub memory_mib: u32,
+
+    /// Boot a fresh transient VM, run the call, tear down (the v1
+    /// default — wired explicitly so future versions can flip the
+    /// default to warm-session reuse without breaking scripts).
+    #[arg(long, conflicts_with = "reset")]
+    pub fresh: bool,
+
+    /// Restore the session VM from its post-boot snapshot before the
+    /// next call. Wired but no-op in v1; lands with the session-pool
+    /// plan.
+    #[arg(long)]
+    pub reset: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    if args.reset {
+        ui::warn(
+            "--reset is wired but no-op in this build (session-pool plan); \
+             treating as default behaviour",
+        );
+    }
+
+    // v1: invoke targets a *template*. Resolve through the same shared
+    // helper as `mvmctl exec --manifest`. Slot-hash and registered-name
+    // both resolve to a string the lifecycle helpers consume.
+    let template_id = match super::shared::resolve_manifest_arg(&args.manifest)? {
+        super::shared::ManifestArgRef::Name(n) => n,
+        super::shared::ManifestArgRef::Slot { slot_hash } => slot_hash,
+    };
+
+    let stdin_bytes = read_stdin_payload(args.stdin.as_deref())?;
+
+    ui::info(&format!(
+        "invoke: booting transient VM for template '{template_id}'"
+    ));
+    let vm = crate::exec::boot_session_vm(&template_id, "invoke", args.cpus, args.memory_mib)
+        .context("Booting VM for invoke")?;
+
+    if !crate::exec::wait_for_agent(&vm.vm_name, 30) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            crate::exec::tear_down_session_vm(crate::exec::SessionVm {
+                vm_name: vm.vm_name.clone(),
+            })
+        }));
+        anyhow::bail!("guest agent did not become reachable within 30s");
+    }
+
+    // Run the call. We always tear down the VM after, even if dispatch
+    // fails — match `mvmctl exec` lifecycle so transient resources
+    // (TAPs, sockets, snapshot dirs) don't leak.
+    let dispatch_result = dispatch(&vm.vm_name, stdin_bytes, args.timeout);
+
+    // Tear down. Errors here are warned but not propagated — the
+    // call's exit code is what the caller cares about.
+    crate::exec::tear_down_session_vm(crate::exec::SessionVm {
+        vm_name: vm.vm_name.clone(),
+    });
+
+    match dispatch_result {
+        Ok(exit_code) => {
+            if exit_code != 0 {
+                std::process::exit(exit_code);
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Read the stdin payload for the call.
+///
+/// - `None`: empty payload.
+/// - `Some("-")`: read everything from mvmctl's own stdin.
+/// - `Some(path)`: read the file at `path`.
+fn read_stdin_payload(spec: Option<&str>) -> Result<Vec<u8>> {
+    match spec {
+        None => Ok(Vec::new()),
+        Some("-") => {
+            let mut buf = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut buf)
+                .context("Reading stdin from mvmctl's own stdin")?;
+            Ok(buf)
+        }
+        Some(path) => std::fs::read(path).with_context(|| format!("Reading stdin from {path}")),
+    }
+}
+
+/// Send the `RunEntrypoint` request and stream output back. Returns
+/// the wrapper's exit code, or a non-zero placeholder on agent-side
+/// errors. The placeholders reuse standard Unix conventions:
+/// `124` for timeout (matching `timeout(1)`), `137` for SIGKILL
+/// (8+9), `1` for everything else.
+fn dispatch(vm_name: &str, stdin: Vec<u8>, timeout_secs: u64) -> Result<i32> {
+    let mut stream =
+        mvm_apple_container::vsock_connect(vm_name, mvm_guest::vsock::GUEST_AGENT_PORT)
+            .map_err(|e| anyhow::anyhow!("Connecting to guest agent on '{vm_name}': {e}"))?;
+
+    let terminal = mvm_guest::vsock::send_run_entrypoint(
+        &mut stream,
+        stdin,
+        timeout_secs,
+        |event| match event {
+            mvm_guest::vsock::EntrypointEvent::Stdout { chunk } => {
+                let _ = std::io::stdout().write_all(chunk);
+            }
+            mvm_guest::vsock::EntrypointEvent::Stderr { chunk } => {
+                let _ = std::io::stderr().write_all(chunk);
+            }
+            // Terminal events are returned by send_run_entrypoint; the
+            // handler is only invoked for streaming chunks.
+            _ => {}
+        },
+    )
+    .context("Streaming RunEntrypoint response")?;
+
+    // Flush before potentially exiting.
+    let _ = std::io::stdout().flush();
+    let _ = std::io::stderr().flush();
+
+    Ok(exit_code_for(&terminal))
+}
+
+fn exit_code_for(event: &mvm_guest::vsock::EntrypointEvent) -> i32 {
+    use mvm_guest::vsock::{EntrypointEvent, RunEntrypointError};
+    match event {
+        EntrypointEvent::Exit { code } => *code,
+        EntrypointEvent::Error { kind, message } => {
+            let (code, label) = match kind {
+                RunEntrypointError::Timeout => (124, "timeout"),
+                RunEntrypointError::Busy => (1, "busy"),
+                RunEntrypointError::PayloadCap => (1, "payload cap exceeded"),
+                RunEntrypointError::WrapperCrashed => (137, "wrapper crashed"),
+                RunEntrypointError::EntrypointInvalid => (1, "entrypoint invalid"),
+                RunEntrypointError::InternalError => (1, "internal error"),
+            };
+            ui::warn(&format!("invoke: {label}: {message}"));
+            code
+        }
+        // Non-terminal events shouldn't reach this function — the
+        // streaming consumer only returns terminal events. Defensive:
+        // treat as internal error.
+        _ => {
+            ui::warn("invoke: dispatcher returned non-terminal event");
+            1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exit_code_normal_exit_zero() {
+        let evt = mvm_guest::vsock::EntrypointEvent::Exit { code: 0 };
+        assert_eq!(exit_code_for(&evt), 0);
+    }
+
+    #[test]
+    fn test_exit_code_normal_exit_preserves_nonzero() {
+        let evt = mvm_guest::vsock::EntrypointEvent::Exit { code: 7 };
+        assert_eq!(exit_code_for(&evt), 7);
+    }
+
+    #[test]
+    fn test_exit_code_timeout_maps_to_124() {
+        let evt = mvm_guest::vsock::EntrypointEvent::Error {
+            kind: mvm_guest::vsock::RunEntrypointError::Timeout,
+            message: "killed".into(),
+        };
+        assert_eq!(exit_code_for(&evt), 124);
+    }
+
+    #[test]
+    fn test_exit_code_wrapper_crash_maps_to_137() {
+        let evt = mvm_guest::vsock::EntrypointEvent::Error {
+            kind: mvm_guest::vsock::RunEntrypointError::WrapperCrashed,
+            message: "segfault".into(),
+        };
+        assert_eq!(exit_code_for(&evt), 137);
+    }
+
+    #[test]
+    fn test_exit_code_busy_payload_invalid_internal_all_map_to_1() {
+        use mvm_guest::vsock::RunEntrypointError as E;
+        for kind in [
+            E::Busy,
+            E::PayloadCap,
+            E::EntrypointInvalid,
+            E::InternalError,
+        ] {
+            let evt = mvm_guest::vsock::EntrypointEvent::Error {
+                kind,
+                message: "x".into(),
+            };
+            assert_eq!(exit_code_for(&evt), 1, "expected 1 for {kind:?}");
+        }
+    }
+
+    #[test]
+    fn test_read_stdin_none_is_empty() {
+        let bytes = read_stdin_payload(None).unwrap();
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn test_read_stdin_file_returns_contents() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"hello-stdin").unwrap();
+        let bytes = read_stdin_payload(Some(tmp.path().to_str().unwrap())).unwrap();
+        assert_eq!(bytes, b"hello-stdin");
+    }
+
+    #[test]
+    fn test_read_stdin_missing_file_errors() {
+        let err = read_stdin_payload(Some("/this/does/not/exist")).unwrap_err();
+        assert!(err.to_string().contains("Reading stdin from"));
+    }
+}

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -5,6 +5,7 @@ pub(super) mod diff;
 pub(super) mod down;
 pub(super) mod exec;
 pub(super) mod forward;
+pub(super) mod invoke;
 pub(super) mod logs;
 pub(super) mod ps;
 pub(super) mod up;

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -893,7 +893,7 @@ pub fn tear_down_session_vm(vm: SessionVm) {
     }
 }
 
-fn wait_for_agent(vm_name: &str, timeout_secs: u64) -> bool {
+pub fn wait_for_agent(vm_name: &str, timeout_secs: u64) -> bool {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
     while std::time::Instant::now() < deadline {
         if mvm_apple_container::vsock_connect(vm_name, mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -779,6 +779,48 @@ pub fn send_request(stream: &mut UnixStream, req: &GuestRequest) -> Result<Guest
     serde_json::from_slice(&buf).with_context(|| "Failed to deserialize response")
 }
 
+/// Send a `RunEntrypoint` request and consume the streaming
+/// `EntrypointEvent` response. ADR-007 / plan 41 W3.
+///
+/// `on_event` is invoked for each non-terminal event (`Stdout` /
+/// `Stderr` chunk) as it arrives — callers can stream output to their
+/// own stdout/stderr without buffering. Returns the terminal event
+/// (`Exit` or `Error`) for the caller to inspect.
+///
+/// The wire format is the same length-prefixed JSON envelope as every
+/// other vsock verb. v1 emits exactly three frames per call: one
+/// `Stdout`, one `Stderr`, and one terminal event. v2 may chunk
+/// progressively without changing this consumer — termination is
+/// detected via [`EntrypointEvent::is_terminal`], not frame count.
+pub fn send_run_entrypoint<F>(
+    stream: &mut UnixStream,
+    stdin: Vec<u8>,
+    timeout_secs: u64,
+    mut on_event: F,
+) -> Result<EntrypointEvent>
+where
+    F: FnMut(&EntrypointEvent),
+{
+    let req = GuestRequest::RunEntrypoint {
+        stdin,
+        timeout_secs,
+    };
+    write_frame(stream, &req)?;
+
+    loop {
+        let resp: GuestResponse = read_frame(stream)?;
+        let event = match resp {
+            GuestResponse::EntrypointEvent(e) => e,
+            GuestResponse::Error { message } => bail!("guest agent error: {message}"),
+            other => bail!("expected EntrypointEvent during RunEntrypoint stream, got {other:?}"),
+        };
+        if event.is_terminal() {
+            return Ok(event);
+        }
+        on_event(&event);
+    }
+}
+
 // ============================================================================
 // High-level API
 // ============================================================================
@@ -1985,6 +2027,181 @@ mod tests {
             read_authenticated_frame(&mut host_stream, &guest_vk, session_id, 0).unwrap();
         assert!(matches!(resp, GuestResponse::Pong));
         assert_eq!(seq, 1);
+    }
+
+    // -------------------------------------------------------------------
+    // ADR-007 / plan 41 W3 — send_run_entrypoint streaming consumer
+    // -------------------------------------------------------------------
+
+    fn write_event_frame(stream: &mut UnixStream, event: &EntrypointEvent) {
+        write_frame(stream, &GuestResponse::EntrypointEvent(event.clone())).unwrap();
+    }
+
+    #[test]
+    fn test_send_run_entrypoint_collects_events_until_terminal() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        guest
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        // Guest side: read the request, emit Stdout, Stderr, Exit.
+        let guest_handle = std::thread::spawn(move || {
+            let req: GuestRequest = read_frame(&mut guest).unwrap();
+            assert!(matches!(
+                req,
+                GuestRequest::RunEntrypoint {
+                    timeout_secs: 30,
+                    ..
+                }
+            ));
+            write_event_frame(
+                &mut guest,
+                &EntrypointEvent::Stdout {
+                    chunk: b"out".to_vec(),
+                },
+            );
+            write_event_frame(
+                &mut guest,
+                &EntrypointEvent::Stderr {
+                    chunk: b"err".to_vec(),
+                },
+            );
+            write_event_frame(&mut guest, &EntrypointEvent::Exit { code: 0 });
+        });
+
+        let mut received: Vec<EntrypointEvent> = Vec::new();
+        let terminal = send_run_entrypoint(&mut host, b"in".to_vec(), 30, |evt| {
+            received.push(evt.clone())
+        })
+        .expect("send_run_entrypoint");
+
+        guest_handle.join().unwrap();
+
+        assert_eq!(received.len(), 2);
+        assert!(matches!(
+            received[0],
+            EntrypointEvent::Stdout { ref chunk } if chunk == b"out"
+        ));
+        assert!(matches!(
+            received[1],
+            EntrypointEvent::Stderr { ref chunk } if chunk == b"err"
+        ));
+        assert!(matches!(terminal, EntrypointEvent::Exit { code: 0 }));
+    }
+
+    #[test]
+    fn test_send_run_entrypoint_terminates_on_error() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        guest
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        // Guest side: emit one Stdout chunk, then a terminal Error.
+        // The handler must observe the Stdout but stop reading after
+        // Error.
+        let guest_handle = std::thread::spawn(move || {
+            let _req: GuestRequest = read_frame(&mut guest).unwrap();
+            write_event_frame(
+                &mut guest,
+                &EntrypointEvent::Stdout {
+                    chunk: b"partial".to_vec(),
+                },
+            );
+            write_event_frame(
+                &mut guest,
+                &EntrypointEvent::Error {
+                    kind: RunEntrypointError::Timeout,
+                    message: "killed at 30s".into(),
+                },
+            );
+            // Write a bogus extra frame after the terminal — the
+            // consumer must not read it.
+            write_event_frame(
+                &mut guest,
+                &EntrypointEvent::Stdout {
+                    chunk: b"should-not-be-read".to_vec(),
+                },
+            );
+        });
+
+        let mut received: Vec<EntrypointEvent> = Vec::new();
+        let terminal = send_run_entrypoint(&mut host, b"".to_vec(), 30, |evt| {
+            received.push(evt.clone())
+        })
+        .expect("send_run_entrypoint");
+
+        guest_handle.join().unwrap();
+
+        assert_eq!(received.len(), 1);
+        assert!(matches!(
+            received[0],
+            EntrypointEvent::Stdout { ref chunk } if chunk == b"partial"
+        ));
+        assert!(matches!(
+            terminal,
+            EntrypointEvent::Error {
+                kind: RunEntrypointError::Timeout,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_send_run_entrypoint_rejects_unexpected_response() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        guest
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        // Guest writes a Pong instead of an EntrypointEvent.
+        let guest_handle = std::thread::spawn(move || {
+            let _req: GuestRequest = read_frame(&mut guest).unwrap();
+            write_frame(&mut guest, &GuestResponse::Pong).unwrap();
+        });
+
+        let result = send_run_entrypoint(&mut host, b"".to_vec(), 30, |_| {});
+        guest_handle.join().unwrap();
+
+        let err = result.expect_err("should reject Pong");
+        assert!(
+            err.to_string().contains("expected EntrypointEvent"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn test_send_run_entrypoint_surfaces_guest_error() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        guest
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        // Guest writes a generic Error (not an EntrypointEvent::Error).
+        // This shouldn't normally happen for RunEntrypoint, but the
+        // host-side consumer should map it to a clear Result error.
+        let guest_handle = std::thread::spawn(move || {
+            let _req: GuestRequest = read_frame(&mut guest).unwrap();
+            write_frame(
+                &mut guest,
+                &GuestResponse::Error {
+                    message: "agent panicked before dispatch".into(),
+                },
+            )
+            .unwrap();
+        });
+
+        let result = send_run_entrypoint(&mut host, b"".to_vec(), 30, |_| {});
+        guest_handle.join().unwrap();
+
+        let err = result.expect_err("should surface guest error");
+        assert!(
+            err.to_string().contains("agent panicked"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Stacked on #68 (W2 agent handler). Adds the `mvmctl invoke` top-level verb — the production-safe call surface that dispatches the `RunEntrypoint` vsock verb.

```
mvmctl invoke <MANIFEST> [--stdin <PATH>|-] [--timeout <SECS>]
                         [--cpus N] [--memory-mib N]
                         [--fresh | --reset]
```

Distinct from `mvmctl exec` (dev-only, arbitrary shell). `invoke` boots a microVM, dispatches `RunEntrypoint`, streams `Stdout`/`Stderr` events back to mvmctl's own streams as they arrive, tears down. The agent serves it only by spawning the program named in `/etc/mvm/entrypoint`.

## Two new pieces

**`mvm_guest::vsock::send_run_entrypoint(stream, stdin, timeout, on_event)`** — sends the request, reads `EntrypointEvent` frames in a loop until terminal, invokes `on_event` for each non-terminal chunk so callers can stream output without buffering. Tested with `UnixStream::pair()` against four shapes.

**`vm::invoke` command module** — boots a transient VM via `boot_session_vm`, waits for the agent (`wait_for_agent` made `pub`), opens vsock, dispatches with a streaming handler that writes `Stdout`/`Stderr` to mvmctl's own streams, tears down the VM (always — even on dispatch failure), exits with the wrapper's exit code.

## Exit-code mapping (Unix conventions)

| Outcome | Exit code |
| --- | --- |
| `Exit { code }` | wrapper's own code |
| `Error { kind: Timeout }` | 124 (matches `timeout(1)`) |
| `Error { kind: WrapperCrashed }` | 137 (8+9, SIGKILL convention) |
| Other `Error { kind }` (Busy, PayloadCap, EntrypointInvalid, InternalError) | 1 + warn-line to stderr |

## v1 deferrals

- `--fresh` and `--reset` are accepted but informational. Current behaviour matches `--fresh` (no warm session reuse). When the session-pool plan lands the default flips to "reuse warm VM" and `--fresh` becomes the opt-out.
- VM-name targeting (vs template) is deferred. Today only template manifests are accepted.

## Test plan

- [x] 4 streaming consumer tests in `mvm-guest::vsock` (collects until terminal, terminates on Error and ignores frames after, rejects non-event responses, surfaces guest errors).
- [x] 7 invoke unit tests (exit-code mapping for each event variant + stdin payload reading: None / file / missing-file).
- [x] `cargo test --workspace` — 255 mvm-cli tests + 110 mvm-guest tests pass on host.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `mvmctl invoke --help` renders cleanly.
- [x] `scripts/check-prod-agent-no-exec.sh` passes.
- [ ] Live-KVM integration test pending (W2 + W3 together against a real wrapper at `/etc/mvm/entrypoint`).

## Stacked on

- #67 (W1 wire protocol)
- #68 (W2 agent handler)

This PR's base is `feat/runentrypoint-handler`. When #68 merges, GitHub auto-retargets to whatever #68 was based on; once both #67 and #68 land on main this PR will retarget to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)