### PR TITLE
fix(security): move vsock guest-agent port out of priv range (ADR-002 §W4.5)

### DIFF
--- a/crates/mvm-apple-container/src/lib.rs
+++ b/crates/mvm-apple-container/src/lib.rs
@@ -209,7 +209,13 @@ pub fn vsock_connect_any(id: &str, port: u32) -> Result<std::os::unix::net::Unix
 }
 
 /// Guest agent vsock port.
-pub const GUEST_AGENT_PORT: u32 = 52;
+///
+/// Must stay in lockstep with `mvm_guest::vsock::GUEST_AGENT_PORT`.
+/// Duplicated here because `mvm-apple-container` is a leaf crate that
+/// can't depend on `mvm-guest`. See the doc comment on the canonical
+/// definition for why this lives at 5252 (>1023, so `bind(2)` succeeds
+/// under W4.5's reduced agent capability set).
+pub const GUEST_AGENT_PORT: u32 = 5252;
 
 /// List running VM IDs.
 pub fn list_ids() -> Vec<String> {

--- a/crates/mvm-apple-container/src/macos.rs
+++ b/crates/mvm-apple-container/src/macos.rs
@@ -110,16 +110,17 @@ fn start_vsock_proxy_listener(id: &str) -> Result<(), String> {
 /// happens to have listening — not just the guest agent. We restrict
 /// to the three ranges mvmctl actually uses:
 ///
-/// * `52` — guest agent control channel.
+/// * `5252` — guest agent control channel (`GUEST_AGENT_PORT`,
+///   formerly 52; moved out of the privileged-port range so the agent
+///   can bind it as uid 901 — see `mvm_guest::vsock::GUEST_AGENT_PORT`).
 /// * `PORT_FORWARD_BASE..=BASE+65535` — traffic forwarders set up by
 ///   `start_port_proxy` (BASE = 10000).
 /// * `CONSOLE_PORT_BASE..=BASE+65535` — `ConsoleOpen` data ports
 ///   (BASE = 20000).
 fn proxy_port_is_allowed(port: u32) -> bool {
-    const GUEST_AGENT: u32 = 52;
     const PORT_FORWARD_BASE: u32 = 10_000;
     const CONSOLE_PORT_BASE: u32 = 20_000;
-    port == GUEST_AGENT
+    port == crate::GUEST_AGENT_PORT
         || (PORT_FORWARD_BASE..=PORT_FORWARD_BASE + 65_535).contains(&port)
         || (CONSOLE_PORT_BASE..=CONSOLE_PORT_BASE + 65_535).contains(&port)
 }
@@ -698,8 +699,9 @@ pub fn start_vm(
             VZVirtioTraditionalMemoryBalloonDeviceConfiguration::new(),
         )]));
 
-        // Vsock device — enables host↔guest communication on port 52
-        // (same protocol as Firecracker vsock, used by the guest agent)
+        // Vsock device — enables host↔guest communication on
+        // GUEST_AGENT_PORT (5252; same protocol as Firecracker vsock,
+        // used by the guest agent).
         let vsock = VZVirtioSocketDeviceConfiguration::new();
         config.setSocketDevices(&NSArray::from_retained_slice(&[Retained::into_super(
             vsock,
@@ -918,7 +920,7 @@ pub fn proxy_socket_path(id: &str) -> std::path::PathBuf {
 ///
 /// Uses the stored VZVirtualMachine reference to access the socket device,
 /// then calls `connectToPort:completionHandler:` to establish a vsock
-/// connection to the guest agent on port 52.
+/// connection to the guest agent on `GUEST_AGENT_PORT` (5252).
 ///
 /// Returns an `std::os::unix::net::UnixStream` wrapping the connection's
 /// file descriptor.
@@ -1075,7 +1077,9 @@ mod tests {
             // will hand off to vsock_connect, which fails (no in-process
             // VM), but the protocol read on this side must succeed.
             let mut client = UnixStream::connect(&path).expect("connect to proxy");
-            client.write_all(&52u32.to_le_bytes()).expect("write port");
+            client
+                .write_all(&crate::GUEST_AGENT_PORT.to_le_bytes())
+                .expect("write port");
 
             // Read should return EOF (0 bytes) once the worker thread gives
             // up on vsock_connect — that's the contract.
@@ -1122,17 +1126,21 @@ mod tests {
     /// Pure logic — no daemon needed; just the predicate.
     ///
     /// Ranges:
-    ///   guest_agent:  {52}
+    ///   guest_agent:  {GUEST_AGENT_PORT} (= 5252)
     ///   port_forward: 10_000..=75_535  (BASE 10_000 + 0..=65_535)
     ///   console_data: 20_000..=85_535  (BASE 20_000 + 0..=65_535)
     ///
     /// The port_forward and console_data ranges legitimately overlap;
     /// any port in the union is fine. Only the gaps below 10_000
-    /// (excluding 52) and above 85_535 are forbidden.
+    /// (excluding GUEST_AGENT_PORT) and above 85_535 are forbidden.
     #[test]
     fn test_proxy_port_allowlist() {
         // Allowed: guest agent control channel.
-        assert!(proxy_port_is_allowed(52));
+        assert!(proxy_port_is_allowed(crate::GUEST_AGENT_PORT));
+        // Specifically, 52 — the historical privileged-port choice —
+        // must be rejected now: it's outside the agent port and outside
+        // both forwarder ranges. ADR-002 §W4.5.
+        assert!(!proxy_port_is_allowed(52));
 
         // Allowed: port-forward range edges + interior.
         assert!(proxy_port_is_allowed(10_000));
@@ -1145,12 +1153,18 @@ mod tests {
         assert!(proxy_port_is_allowed(20_001));
         assert!(proxy_port_is_allowed(85_535));
 
-        // Rejected: low ports outside the agent slot.
+        // Rejected: low ports outside the agent slot. Includes the old
+        // pre-5252 historical port (52) — anyone still pointing at it
+        // is using stale config and we'd rather fail loudly.
         assert!(!proxy_port_is_allowed(0));
         assert!(!proxy_port_is_allowed(1));
         assert!(!proxy_port_is_allowed(22));
         assert!(!proxy_port_is_allowed(51));
         assert!(!proxy_port_is_allowed(53));
+
+        // Rejected: agent-slot boundary (only the exact port is allowed).
+        assert!(!proxy_port_is_allowed(crate::GUEST_AGENT_PORT - 1));
+        assert!(!proxy_port_is_allowed(crate::GUEST_AGENT_PORT + 1));
 
         // Rejected: gap between agent slot and port-forward range.
         assert!(!proxy_port_is_allowed(100));

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -717,7 +717,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
     // Apple Virtualization VMs live in-process — the process must stay alive.
     if effective_hypervisor == "apple-container" && !detach {
         // Set up port forwarding via vsock (no guest IP needed).
-        // 1. Wait for guest agent to be ready on vsock port 52
+        // 1. Wait for guest agent to be ready on `GUEST_AGENT_PORT` (5252)
         // 2. Tell the agent to start vsock→TCP forwarders for each port
         // 3. Start host-side TCP→vsock proxies
         if has_ports {

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -452,12 +452,15 @@ mod tests {
 
     #[test]
     fn test_guest_channel_info_vsock_serde_roundtrip() {
-        let info = GuestChannelInfo::Vsock { cid: 3, port: 52 };
+        // Arbitrary cid/port — this test exercises serde, not the
+        // agent port choice. The agent's actual port lives in
+        // `mvm_guest::vsock::GUEST_AGENT_PORT`.
+        let info = GuestChannelInfo::Vsock { cid: 3, port: 4242 };
         let json = serde_json::to_string(&info).unwrap();
         let parsed: GuestChannelInfo = serde_json::from_str(&json).unwrap();
         assert!(matches!(
             parsed,
-            GuestChannelInfo::Vsock { cid: 3, port: 52 }
+            GuestChannelInfo::Vsock { cid: 3, port: 4242 }
         ));
     }
 

--- a/crates/mvm-guest/README.md
+++ b/crates/mvm-guest/README.md
@@ -16,14 +16,19 @@ All communication uses **4-byte big-endian length prefix + JSON body** over Fire
 
 | Port | Direction | Purpose |
 |------|-----------|---------|
-| 52 | Host -> Guest | Guest agent control (Ping, WorkerStatus, SleepPrep, Wake) |
+| 5252 | Host -> Guest | Guest agent control (Ping, WorkerStatus, SleepPrep, Wake) |
 | 53 | Guest -> Host | Host-bound requests (WakeInstance, QueryInstanceStatus) |
-| 54 | Host -> Guest | Builder agent (NixBuild, HealthCheck) |
+| 21470 | Host -> Guest | Builder agent (NixBuild, HealthCheck) |
+
+> Listen-side ports (Host → Guest direction) live above 1023 because the
+> agent runs as uid 901 with no `CAP_NET_BIND_SERVICE` (ADR-002 §W4.5).
+> The connect-side port 53 is fine where it is — the guest *connects*
+> to the host UDS, no `bind(2)` involved.
 
 ## Binaries
 
-- **mvm-guest-agent** — Runs inside tenant instances on port 52. Handles health checks, load sampling, sleep/wake lifecycle, and integration status reporting.
-- **mvm-builder-agent** — Runs inside ephemeral builder VMs on port 54. Accepts `nix build` commands and reports results.
+- **mvm-guest-agent** — Runs inside tenant instances on port 5252. Handles health checks, load sampling, sleep/wake lifecycle, and integration status reporting.
+- **mvm-builder-agent** — Runs inside ephemeral builder VMs on port 21470. Accepts `nix build` commands and reports results.
 
 ## Integration System
 

--- a/crates/mvm-guest/fuzz/fuzz_targets/fuzz_guest_request.rs
+++ b/crates/mvm-guest/fuzz/fuzz_targets/fuzz_guest_request.rs
@@ -1,8 +1,9 @@
 // ADR-002 §W4.2 — fuzz the host→guest JSON deserializer. Every byte
-// arriving on vsock port 52 lands in `serde_json::from_slice::<GuestRequest>`
-// before any agent logic runs, so this is the agent's first parser-shaped
-// surface. The fuzzer must never produce a panic; deserialization errors
-// are the expected result for malformed input.
+// arriving on `GUEST_AGENT_PORT` (5252) lands in
+// `serde_json::from_slice::<GuestRequest>` before any agent logic
+// runs, so this is the agent's first parser-shaped surface. The
+// fuzzer must never produce a panic; deserialization errors are the
+// expected result for malformed input.
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -1,4 +1,5 @@
-//! Guest vsock agent — runs inside the microVM, listens on vsock port 52.
+//! Guest vsock agent — runs inside the microVM, listens on
+//! `GUEST_AGENT_PORT` (5252).
 //!
 //! Handles host-to-guest requests (Ping, WorkerStatus, SleepPrep, Wake, etc.)
 //! and reports real system metrics via a background monitoring thread.
@@ -10,7 +11,7 @@
 //!
 //! Options:
 //!   --config <path>            JSON config file (default: /etc/mvm/agent.json)
-//!   --port <port>              Vsock port to listen on (default: 52)
+//!   --port <port>              Vsock port to listen on (default: 5252)
 //!   --busy-threshold <float>   Load average threshold for busy (default: 0.1)
 //!   --sample-interval <secs>   Monitoring sample interval (default: 5)
 //!   --help, -h                 Print usage

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -15,7 +15,30 @@ use serde::{Deserialize, Serialize};
 pub const GUEST_CID: u32 = 3;
 
 /// Port the guest vsock agent listens on.
-pub const GUEST_AGENT_PORT: u32 = 52;
+///
+/// **Why 5252 (and why not <1024).** Linux gates `bind(2)` on AF_VSOCK
+/// ports ≤ 1023 behind `CAP_NET_BIND_SERVICE` — the same way it gates
+/// AF_INET. The agent runs as uid 901 with `--bounding-set=-all`
+/// (ADR-002 §W4.5), so it has no caps to spend on a privileged port.
+/// Any port < 1024 would force us to either grant the agent
+/// `CAP_NET_BIND_SERVICE` (weakening W4.5 to work around port choice)
+/// or bind in init and pass the fd in (extra surface for no
+/// architectural benefit). Port 52 was picked when the agent ran as
+/// root and the codebase incorrectly assumed vsock binds were
+/// unprivileged on Linux — see the corrected comment in
+/// `nix/lib/minimal-init/default.nix::guestAgentBlock`.
+///
+/// 5252 sits clearly above 1023 and below the port-forward range
+/// (`PORT_FORWARD_BASE` = 10_000) and the console-data range
+/// (`CONSOLE_PORT_BASE` = 20_000), so the host-side proxy allowlist
+/// (ADR-002 §W1.3) keeps its disjoint-union shape. The "52" tail is a
+/// callback to the historical port for grep-ability.
+///
+/// **Single source of truth.** `mvm-apple-container` and
+/// `mvm-runtime::vm::vminitd_client` re-declare this value because
+/// they cannot depend on `mvm-guest`. If you change this, update those
+/// duplicates in the same commit; the workspace tests catch drift.
+pub const GUEST_AGENT_PORT: u32 = 5252;
 
 /// Base vsock port for TCP port forwarding.
 /// The forwarded vsock port = `PORT_FORWARD_BASE + guest_tcp_port`.
@@ -1643,7 +1666,11 @@ mod tests {
     #[test]
     fn test_constants() {
         assert_eq!(GUEST_CID, 3);
-        assert_eq!(GUEST_AGENT_PORT, 52);
+        // Must stay > 1023 — vsock binds <= 1023 require
+        // CAP_NET_BIND_SERVICE, which the agent (uid 901) doesn't have
+        // (ADR-002 §W4.5). See the doc comment on GUEST_AGENT_PORT.
+        const _: () = assert!(GUEST_AGENT_PORT > 1023);
+        assert_eq!(GUEST_AGENT_PORT, 5252);
         assert_eq!(DEFAULT_TIMEOUT_SECS, 10);
     }
 

--- a/crates/mvm-runtime/src/vm/apple_container.rs
+++ b/crates/mvm-runtime/src/vm/apple_container.rs
@@ -177,7 +177,8 @@ impl VmBackend for AppleContainerBackend {
 
     fn guest_channel_info(&self, _id: &VmId) -> Result<GuestChannelInfo> {
         // Apple VZ backend uses vsock directly (VZVirtioSocketDevice).
-        // The guest agent listens on port 52, same as Firecracker.
+        // The guest agent listens on `GUEST_AGENT_PORT` (5252), same as
+        // Firecracker.
         Ok(GuestChannelInfo::Vsock {
             cid: 3, // standard guest CID
             port: mvm_apple_container::GUEST_AGENT_PORT,

--- a/crates/mvm-runtime/src/vm/vminitd_client.rs
+++ b/crates/mvm-runtime/src/vm/vminitd_client.rs
@@ -39,7 +39,13 @@ use anyhow::Result;
 pub const VMINITD_VSOCK_PORT: u32 = 1024;
 
 /// Port that the mvm guest agent listens on (same as Firecracker).
-pub const GUEST_AGENT_VSOCK_PORT: u32 = 52;
+///
+/// Must stay in lockstep with `mvm_guest::vsock::GUEST_AGENT_PORT`.
+/// Duplicated here to avoid pulling `mvm-guest` into this client's
+/// dependency surface. See the canonical doc comment for why this
+/// lives at 5252 (>1023, so the agent can bind it under W4.5's
+/// reduced capability set).
+pub const GUEST_AGENT_VSOCK_PORT: u32 = 5252;
 
 /// Configuration for launching a process inside an Apple Container via vminitd.
 #[derive(Debug, Clone)]
@@ -77,8 +83,8 @@ impl VminitdClient {
     /// Launch the mvm guest agent inside the container.
     ///
     /// Uses CreateProcess + StartProcess to start the guest agent binary,
-    /// which then listens on vsock port 52 for health checks and
-    /// integration probes (same protocol as Firecracker).
+    /// which then listens on `GUEST_AGENT_VSOCK_PORT` (5252) for health
+    /// checks and integration probes (same protocol as Firecracker).
     pub fn launch_guest_agent(&self) -> Result<()> {
         let _config = ProcessConfig {
             id: format!("{}-guest-agent", self.container_id),
@@ -133,11 +139,12 @@ mod tests {
 
     #[test]
     fn test_process_config() {
+        let port = GUEST_AGENT_VSOCK_PORT.to_string();
         let config = ProcessConfig {
             id: "agent-1".to_string(),
             path: "/usr/local/bin/mvm-guest-agent".to_string(),
-            args: vec!["--port".to_string(), "52".to_string()],
-            env: vec!["MVM_VSOCK_PORT=52".to_string()],
+            args: vec!["--port".to_string(), port.clone()],
+            env: vec![format!("MVM_VSOCK_PORT={port}")],
             cwd: "/".to_string(),
         };
         assert_eq!(config.id, "agent-1");
@@ -147,6 +154,9 @@ mod tests {
     #[test]
     fn test_vsock_port_constants() {
         assert_eq!(VMINITD_VSOCK_PORT, 1024);
-        assert_eq!(GUEST_AGENT_VSOCK_PORT, 52);
+        assert_eq!(GUEST_AGENT_VSOCK_PORT, 5252);
+        // Sanity: must stay above the privileged-port gate so the
+        // agent (uid 901, no caps) can bind. ADR-002 §W4.5.
+        const _: () = assert!(GUEST_AGENT_VSOCK_PORT > 1023);
     }
 }

--- a/crates/mvm-runtime/src/vsock_transport.rs
+++ b/crates/mvm-runtime/src/vsock_transport.rs
@@ -160,7 +160,9 @@ mod tests {
         // factory contract has a regression net even on hosts where
         // `tempfile` + UDS listeners would be flaky in CI.
         let t = VsockProxyTransport::new("/tmp/mvm-proxy-does-not-exist.sock");
-        let err = t.connect(52).expect_err("should fail to connect");
+        let err = t
+            .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+            .expect_err("should fail to connect");
         assert!(
             err.to_string().contains("vsock proxy"),
             "error didn't mention proxy: {err}"
@@ -172,7 +174,9 @@ mod tests {
         let t = FirecrackerTransport::new("/tmp/no-such-instance", 1);
         // No real socket → error mentions the UDS path so callers
         // can tell which backend is being attempted.
-        let err = t.connect(52).expect_err("should fail to connect");
+        let err = t
+            .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+            .expect_err("should fail to connect");
         let msg = err.to_string();
         assert!(
             msg.contains("/tmp/no-such-instance"),

--- a/nix/lib/minimal-init/default.nix
+++ b/nix/lib/minimal-init/default.nix
@@ -48,21 +48,22 @@
 #     extraPathDirs = [ "${pkgs.git}/bin" ];
 #   };
 
-{ pkgs
-, lib ? pkgs.lib
-, busybox ? pkgs.pkgsStatic.busybox
-, hostname ? "mvm"
-, serviceGroup ? "mvm"
-, users ? {}
-, services ? {}
-, healthChecks ? {}
-, guestAgentPkg ? null
-, extraPathDirs ? []
-# `pkgs.util-linux` shipped to the rootfs by mkGuest. Init's service
-# launches use `setpriv(1)` from this package to drop capabilities,
-# clear the inheritable cap set, and set `no_new_privs` before
-# handing off to the user's command. ADR-002 §W2.3.
-, utilLinux ? pkgs.util-linux
+{
+  pkgs,
+  lib ? pkgs.lib,
+  busybox ? pkgs.pkgsStatic.busybox,
+  hostname ? "mvm",
+  serviceGroup ? "mvm",
+  users ? { },
+  services ? { },
+  healthChecks ? { },
+  guestAgentPkg ? null,
+  extraPathDirs ? [ ],
+  # `pkgs.util-linux` shipped to the rootfs by mkGuest. Init's service
+  # launches use `setpriv(1)` from this package to drop capabilities,
+  # clear the inheritable cap set, and set `no_new_privs` before
+  # handing off to the user's command. ADR-002 §W2.3.
+  utilLinux ? pkgs.util-linux,
 }:
 
 let
@@ -70,26 +71,39 @@ let
 
   # ── Users ────────────────────────────────────────────────────────
   # Auto-assign UIDs starting from 1000 for users that don't specify one.
-  userList = lib.mapAttrsToList (name: cfg: { inherit name; config = cfg; }) users;
-  assignUids = idx: remaining:
-    if remaining == [] then []
+  userList = lib.mapAttrsToList (name: cfg: {
+    inherit name;
+    config = cfg;
+  }) users;
+  assignUids =
+    idx: remaining:
+    if remaining == [ ] then
+      [ ]
     else
       let
         head = builtins.head remaining;
         tail = builtins.tail remaining;
         uid = head.config.uid or (1000 + idx);
       in
-        [{ name = head.name; uid = uid; config = head.config; }]
-        ++ assignUids (idx + 1) tail;
+      [
+        {
+          name = head.name;
+          uid = uid;
+          config = head.config;
+        }
+      ]
+      ++ assignUids (idx + 1) tail;
   usersWithUids = assignUids 0 userList;
 
-  mkUserBlock = entry:
+  mkUserBlock =
+    entry:
     let
       name = entry.name;
       uid = toString entry.uid;
       group = entry.config.group or name;
       home = entry.config.home or "/home/${name}";
-    in ''
+    in
+    ''
       # User blocks write to /run/mvm-etc/{passwd,group} (the staging
       # tmpfs); the bind-mount onto /etc/* runs after every block has
       # appended its entries (see lib/04-etc-and-users.sh.in). The
@@ -141,103 +155,141 @@ let
   # to land in the [0, 7999] window, plus 1100 base. The base sits
   # above the dev-image's user IDs (root, default service group at
   # 900, guest-agent at 901, and the auto-assigned-1000 customs).
-  hashName = name:
+  hashName =
+    name:
     let
       hex = builtins.substring 0 8 (builtins.hashString "sha256" name);
       # Convert 8-char hex to integer via byte-wise arithmetic. Nix's
       # bitwise ops are limited; this is the documented idiom.
-      hexDigit = c:
-        if c == "0" then 0
-        else if c == "1" then 1
-        else if c == "2" then 2
-        else if c == "3" then 3
-        else if c == "4" then 4
-        else if c == "5" then 5
-        else if c == "6" then 6
-        else if c == "7" then 7
-        else if c == "8" then 8
-        else if c == "9" then 9
-        else if c == "a" then 10
-        else if c == "b" then 11
-        else if c == "c" then 12
-        else if c == "d" then 13
-        else if c == "e" then 14
-        else 15;  # f
-      go = i: acc:
-        if i >= 8 then acc
-        else go (i + 1) (acc * 16 + hexDigit (builtins.substring i 1 hex));
+      hexDigit =
+        c:
+        if c == "0" then
+          0
+        else if c == "1" then
+          1
+        else if c == "2" then
+          2
+        else if c == "3" then
+          3
+        else if c == "4" then
+          4
+        else if c == "5" then
+          5
+        else if c == "6" then
+          6
+        else if c == "7" then
+          7
+        else if c == "8" then
+          8
+        else if c == "9" then
+          9
+        else if c == "a" then
+          10
+        else if c == "b" then
+          11
+        else if c == "c" then
+          12
+        else if c == "d" then
+          13
+        else if c == "e" then
+          14
+        else
+          15; # f
+      go = i: acc: if i >= 8 then acc else go (i + 1) (acc * 16 + hexDigit (builtins.substring i 1 hex));
     in
-      go 0 0;
+    go 0 0;
 
   serviceUid = name: 1100 + (lib.mod (hashName name) 8000);
 
   # The service-derived attrs get used by both the user-block
   # generator (so /etc/passwd has the entry) and the launch block.
-  serviceIdentity = name: svc:
+  serviceIdentity =
+    name: svc:
     if svc ? user then
       # Caller specified an explicit user — assume they also added it
       # to `users`. The setpriv launcher reads uid/gid from the live
       # /etc, so we don't need them at Nix-eval time.
-      { user = svc.user; explicit = true; uid = null; gid = null; }
+      {
+        user = svc.user;
+        explicit = true;
+        uid = null;
+        gid = null;
+      }
     else
-      let uid = serviceUid name;
-      in { user = "svc-${name}"; explicit = false; uid = uid; gid = uid; }
-  ;
+      let
+        uid = serviceUid name;
+      in
+      {
+        user = "svc-${name}";
+        explicit = false;
+        uid = uid;
+        gid = uid;
+      };
 
   # Per-service /etc entries. Joined into `userBlocks` alongside the
   # caller's explicit `users.*` entries. Writes target /run/mvm-etc/*
   # (staging) — the bind-mount onto /etc/* runs after every block has
   # appended; see lib/04-etc-and-users.sh.in.
-  mkServiceUserBlock = name: svc:
-    let id = serviceIdentity name svc; in
-    if id.explicit then ""
-    else ''
-      # Auto-derived service identity for ${name} (ADR-002 §W2.1)
-      grep -q "^${id.user}:" /run/mvm-etc/group || echo '${id.user}:x:${toString id.gid}:' >> /run/mvm-etc/group
-      grep -q "^${id.user}:" /run/mvm-etc/passwd || echo '${id.user}:x:${toString id.uid}:${toString id.gid}:${id.user}:/var/empty:${bb}/bin/sh' >> /run/mvm-etc/passwd
-      # Add to ${serviceGroup} so this user can read shared secrets at
-      # /mnt/secrets (mode 0440 root:${serviceGroup}). Per-service
-      # secrets at /run/mvm-secrets/${name}/ are mode 0400 owned by
-      # this uid directly — they don't go through the group.
-      sed -i 's/^${serviceGroup}:x:900:.*$/&,${id.user}/' /run/mvm-etc/group
-      sed -i 's/^${serviceGroup}:x:900:,/${serviceGroup}:x:900:/' /run/mvm-etc/group
-    '';
+  mkServiceUserBlock =
+    name: svc:
+    let
+      id = serviceIdentity name svc;
+    in
+    if id.explicit then
+      ""
+    else
+      ''
+        # Auto-derived service identity for ${name} (ADR-002 §W2.1)
+        grep -q "^${id.user}:" /run/mvm-etc/group || echo '${id.user}:x:${toString id.gid}:' >> /run/mvm-etc/group
+        grep -q "^${id.user}:" /run/mvm-etc/passwd || echo '${id.user}:x:${toString id.uid}:${toString id.gid}:${id.user}:/var/empty:${bb}/bin/sh' >> /run/mvm-etc/passwd
+        # Add to ${serviceGroup} so this user can read shared secrets at
+        # /mnt/secrets (mode 0440 root:${serviceGroup}). Per-service
+        # secrets at /run/mvm-secrets/${name}/ are mode 0400 owned by
+        # this uid directly — they don't go through the group.
+        sed -i 's/^${serviceGroup}:x:900:.*$/&,${id.user}/' /run/mvm-etc/group
+        sed -i 's/^${serviceGroup}:x:900:,/${serviceGroup}:x:900:/' /run/mvm-etc/group
+      '';
 
-  serviceUserBlocks = lib.concatStringsSep "\n" (
-    lib.mapAttrsToList mkServiceUserBlock services
-  );
+  serviceUserBlocks = lib.concatStringsSep "\n" (lib.mapAttrsToList mkServiceUserBlock services);
 
   # Per-service secrets directory. Each service gets a subdir under
   # /run/mvm-secrets/ owned by its uid mode 0400 — siblings can't
   # cross-read. The legacy /run/mvm-secrets/ shared view is preserved
   # for back-compat but flagged in a deprecation notice.
-  mkServiceSecretsBlock = name: svc:
-    let id = serviceIdentity name svc; in
+  mkServiceSecretsBlock =
+    name: svc:
+    let
+      id = serviceIdentity name svc;
+    in
     let
       # Filter the staged secrets to those whose filename starts with
       # "<svc-name>." or matches "<svc-name>" exactly. Anything else
       # stays in the shared bucket.
       copyCmd =
-        if id.explicit then ''
-          mkdir -p /run/mvm-secrets/${name}
-          for f in /run/mvm-secrets/${name}.* /run/mvm-secrets/${name}; do
-            [ -e "$f" ] || continue
-            cp "$f" /run/mvm-secrets/${name}/$(basename "$f")
-          done
-          chown -R ${id.user}:${id.user} /run/mvm-secrets/${name} 2>/dev/null || true
-          chmod 0500 /run/mvm-secrets/${name}
-          chmod 0400 /run/mvm-secrets/${name}/* 2>/dev/null || true
-        '' else ''
-          mkdir -p /run/mvm-secrets/${name}
-          for f in /run/mvm-secrets/${name}.* /run/mvm-secrets/${name}; do
-            [ -e "$f" ] || continue
-            cp "$f" /run/mvm-secrets/${name}/$(basename "$f")
-          done
-          chown -R ${toString id.uid}:${toString id.gid} /run/mvm-secrets/${name} 2>/dev/null || true
-          chmod 0500 /run/mvm-secrets/${name}
-          chmod 0400 /run/mvm-secrets/${name}/* 2>/dev/null || true
-        '';
-    in copyCmd;
+        if id.explicit then
+          ''
+            mkdir -p /run/mvm-secrets/${name}
+            for f in /run/mvm-secrets/${name}.* /run/mvm-secrets/${name}; do
+              [ -e "$f" ] || continue
+              cp "$f" /run/mvm-secrets/${name}/$(basename "$f")
+            done
+            chown -R ${id.user}:${id.user} /run/mvm-secrets/${name} 2>/dev/null || true
+            chmod 0500 /run/mvm-secrets/${name}
+            chmod 0400 /run/mvm-secrets/${name}/* 2>/dev/null || true
+          ''
+        else
+          ''
+            mkdir -p /run/mvm-secrets/${name}
+            for f in /run/mvm-secrets/${name}.* /run/mvm-secrets/${name}; do
+              [ -e "$f" ] || continue
+              cp "$f" /run/mvm-secrets/${name}/$(basename "$f")
+            done
+            chown -R ${toString id.uid}:${toString id.gid} /run/mvm-secrets/${name} 2>/dev/null || true
+            chmod 0500 /run/mvm-secrets/${name}
+            chmod 0400 /run/mvm-secrets/${name}/* 2>/dev/null || true
+          '';
+    in
+    copyCmd;
 
   serviceSecretsBlocks = lib.concatStringsSep "\n" (
     lib.mapAttrsToList mkServiceSecretsBlock services
@@ -260,7 +312,8 @@ let
   # Capabilities are dropped *before* the command runs; the bounding
   # set is empty so a setuid root binary the command might invoke
   # gets uid 0 with zero capabilities — meaningless escalation.
-  mkServiceBlock = name: svc:
+  mkServiceBlock =
+    name: svc:
     let
       preStart = svc.preStart or "";
       preBlock = lib.optionalString (preStart != "") ''
@@ -271,12 +324,9 @@ let
       # --env flags sourced globally from mvm-env.env). This lets
       # `mvmctl up --env PORT=9000` override `env.PORT = "3100"`.
       envLines = lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (k: v: ": \${${k}:='${v}'} ; export ${k}") (svc.env or {})
+        lib.mapAttrsToList (k: v: ": \${${k}:='${v}'} ; export ${k}") (svc.env or { })
       );
-      redirect = if (svc ? logFile) then
-        ">> ${svc.logFile} 2>&1"
-      else
-        "> /dev/console 2>&1";
+      redirect = if (svc ? logFile) then ">> ${svc.logFile} 2>&1" else "> /dev/console 2>&1";
       logSetup = lib.optionalString (svc ? logFile) ''
         mkdir -p "$(dirname '${svc.logFile}')"
       '';
@@ -290,25 +340,24 @@ let
         if id.explicit then
           "${utilLinux}/bin/setpriv --reuid=${id.user} --regid=${id.user} --init-groups --bounding-set=-all --no-new-privs --inh-caps=-all"
         else
-          "${utilLinux}/bin/setpriv --reuid=${toString id.uid} --regid=${toString id.gid} --groups=${toString id.gid},900 --bounding-set=-all --no-new-privs --inh-caps=-all"
-      ;
+          "${utilLinux}/bin/setpriv --reuid=${toString id.uid} --regid=${toString id.gid} --groups=${toString id.gid},900 --bounding-set=-all --no-new-privs --inh-caps=-all";
       # The seccomp shim. `mvm-seccomp-apply` ships in the guest agent's
       # closure, so we look it up via guestAgentPkg's bin dir. When
       # guestAgentPkg is null (production OCI-only consumers), skip
       # the seccomp wrap — the resulting image has no `setpriv` or
       # `mvm-seccomp-apply` for service launches anyway.
       seccompPrefix =
-        if guestAgentPkg == null then ""
-        else "${guestAgentPkg}/bin/mvm-seccomp-apply ${tier} --"
-      ;
+        if guestAgentPkg == null then "" else "${guestAgentPkg}/bin/mvm-seccomp-apply ${tier} --";
       cmdLine =
         if seccompPrefix == "" then
           "${setprivPrefix} -- ${bb}/bin/sh -c '${svc.command}'"
         else
-          "${seccompPrefix} ${setprivPrefix} -- ${bb}/bin/sh -c '${svc.command}'"
-      ;
-    in ''
-      # --- Service: ${name} (uid=${if id.explicit then id.user else toString id.uid}, seccomp=${tier}) ---
+          "${seccompPrefix} ${setprivPrefix} -- ${bb}/bin/sh -c '${svc.command}'";
+    in
+    ''
+      # --- Service: ${name} (uid=${
+        if id.explicit then id.user else toString id.uid
+      }, seccomp=${tier}) ---
       (
         ${envLines}
         ${logSetup}
@@ -329,36 +378,38 @@ let
       ) &
       SERVICE_PIDS="$SERVICE_PIDS $!"
     '';
-  serviceBlocks = lib.concatStringsSep "\n" (
-    lib.mapAttrsToList mkServiceBlock services
-  );
+  serviceBlocks = lib.concatStringsSep "\n" (lib.mapAttrsToList mkServiceBlock services);
 
   # ── Health checks ────────────────────────────────────────────────
-  mkHealthCheckFile = name: check:
+  mkHealthCheckFile =
+    name: check:
     let
       obj = {
         inherit name;
         health_cmd = check.healthCmd;
         health_interval_secs = check.healthIntervalSecs or 30;
         health_timeout_secs = check.healthTimeoutSecs or 10;
-      } // lib.optionalAttrs (check ? checkpointCmd) {
+      }
+      // lib.optionalAttrs (check ? checkpointCmd) {
         checkpoint_cmd = check.checkpointCmd;
-      } // lib.optionalAttrs (check ? restoreCmd) {
+      }
+      // lib.optionalAttrs (check ? restoreCmd) {
         restore_cmd = check.restoreCmd;
-      } // lib.optionalAttrs (check ? critical) {
+      }
+      // lib.optionalAttrs (check ? critical) {
         critical = check.critical;
-      } // lib.optionalAttrs (check ? startupGraceSecs) {
+      }
+      // lib.optionalAttrs (check ? startupGraceSecs) {
         startup_grace_secs = check.startupGraceSecs;
       };
       json = builtins.toJSON obj;
-    in ''
+    in
+    ''
       cat > /etc/mvm/integrations.d/${name}.json <<'HEALTHEOF'
       ${json}
       HEALTHEOF
     '';
-  healthCheckBlocks = lib.concatStringsSep "\n" (
-    lib.mapAttrsToList mkHealthCheckFile healthChecks
-  );
+  healthCheckBlocks = lib.concatStringsSep "\n" (lib.mapAttrsToList mkHealthCheckFile healthChecks);
 
   # ── Guest agent ──────────────────────────────────────────────────
   #
@@ -367,8 +418,16 @@ let
   # important. ADR-002 §W4.5.
   #
   # Why setpriv works for the agent:
-  #   - vsock binds are unprivileged on Linux (the kernel validates only
-  #     the family + CID, no port-range gate like AF_INET);
+  #   - the agent's vsock listen port (`GUEST_AGENT_PORT`, 5252) sits
+  #     above 1023, so the kernel's `LAST_RESERVED_PORT` gate in
+  #     `__vsock_bind_stream` is *not* invoked and `bind(2)` succeeds
+  #     without `CAP_NET_BIND_SERVICE`. (An earlier comment here
+  #     incorrectly claimed vsock binds are *always* unprivileged on
+  #     Linux. They aren't — vsock has the same priv-port gate as
+  #     AF_INET. Port 52 was the historical agent port; it's been
+  #     moved out of the privileged range so the agent can bind
+  #     it under W4.5's reduced capability set. See
+  #     `mvm_guest::vsock::GUEST_AGENT_PORT`.)
   #   - the agent reads drop-in configs from /etc/mvm/integrations.d/
   #     and writes its log line to /dev/console (mode 0666 by default
   #     under devtmpfs);
@@ -414,8 +473,9 @@ let
   '';
 
   # ── PATH ─────────────────────────────────────────────────────────
-  extraPathDirsRendered = lib.optionalString (extraPathDirs != [])
-    (":" + lib.concatStringsSep ":" extraPathDirs);
+  extraPathDirsRendered = lib.optionalString (extraPathDirs != [ ]) (
+    ":" + lib.concatStringsSep ":" extraPathDirs
+  );
 
   # ── udhcpc helper ────────────────────────────────────────────────
   # The udhcpc(8) action script must live somewhere the daemon can
@@ -456,50 +516,46 @@ let
   # scan each fragment for the `@name@` tokens it actually uses and pass
   # only those — the lib's substitution table is the union, and each
   # fragment subscribes to whatever subset it references.
-  pickSubsts = source:
+  pickSubsts =
+    source:
     let
-      tokens = builtins.match
-        ".*"
-        source;
+      tokens = builtins.match ".*" source;
       # `match` returns null on failure or a list of capture groups; we
       # don't use captures, so a non-null result just means "the file is
       # readable text". Token discovery uses a simple regex split.
       matches = builtins.split "@([a-zA-Z][a-zA-Z0-9_]*)@" source;
       names = lib.unique (
-        builtins.filter builtins.isString (
-          builtins.concatLists (
-            builtins.filter builtins.isList matches
-          )
-        )
+        builtins.filter builtins.isString (builtins.concatLists (builtins.filter builtins.isList matches))
       );
       _ = tokens;
     in
-      lib.filterAttrs (name: _: builtins.elem name names) libSubsts;
+    lib.filterAttrs (name: _: builtins.elem name names) libSubsts;
 
   # Render one fragment to a string. `.sh.in` files are run through
   # `replaceVars`; `.sh` files are read verbatim. We use
   # `builtins.readFile` on the rendered store path so the result is
   # an inline string that can itself be substituted into init.sh.in —
   # this keeps the final /init a single concatenated script.
-  renderLib = path:
+  renderLib =
+    path:
     if lib.hasSuffix ".sh.in" (toString path) then
       let
         contents = builtins.readFile path;
         substs = pickSubsts contents;
       in
-        builtins.readFile (pkgs.replaceVars path substs)
+      builtins.readFile (pkgs.replaceVars path substs)
     else
       builtins.readFile path;
 
   initLibs = {
-    mountsLib            = renderLib ./lib/01-mounts.sh;
-    nixOverlayLib        = renderLib ./lib/02-nix-overlay.sh;
-    hostSharesLib        = renderLib ./lib/03-host-shares.sh;
-    etcAndUsersLib       = renderLib ./lib/04-etc-and-users.sh.in;
-    networkingLib        = renderLib ./lib/05-networking.sh.in;
-    optionalDrivesLib    = renderLib ./lib/06-optional-drives.sh.in;
-    servicesAndAgentLib  = renderLib ./lib/07-services-and-agent.sh.in;
-    signalHandlersLib    = renderLib ./lib/08-signal-handlers.sh.in;
+    mountsLib = renderLib ./lib/01-mounts.sh;
+    nixOverlayLib = renderLib ./lib/02-nix-overlay.sh;
+    hostSharesLib = renderLib ./lib/03-host-shares.sh;
+    etcAndUsersLib = renderLib ./lib/04-etc-and-users.sh.in;
+    networkingLib = renderLib ./lib/05-networking.sh.in;
+    optionalDrivesLib = renderLib ./lib/06-optional-drives.sh.in;
+    servicesAndAgentLib = renderLib ./lib/07-services-and-agent.sh.in;
+    signalHandlersLib = renderLib ./lib/08-signal-handlers.sh.in;
   };
 
   # Same pickSubsts treatment as the lib fragments: only pass the
@@ -507,13 +563,19 @@ let
   # (`@hostname@`, `@userBlocks@`, …) is consumed by lib fragments
   # before they're inlined here.
   initSource = builtins.readFile ./init.sh.in;
-  initSubsts = let all = libSubsts // initLibs; in
-    lib.filterAttrs
-      (name: _: builtins.any (s: s == name)
-        (builtins.filter builtins.isString
-          (builtins.concatLists
-            (builtins.filter builtins.isList
-              (builtins.split "@([a-zA-Z][a-zA-Z0-9_]*)@" initSource)))))
-      all;
+  initSubsts =
+    let
+      all = libSubsts // initLibs;
+    in
+    lib.filterAttrs (
+      name: _:
+      builtins.any (s: s == name) (
+        builtins.filter builtins.isString (
+          builtins.concatLists (
+            builtins.filter builtins.isList (builtins.split "@([a-zA-Z][a-zA-Z0-9_]*)@" initSource)
+          )
+        )
+      )
+    ) all;
 in
 pkgs.replaceVars ./init.sh.in initSubsts

--- a/nix/lib/minimal-init/lib/04-etc-and-users.sh.in
+++ b/nix/lib/minimal-init/lib/04-etc-and-users.sh.in
@@ -43,8 +43,10 @@ chown 900:900 /home/@serviceGroup@
 # RPC endpoint and must not run as root — see ADR-002 §W4.5. It is
 # enrolled in @serviceGroup@ (gid 900) so it can read shared
 # integration drop-in configs at /etc/mvm/integrations.d/ and the
-# legacy shared-secret bucket. Vsock binds are unprivileged on Linux,
-# so port 52 + the host-bound port can be opened without CAP_NET_*.
+# legacy shared-secret bucket. The agent's vsock listen port
+# (GUEST_AGENT_PORT, 5252) sits above 1023, so bind(2) succeeds
+# without CAP_NET_BIND_SERVICE — vsock applies the same priv-port
+# gate as AF_INET (LAST_RESERVED_PORT = 1023 in the kernel).
 echo "mvm-agent:x:901:" >> /run/mvm-etc/group
 echo "mvm-agent:x:901:901:mvm-agent:/var/empty:@busybox@/bin/sh" >> /run/mvm-etc/passwd
 sed -i 's/^@serviceGroup@:x:900:.*$/&,mvm-agent/' /run/mvm-etc/group

--- a/public/src/content/docs/guides/networking.md
+++ b/public/src/content/docs/guides/networking.md
@@ -45,9 +45,9 @@ MicroVMs don't use networking for host communication -- they use **vsock**:
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
-| 52 | Length-prefixed JSON | Guest agent (health checks, status, snapshot lifecycle) |
+| 5252 | Length-prefixed JSON | Guest agent (health checks, status, snapshot lifecycle) |
 
-The host connects by writing `CONNECT 52\n` to the vsock socket and reading `OK 52\n`. All requests are request/response pairs. vsock is supported on Firecracker, Apple Container, and microvm.nix backends. Docker uses a unix socket instead.
+The host connects by writing `CONNECT 5252\n` to the vsock socket and reading `OK 5252\n`. All requests are request/response pairs. vsock is supported on Firecracker, Apple Container, and microvm.nix backends. Docker uses a unix socket instead.
 
 ## No SSH
 

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -3,7 +3,7 @@ title: Guest Agent
 description: The mvm guest agent provides host visibility and control over microVMs via vsock.
 ---
 
-Every microVM built with `mkGuest` includes **mvm-guest-agent**, a lightweight Rust daemon that runs inside the guest on vsock port 52.
+Every microVM built with `mkGuest` includes **mvm-guest-agent**, a lightweight Rust daemon that runs inside the guest on vsock port 5252.
 
 ## Capabilities
 
@@ -21,8 +21,8 @@ Every microVM built with `mkGuest` includes **mvm-guest-agent**, a lightweight R
 
 The agent communicates using **length-prefixed JSON frames** over vsock (Firecracker, Apple Container, microvm.nix) or a unix socket (Docker):
 
-1. Host writes `CONNECT 52\n` to the socket
-2. Agent responds with `OK 52\n`
+1. Host writes `CONNECT 5252\n` to the socket
+2. Agent responds with `OK 5252\n`
 3. All subsequent communication is request/response pairs
 
 Request types: `ping`, `status`, `sleep-prep`, `wake`, and more.

--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -77,7 +77,7 @@ Each is addressed in the corresponding workstream of plan 25.
 | VirtioFS workdir share | Writable, scoped to project dir | Unchanged shape, but per-service uid means no service can write there without explicit user grant (W2.1) |
 | VirtioFS datadir share | Writable, scoped to `~/.mvm` | Same; mode-locked containment via uid + `nosuid,nodev` mount opts (W2.3) |
 | Host-side proxy socket | Mode inherits umask (typ. 0755) | Mode `0700` post-bind (W1.2) |
-| Vsock proxy port-forward | Any port allowed | Allowlist: 52 + `PORT_FORWARD_BASE..+65535` (W1.3) |
+| Vsock proxy port-forward | Any port allowed | Allowlist: `GUEST_AGENT_PORT` (5252) + `PORT_FORWARD_BASE..+65535` (W1.3) |
 | Console log + daemon log | Mode inherits umask | Mode `0600` (W1.4) |
 | Block device passthrough | `nix-store.img` attached as `/dev/vdb`; host doesn't mount it | Documented invariant: host shall never `mount` this file. Static-check in code review. |
 


### PR DESCRIPTION
## Summary

- Moves `mvm_guest::vsock::GUEST_AGENT_PORT` from **52 → 5252** so the guest agent can `bind(2)` under W4.5's reduced cap set (uid 901, no `CAP_NET_BIND_SERVICE`). AF_VSOCK on Linux applies the same `LAST_RESERVED_PORT = 1023` gate as AF_INET — a code comment in `nix/lib/minimal-init` had this wrong.
- Updates the two duplicate constants (`mvm-apple-container`, `mvm-runtime/src/vm/vminitd_client`) with lockstep doc comments, plus `const _: () = assert!(GUEST_AGENT_PORT > 1023);` static guards in two places so future drift fails to compile.
- Apple-container proxy allowlist now references the constant and explicitly asserts that 52 is rejected; ADR-002 §W1.3 + README + public docs + nix init scripts all updated.

## Why 5252

5252 is >1023 (clears the priv-port gate) and below `PORT_FORWARD_BASE` at 10_000 and `CONSOLE_PORT_BASE` at 20_000, so the host-side proxy allowlist keeps its disjoint-union shape. The "52" tail is a callback to the historical port for grep-ability.

## Note on diff size

`nix fmt` reformatted `nix/lib/minimal-init/default.nix` on commit (project pre-commit hook). The semantic change in that file is a single corrected comment — the rest is whitespace churn. Reviewable as such.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all suites pass, including:
  - apple-container allowlist test now asserts 52 is rejected and the agent slot ports are exact-match
  - vsock_transport tests use `mvm_guest::vsock::GUEST_AGENT_PORT` instead of literal 52
  - new compile-time `assert!(... > 1023)` guards in `mvm-guest` and `mvm-runtime/vminitd_client`
- [ ] Live KVM smoke (next CI run): confirm guest agent still answers on the new port end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)