### PR TITLE
feat: prod-agent symbol contract + doctor probes — plan 41 W5

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,13 +68,16 @@ jobs:
         # discoverable way to keep the two tools in sync.
         run: cargo audit --ignore RUSTSEC-2025-0057 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0009
 
-  # ── Lane 2: Production-agent symbol gate ──────────────────────────
-  # ADR-002 §W4.3 — production builds of mvm-guest-agent must not
-  # contain mvm_guest_agent::do_exec. Catches accidental re-enable
-  # of the dev-shell feature. Anchors on the binary's crate name to
-  # skip stdlib's identically-named symbol.
-  prod-agent-no-exec:
-    name: Guest agent — no dev-shell symbols (ADR-002 §W4.3)
+  # ── Lane 2: Production-agent symbol contract ─────────────────────
+  # ADR-002 §W4.3 + ADR-007 §W5 — combined contract on the production
+  # guest agent binary. ONE build, ONE step, BOTH assertions:
+  #   • mvm_guest_agent::do_exec is ABSENT (W4.3 — no dev-shell leak)
+  #   • mvm_guest_agent::handle_run_entrypoint is PRESENT (W5 — the
+  #     constrained RunEntrypoint handler ships).
+  # Asserting both on the *same* binary in a single step prevents
+  # feature-flag drift from regressing half the contract silently.
+  prod-agent-runentry-contract:
+    name: Guest agent — symbol contract (ADR-002 §W4.3 + ADR-007 §W5)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -92,7 +95,7 @@ jobs:
           key: cargo-prodagent-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-prodagent-
 
-      - name: Build prod agent and check for do_exec
+      - name: Build prod agent and assert symbol contract
         run: ./scripts/check-prod-agent-no-exec.sh
 
   # ── Lane 3: Reproducibility ────────────────────────────────────────

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -94,6 +94,8 @@ pub fn run(json: bool) -> Result<()> {
     checks.push(security_dev_image_check());
     checks.push(security_deny_config_check());
     checks.push(security_default_network_check());
+    checks.push(security_snapshot_key_check());
+    checks.push(security_snapshot_dirs_check());
 
     // ── Render ────────────────────────────────────────────────────
     let all_ok = checks.iter().all(|c| c.ok);
@@ -832,6 +834,142 @@ fn security_default_network_check() -> Check {
             "configured".to_string()
         } else {
             "not configured — run `mvmctl network create default`".to_string()
+        },
+    }
+}
+
+/// `~/.mvm/snapshot.key` should be mode 0600 (ADR-007 §W4 / M9).
+///
+/// Absence is informational — the file is created lazily on first
+/// snapshot seal. Existence with looser perms is a security finding:
+/// any local user could read the key and forge sidecars.
+fn security_snapshot_key_check() -> Check {
+    let path = mvm_security::snapshot_hmac::default_key_path(std::path::Path::new(
+        &mvm_core::config::mvm_data_dir(),
+    ));
+    let Ok(meta) = std::fs::symlink_metadata(&path) else {
+        return Check {
+            name: "snapshot HMAC key",
+            category: "security",
+            ok: true,
+            info: format!(
+                "not yet created at {} (lazy — created on first snapshot seal)",
+                path.display()
+            ),
+        };
+    };
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = meta.permissions().mode() & 0o777;
+        let expected = 0o600;
+        let len_ok = meta.len() == mvm_security::snapshot_hmac::HMAC_KEY_BYTES as u64;
+        Check {
+            name: "snapshot HMAC key",
+            category: "security",
+            ok: mode == expected && len_ok,
+            info: if mode != expected {
+                format!(
+                    "expected mode 0{expected:o}, got 0{mode:o} at {} — \
+                     a local-user-readable HMAC key can be used to forge sidecars",
+                    path.display()
+                )
+            } else if !len_ok {
+                format!(
+                    "key file at {} is {} bytes (expected {}) — corrupt; rotate by deleting the file",
+                    path.display(),
+                    meta.len(),
+                    mvm_security::snapshot_hmac::HMAC_KEY_BYTES
+                )
+            } else {
+                format!("0{mode:o} at {}", path.display())
+            },
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = meta;
+        Check {
+            name: "snapshot HMAC key",
+            category: "security",
+            ok: true,
+            info: "non-Unix host; mode check skipped".to_string(),
+        }
+    }
+}
+
+/// All template snapshot directories should be mode 0700 (ADR-007
+/// §W4 / M9). Walks `~/.mvm/templates/*/artifacts/*/snapshot/`,
+/// reports the first looser-perm directory found (or "all OK" /
+/// "none built yet" otherwise).
+fn security_snapshot_dirs_check() -> Check {
+    let templates_dir = mvm_core::domain::template::templates_base_dir();
+    let templates_path = std::path::Path::new(&templates_dir);
+    if !templates_path.exists() {
+        return Check {
+            name: "snapshot dir mode",
+            category: "security",
+            ok: true,
+            info: format!("no templates directory at {templates_dir}"),
+        };
+    }
+
+    let mut total = 0u32;
+    let mut bad: Option<(std::path::PathBuf, u32)> = None;
+    if let Ok(entries) = std::fs::read_dir(templates_path) {
+        for tpl in entries.flatten() {
+            let artifacts = tpl.path().join("artifacts");
+            let Ok(rev_entries) = std::fs::read_dir(&artifacts) else {
+                continue;
+            };
+            for rev in rev_entries.flatten() {
+                let snap = rev.path().join("snapshot");
+                if !snap.is_dir() {
+                    continue;
+                }
+                total += 1;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    if let Ok(meta) = std::fs::symlink_metadata(&snap) {
+                        let mode = meta.permissions().mode() & 0o777;
+                        if mode != 0o700 && bad.is_none() {
+                            bad = Some((snap, mode));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if total == 0 {
+        return Check {
+            name: "snapshot dir mode",
+            category: "security",
+            ok: true,
+            info: format!("no snapshots built yet under {templates_dir}"),
+        };
+    }
+    match bad {
+        Some((path, mode)) => Check {
+            name: "snapshot dir mode",
+            category: "security",
+            ok: false,
+            info: format!(
+                "expected 0700, got 0{mode:o} at {} (1 of {total} snapshot dir{}; \
+                 looser perms let local users tamper with snapshots)",
+                path.display(),
+                if total == 1 { "" } else { "s" }
+            ),
+        },
+        None => Check {
+            name: "snapshot dir mode",
+            category: "security",
+            ok: true,
+            info: format!(
+                "0700 across {total} snapshot dir{}",
+                if total == 1 { "" } else { "s" }
+            ),
         },
     }
 }

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -1222,6 +1222,28 @@ fn handle_client(
                 }
             }
         }
+
+        // ADR-007 / plan 41 W5 — report whether boot-time entrypoint
+        // validation succeeded. Used by `mvmctl doctor` against a
+        // running guest. Prod-safe — no inputs, no secrets in the
+        // response (just a path + reason string).
+        GuestRequest::EntrypointStatus => match VALIDATED_ENTRYPOINT.get() {
+            Some(Ok(v)) => GuestResponse::EntrypointStatusReport {
+                ok: true,
+                path: Some(v.resolved.display().to_string()),
+                detail: None,
+            },
+            Some(Err(msg)) => GuestResponse::EntrypointStatusReport {
+                ok: false,
+                path: None,
+                detail: Some(msg.clone()),
+            },
+            None => GuestResponse::EntrypointStatusReport {
+                ok: false,
+                path: None,
+                detail: Some("entrypoint validation never ran".to_string()),
+            },
+        },
     };
 
     write_response(&mut file, &resp);

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -122,6 +122,11 @@ pub enum GuestRequest {
         cols: u16,
         rows: u16,
     },
+    /// Query whether the agent's boot-time entrypoint validation
+    /// succeeded. Used by `mvmctl doctor` to confirm a running guest
+    /// can actually serve `RunEntrypoint`. ADR-007 / plan 41 W5.
+    /// Prod-safe — reveals no secrets, takes no inputs.
+    EntrypointStatus,
 }
 
 /// Response from guest vsock agent to host.
@@ -192,6 +197,18 @@ pub enum GuestResponse {
     ConsoleExited { session_id: u32, exit_code: i32 },
     /// Console resize acknowledged.
     ConsoleResized { session_id: u32 },
+    /// Result of an `EntrypointStatus` query. ADR-007 / plan 41 W5.
+    ///
+    /// `ok = true` means the agent successfully validated
+    /// `/etc/mvm/entrypoint` at boot and will serve `RunEntrypoint`.
+    /// `ok = false` means validation failed — `path` carries the
+    /// resolved path attempt (or the marker contents if resolution
+    /// itself failed) and `detail` carries a human-readable reason.
+    EntrypointStatusReport {
+        ok: bool,
+        path: Option<String>,
+        detail: Option<String>,
+    },
 }
 
 /// A single filesystem change detected since boot.
@@ -1482,6 +1499,68 @@ mod tests {
                 timeout_secs: 15,
             } if stdin.is_empty()
         ));
+    }
+
+    // -------------------------------------------------------------------
+    // ADR-007 / plan 41 W5 — EntrypointStatus query
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn test_entrypoint_status_request_roundtrip() {
+        let req = GuestRequest::EntrypointStatus;
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(json, r#""EntrypointStatus""#);
+        let decoded: GuestRequest = serde_json::from_str(&json).unwrap();
+        assert!(matches!(decoded, GuestRequest::EntrypointStatus));
+    }
+
+    #[test]
+    fn test_entrypoint_status_report_ok_roundtrip() {
+        let resp = GuestResponse::EntrypointStatusReport {
+            ok: true,
+            path: Some("/usr/lib/mvm/wrappers/python-runner".into()),
+            detail: None,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let decoded: GuestResponse = serde_json::from_str(&json).unwrap();
+        match decoded {
+            GuestResponse::EntrypointStatusReport { ok, path, detail } => {
+                assert!(ok);
+                assert_eq!(path.as_deref(), Some("/usr/lib/mvm/wrappers/python-runner"));
+                assert!(detail.is_none());
+            }
+            other => panic!("expected EntrypointStatusReport, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_entrypoint_status_report_failed_roundtrip() {
+        let resp = GuestResponse::EntrypointStatusReport {
+            ok: false,
+            path: None,
+            detail: Some("entrypoint validation never ran".into()),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let decoded: GuestResponse = serde_json::from_str(&json).unwrap();
+        match decoded {
+            GuestResponse::EntrypointStatusReport { ok, path, detail } => {
+                assert!(!ok);
+                assert!(path.is_none());
+                assert!(detail.unwrap().contains("never ran"));
+            }
+            other => panic!("expected EntrypointStatusReport, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_entrypoint_status_report_rejects_unknown_field() {
+        let json =
+            r#"{"EntrypointStatusReport":{"ok":true,"path":null,"detail":null,"smuggled":1}}"#;
+        let err = serde_json::from_str::<GuestResponse>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("unknown field") && err.to_string().contains("smuggled"),
+            "expected 'unknown field smuggled', got: {err}"
+        );
     }
 
     /// Sanity check: the well-formed frames the same tests cover above must

--- a/scripts/check-prod-agent-no-exec.sh
+++ b/scripts/check-prod-agent-no-exec.sh
@@ -1,17 +1,27 @@
 #!/usr/bin/env bash
-# ADR-002 §W4.3 — production guest agent binary must not contain the dev-only
-# Exec command path. The `dev-shell` Cargo feature gates `do_exec` and the
-# `GuestRequest::Exec` handler; any production-targeted build must omit the
-# feature, and the symbol must therefore be absent from the resulting binary.
+# Combined production-agent symbol contract (ADR-002 §W4.3 + ADR-007 §W5).
 #
-# This gate builds the agent without `--features dev-shell` and asserts the
-# `do_exec` symbol is not present in the output. A failure means either
-# (a) someone re-enabled the feature in a default-features path, or
-# (b) `do_exec` was moved out from behind the feature gate.
+# The production guest agent binary has TWO load-bearing symbol-level
+# invariants that must hold against the *same* binary that ships:
+#
+#   1. The dev-only `mvm_guest_agent::do_exec` symbol must be ABSENT.
+#      This is the W4.3 invariant — `do_exec` is the dev-shell-gated
+#      arbitrary-shell handler. A prod build must omit `--features
+#      dev-shell` and therefore must not contain the symbol.
+#
+#   2. The W2 `mvm_guest_agent::handle_run_entrypoint` symbol must be
+#      PRESENT. This is the constrained `RunEntrypoint` handler —
+#      ADR-007's production-safe call surface. A prod build that lacks
+#      it can't actually serve `mvmctl invoke`, which means the
+#      shipping artifact is broken.
+#
+# Asserting both on the same binary in one CI step prevents
+# feature-flag drift from regressing half the contract silently
+# (ADR-007 / plan 41 W5).
 #
 # Usage: scripts/check-prod-agent-no-exec.sh
 #
-# Exit codes: 0 = clean, 1 = forbidden symbol present, 2 = build failed.
+# Exit codes: 0 = clean, 1 = symbol contract violated, 2 = build failed.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -66,6 +76,24 @@ if "${NM_CMD[@]}" "$BIN" 2>/dev/null | grep -F "$PATTERN" >/dev/null; then
 fi
 
 echo "==> ok: no do_exec symbol in $BIN"
+
+# ─── Positive: handle_run_entrypoint must be PRESENT (ADR-007 §W5) ─────
+# The W2 handler is feature-independent (no `dev-shell` gate) — every
+# prod build must contain it. Absence means either the function was
+# accidentally removed, gated behind a feature, or renamed without
+# updating this gate. Either way, the prod artifact can't serve
+# `mvmctl invoke` and is broken.
+RUNENTRY_PATTERN='mvm_guest_agent::handle_run_entrypoint'
+if ! "${NM_CMD[@]}" "$BIN" 2>/dev/null | grep -F "$RUNENTRY_PATTERN" >/dev/null; then
+    echo "error: required symbol '$RUNENTRY_PATTERN' missing from production guest agent" >&2
+    echo "       this means the W2 RunEntrypoint handler is not compiled in," >&2
+    echo "       and the shipping artifact cannot serve 'mvmctl invoke'." >&2
+    echo "       See ADR-007 §W5 and the handler in" >&2
+    echo "       crates/mvm-guest/src/bin/mvm-guest-agent.rs::handle_run_entrypoint." >&2
+    exit 1
+fi
+
+echo "==> ok: handle_run_entrypoint symbol present in $BIN"
 
 # ─── Variant ↔ feature pairing (W7.1) ────────────────────────────────────
 # `mkGuest` (in nix/flake.nix) asserts at build time that:


### PR DESCRIPTION
## Summary

Stacked on #70 (W4 snapshot HMAC). Three pieces that stitch the W1–W4 substrate to the operational surface a release can actually depend on.

### 1. Combined symbol contract on the prod agent

`scripts/check-prod-agent-no-exec.sh` (and the matching CI lane, renamed to `prod-agent-runentry-contract`) now asserts BOTH halves on the same binary in one step:

- `mvm_guest_agent::do_exec` is **ABSENT** (W4.3 — no dev-shell leak)
- `mvm_guest_agent::handle_run_entrypoint` is **PRESENT** (W5 — the constrained handler ships)

Asserting both on the *same* binary in one step prevents feature-flag drift from regressing half the contract silently. Local run confirms both checks green against the prod build.

### 2. Doctor checks for snapshot integrity infrastructure

`mvmctl doctor` now reports two new findings under the security category:

- **`snapshot HMAC key`** — `~/.mvm/snapshot.key` mode 0600 + correct length. Absence is informational (lazy creation on first seal). Looser perms or wrong length is a security finding.
- **`snapshot dir mode`** — walks `~/.mvm/templates/*/artifacts/*/snapshot/` and reports the first looser-than-0700 directory found, or "all OK" / "none built yet" otherwise.

Both follow the existing `Check { name, category, ok, info }` convention so JSON and text renderers handle them uniformly.

### 3. `EntrypointStatus` vsock query for live-VM doctor

New `GuestRequest::EntrypointStatus` (no inputs, prod-safe) and `GuestResponse::EntrypointStatusReport { ok, path, detail }`. Agent reads its already-populated `VALIDATED_ENTRYPOINT` `OnceLock` and reports back. Used by future doctor probes against running guests to confirm `/etc/mvm/entrypoint` validation succeeded at boot. Does not re-validate — the boot-time result is what the agent will actually use to serve `RunEntrypoint`.

## Test plan

- [x] 4 new vsock roundtrip + tampered-frame tests for `EntrypointStatus` / `EntrypointStatusReport`.
- [x] `cargo test --workspace` clean (114 mvm-guest tests now, +4).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `scripts/check-prod-agent-no-exec.sh` runs locally and reports both checks green against the prod build.
- [ ] Live-KVM smoke: `mvmctl invoke <template>` against a function-entrypoint rootfs that has `/etc/mvm/entrypoint` baked.

## Stacked on

- #67 (W1 wire protocol)
- #68 (W2 agent handler)
- #69 (W3 mvmctl invoke)
- #70 (W4 snapshot HMAC)

This PR's base is `feat/snapshot-hmac`. As the lower PRs land, this auto-retargets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)