### PR TITLE
fix(ci): symbol-contract gate now actually inspects what it claims to

### DIFF
--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -850,6 +850,17 @@ fn evt(e: EntrypointEvent) -> GuestResponse {
 /// Handle a `RunEntrypoint` request. Writes streaming events directly via
 /// `write_response` and returns the terminal event for the dispatcher to
 /// send through the existing `match` arm pattern.
+///
+/// `#[inline(never)]` is load-bearing for the W5 symbol-contract gate.
+/// LTO inlines functions called from a single site (line ~1133), which
+/// would erase the `mvm_guest_agent::handle_run_entrypoint` symbol from
+/// `nm` output even though the handler is logically compiled in. The
+/// gate (`scripts/check-prod-agent-no-exec.sh`, ADR-007 §W5) requires
+/// the symbol to be present as positive evidence that the W2 handler
+/// is wired up. Without `inline(never)` the gate fails on every prod
+/// build. Cost: one extra call boundary in a slow-path RPC handler —
+/// imperceptible.
+#[inline(never)]
 fn handle_run_entrypoint(
     file: &mut std::fs::File,
     stdin: Vec<u8>,

--- a/scripts/check-prod-agent-no-exec.sh
+++ b/scripts/check-prod-agent-no-exec.sh
@@ -33,11 +33,22 @@ echo "==> building mvm-guest-agent (production: no dev-shell feature, profile=$P
 # --no-default-features and explicit feature list both omit dev-shell, but
 # the crate has no default features today so --no-default-features is the
 # defensive choice — adding a default later won't silently arm the gate.
+#
+# `profile.release.strip = "none"` override: the workspace's release
+# profile sets `strip = true`, which removes ALL symbols from the
+# binary. Without this override every `nm`-based check below would
+# trivially "succeed" on the negative gate (do_exec absent because
+# everything is stripped) and "fail" on the positive gate
+# (handle_run_entrypoint absent for the same reason). The override
+# only affects this verification build under `target/release/`; the
+# shipping artifact built by callers without this script still gets
+# stripped per the workspace profile.
 cargo build \
     -p mvm-guest \
     --bin mvm-guest-agent \
     --profile "$PROFILE" \
-    --no-default-features
+    --no-default-features \
+    --config 'profile.release.strip="none"'
 
 case "$PROFILE" in
     dev) PROFILE_DIR="debug" ;;


### PR DESCRIPTION
## Summary

`scripts/check-prod-agent-no-exec.sh` (ADR-002 §W4.3 + ADR-007 §W5) has been silently failing on `main` since it landed in #71. The check asserts two contracts on the same release binary, both of which were broken:

- **Negative gate** (`mvm_guest_agent::do_exec` ABSENT): trivially passed, because `[profile.release] strip = true` removes _all_ Rust symbols — `do_exec` was "absent" not because it was cfg-gated out, but because nothing was visible.
- **Positive gate** (`mvm_guest_agent::handle_run_entrypoint` PRESENT): trivially failed for the same reason. Even with strip disabled, LTO inlines the function at its single call site in the dispatcher, erasing the symbol.

Two fixes:

1. `scripts/check-prod-agent-no-exec.sh`: pass `--config 'profile.release.strip="none"'` to the verification build so symbols exist for `nm` to inspect. The shipping artifact (built by callers without this script) is unaffected and still stripped per the workspace profile.
2. `crates/mvm-guest/src/bin/mvm-guest-agent.rs`: `#[inline(never)]` on `handle_run_entrypoint`. Cost is one extra call boundary in a slow-path RPC handler.

After both, the gate runs the assertions it always intended to: `do_exec` genuinely absent (cfg-gated out), `handle_run_entrypoint` genuinely present (compiled in, not inlined).

## Test plan

- [x] `./scripts/check-prod-agent-no-exec.sh` locally — both gates now report ok
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p mvm-guest` — all 114 tests pass
- [ ] CI: same job will show "ok: handle_run_entrypoint symbol present" instead of the missing-symbol error that's been on `main`

## Why this matters

The gate was load-bearing-by-design — it's the CI evidence that the W2 handler ships in production builds. Today's broken state means the contract isn't actually enforced; a future regression that removed `handle_run_entrypoint` entirely would still pass CI. This restores the assertion to working order without changing the production binary's shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)