### PR TITLE
feat(mvm-guest): seccomp tier functional denial test (ADR-002 §W2.4)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -98,6 +98,38 @@ jobs:
       - name: Build prod agent and assert symbol contract
         run: ./scripts/check-prod-agent-no-exec.sh
 
+  # ── Lane 2b: Seccomp tier functional denial (ADR-002 §W2.4) ───────
+  # Tier-structure unit tests in `mvm-security` cover cumulative-subset
+  # and serde shapes; they don't exercise the BPF program at runtime.
+  # This lane spawns `mvm-seccomp-apply <tier> -- syscall-probe` on
+  # Linux and asserts:
+  #   • unrestricted / network → socket(AF_INET) succeeds
+  #   • standard               → socket(AF_INET) returns EPERM
+  # Catches regressions where a syscall list passes structural tests
+  # but fails to translate to a working seccomp filter (e.g., wrong
+  # syscall number, missing arch coverage, NNP not set).
+  seccomp-functional:
+    name: Seccomp tier functional denial (ADR-002 §W2.4)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-seccomp-fn-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-seccomp-fn-
+
+      - name: Run seccomp functional tests
+        run: cargo test -p mvm-guest --test seccomp_apply
+
   # ── Lane 3: Reproducibility ────────────────────────────────────────
   # ADR-002 §W5.3 — two clean builds must produce byte-identical
   # binaries. Catches build-time non-determinism that could mask

--- a/crates/mvm-guest/Cargo.toml
+++ b/crates/mvm-guest/Cargo.toml
@@ -34,6 +34,14 @@ path = "src/bin/mvm-seccomp-apply.rs"
 name = "mvm-verity-init"
 path = "src/bin/mvm-verity-init.rs"
 
+# Test-only probe used by `tests/seccomp_apply.rs` to verify that
+# tier allowlists actually deny what they claim (ADR-002 §W2.4). Not
+# selected by `nix/packages/mvm-guest-agent.nix`, so it never ships
+# in the guest closure.
+[[bin]]
+name = "syscall-probe"
+path = "src/bin/syscall-probe.rs"
+
 [features]
 dev-shell = []
 

--- a/crates/mvm-guest/src/bin/mvm-seccomp-apply.rs
+++ b/crates/mvm-guest/src/bin/mvm-seccomp-apply.rs
@@ -97,6 +97,8 @@ fn main() {
 /// failures are explicit, not catastrophic.
 #[cfg(target_os = "linux")]
 fn apply_filter(tier: SeccompTier) -> anyhow::Result<()> {
+    set_no_new_privs()?;
+
     let allowed = tier.syscalls();
     let mut rules: std::collections::BTreeMap<i64, Vec<SeccompRule>> =
         std::collections::BTreeMap::new();
@@ -123,6 +125,30 @@ fn apply_filter(tier: SeccompTier) -> anyhow::Result<()> {
     let program: BpfProgram = filter.try_into()?;
     seccompiler::apply_filter(&program)?;
     Ok(())
+}
+
+/// Set PR_SET_NO_NEW_PRIVS on the current process. Defense-in-depth:
+/// the kernel requires NNP for an unprivileged process to install a
+/// seccomp filter, and the launch wrapper already passes
+/// `setpriv --no-new-privs`. Owning the call here means a future
+/// caller that forgets the setpriv flag still gets the filter
+/// installed instead of a late EACCES from `seccomp(2)`. The bit is
+/// idempotent — setting it when already set is a no-op.
+#[cfg(target_os = "linux")]
+fn set_no_new_privs() -> anyhow::Result<()> {
+    // SAFETY: prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) takes only scalar
+    // args and has no preconditions on process state. The kernel
+    // returns 0 on success and -1 with errno on failure; we surface
+    // the errno via std::io::Error::last_os_error.
+    let rc = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "prctl(PR_SET_NO_NEW_PRIVS) failed: {}",
+            std::io::Error::last_os_error()
+        ))
+    }
 }
 
 /// Map a syscall name to its number on this target. The list is

--- a/crates/mvm-guest/src/bin/syscall-probe.rs
+++ b/crates/mvm-guest/src/bin/syscall-probe.rs
@@ -1,0 +1,36 @@
+//! `syscall-probe` — exits with the errno of an attempted `socket(2)` call.
+//!
+//! Test-only binary. Spawned by `tests/seccomp_apply.rs` under
+//! `mvm-seccomp-apply <tier> --` to verify that tier allowlists
+//! actually deny what they claim. Exit-code contract:
+//!
+//! - 0 → `socket(AF_INET, SOCK_STREAM, 0)` succeeded.
+//! - 1 → call failed with `EPERM` (the seccomp-shaped denial).
+//! - other → call failed with a different errno (raw value, capped at 254).
+//!
+//! Not shipped in production: `nix/packages/mvm-guest-agent.nix`
+//! explicitly selects `mvm-guest-agent` and `mvm-seccomp-apply` as
+//! the bins to build, so this binary stays in `target/` only.
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("syscall-probe runs inside Linux microVM guests only");
+    std::process::exit(2);
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+    if fd < 0 {
+        let err = std::io::Error::last_os_error();
+        let errno = err.raw_os_error().unwrap_or(255);
+        eprintln!("syscall-probe: socket(AF_INET, SOCK_STREAM) failed: errno={errno} ({err})");
+        // Exit codes are u8; cap below 255 so the kernel's "killed by
+        // signal" channel stays distinct.
+        std::process::exit(errno.min(254));
+    }
+    unsafe {
+        libc::close(fd);
+    }
+    std::process::exit(0);
+}

--- a/crates/mvm-guest/tests/seccomp_apply.rs
+++ b/crates/mvm-guest/tests/seccomp_apply.rs
@@ -1,0 +1,71 @@
+//! Functional integration test for `mvm-seccomp-apply` (ADR-002 §W2.4).
+//!
+//! The unit tests in `mvm-security::seccomp` cover tier *structure*
+//! (cumulative-subset, no duplicates, manifest roundtrip). They don't
+//! exercise the BPF program at runtime. This test does:
+//!
+//! 1. Spawn `mvm-seccomp-apply <tier> -- syscall-probe`.
+//! 2. The probe attempts `socket(AF_INET, SOCK_STREAM, 0)`.
+//! 3. Assert the probe's exit code matches the tier's promise:
+//!    - `unrestricted` / `network` → 0 (call allowed)
+//!    - `standard` → `EPERM` (call denied with seccomp errno-action)
+//!
+//! Linux-only because seccomp is a Linux kernel feature. The crate
+//! still builds on macOS (the gated stub binaries pass `cargo check`),
+//! but the test is skipped at compile time.
+
+#![cfg(target_os = "linux")]
+
+use std::process::{Command, Output};
+
+fn shim() -> &'static str {
+    env!("CARGO_BIN_EXE_mvm-seccomp-apply")
+}
+
+fn probe() -> &'static str {
+    env!("CARGO_BIN_EXE_syscall-probe")
+}
+
+fn run_under(tier: &str) -> Output {
+    Command::new(shim())
+        .arg(tier)
+        .arg("--")
+        .arg(probe())
+        .output()
+        .expect("spawn mvm-seccomp-apply")
+}
+
+#[test]
+fn unrestricted_allows_socket() {
+    let out = run_under("unrestricted");
+    assert!(
+        out.status.success(),
+        "expected socket() to succeed under unrestricted; status={:?} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn network_tier_allows_socket() {
+    let out = run_under("network");
+    assert!(
+        out.status.success(),
+        "expected socket() to succeed under network tier; status={:?} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn standard_tier_denies_socket_with_eperm() {
+    let out = run_under("standard");
+    assert_eq!(
+        out.status.code(),
+        Some(libc::EPERM),
+        "expected EPERM ({}) under standard tier; status={:?} stderr={}",
+        libc::EPERM,
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

The unit tests in `mvm-security::seccomp` cover tier *structure* (cumulative-subset, no duplicates, manifest serde). They never proved a denied syscall actually returns EPERM at runtime — the audit gap behind ADR-002 claim #4 ("seccomp tiers actually deny what they claim").

This PR closes that gap end-to-end:

### 1. Functional integration test (`tests/seccomp_apply.rs`)

Three Linux-gated tests that spawn `mvm-seccomp-apply <tier> -- syscall-probe` and assert the probe's exit code against the tier's promise:

- **unrestricted / network** → `socket(AF_INET, SOCK_STREAM, 0)` succeeds (exit 0).
- **standard** → `socket()` returns `EPERM` (exit 1).

Catches regressions where a syscall list passes structural tests but fails to translate to a working seccomp filter (wrong syscall number, missing arch coverage, NNP not set, etc.).

### 2. New `syscall-probe` test binary

Tiny, single-purpose, Linux-gated. Attempts the syscall, exits with the errno value (capped at 254). Not selected by `nix/packages/mvm-guest-agent.nix`, so it never ships in the production guest closure.

### 3. CI lane (`security.yml`)

New `seccomp-functional` job (Lane 2b) that runs the tests on every PR, making claim #4 CI-enforced rather than only structurally validated.

### 4. Defense-in-depth: own the NNP bit

`mvm-seccomp-apply::apply_filter` now calls `prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)` itself before `seccompiler::apply_filter`. The kernel requires NNP for an unprivileged process to install a seccomp filter, and the launch wrapper already passes `setpriv --no-new-privs`. Owning the call here means a future caller that forgets the flag still gets the filter installed instead of a late EACCES from `seccomp(2)`. The bit is idempotent — existing setpriv path is unaffected. The new tests rely on this: they invoke the shim directly without `setpriv` and the filter still installs.

## Test plan

- [x] `cargo check --workspace --all-targets` clean on macOS host.
- [x] `cargo clippy -p mvm-guest --all-targets -- -D warnings` clean on macOS host.
- [x] `cargo test -p mvm-guest --test seccomp_apply` — all 3 tests pass inside Lima (aarch64-linux).
- [ ] Lane `seccomp-functional` green on x86_64 in CI.
- [ ] Existing seccomp lanes (`prod-agent-runentry-contract`, etc.) stay green — no functional regression to the shim's launch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)