### PR TITLE
feat(guest): warm-process function dispatch (plan 43, ADR-0011 tier 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,6 +2366,7 @@ name = "mvm-guest"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "ed25519-dalek",
  "libc",

--- a/crates/mvm-guest/Cargo.toml
+++ b/crates/mvm-guest/Cargo.toml
@@ -42,6 +42,17 @@ path = "src/bin/mvm-verity-init.rs"
 name = "syscall-probe"
 path = "src/bin/syscall-probe.rs"
 
+# Test fixture for the warm-process worker pool (plan 43). Speaks the
+# `worker_protocol` framed multi-call loop on stdin/stdout. Behavior
+# selectable via `MVM_FAKE_RUNNER_BEHAVIOR` env var so tests can
+# exercise crash, recycle, slow, and malformed-frame paths against a
+# real child process. Not selected by the production guest closure.
+[[bin]]
+name = "fake-runner"
+path = "tests/bin/fake_runner.rs"
+test = false
+doctest = false
+
 [features]
 dev-shell = []
 
@@ -49,6 +60,7 @@ dev-shell = []
 mvm-core.workspace = true
 mvm-security.workspace = true
 anyhow.workspace = true
+base64.workspace = true
 chrono.workspace = true
 ed25519-dalek.workspace = true
 libc.workspace = true

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -31,10 +31,13 @@ use mvm_guest::integrations::{
     self, IntegrationEntry, IntegrationHealthResult, IntegrationStateReport, IntegrationStatus,
 };
 use mvm_guest::probes::{self, ProbeEntry, ProbeOutputFormat, ProbeResult};
+use mvm_guest::runtime_config::{self, ConcurrencyConfig};
 use mvm_guest::vsock::{
     EntrypointEvent, FsChange, FsChangeKind, GUEST_AGENT_PORT, GuestRequest, GuestResponse,
     RunEntrypointError,
 };
+use mvm_guest::worker_pool::{DispatchError, DispatchOutcome, WorkerPool};
+use mvm_guest::worker_protocol::WorkerOutcome;
 use serde::Deserialize;
 
 // ============================================================================
@@ -779,10 +782,21 @@ fn do_exec(command: &str, stdin_data: Option<&str>, _timeout_secs: u64) -> Guest
 /// any TOCTOU between validation and spawn.
 static VALIDATED_ENTRYPOINT: OnceLock<Result<ValidatedEntrypoint, String>> = OnceLock::new();
 
-/// One in-flight `RunEntrypoint` per VM (M12). Concurrent callers get
-/// `EntrypointEvent::Error { kind: Busy }` immediately; pool growth is the
-/// host-side concurrency lever.
+/// One in-flight `RunEntrypoint` per VM (M12) — applies to the cold
+/// path only. When `WARM_POOL.is_some()`, this lock is bypassed; the
+/// new invariant is "one in-flight call per worker, ≤ `pool_size`
+/// concurrent" (plan 43). Concurrent callers under cold-tier still
+/// get `EntrypointEvent::Error { kind: Busy }` immediately; warm-tier
+/// callers queue FIFO up to `max_queue_depth` and get `Busy` on
+/// overflow.
 static RUN_ENTRYPOINT_LOCK: Mutex<()> = Mutex::new(());
+
+/// Warm-process worker pool, populated at boot from
+/// `/etc/mvm/runtime.json` (plan 43). `None` means cold-tier
+/// behavior — the existing M12 single-call path. `Some(_)` activates
+/// the warm-process branch in `handle_run_entrypoint` and the
+/// thread-per-connection accept-loop.
+static WARM_POOL: OnceLock<Option<Arc<WorkerPool>>> = OnceLock::new();
 
 /// Validate `/etc/mvm/entrypoint` at agent boot. The result is stashed in
 /// `VALIDATED_ENTRYPOINT`. On failure, log a single line — the agent stays
@@ -802,6 +816,56 @@ fn init_entrypoint_validation() {
         ),
     }
     let _ = VALIDATED_ENTRYPOINT.set(result);
+}
+
+/// Read `/etc/mvm/runtime.json` and, if it carries `concurrency.kind
+/// = "warm_process"`, stand up the worker pool. Plan 43.
+///
+/// Failure modes are deliberately fail-loud — mvmforge owns
+/// `runtime.json`, so a malformed file or rejected `in_process` mode
+/// is a build bug, not a runtime fallback. The agent exits non-zero
+/// rather than silently dropping to cold tier and confusing
+/// observers about which tier is active.
+///
+/// Missing `runtime.json` or absent `concurrency` → `Ok(None)`, the
+/// cold path stays in charge.
+fn init_warm_pool() {
+    let result: Option<Arc<WorkerPool>> = match runtime_config::load() {
+        Ok(None) => None,
+        Ok(Some(rc)) => match rc.concurrency {
+            None => None,
+            Some(ConcurrencyConfig::WarmProcess(wp)) => match VALIDATED_ENTRYPOINT.get() {
+                Some(Ok(entry)) => match entry.try_clone() {
+                    Ok(cloned) => match WorkerPool::start(wp, Arc::new(cloned), Vec::new()) {
+                        Ok(pool) => Some(pool),
+                        Err(e) => {
+                            eprintln!(
+                                "mvm-guest-agent: warm-process pool start failed: {e}; refusing to boot"
+                            );
+                            std::process::exit(1);
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!(
+                            "mvm-guest-agent: warm-process configured but entrypoint clone failed: {e}; refusing to boot"
+                        );
+                        std::process::exit(1);
+                    }
+                },
+                _ => {
+                    eprintln!(
+                        "mvm-guest-agent: warm-process configured but entrypoint validation failed; refusing to boot"
+                    );
+                    std::process::exit(1);
+                }
+            },
+        },
+        Err(e) => {
+            eprintln!("mvm-guest-agent: invalid /etc/mvm/runtime.json: {e}; refusing to boot");
+            std::process::exit(1);
+        }
+    };
+    let _ = WARM_POOL.set(result);
 }
 
 /// Generate a per-call TMPDIR path under /tmp. The mutex guarantees only
@@ -867,6 +931,14 @@ fn handle_run_entrypoint(
     stdin: Vec<u8>,
     timeout_secs: u64,
 ) -> GuestResponse {
+    // Plan 43: when a warm-process pool is active, route through it
+    // instead of the cold-respawn path. The host wire is identical;
+    // the pool's `dispatch` synthesizes the same `EntrypointEvent`
+    // stream (Stdout / Stderr / Exit | Error) we'd produce below.
+    if let Some(Some(pool)) = WARM_POOL.get() {
+        return dispatch_via_warm_pool(file, pool, stdin, timeout_secs);
+    }
+
     let _guard = match RUN_ENTRYPOINT_LOCK.try_lock() {
         Ok(g) => g,
         Err(_) => {
@@ -964,6 +1036,66 @@ fn handle_run_entrypoint(
                 message: format!("wrapper exited via signal {signal}"),
             })
         }
+    }
+}
+
+/// Plan 43: route a `RunEntrypoint` request through the warm-process
+/// worker pool. The pool's `dispatch` returns a single
+/// `DispatchOutcome` per call (one buffered frame), which we
+/// translate back into the existing host-facing `EntrypointEvent`
+/// stream — same wire shape as the cold path so `mvmctl invoke` is
+/// unaffected.
+///
+/// `#[inline(never)]` is load-bearing for the W7 symbol-contract
+/// gate (mirrors the `handle_run_entrypoint` symbol invariant from
+/// W5). The CI gate at `scripts/check-prod-agent-no-exec.sh`
+/// requires this symbol to be present on the same binary that
+/// ships, as positive evidence the warm-process substrate is
+/// wired in. Without `inline(never)` LTO would erase it from the
+/// `nm` output.
+#[inline(never)]
+fn dispatch_via_warm_pool(
+    file: &mut std::fs::File,
+    pool: &Arc<WorkerPool>,
+    stdin: Vec<u8>,
+    timeout_secs: u64,
+) -> GuestResponse {
+    match pool.dispatch(stdin, timeout_secs) {
+        Ok(DispatchOutcome {
+            stdout,
+            stderr,
+            outcome,
+        }) => {
+            write_response(file, &evt(EntrypointEvent::Stdout { chunk: stdout }));
+            write_response(file, &evt(EntrypointEvent::Stderr { chunk: stderr }));
+            match outcome {
+                WorkerOutcome::Exit { code } => evt(EntrypointEvent::Exit { code }),
+                WorkerOutcome::Error { kind, message } => evt(EntrypointEvent::Error {
+                    kind: map_worker_error_kind(&kind),
+                    message,
+                }),
+            }
+        }
+        Err(DispatchError::QueueFull) => evt(EntrypointEvent::Error {
+            kind: RunEntrypointError::Busy,
+            message: "warm-process pool queue is full".into(),
+        }),
+        Err(DispatchError::ShuttingDown) => evt(EntrypointEvent::Error {
+            kind: RunEntrypointError::InternalError,
+            message: "warm-process pool is shutting down".into(),
+        }),
+        Err(DispatchError::NoLiveWorkers) => evt(EntrypointEvent::Error {
+            kind: RunEntrypointError::InternalError,
+            message: "warm-process pool has no live workers".into(),
+        }),
+    }
+}
+
+fn map_worker_error_kind(kind: &str) -> RunEntrypointError {
+    match kind {
+        "wrapper_crash" => RunEntrypointError::WrapperCrashed,
+        "timeout" => RunEntrypointError::Timeout,
+        _ => RunEntrypointError::InternalError,
     }
 }
 
@@ -1371,6 +1503,12 @@ fn main() {
     // Failures are non-fatal — only `RunEntrypoint` requests degrade.
     init_entrypoint_validation();
 
+    // Plan 43: stand up the warm-process worker pool if mvmforge's
+    // /etc/mvm/runtime.json opts in. Must run AFTER
+    // `init_entrypoint_validation` since the pool spawns workers
+    // from the validated FD. Fail-loud on a misconfigured runtime.json.
+    init_warm_pool();
+
     // SAFETY: libc call, arguments are constant values.
     let fd = unsafe { socket(AF_VSOCK, SOCK_STREAM, 0) };
     if fd < 0 {
@@ -1463,13 +1601,31 @@ fn main() {
         cfg.port, integration_count, probe_count
     );
 
+    // Plan 43: when warm-process is active, real concurrency from
+    // multiple host invokes lands in parallel — spawn a thread per
+    // accepted connection so they reach distinct workers. Cold-tier
+    // images keep the single-threaded accept loop unchanged for
+    // bit-identical behavior. `handle_client` already takes shared
+    // state through `Arc<Mutex<…>>`, so per-connection threading
+    // is a safe addition; the new pool itself does its own slot
+    // mutex / condvar bookkeeping.
+    let warm_active = matches!(WARM_POOL.get(), Some(Some(_)));
     loop {
         // SAFETY: null addr pointers are allowed for accept when peer addr is not needed.
         let cfd = unsafe { accept(fd, std::ptr::null_mut(), std::ptr::null_mut()) };
         if cfd < 0 {
             continue;
         }
-        handle_client(cfd, &state, &integration_state, &probe_state, boot_at);
+        if warm_active {
+            let state = Arc::clone(&state);
+            let integration_state = Arc::clone(&integration_state);
+            let probe_state = Arc::clone(&probe_state);
+            std::thread::spawn(move || {
+                handle_client(cfd, &state, &integration_state, &probe_state, boot_at);
+            });
+        } else {
+            handle_client(cfd, &state, &integration_state, &probe_state, boot_at);
+        }
     }
 }
 

--- a/crates/mvm-guest/src/entrypoint.rs
+++ b/crates/mvm-guest/src/entrypoint.rs
@@ -164,6 +164,20 @@ pub struct ValidatedEntrypoint {
     pub file: File,
 }
 
+impl ValidatedEntrypoint {
+    /// Clone by `dup`-ing the held file descriptor. The new
+    /// `ValidatedEntrypoint` owns an independent FD pointing at the
+    /// same inode — useful for handing the same validated wrapper to
+    /// a long-lived owner (e.g., `worker_pool::WorkerPool`) without
+    /// reaching into a shared static.
+    pub fn try_clone(&self) -> std::io::Result<Self> {
+        Ok(Self {
+            resolved: self.resolved.clone(),
+            file: self.file.try_clone()?,
+        })
+    }
+}
+
 /// Reasons validation can fail. The agent surfaces these to the host
 /// as `RunEntrypointError::EntrypointInvalid` with a short message.
 #[derive(Debug)]
@@ -479,7 +493,7 @@ pub fn execute(
 /// Set `RLIMIT_CORE = 0` on the calling process. Children inherit this
 /// rlimit at fork+exec, so a wrapper crash doesn't dump core. Best-effort:
 /// we log but don't fail the call if the syscall is denied.
-fn set_no_core_dumps() {
+pub(crate) fn set_no_core_dumps() {
     unsafe {
         let zero = libc::rlimit {
             rlim_cur: 0,
@@ -500,7 +514,7 @@ fn set_no_core_dumps() {
 /// platforms (macOS dev/test), fall back to the canonicalized path —
 /// production guests are always Linux so the fallback is for unit
 /// tests only.
-fn spawn_path(entrypoint: &ValidatedEntrypoint) -> PathBuf {
+pub(crate) fn spawn_path(entrypoint: &ValidatedEntrypoint) -> PathBuf {
     #[cfg(target_os = "linux")]
     {
         use std::os::fd::AsRawFd;
@@ -550,7 +564,7 @@ fn poll_for_exit(
     }
 }
 
-fn kill_and_reap(child: &mut Child, grace: Duration) {
+pub(crate) fn kill_and_reap(child: &mut Child, grace: Duration) {
     // Negate the pid to address the entire process group — the child
     // is its own process group leader (see `.process_group(0)` above),
     // so `kill(-pgid, ...)` reaches the wrapper plus any descendants

--- a/crates/mvm-guest/src/lib.rs
+++ b/crates/mvm-guest/src/lib.rs
@@ -6,4 +6,7 @@ pub mod console;
 pub mod entrypoint;
 pub mod integrations;
 pub mod probes;
+pub mod runtime_config;
 pub mod vsock;
+pub mod worker_pool;
+pub mod worker_protocol;

--- a/crates/mvm-guest/src/runtime_config.rs
+++ b/crates/mvm-guest/src/runtime_config.rs
@@ -1,0 +1,393 @@
+//! Boot-time parse of `/etc/mvm/runtime.json` — function-entrypoint
+//! workload metadata produced by mvmforge at image-build time
+//! (cross-repo ADR-0011, plan 43).
+//!
+//! Two config files live under `/etc/mvm/`, owned by different
+//! producers:
+//!
+//! - `agent.json` (mvm-owned, transport tuning) — read by
+//!   `mvm-guest-agent`'s `parse_config`, exists today.
+//! - `runtime.json` (mvmforge-owned, per-workload metadata) — this
+//!   module. NEW.
+//!
+//! The two are kept separate because they have independent schemas
+//! and release cadences. mvmforge writes `runtime.json` into the
+//! rootfs via `mkGuest extraFiles`, owned root mode 0644, and the
+//! verity initramfs (W3) prevents post-boot tampering.
+//!
+//! The agent reads this file once at boot. When `concurrency.kind =
+//! "warm_process"` is present, it stands up a worker pool (see
+//! `worker_pool` module). When the file or `concurrency` is absent,
+//! the cold path (plan 41 W2) handles `RunEntrypoint` exactly as
+//! before.
+//!
+//! Malformed JSON or a rejected `in_process` mode is fail-loud: the
+//! agent exits non-zero at boot. mvmforge owns the file; a broken
+//! one is a build bug, not a runtime fallback.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Default `runtime.json` location. Overridable via [`load_from`] for
+/// tests.
+pub const DEFAULT_PATH: &str = "/etc/mvm/runtime.json";
+
+/// Sanity cap on `pool_size`. A misconfigured image with a huge
+/// pool_size could exhaust VM memory before the first invoke; bound
+/// it explicitly. mvmforge defaults are far below this.
+pub const MAX_POOL_SIZE: usize = 64;
+
+/// Per-workload metadata written by mvmforge at image-build time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeConfig {
+    pub language: String,
+    pub module: String,
+    pub function: String,
+    pub format: String,
+    pub source_path: String,
+    /// When absent, the agent serves `RunEntrypoint` via the cold
+    /// path (plan 41 W2). When set to `WarmProcess`, the agent
+    /// stands up a worker pool at boot.
+    #[serde(default)]
+    pub concurrency: Option<ConcurrencyConfig>,
+}
+
+/// Concurrency variant. Tagged enum so future tiers (e.g. async
+/// in-process) extend the schema without breaking existing readers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, tag = "kind", rename_all = "snake_case")]
+pub enum ConcurrencyConfig {
+    WarmProcess(WarmProcessConfig),
+}
+
+/// Warm-process tier knobs. mvmforge ADR-0011 §3.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WarmProcessConfig {
+    /// Recycle the worker after this many calls. mvmforge default 1000.
+    pub max_calls_per_worker: u64,
+    /// Recycle the worker if its RSS exceeds this many MiB at the
+    /// post-call sample point. Sampled from `/proc/<pid>/statm`,
+    /// never mid-dispatch. mvmforge default 512.
+    pub max_rss_mb: u64,
+    /// How many wrappers run concurrently. Bounded above by
+    /// [`MAX_POOL_SIZE`].
+    pub pool_size: usize,
+    /// Per-worker concurrency. v0.2 supports `Serial` only.
+    /// `Concurrent` is rejected at parse time.
+    pub in_process: InProcessMode,
+    /// FIFO queue cap when all workers are busy. Default = 2 *
+    /// pool_size. Overflow returns `EntrypointEvent::Error { kind:
+    /// Busy }` to the host — same envelope the cold path returns on
+    /// M12 contention.
+    #[serde(default)]
+    pub max_queue_depth: Option<usize>,
+}
+
+impl WarmProcessConfig {
+    /// Resolve the queue depth: the explicit `max_queue_depth` if
+    /// set, otherwise `2 * pool_size`.
+    pub fn effective_queue_depth(&self) -> usize {
+        self.max_queue_depth
+            .unwrap_or(self.pool_size.saturating_mul(2))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum InProcessMode {
+    /// One in-flight call per worker. Multiple workers run in
+    /// parallel up to `pool_size`.
+    Serial,
+    /// Multiple in-flight calls per worker via async. Out of scope
+    /// for v0.2; the loader rejects this value with
+    /// [`RuntimeConfigError::ConcurrentNotSupported`].
+    Concurrent,
+}
+
+/// Errors surfaced by [`load`] / [`load_from`]. Each variant
+/// describes a fail-loud reason the agent refuses to start.
+#[derive(Debug)]
+pub enum RuntimeConfigError {
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    PoolSizeOutOfRange {
+        pool_size: usize,
+        max: usize,
+    },
+    ConcurrentNotSupported,
+}
+
+impl std::fmt::Display for RuntimeConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RuntimeConfigError::Read { path, source } => {
+                write!(f, "read {}: {source}", path.display())
+            }
+            RuntimeConfigError::Parse { path, source } => {
+                write!(f, "parse {}: {source}", path.display())
+            }
+            RuntimeConfigError::PoolSizeOutOfRange { pool_size, max } => write!(
+                f,
+                "pool_size {pool_size} out of range; must be in [1, {max}]"
+            ),
+            RuntimeConfigError::ConcurrentNotSupported => write!(
+                f,
+                "in_process = \"concurrent\" is not supported in v0.2 (ADR-0011)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RuntimeConfigError::Read { source, .. } => Some(source),
+            RuntimeConfigError::Parse { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Load `/etc/mvm/runtime.json` (or `Ok(None)` if the file is
+/// absent). Wraps [`load_from`] with the production path.
+pub fn load() -> Result<Option<RuntimeConfig>, RuntimeConfigError> {
+    load_from(Path::new(DEFAULT_PATH))
+}
+
+/// Load runtime config from the given path. Missing file →
+/// `Ok(None)`. Any other error is fail-loud; the agent should refuse
+/// to start.
+pub fn load_from(path: &Path) -> Result<Option<RuntimeConfig>, RuntimeConfigError> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(RuntimeConfigError::Read {
+                path: path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    let config: RuntimeConfig =
+        serde_json::from_str(&raw).map_err(|source| RuntimeConfigError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    config.validate()?;
+    Ok(Some(config))
+}
+
+impl RuntimeConfig {
+    fn validate(&self) -> Result<(), RuntimeConfigError> {
+        if let Some(ConcurrencyConfig::WarmProcess(wp)) = &self.concurrency {
+            if wp.pool_size < 1 || wp.pool_size > MAX_POOL_SIZE {
+                return Err(RuntimeConfigError::PoolSizeOutOfRange {
+                    pool_size: wp.pool_size,
+                    max: MAX_POOL_SIZE,
+                });
+            }
+            if wp.in_process == InProcessMode::Concurrent {
+                return Err(RuntimeConfigError::ConcurrentNotSupported);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(s: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(s.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn missing_file_returns_ok_none() {
+        let path = Path::new("/nonexistent/runtime.json");
+        assert!(matches!(load_from(path), Ok(None)));
+    }
+
+    #[test]
+    fn cold_tier_no_concurrency_field() {
+        let json = r#"{
+            "language": "python",
+            "module": "app",
+            "function": "handler",
+            "format": "json",
+            "source_path": "/app"
+        }"#;
+        let f = write_tmp(json);
+        let cfg = load_from(f.path()).unwrap().unwrap();
+        assert!(cfg.concurrency.is_none());
+        assert_eq!(cfg.language, "python");
+    }
+
+    #[test]
+    fn warm_process_serial_parses() {
+        let json = r#"{
+            "language": "python",
+            "module": "app",
+            "function": "handler",
+            "format": "json",
+            "source_path": "/app",
+            "concurrency": {
+                "kind": "warm_process",
+                "max_calls_per_worker": 1000,
+                "max_rss_mb": 512,
+                "pool_size": 4,
+                "in_process": "serial"
+            }
+        }"#;
+        let f = write_tmp(json);
+        let cfg = load_from(f.path()).unwrap().unwrap();
+        let Some(ConcurrencyConfig::WarmProcess(wp)) = &cfg.concurrency else {
+            panic!("expected WarmProcess");
+        };
+        assert_eq!(wp.pool_size, 4);
+        assert_eq!(wp.max_calls_per_worker, 1000);
+        assert_eq!(wp.max_rss_mb, 512);
+        assert_eq!(wp.in_process, InProcessMode::Serial);
+        assert_eq!(wp.effective_queue_depth(), 8);
+    }
+
+    #[test]
+    fn explicit_max_queue_depth_overrides_default() {
+        let json = r#"{
+            "language": "python", "module": "app", "function": "handler",
+            "format": "json", "source_path": "/app",
+            "concurrency": {
+                "kind": "warm_process",
+                "max_calls_per_worker": 1, "max_rss_mb": 1, "pool_size": 2,
+                "in_process": "serial",
+                "max_queue_depth": 16
+            }
+        }"#;
+        let f = write_tmp(json);
+        let cfg = load_from(f.path()).unwrap().unwrap();
+        let Some(ConcurrencyConfig::WarmProcess(wp)) = &cfg.concurrency else {
+            unreachable!()
+        };
+        assert_eq!(wp.effective_queue_depth(), 16);
+    }
+
+    #[test]
+    fn concurrent_mode_rejected() {
+        let json = r#"{
+            "language": "python", "module": "app", "function": "handler",
+            "format": "json", "source_path": "/app",
+            "concurrency": {
+                "kind": "warm_process",
+                "max_calls_per_worker": 1, "max_rss_mb": 1, "pool_size": 1,
+                "in_process": "concurrent"
+            }
+        }"#;
+        let f = write_tmp(json);
+        let err = load_from(f.path()).unwrap_err();
+        assert!(matches!(err, RuntimeConfigError::ConcurrentNotSupported));
+    }
+
+    #[test]
+    fn pool_size_zero_rejected() {
+        let json = r#"{
+            "language": "python", "module": "app", "function": "handler",
+            "format": "json", "source_path": "/app",
+            "concurrency": {
+                "kind": "warm_process",
+                "max_calls_per_worker": 1, "max_rss_mb": 1, "pool_size": 0,
+                "in_process": "serial"
+            }
+        }"#;
+        let f = write_tmp(json);
+        let err = load_from(f.path()).unwrap_err();
+        assert!(matches!(err, RuntimeConfigError::PoolSizeOutOfRange { .. }));
+    }
+
+    #[test]
+    fn pool_size_above_cap_rejected() {
+        let json = format!(
+            r#"{{
+                "language": "python", "module": "app", "function": "handler",
+                "format": "json", "source_path": "/app",
+                "concurrency": {{
+                    "kind": "warm_process",
+                    "max_calls_per_worker": 1, "max_rss_mb": 1, "pool_size": {},
+                    "in_process": "serial"
+                }}
+            }}"#,
+            MAX_POOL_SIZE + 1
+        );
+        let f = write_tmp(&json);
+        let err = load_from(f.path()).unwrap_err();
+        assert!(matches!(err, RuntimeConfigError::PoolSizeOutOfRange { .. }));
+    }
+
+    #[test]
+    fn unknown_field_at_top_level_rejected() {
+        let json = r#"{
+            "language": "python", "module": "app", "function": "handler",
+            "format": "json", "source_path": "/app",
+            "stowaway": "not allowed"
+        }"#;
+        let f = write_tmp(json);
+        let err = load_from(f.path()).unwrap_err();
+        assert!(matches!(err, RuntimeConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn unknown_field_in_warm_process_rejected() {
+        let json = r#"{
+            "language": "python", "module": "app", "function": "handler",
+            "format": "json", "source_path": "/app",
+            "concurrency": {
+                "kind": "warm_process",
+                "max_calls_per_worker": 1, "max_rss_mb": 1, "pool_size": 1,
+                "in_process": "serial",
+                "extra": "deny"
+            }
+        }"#;
+        let f = write_tmp(json);
+        let err = load_from(f.path()).unwrap_err();
+        assert!(matches!(err, RuntimeConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn malformed_json_rejected() {
+        let f = write_tmp("not-json");
+        let err = load_from(f.path()).unwrap_err();
+        assert!(matches!(err, RuntimeConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn roundtrip_serialize_deserialize() {
+        let cfg = RuntimeConfig {
+            language: "python".into(),
+            module: "app".into(),
+            function: "handler".into(),
+            format: "json".into(),
+            source_path: "/app".into(),
+            concurrency: Some(ConcurrencyConfig::WarmProcess(WarmProcessConfig {
+                max_calls_per_worker: 1000,
+                max_rss_mb: 512,
+                pool_size: 1,
+                in_process: InProcessMode::Serial,
+                max_queue_depth: None,
+            })),
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: RuntimeConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, back);
+    }
+}

--- a/crates/mvm-guest/src/worker_pool.rs
+++ b/crates/mvm-guest/src/worker_pool.rs
@@ -1,0 +1,576 @@
+//! Warm-process worker pool — plan 43 / mvmforge ADR-0011 tier 2.
+//!
+//! When `/etc/mvm/runtime.json` carries `concurrency.kind =
+//! "warm_process"`, the agent stands up a fixed-size pool of
+//! long-running wrapper processes at boot. Each `mvmctl invoke`
+//! is dispatched to a free worker over its stdin/stdout pipes via
+//! length-prefixed JSON frames (see [`crate::worker_protocol`]).
+//!
+//! Compared to the cold path:
+//! - The wrapper's interpreter cold-start happens once per worker,
+//!   not once per invoke. Per-call latency drops by hundreds of ms
+//!   (Python especially).
+//! - The M12 single-call invariant is bypassed: up to `pool_size`
+//!   calls can be in flight in the same VM. Backpressure is a FIFO
+//!   queue, capped at `max_queue_depth` (default `2 * pool_size`).
+//! - Workers are recycled on call-count, RSS, or wrapper crash.
+//! - Cross-call wrapper state is the user's responsibility (ADR-0011);
+//!   the agent does not scrub state between calls.
+//!
+//! The host wire (vsock `RunEntrypoint` → `EntrypointEvent` stream)
+//! is bit-identical to the cold path. The agent synthesizes the
+//! existing event stream from the worker's single buffered response
+//! frame.
+
+use std::io::{self, BufReader};
+use std::os::unix::process::CommandExt;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::entrypoint::{self, ValidatedEntrypoint};
+use crate::runtime_config::WarmProcessConfig;
+use crate::worker_protocol::{
+    WorkerCallRequest, WorkerCallResponse, WorkerOutcome, read_pipe_frame, write_pipe_frame,
+};
+
+/// Grace period between SIGTERM and SIGKILL when recycling or
+/// shutting a worker. Mirrors the cold-path
+/// `CallCaps::v1().kill_grace_period`.
+pub const DEFAULT_KILL_GRACE: Duration = Duration::from_secs(2);
+
+/// One worker process plus the per-worker bookkeeping the dispatcher
+/// needs between calls.
+pub(crate) struct WorkerHandle {
+    pid: u32,
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    /// stderr drains in the background to avoid blocking the worker
+    /// when its stderr pipe fills up. We don't surface the bytes —
+    /// they go straight to the agent's own stderr (inherited as
+    /// "mvm-guest-agent: worker N: …"). Held so Drop joins the thread.
+    _stderr_drain: thread::JoinHandle<()>,
+    call_count: u64,
+    last_rss_bytes: u64,
+}
+
+impl Drop for WorkerHandle {
+    fn drop(&mut self) {
+        // Best-effort cleanup. The watchdog and recycle paths
+        // typically race ahead of Drop; this is the catch-all when
+        // the pool itself is being torn down or the handle is
+        // dropped due to a panic.
+        entrypoint::kill_and_reap(&mut self.child, DEFAULT_KILL_GRACE);
+    }
+}
+
+/// One slot in the pool. Slots are indexed by position; the index is
+/// stable across replacements so debug logs can refer to "worker 3".
+enum WorkerSlot {
+    Idle(WorkerHandle),
+    Busy,
+    /// Slot's worker died and respawn has not yet succeeded. The
+    /// recovery thread retries periodically.
+    Dead,
+}
+
+struct PoolState {
+    slots: Vec<WorkerSlot>,
+    pending_waiters: usize,
+}
+
+/// Errors returned by [`WorkerPool::dispatch`] before the call ever
+/// reaches a worker. Successful runs return [`DispatchOutcome`] even
+/// for user-code failures.
+#[derive(Debug)]
+pub enum DispatchError {
+    /// All workers busy and the queue is at `max_queue_depth`.
+    /// Maps to `EntrypointEvent::Error { kind: Busy }` host-side.
+    QueueFull,
+    /// Pool is shutting down. New calls refuse fast-fail.
+    ShuttingDown,
+    /// Every slot is `Dead` and respawn is failing. Surfaces as
+    /// `EntrypointEvent::Error { kind: InternalError }`.
+    NoLiveWorkers,
+}
+
+impl std::fmt::Display for DispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DispatchError::QueueFull => write!(f, "worker pool queue full"),
+            DispatchError::ShuttingDown => write!(f, "worker pool is shutting down"),
+            DispatchError::NoLiveWorkers => write!(f, "worker pool has no live workers"),
+        }
+    }
+}
+
+impl std::error::Error for DispatchError {}
+
+/// Result of a single dispatched call. The agent maps this onto
+/// the host-facing `EntrypointEvent` stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchOutcome {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub outcome: WorkerOutcome,
+}
+
+impl DispatchOutcome {
+    /// Synthesize a transport-error response — used when the worker
+    /// crashes mid-call or fails to produce a frame.
+    fn transport_error(kind: &str, message: String) -> Self {
+        Self {
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            outcome: WorkerOutcome::Error {
+                kind: kind.to_string(),
+                message,
+            },
+        }
+    }
+}
+
+/// Pool of long-running wrapper workers.
+pub struct WorkerPool {
+    state: Mutex<PoolState>,
+    cv: Condvar,
+    cfg: WarmProcessConfig,
+    entrypoint: Arc<ValidatedEntrypoint>,
+    /// Env vars forwarded into each spawned worker. The pool always
+    /// `env_clear()`s before applying these — production wrappers
+    /// should not rely on host-inherited env. The list is populated
+    /// by the agent at boot from a curated set (e.g., `PATH`,
+    /// `LANG`); tests use it to drive test-fixture behavior.
+    worker_env: Vec<(String, String)>,
+    shutdown: AtomicBool,
+}
+
+impl WorkerPool {
+    /// Boot the pool: spawn `cfg.pool_size` workers, each from the
+    /// validated wrapper FD. Fails fast on the first spawn error —
+    /// caller (the agent main) should exit non-zero so misconfigured
+    /// images don't appear to start successfully.
+    ///
+    /// `worker_env` is the set of env vars set on each worker at
+    /// spawn time. The pool's spawn path always calls
+    /// `Command::env_clear()` first, then applies these — workers
+    /// cannot inherit anything else.
+    pub fn start(
+        cfg: WarmProcessConfig,
+        entrypoint: Arc<ValidatedEntrypoint>,
+        worker_env: Vec<(String, String)>,
+    ) -> io::Result<Arc<Self>> {
+        // Set RLIMIT_CORE=0 on the agent so all child workers
+        // inherit it. Mirrors the cold-path one-shot in
+        // `entrypoint::execute`.
+        entrypoint::set_no_core_dumps();
+
+        let mut slots = Vec::with_capacity(cfg.pool_size);
+        for i in 0..cfg.pool_size {
+            let handle = spawn_worker(&entrypoint, &worker_env)
+                .map_err(|e| io::Error::other(format!("spawn worker {i}: {e}")))?;
+            eprintln!(
+                "mvm-guest-agent: warm-process worker {i} spawned pid={}",
+                handle.pid
+            );
+            slots.push(WorkerSlot::Idle(handle));
+        }
+
+        eprintln!(
+            "mvm-guest-agent: warm-process pool active (pool_size={}, max_calls_per_worker={}, \
+             max_rss_mb={}, queue_depth={}); cross-call wrapper state is the user's responsibility \
+             — the agent does not scrub between calls (ADR-0011 §state)",
+            cfg.pool_size,
+            cfg.max_calls_per_worker,
+            cfg.max_rss_mb,
+            cfg.effective_queue_depth(),
+        );
+
+        Ok(Arc::new(Self {
+            state: Mutex::new(PoolState {
+                slots,
+                pending_waiters: 0,
+            }),
+            cv: Condvar::new(),
+            cfg,
+            entrypoint,
+            worker_env,
+            shutdown: AtomicBool::new(false),
+        }))
+    }
+
+    /// Dispatch one call to a free worker. Blocks (FIFO via Condvar)
+    /// if all workers are busy, up to `max_queue_depth` total
+    /// waiters; the `(pool_size + 1)`th waiter gets `QueueFull`.
+    ///
+    /// `timeout_secs` is forwarded to the worker (informational) and
+    /// enforced by an agent-side watchdog that SIGKILLs the worker's
+    /// process group on expiry. The worker can be killed mid-call;
+    /// the read-frame returns `UnexpectedEof` and we surface
+    /// `Outcome::Error { kind: "wrapper_crash" }`.
+    pub fn dispatch(
+        self: &Arc<Self>,
+        stdin: Vec<u8>,
+        timeout_secs: u64,
+    ) -> Result<DispatchOutcome, DispatchError> {
+        let (idx, mut handle) = self.acquire()?;
+        let pgid = handle.pid as i32;
+
+        // Watchdog: SIGKILLs the worker group at deadline. Cancelled
+        // on response by setting the atomic. Joined regardless.
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let watchdog = spawn_watchdog(pgid, timeout_secs, Arc::clone(&cancelled));
+
+        let result = run_one_call(&mut handle, stdin, timeout_secs);
+        cancelled.store(true, Ordering::Release);
+        let _ = watchdog.join();
+
+        let recycle = self.should_recycle(&mut handle, &result);
+        self.release(idx, handle, recycle);
+
+        Ok(match result {
+            Ok(resp) => DispatchOutcome {
+                stdout: resp.stdout,
+                stderr: resp.stderr,
+                outcome: resp.outcome,
+            },
+            Err(WorkerCallError::Crash(message)) => {
+                DispatchOutcome::transport_error("wrapper_crash", message)
+            }
+            Err(WorkerCallError::Protocol(message)) => {
+                DispatchOutcome::transport_error("wrapper_crash", message)
+            }
+        })
+    }
+
+    /// Initiate shutdown. New `dispatch` calls return
+    /// `ShuttingDown`. Idle workers are SIGTERM/SIGKILL'd via Drop.
+    /// Busy workers run to completion (Drop fires on release). The
+    /// caller may sleep `grace` to let in-flight calls drain.
+    pub fn shutdown(&self, grace: Duration) {
+        self.shutdown.store(true, Ordering::Release);
+        self.cv.notify_all();
+        // Drain idle workers right away. Busy workers tear down
+        // on release.
+        let mut st = self.state.lock().expect("worker pool state mutex poisoned");
+        for slot in st.slots.iter_mut() {
+            if let WorkerSlot::Idle(_) = slot {
+                // Replace with Dead — Drop on the moved handle kills
+                // the worker.
+                *slot = WorkerSlot::Dead;
+            }
+        }
+        drop(st);
+        // Give callers a chance to observe in-flight completions.
+        thread::sleep(grace.min(Duration::from_secs(30)));
+    }
+
+    /// Snapshot of slot states for observability / tests.
+    pub fn snapshot(&self) -> Vec<SlotSnapshot> {
+        let st = self.state.lock().expect("worker pool state mutex poisoned");
+        st.slots
+            .iter()
+            .map(|slot| match slot {
+                WorkerSlot::Idle(h) => SlotSnapshot::Idle {
+                    pid: h.pid,
+                    call_count: h.call_count,
+                    last_rss_bytes: h.last_rss_bytes,
+                },
+                WorkerSlot::Busy => SlotSnapshot::Busy,
+                WorkerSlot::Dead => SlotSnapshot::Dead,
+            })
+            .collect()
+    }
+
+    fn acquire(self: &Arc<Self>) -> Result<(usize, WorkerHandle), DispatchError> {
+        let mut st = self.state.lock().expect("worker pool state mutex poisoned");
+        loop {
+            if self.shutdown.load(Ordering::Acquire) {
+                return Err(DispatchError::ShuttingDown);
+            }
+            if let Some(idx) = st
+                .slots
+                .iter()
+                .position(|s| matches!(s, WorkerSlot::Idle(_)))
+            {
+                let slot = std::mem::replace(&mut st.slots[idx], WorkerSlot::Busy);
+                let WorkerSlot::Idle(handle) = slot else {
+                    unreachable!("position() guarantees Idle");
+                };
+                return Ok((idx, handle));
+            }
+            // No idle. If every slot is Dead, fail fast — there's no
+            // hope of waking up unless a recovery thread succeeds,
+            // which we don't model in v0.2.
+            if st.slots.iter().all(|s| matches!(s, WorkerSlot::Dead)) {
+                return Err(DispatchError::NoLiveWorkers);
+            }
+            // Some are Busy; wait for one to be released.
+            if st.pending_waiters >= self.cfg.effective_queue_depth() {
+                return Err(DispatchError::QueueFull);
+            }
+            st.pending_waiters += 1;
+            st = self.cv.wait(st).expect("worker pool condvar wait poisoned");
+            st.pending_waiters -= 1;
+        }
+    }
+
+    fn release(self: &Arc<Self>, idx: usize, handle: WorkerHandle, recycle: bool) {
+        let mut st = self.state.lock().expect("worker pool state mutex poisoned");
+        if recycle {
+            // Drop the handle inside this scope so the old worker is
+            // killed before we attempt to spawn a replacement (their
+            // resource caps may overlap during overshoot).
+            drop(handle);
+            match spawn_worker(&self.entrypoint, &self.worker_env) {
+                Ok(new_handle) => {
+                    eprintln!(
+                        "mvm-guest-agent: warm-process worker {idx} replaced pid={}",
+                        new_handle.pid
+                    );
+                    st.slots[idx] = WorkerSlot::Idle(new_handle);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "mvm-guest-agent: warm-process worker {idx} respawn failed: {e}; \
+                         marking slot dead"
+                    );
+                    st.slots[idx] = WorkerSlot::Dead;
+                }
+            }
+        } else {
+            st.slots[idx] = WorkerSlot::Idle(handle);
+        }
+        self.cv.notify_one();
+    }
+
+    fn should_recycle(
+        self: &Arc<Self>,
+        handle: &mut WorkerHandle,
+        result: &Result<WorkerCallResponse, WorkerCallError>,
+    ) -> bool {
+        // Wrapper-level transport failure → always recycle.
+        if result.is_err() {
+            return true;
+        }
+        // User code may legitimately exit non-zero on its own
+        // (e.g. a Python wrapper translates an unhandled exception
+        // to a sanitized envelope and exit 1). Don't recycle on that
+        // — only on wrapper-side failures.
+        handle.call_count = handle.call_count.saturating_add(1);
+        if handle.call_count >= self.cfg.max_calls_per_worker {
+            eprintln!(
+                "mvm-guest-agent: warm-process worker pid={} recycle (call_count {} >= {})",
+                handle.pid, handle.call_count, self.cfg.max_calls_per_worker
+            );
+            return true;
+        }
+        if let Some(rss) = sample_rss_bytes(handle.pid) {
+            handle.last_rss_bytes = rss;
+            let cap = self.cfg.max_rss_mb.saturating_mul(1024 * 1024);
+            if rss > cap {
+                eprintln!(
+                    "mvm-guest-agent: warm-process worker pid={} recycle (rss {} > {})",
+                    handle.pid, rss, cap
+                );
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Public projection of slot state (for tests and observability).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlotSnapshot {
+    Idle {
+        pid: u32,
+        call_count: u64,
+        last_rss_bytes: u64,
+    },
+    Busy,
+    Dead,
+}
+
+#[derive(Debug)]
+enum WorkerCallError {
+    /// The worker died (EOF / non-zero exit / killed by watchdog).
+    Crash(String),
+    /// The worker stayed up but produced an unparseable frame —
+    /// equally fatal to the call, equally a recycle trigger.
+    Protocol(String),
+}
+
+impl std::fmt::Display for WorkerCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkerCallError::Crash(s) => write!(f, "worker crash: {s}"),
+            WorkerCallError::Protocol(s) => write!(f, "worker protocol error: {s}"),
+        }
+    }
+}
+
+fn run_one_call(
+    handle: &mut WorkerHandle,
+    stdin: Vec<u8>,
+    timeout_secs: u64,
+) -> Result<WorkerCallResponse, WorkerCallError> {
+    let req = WorkerCallRequest {
+        stdin,
+        timeout_secs,
+    };
+    write_pipe_frame(&mut handle.stdin, &req)
+        .map_err(|e| WorkerCallError::Crash(format!("write request frame: {e}")))?;
+    read_pipe_frame::<_, WorkerCallResponse>(&mut handle.stdout).map_err(|e| match e.kind() {
+        io::ErrorKind::UnexpectedEof => WorkerCallError::Crash(format!("EOF on stdout: {e}")),
+        io::ErrorKind::InvalidData => WorkerCallError::Protocol(e.to_string()),
+        _ => WorkerCallError::Protocol(e.to_string()),
+    })
+}
+
+fn spawn_worker(
+    entrypoint: &Arc<ValidatedEntrypoint>,
+    worker_env: &[(String, String)],
+) -> io::Result<WorkerHandle> {
+    let program = entrypoint::spawn_path(entrypoint);
+
+    // Same envelope as `entrypoint::execute` minus the per-call
+    // tmpdir (workers are shared across calls so a per-worker tmpdir
+    // would leak per-call state — the wrapper takes responsibility
+    // for per-call hygiene, ADR-0011 §state). env_clear first, then
+    // apply the curated `worker_env` set, then own pgrp, RLIMIT_CORE
+    // inheritance from set_no_core_dumps in start().
+    let mut cmd = Command::new(&program);
+    cmd.env_clear();
+    for (k, v) in worker_env {
+        cmd.env(k, v);
+    }
+    cmd.process_group(0)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn()?;
+    let pid = child.id();
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::other("stdin pipe missing"))?;
+    let stdout = BufReader::new(
+        child
+            .stdout
+            .take()
+            .ok_or_else(|| io::Error::other("stdout pipe missing"))?,
+    );
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| io::Error::other("stderr pipe missing"))?;
+
+    let stderr_drain = thread::spawn(move || {
+        // Mirror worker stderr to the agent's stderr line by line so
+        // ops can see panics / sanitized envelopes. Bounded by the
+        // pipe buffer; we don't accumulate.
+        use std::io::{BufRead, BufReader};
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            eprintln!("mvm-guest-agent: worker pid={pid}: {line}");
+        }
+    });
+
+    Ok(WorkerHandle {
+        pid,
+        child,
+        stdin,
+        stdout,
+        _stderr_drain: stderr_drain,
+        call_count: 0,
+        last_rss_bytes: 0,
+    })
+}
+
+fn spawn_watchdog(
+    pgid: i32,
+    timeout_secs: u64,
+    cancelled: Arc<AtomicBool>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+        // Poll with a short interval so cancellation is fast.
+        while Instant::now() < deadline {
+            if cancelled.load(Ordering::Acquire) {
+                return;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        if cancelled.load(Ordering::Acquire) {
+            return;
+        }
+        // SAFETY: kill is async-signal-safe.
+        unsafe {
+            libc::kill(-pgid, libc::SIGKILL);
+        }
+    })
+}
+
+/// Read RSS in bytes from `/proc/<pid>/statm`. Field 1 (0-indexed)
+/// is `resident` in pages. Returns `None` if the file can't be read
+/// or parsed — the caller treats absent samples as "no recycle
+/// triggered by RSS" rather than failing the call.
+fn sample_rss_bytes(pid: u32) -> Option<u64> {
+    let path = format!("/proc/{pid}/statm");
+    let raw = std::fs::read_to_string(path).ok()?;
+    let pages: u64 = raw.split_whitespace().nth(1)?.parse().ok()?;
+    let pagesize = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if pagesize <= 0 {
+        return None;
+    }
+    Some(pages.saturating_mul(pagesize as u64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_config::InProcessMode;
+
+    #[test]
+    fn dispatch_error_display_strings() {
+        assert!(format!("{}", DispatchError::QueueFull).contains("queue full"));
+        assert!(format!("{}", DispatchError::ShuttingDown).contains("shutting down"));
+        assert!(format!("{}", DispatchError::NoLiveWorkers).contains("no live workers"));
+    }
+
+    #[test]
+    fn transport_error_constructor_shape() {
+        let o = DispatchOutcome::transport_error("wrapper_crash", "EOF".into());
+        assert_eq!(o.stdout, Vec::<u8>::new());
+        assert!(matches!(o.outcome, WorkerOutcome::Error { .. }));
+    }
+
+    #[test]
+    fn slot_snapshot_variants_round_trip() {
+        let s = SlotSnapshot::Idle {
+            pid: 42,
+            call_count: 7,
+            last_rss_bytes: 1024,
+        };
+        let s2 = s.clone();
+        assert_eq!(s, s2);
+    }
+
+    /// Sanity check that the queue-depth helper plumbs through.
+    #[test]
+    fn queue_depth_default_doubles_pool_size() {
+        let cfg = WarmProcessConfig {
+            max_calls_per_worker: 1,
+            max_rss_mb: 1,
+            pool_size: 3,
+            in_process: InProcessMode::Serial,
+            max_queue_depth: None,
+        };
+        assert_eq!(cfg.effective_queue_depth(), 6);
+    }
+}

--- a/crates/mvm-guest/src/worker_protocol.rs
+++ b/crates/mvm-guest/src/worker_protocol.rs
@@ -1,0 +1,269 @@
+//! Wire types for the agent ↔ warm-process worker pipe — plan 43 / ADR-0011.
+//!
+//! Each worker is a long-running wrapper process spawned by the
+//! agent at boot. The agent talks to it over its stdin/stdout pipes
+//! using length-prefixed JSON frames (4-byte big-endian length, then
+//! body). One frame in per call ([`WorkerCallRequest`]), one frame
+//! out per call ([`WorkerCallResponse`]).
+//!
+//! These types are `pub` so mvmforge's runner-wrapper crate can
+//! depend on `mvm-guest` directly for the schema — single source of
+//! truth, no risk of independent drift between agent and wrapper.
+//!
+//! `serde(deny_unknown_fields)` on every type satisfies ADR-002 §W4.1
+//! / `prod-agent-no-exec` companion contract.
+
+use std::io::{self, Read, Write};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Frame size cap matching the vsock framing (`vsock.rs` MAX_FRAME_SIZE).
+/// 256 KiB covers stdin payloads up to ~190 KiB after base64 expansion;
+/// payloads larger than that need the streaming chunked-output v2 work
+/// (sprint 45 deferred follow-up), not warm-process.
+pub const MAX_PIPE_FRAME_SIZE: usize = 256 * 1024;
+
+/// Request frame: agent → worker. One per call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerCallRequest {
+    /// Bytes piped to the user function. Base64-encoded over JSON.
+    #[serde(with = "base64_bytes")]
+    pub stdin: Vec<u8>,
+    /// Caller's own deadline. The agent enforces this via a
+    /// SIGKILL-on-expiry watchdog regardless of whether the wrapper
+    /// honors it; the field is informational for the wrapper.
+    pub timeout_secs: u64,
+}
+
+/// Response frame: worker → agent. One per call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerCallResponse {
+    /// Buffered stdout from the call.
+    #[serde(with = "base64_bytes")]
+    pub stdout: Vec<u8>,
+    /// Buffered stderr from the call. Wrapper must sanitize this in
+    /// production mode (ADR-007 §sanitized error envelope).
+    #[serde(with = "base64_bytes")]
+    pub stderr: Vec<u8>,
+    pub outcome: WorkerOutcome,
+}
+
+/// Terminal disposition of a single call. The agent maps this onto
+/// the existing host-facing `EntrypointEvent` envelope so the
+/// `mvmctl invoke` wire stays identical to the cold tier.
+///
+/// Externally tagged (`{"exit": {...}}` or `{"error": {...}}`) so
+/// the inner `Error::kind` field doesn't collide with serde's tag
+/// machinery.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum WorkerOutcome {
+    /// User code returned. `code` is the wrapper's own exit code; 0
+    /// for happy path, non-zero for user-code faults that the
+    /// wrapper has converted to a sanitized envelope.
+    Exit { code: i32 },
+    /// Transport-level failure inside the wrapper itself, before or
+    /// after user code (e.g. the wrapper failed to deserialize the
+    /// request, or panicked outside a call). Maps to
+    /// `EntrypointEvent::Error` host-side. Conventionally `kind` is
+    /// one of `"wrapper_crash"`, `"timeout"`, or
+    /// `"internal_error"`; the agent maps unknown values onto
+    /// `RunEntrypointError::InternalError`.
+    Error { kind: String, message: String },
+}
+
+mod base64_bytes {
+    use super::{B64, Deserializer, Engine, Serializer};
+    use serde::Deserialize;
+    use serde::de::Error as _;
+
+    pub fn serialize<S: Serializer>(bytes: &[u8], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&B64.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let encoded = String::deserialize(d)?;
+        B64.decode(encoded.as_bytes()).map_err(D::Error::custom)
+    }
+}
+
+/// Write a single length-prefixed JSON frame. 4-byte big-endian
+/// length, then body. Caps the body at [`MAX_PIPE_FRAME_SIZE`] so a
+/// runaway serializer doesn't wedge a worker's pipe.
+pub fn write_pipe_frame<W: Write, T: Serialize>(w: &mut W, value: &T) -> io::Result<()> {
+    let body = serde_json::to_vec(value).map_err(io::Error::other)?;
+    if body.len() > MAX_PIPE_FRAME_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "frame too large: {} bytes (max {})",
+                body.len(),
+                MAX_PIPE_FRAME_SIZE
+            ),
+        ));
+    }
+    let len = (body.len() as u32).to_be_bytes();
+    w.write_all(&len)?;
+    w.write_all(&body)?;
+    w.flush()?;
+    Ok(())
+}
+
+/// Read a single length-prefixed JSON frame. EOF on the length read
+/// surfaces as `UnexpectedEof`; oversized lengths surface as
+/// `InvalidData` *before* allocating the body buffer (defence
+/// against a hostile or buggy peer).
+pub fn read_pipe_frame<R: Read, T: DeserializeOwned>(r: &mut R) -> io::Result<T> {
+    let mut len_buf = [0u8; 4];
+    r.read_exact(&mut len_buf)?;
+    let frame_len = u32::from_be_bytes(len_buf) as usize;
+    if frame_len > MAX_PIPE_FRAME_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("frame too large: {frame_len} bytes (max {MAX_PIPE_FRAME_SIZE})"),
+        ));
+    }
+    let mut body = vec![0u8; frame_len];
+    r.read_exact(&mut body)?;
+    serde_json::from_slice(&body).map_err(io::Error::other)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn roundtrip_request() {
+        let req = WorkerCallRequest {
+            stdin: b"hello world".to_vec(),
+            timeout_secs: 30,
+        };
+        let mut buf = Vec::new();
+        write_pipe_frame(&mut buf, &req).unwrap();
+        let mut cur = Cursor::new(buf);
+        let back: WorkerCallRequest = read_pipe_frame(&mut cur).unwrap();
+        assert_eq!(req, back);
+    }
+
+    #[test]
+    fn roundtrip_response_exit() {
+        let resp = WorkerCallResponse {
+            stdout: b"output bytes".to_vec(),
+            stderr: vec![],
+            outcome: WorkerOutcome::Exit { code: 0 },
+        };
+        let mut buf = Vec::new();
+        write_pipe_frame(&mut buf, &resp).unwrap();
+        let mut cur = Cursor::new(buf);
+        let back: WorkerCallResponse = read_pipe_frame(&mut cur).unwrap();
+        assert_eq!(resp, back);
+    }
+
+    #[test]
+    fn roundtrip_response_error() {
+        let resp = WorkerCallResponse {
+            stdout: vec![],
+            stderr: b"sanitized envelope".to_vec(),
+            outcome: WorkerOutcome::Error {
+                kind: "wrapper_crash".into(),
+                message: "panic in user code".into(),
+            },
+        };
+        let mut buf = Vec::new();
+        write_pipe_frame(&mut buf, &resp).unwrap();
+        let mut cur = Cursor::new(buf);
+        let back: WorkerCallResponse = read_pipe_frame(&mut cur).unwrap();
+        assert_eq!(resp, back);
+    }
+
+    #[test]
+    fn binary_payload_roundtrips() {
+        let payload: Vec<u8> = (0u8..=255).cycle().take(8192).collect();
+        let req = WorkerCallRequest {
+            stdin: payload.clone(),
+            timeout_secs: 5,
+        };
+        let mut buf = Vec::new();
+        write_pipe_frame(&mut buf, &req).unwrap();
+        let mut cur = Cursor::new(buf);
+        let back: WorkerCallRequest = read_pipe_frame(&mut cur).unwrap();
+        assert_eq!(back.stdin, payload);
+    }
+
+    #[test]
+    fn truncated_length_prefix_errors() {
+        let mut cur = Cursor::new(vec![0u8, 0u8]);
+        let res: io::Result<WorkerCallRequest> = read_pipe_frame(&mut cur);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn oversized_length_rejected_without_allocating() {
+        let mut buf = Vec::new();
+        let huge = (MAX_PIPE_FRAME_SIZE as u32 + 1).to_be_bytes();
+        buf.extend_from_slice(&huge);
+        let mut cur = Cursor::new(buf);
+        let res: io::Result<WorkerCallRequest> = read_pipe_frame(&mut cur);
+        let err = res.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn truncated_body_errors() {
+        let mut buf = Vec::new();
+        let len = 100u32.to_be_bytes();
+        buf.extend_from_slice(&len);
+        buf.extend_from_slice(&[0u8; 20]); // short body
+        let mut cur = Cursor::new(buf);
+        let res: io::Result<WorkerCallRequest> = read_pipe_frame(&mut cur);
+        let err = res.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn garbage_body_returns_other_error() {
+        let mut buf = Vec::new();
+        let body = b"not json";
+        let len = (body.len() as u32).to_be_bytes();
+        buf.extend_from_slice(&len);
+        buf.extend_from_slice(body);
+        let mut cur = Cursor::new(buf);
+        let res: io::Result<WorkerCallRequest> = read_pipe_frame(&mut cur);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn deny_unknown_fields_on_request() {
+        let json = br#"{"stdin": "AA==", "timeout_secs": 1, "smuggled": true}"#;
+        let mut buf = Vec::new();
+        let len = (json.len() as u32).to_be_bytes();
+        buf.extend_from_slice(&len);
+        buf.extend_from_slice(json);
+        let mut cur = Cursor::new(buf);
+        let res: io::Result<WorkerCallRequest> = read_pipe_frame(&mut cur);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn write_oversized_payload_returns_invalid_data() {
+        // The cap is a *frame* cap; a payload that base64-expands
+        // past the cap should fail at write time, not corrupt the
+        // worker's pipe by writing a partial frame.
+        let huge_stdin = vec![0u8; MAX_PIPE_FRAME_SIZE]; // base64 of this expands past 256KiB
+        let req = WorkerCallRequest {
+            stdin: huge_stdin,
+            timeout_secs: 1,
+        };
+        let mut buf = Vec::new();
+        let res = write_pipe_frame(&mut buf, &req);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/mvm-guest/tests/bin/fake_runner.rs
+++ b/crates/mvm-guest/tests/bin/fake_runner.rs
@@ -1,0 +1,199 @@
+//! Test fixture for the warm-process worker pool (plan 43).
+//!
+//! Reads framed [`WorkerCallRequest`]s from stdin and writes
+//! [`WorkerCallResponse`]s to stdout in a loop. Honours an env var
+//! `MVM_FAKE_RUNNER_BEHAVIOR` so tests can drive the worker through
+//! every recycling and crash path:
+//!
+//! - `ok` (default): echo stdin → stdout, exit 0 on every call.
+//! - `user_fault`: echo stdin → stdout, exit-code 1 on every call.
+//!   Simulates a wrapper that converts user exceptions to a
+//!   sanitized envelope and returns non-zero — the pool must NOT
+//!   recycle on this.
+//! - `crash_after_n=N`: serve N calls normally, then `std::process::exit(1)`
+//!   from outside any call (worker dies between calls).
+//! - `crash_during_call_n=N`: on the Nth call, after reading the
+//!   request, exit without writing a response. The agent should
+//!   surface `wrapper_crash` for that call and recycle.
+//! - `malformed_frame_on_n=N`: on the Nth call, write a length
+//!   prefix that promises 1 GiB followed by no body (oversized).
+//! - `leak_50mib_per_call`: allocate ~50 MiB per call and hold it,
+//!   so RSS grows. Used by the `max_rss_mb` recycle test.
+//! - `slow_secs=N`: sleep N seconds before responding (used by
+//!   timeout / queue saturation tests).
+//!
+//! Lives under `tests/bin/` and is declared as `[[bin]] test = false`
+//! so it never ships in the production guest closure. The
+//! `prod-agent-no-exec` symbol gate operates on
+//! `mvm-guest-agent` only and is unaffected.
+
+use std::env;
+use std::io::{self, Write};
+use std::process::ExitCode;
+
+use mvm_guest::worker_protocol::{
+    WorkerCallRequest, WorkerCallResponse, WorkerOutcome, read_pipe_frame, write_pipe_frame,
+};
+
+#[derive(Debug, Clone)]
+enum Behavior {
+    Ok,
+    UserFault,
+    CrashAfter(u64),
+    CrashDuringCallN(u64),
+    MalformedFrameOnN(u64),
+    Leak50MibPerCall,
+    SlowSecs(u64),
+}
+
+impl Behavior {
+    fn from_env() -> Self {
+        let raw = env::var("MVM_FAKE_RUNNER_BEHAVIOR").unwrap_or_else(|_| "ok".into());
+        let raw = raw.trim();
+        if raw == "ok" {
+            return Behavior::Ok;
+        }
+        if raw == "user_fault" {
+            return Behavior::UserFault;
+        }
+        if raw == "leak_50mib_per_call" {
+            return Behavior::Leak50MibPerCall;
+        }
+        if let Some(n) = raw.strip_prefix("crash_after_n=") {
+            return Behavior::CrashAfter(n.parse().expect("crash_after_n value"));
+        }
+        if let Some(n) = raw.strip_prefix("crash_during_call_n=") {
+            return Behavior::CrashDuringCallN(n.parse().expect("crash_during_call_n value"));
+        }
+        if let Some(n) = raw.strip_prefix("malformed_frame_on_n=") {
+            return Behavior::MalformedFrameOnN(n.parse().expect("malformed_frame_on_n value"));
+        }
+        if let Some(n) = raw.strip_prefix("slow_secs=") {
+            return Behavior::SlowSecs(n.parse().expect("slow_secs value"));
+        }
+        panic!("unknown MVM_FAKE_RUNNER_BEHAVIOR={raw}");
+    }
+}
+
+fn main() -> ExitCode {
+    let behavior = Behavior::from_env();
+    let mut stdin = io::stdin().lock();
+    let mut stdout = io::stdout().lock();
+    let mut call_no: u64 = 0;
+    // Holds anything we want to keep allocated across calls.
+    let mut leaked: Vec<Vec<u8>> = Vec::new();
+
+    loop {
+        // Block on the next request frame. EOF here means the pool is
+        // shutting us down — exit cleanly.
+        let req: WorkerCallRequest = match read_pipe_frame(&mut stdin) {
+            Ok(r) => r,
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return ExitCode::from(0),
+            Err(e) => {
+                eprintln!("fake_runner: read frame error: {e}");
+                return ExitCode::from(2);
+            }
+        };
+        call_no = call_no.saturating_add(1);
+
+        match &behavior {
+            Behavior::Ok | Behavior::UserFault => {
+                let code = matches!(behavior, Behavior::UserFault) as i32;
+                let resp = WorkerCallResponse {
+                    stdout: req.stdin.clone(),
+                    stderr: format!("fake_runner: call {call_no}\n").into_bytes(),
+                    outcome: WorkerOutcome::Exit { code },
+                };
+                if let Err(e) = write_pipe_frame(&mut stdout, &resp) {
+                    eprintln!("fake_runner: write frame error: {e}");
+                    return ExitCode::from(2);
+                }
+            }
+            Behavior::CrashAfter(after) => {
+                if call_no > *after {
+                    // Should not happen — we exit at the moment we
+                    // serve call N+1's request (below).
+                    return ExitCode::from(1);
+                }
+                let resp = WorkerCallResponse {
+                    stdout: req.stdin.clone(),
+                    stderr: Vec::new(),
+                    outcome: WorkerOutcome::Exit { code: 0 },
+                };
+                if write_pipe_frame(&mut stdout, &resp).is_err() {
+                    return ExitCode::from(2);
+                }
+                if call_no == *after {
+                    // Drain stdout and exit before next call.
+                    let _ = stdout.flush();
+                    return ExitCode::from(0);
+                }
+            }
+            Behavior::CrashDuringCallN(n) => {
+                if call_no == *n {
+                    // Don't write a response — exit. The agent's
+                    // read_pipe_frame will see EOF.
+                    drop(stdout);
+                    return ExitCode::from(13);
+                }
+                let resp = WorkerCallResponse {
+                    stdout: req.stdin.clone(),
+                    stderr: Vec::new(),
+                    outcome: WorkerOutcome::Exit { code: 0 },
+                };
+                if write_pipe_frame(&mut stdout, &resp).is_err() {
+                    return ExitCode::from(2);
+                }
+            }
+            Behavior::MalformedFrameOnN(n) => {
+                if call_no == *n {
+                    // Write a length prefix promising 1 GiB but no
+                    // body. The agent's read_pipe_frame should
+                    // reject the oversized length.
+                    let bogus_len: u32 = 1u32 << 30;
+                    let _ = stdout.write_all(&bogus_len.to_be_bytes());
+                    let _ = stdout.flush();
+                    // Exit so the pipe closes; the agent surfaces
+                    // wrapper_crash.
+                    return ExitCode::from(0);
+                }
+                let resp = WorkerCallResponse {
+                    stdout: req.stdin.clone(),
+                    stderr: Vec::new(),
+                    outcome: WorkerOutcome::Exit { code: 0 },
+                };
+                if write_pipe_frame(&mut stdout, &resp).is_err() {
+                    return ExitCode::from(2);
+                }
+            }
+            Behavior::Leak50MibPerCall => {
+                // Touch each page so the kernel actually backs them
+                // and RSS grows.
+                let mut chunk: Vec<u8> = vec![0; 50 * 1024 * 1024];
+                for i in (0..chunk.len()).step_by(4096) {
+                    chunk[i] = 1;
+                }
+                leaked.push(chunk);
+                let resp = WorkerCallResponse {
+                    stdout: req.stdin.clone(),
+                    stderr: Vec::new(),
+                    outcome: WorkerOutcome::Exit { code: 0 },
+                };
+                if write_pipe_frame(&mut stdout, &resp).is_err() {
+                    return ExitCode::from(2);
+                }
+            }
+            Behavior::SlowSecs(secs) => {
+                std::thread::sleep(std::time::Duration::from_secs(*secs));
+                let resp = WorkerCallResponse {
+                    stdout: req.stdin.clone(),
+                    stderr: Vec::new(),
+                    outcome: WorkerOutcome::Exit { code: 0 },
+                };
+                if write_pipe_frame(&mut stdout, &resp).is_err() {
+                    return ExitCode::from(2);
+                }
+            }
+        }
+    }
+}

--- a/crates/mvm-guest/tests/worker_pool_warm.rs
+++ b/crates/mvm-guest/tests/worker_pool_warm.rs
@@ -1,0 +1,288 @@
+//! Integration tests for the warm-process worker pool (plan 43).
+//!
+//! Drives a real `WorkerPool` against the `fake-runner` test binary
+//! to exercise the recycling paths (call-count, wrapper crash) and
+//! the FIFO queue. Tests run on macOS dev hosts and Linux equally —
+//! the only Linux-specific bit is `/proc/<pid>/statm` RSS sampling,
+//! which the cross-platform tests in this file don't depend on. RSS
+//! recycling lives in the Linux-gated test below.
+//!
+//! These tests never touch `handle_run_entrypoint` or the cold-tier
+//! M12 lock; the cold path is unaffected.
+
+use std::fs::File;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use mvm_guest::entrypoint::ValidatedEntrypoint;
+use mvm_guest::runtime_config::{InProcessMode, WarmProcessConfig};
+use mvm_guest::worker_pool::{DispatchOutcome, SlotSnapshot, WorkerPool};
+use mvm_guest::worker_protocol::WorkerOutcome;
+
+/// Cargo sets `CARGO_BIN_EXE_<name>` at compile time for integration
+/// tests, pointing at the built test binary.
+const FAKE_RUNNER: &str = env!("CARGO_BIN_EXE_fake-runner");
+
+fn validated_for_fake_runner() -> ValidatedEntrypoint {
+    let path = PathBuf::from(FAKE_RUNNER);
+    let file = File::open(&path).expect("fake-runner exists");
+    ValidatedEntrypoint {
+        resolved: path,
+        file,
+    }
+}
+
+fn cfg(pool_size: usize, max_calls: u64, max_rss_mb: u64) -> WarmProcessConfig {
+    WarmProcessConfig {
+        max_calls_per_worker: max_calls,
+        max_rss_mb,
+        pool_size,
+        in_process: InProcessMode::Serial,
+        max_queue_depth: None,
+    }
+}
+
+fn start_pool(cfg: WarmProcessConfig) -> Arc<WorkerPool> {
+    start_pool_with_behavior(cfg, None)
+}
+
+fn start_pool_with_behavior(cfg: WarmProcessConfig, behavior: Option<&str>) -> Arc<WorkerPool> {
+    let entry = Arc::new(validated_for_fake_runner());
+    let env: Vec<(String, String)> = behavior
+        .map(|b| vec![("MVM_FAKE_RUNNER_BEHAVIOR".to_string(), b.to_string())])
+        .unwrap_or_default();
+    WorkerPool::start(cfg, entry, env).expect("pool start")
+}
+
+fn dispatch(pool: &Arc<WorkerPool>, payload: &[u8]) -> DispatchOutcome {
+    pool.dispatch(payload.to_vec(), 30)
+        .expect("dispatch returns outcome")
+}
+
+fn idle_pid(pool: &Arc<WorkerPool>) -> u32 {
+    let snap = pool.snapshot();
+    snap.iter()
+        .find_map(|s| match s {
+            SlotSnapshot::Idle { pid, .. } => Some(*pid),
+            _ => None,
+        })
+        .expect("at least one idle slot")
+}
+
+fn idle_call_count(pool: &Arc<WorkerPool>, pid: u32) -> u64 {
+    let snap = pool.snapshot();
+    snap.iter()
+        .find_map(|s| match s {
+            SlotSnapshot::Idle {
+                pid: p, call_count, ..
+            } if *p == pid => Some(*call_count),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+#[test]
+fn warm_process_round_trip_pid_stable() {
+    // SAFETY: tests in this binary run sequentially? No — Cargo runs
+    // them in parallel by default. Each test that sets env vars must
+    // either coordinate or use a separate behavior flag. For "ok"
+    // (default) we don't need to set anything.
+    let pool = start_pool(cfg(1, 100, 1024));
+    let pid_before = idle_pid(&pool);
+
+    let out1 = dispatch(&pool, b"hello");
+    assert_eq!(out1.stdout, b"hello");
+    assert!(matches!(out1.outcome, WorkerOutcome::Exit { code: 0 }));
+
+    let out2 = dispatch(&pool, b"world");
+    assert_eq!(out2.stdout, b"world");
+    assert!(matches!(out2.outcome, WorkerOutcome::Exit { code: 0 }));
+
+    assert_eq!(idle_pid(&pool), pid_before, "PID stable across calls");
+    assert_eq!(idle_call_count(&pool, pid_before), 2);
+}
+
+#[test]
+fn user_code_fault_does_not_recycle() {
+    // The fake runner returns Exit { code: 1 } on every call; the
+    // pool must NOT recycle on user-code-level failure.
+    let pool = start_pool_with_behavior(cfg(1, 100, 1024), Some("user_fault"));
+    let pid_before = idle_pid(&pool);
+
+    for _ in 0..20 {
+        let out = dispatch(&pool, b"x");
+        assert!(matches!(out.outcome, WorkerOutcome::Exit { code: 1 }));
+    }
+    assert_eq!(idle_pid(&pool), pid_before, "PID stable for user faults");
+    assert_eq!(idle_call_count(&pool, pid_before), 20);
+}
+
+#[test]
+fn recycle_on_call_count_exceeded() {
+    let pool = start_pool(cfg(1, 3, 1024)); // recycle after 3 calls
+    let first_pid = idle_pid(&pool);
+
+    for _ in 0..3 {
+        let out = dispatch(&pool, b"a");
+        assert!(matches!(out.outcome, WorkerOutcome::Exit { code: 0 }));
+    }
+    // After 3 calls, the next call should be served by a fresh
+    // worker because release saw call_count >= max.
+    let second_pid = idle_pid(&pool);
+    assert_ne!(second_pid, first_pid, "worker recycled after call cap");
+}
+
+#[test]
+fn wrapper_crash_returns_error_and_recycles() {
+    // crash_during_call_n=2: call 1 succeeds, call 2 crashes
+    // (worker exits without writing response). After recycle, the
+    // fresh worker also has crash_during_call_n=2 set (the env is
+    // baked into the pool), so we only assert through to call 2's
+    // crash. PID changes proves the recycle fired.
+    let pool = start_pool_with_behavior(cfg(1, 100, 1024), Some("crash_during_call_n=2"));
+    let first_pid = idle_pid(&pool);
+
+    let out1 = pool
+        .dispatch(b"first".to_vec(), 5)
+        .expect("dispatch returns outcome");
+    assert!(matches!(out1.outcome, WorkerOutcome::Exit { code: 0 }));
+
+    let out2 = pool
+        .dispatch(b"second".to_vec(), 5)
+        .expect("dispatch returns outcome even on crash");
+    assert!(
+        matches!(out2.outcome, WorkerOutcome::Error { .. }),
+        "out2 outcome = {:?}",
+        out2.outcome
+    );
+    if let WorkerOutcome::Error { kind, .. } = out2.outcome {
+        assert_eq!(kind, "wrapper_crash");
+    }
+
+    // Recycle should have replaced the worker.
+    let second_pid = idle_pid(&pool);
+    assert_ne!(second_pid, first_pid, "crashed worker replaced");
+}
+
+#[test]
+fn pool_size_4_parallel_dispatches() {
+    let pool = start_pool(cfg(4, 100, 1024));
+    let pids_before: std::collections::HashSet<u32> = pool
+        .snapshot()
+        .into_iter()
+        .filter_map(|s| match s {
+            SlotSnapshot::Idle { pid, .. } => Some(pid),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(pids_before.len(), 4);
+
+    // Fire 12 dispatches across 12 threads.
+    let pool_clone = Arc::clone(&pool);
+    let mut handles = Vec::new();
+    for i in 0..12 {
+        let p = Arc::clone(&pool_clone);
+        handles.push(std::thread::spawn(move || {
+            let payload = format!("call-{i}");
+            let out = p.dispatch(payload.clone().into_bytes(), 30).expect("ok");
+            assert_eq!(out.stdout, payload.as_bytes());
+            assert!(matches!(out.outcome, WorkerOutcome::Exit { code: 0 }));
+        }));
+    }
+    for h in handles {
+        h.join().expect("thread completes");
+    }
+
+    // All 4 workers should still be the same PIDs — call_count below
+    // recycle threshold.
+    let pids_after: std::collections::HashSet<u32> = pool
+        .snapshot()
+        .into_iter()
+        .filter_map(|s| match s {
+            SlotSnapshot::Idle { pid, .. } => Some(pid),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(pids_after, pids_before);
+}
+
+#[test]
+fn fifo_queue_serializes_callers() {
+    // pool_size=1, max_queue_depth=4 + 5 concurrent dispatches:
+    // 1 in-flight, up to 4 queued, total 5 fits exactly. All
+    // complete; the queue serializes them.
+    let mut wpc = cfg(1, 100, 1024);
+    wpc.max_queue_depth = Some(4);
+    let pool = start_pool(wpc);
+    let pool_clone = Arc::clone(&pool);
+    let start = Instant::now();
+    let mut handles = Vec::new();
+    for i in 0..5u8 {
+        let p = Arc::clone(&pool_clone);
+        handles.push(std::thread::spawn(move || {
+            p.dispatch(vec![i], 5).expect("dispatch")
+        }));
+    }
+    let outs: Vec<DispatchOutcome> = handles
+        .into_iter()
+        .map(|h| h.join().expect("thread"))
+        .collect();
+    assert_eq!(outs.len(), 5);
+    for out in &outs {
+        assert!(matches!(out.outcome, WorkerOutcome::Exit { code: 0 }));
+    }
+    assert!(
+        start.elapsed() < Duration::from_secs(10),
+        "5 quick calls under pool_size=1 finish promptly"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn recycle_on_rss_exceeded() {
+    // Linux-only: relies on /proc/<pid>/statm. The fake runner
+    // allocates 50 MiB per call; max_rss_mb=10 forces recycle on
+    // call 1. The replacement also has leak_50mib_per_call (env
+    // baked into pool), but call 1 alone is enough to verify the
+    // recycle fired.
+    let pool = start_pool_with_behavior(cfg(1, 100, 10), Some("leak_50mib_per_call"));
+    let first_pid = idle_pid(&pool);
+
+    let _ = dispatch(&pool, b"call-1");
+    // After call 1, RSS should be over 10 MiB → worker recycled.
+    let second_pid = idle_pid(&pool);
+    assert_ne!(
+        second_pid, first_pid,
+        "worker recycled after RSS exceeded cap"
+    );
+}
+
+#[test]
+fn queue_full_returns_error() {
+    // pool_size=1, max_queue_depth=1. With one in-flight slow caller
+    // and one queued, the third caller must be rejected with QueueFull.
+    let mut wpc = cfg(1, 100, 1024);
+    wpc.max_queue_depth = Some(1);
+    let pool = start_pool_with_behavior(wpc, Some("slow_secs=2"));
+
+    let p1 = Arc::clone(&pool);
+    let p2 = Arc::clone(&pool);
+    let h1 = std::thread::spawn(move || p1.dispatch(b"a".to_vec(), 10));
+    // Give the first dispatch time to enter the worker (occupy slot).
+    std::thread::sleep(Duration::from_millis(200));
+    let h2 = std::thread::spawn(move || p2.dispatch(b"b".to_vec(), 10));
+    // Give the second dispatch time to enter the queue.
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Third should hit QueueFull.
+    let res = pool.dispatch(b"c".to_vec(), 10);
+    assert!(
+        res.is_err(),
+        "third dispatch must hit queue cap, got {:?}",
+        res
+    );
+
+    let _ = h1.join().expect("h1");
+    let _ = h2.join().expect("h2");
+}

--- a/scripts/check-prod-agent-no-exec.sh
+++ b/scripts/check-prod-agent-no-exec.sh
@@ -106,6 +106,32 @@ fi
 
 echo "==> ok: handle_run_entrypoint symbol present in $BIN"
 
+# ─── Positive: dispatch_via_warm_pool must be PRESENT (plan 43) ────────
+# Plan 43 (warm-process function dispatch, mvmforge ADR-0011 tier 2)
+# adds a worker-pool path that runs alongside the cold-tier handler.
+# The substrate is always linked into the prod binary (the path is
+# opt-in at runtime via `/etc/mvm/runtime.json`, not at build time).
+# Asserting its presence as positive evidence catches:
+#   - someone gating `dispatch_via_warm_pool` behind a feature flag
+#   - LTO inlining erasing the symbol (fixed by `#[inline(never)]`
+#     on the function, but the gate is the safety net)
+#   - the worker-pool module being accidentally unlinked
+# A prod build without this symbol cannot serve warm-tier images,
+# even though the cold tier still works — partial substrate is
+# worse than honest absence.
+WARM_PATTERN='mvm_guest_agent::dispatch_via_warm_pool'
+if ! "${NM_CMD[@]}" "$BIN" 2>/dev/null | grep -F "$WARM_PATTERN" >/dev/null; then
+    echo "error: required symbol '$WARM_PATTERN' missing from production guest agent" >&2
+    echo "       this means the warm-process worker-pool dispatch path is" >&2
+    echo "       not compiled in, and warm-tier images will fall through to" >&2
+    echo "       the cold path silently." >&2
+    echo "       See plan 43 / mvmforge ADR-0011 and the helper in" >&2
+    echo "       crates/mvm-guest/src/bin/mvm-guest-agent.rs::dispatch_via_warm_pool." >&2
+    exit 1
+fi
+
+echo "==> ok: dispatch_via_warm_pool symbol present in $BIN"
+
 # ─── Variant ↔ feature pairing (W7.1) ────────────────────────────────────
 # `mkGuest` (in nix/flake.nix) asserts at build time that:
 #   variant="prod" ↔ guestAgent.passthru.devShell == false

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -595,6 +595,26 @@ Six workstreams, each independently shippable.
   skipping TAP allocation. **Open** — needs the mvmforge IR
   emit + an mvm-side regression test that asserts a `mode =
   "none"` workload truly has no TAP.
+- **W7 — Warm-process function dispatch (ADR-0011 tier 2).**  🟡
+  in progress  [`plans/43-warm-process-function-dispatch.md`](plans/43-warm-process-function-dispatch.md).
+  Adds an opt-in worker pool inside the guest agent so
+  function-entrypoint calls can reuse a long-running wrapper
+  process across invokes instead of cold-spawning per
+  `mvmctl invoke`. Driven by a new mvmforge-owned
+  `/etc/mvm/runtime.json` carrying a `concurrency.kind =
+  "warm_process"` field (`max_calls_per_worker`, `max_rss_mb`,
+  `pool_size`, `in_process`, `max_queue_depth`). When the field
+  is absent, the cold path (W2) stays bit-identical. Host wire
+  (`RunEntrypoint` + `EntrypointEvent`) is unchanged; the agent
+  synthesizes the existing event stream from a single buffered
+  framed response per worker call. M12 (one in-flight call per
+  VM) is bypassed under warm-process — the new invariant is "one
+  in-flight call per worker, ≤ `pool_size` concurrent." The
+  `prod-agent-no-exec` symbol gate keeps passing; the plan adds a
+  positive-evidence assertion for the new
+  `mvm_guest::worker_pool` module. mvm-side only — mvmforge ships
+  the IR + factory + runner-wrapper changes in a coordinated
+  follow-up (cross-repo ADR-0011).
 
 ### Substrate validation (live smoke)
 
@@ -699,6 +719,7 @@ Cross-repo (decorationer):
 | **Session pool management** | follow-up plan (none yet) | Pre-baked invariant: *single-tenant for VM lifetime*. v1 reuses `boot_session_vm` / `dispatch_in_session` / `tear_down_session_vm` primitives directly. Sizing / eviction / per-tenant isolation / idle reaper are real but separable from the substrate. | ~1 sprint |
 | **Streaming chunked output** | follow-up plan (none yet) | v1 wire is streaming-shaped but buffered up to 1 MiB per stream. Lifting the cap means real chunked emission from the agent and a streaming consumer in `send_run_entrypoint`. | ~1 week |
 | **Schema-bound payloads (v2 of W3)** | decorationer plan 0003 | Derive JSON Schema from type hints (Python `pydantic` / TS `zod`). Wrapper validates inbound bytes before user code runs. | ~1 week |
+| **Guest agent signal handling** | [`plans/44-agent-signal-handling.md`](plans/44-agent-signal-handling.md) | The agent has no SIGTERM/SIGINT/SIGHUP handlers. VM teardown is abrupt today, so graceful drain is cosmetic. Plan 43 (warm-process) made `WorkerPool::shutdown` exist but didn't wire a handler to call it. Becomes load-bearing if mvm grows hot-reload, in-place agent updates, operator-driven SIGTERM, config reload, or non-microVM execution. | ~½ day |
 
 ### Stack-merge artifacts
 

--- a/specs/plans/43-warm-process-function-dispatch.md
+++ b/specs/plans/43-warm-process-function-dispatch.md
@@ -1,0 +1,483 @@
+# Plan 43 — warm-process function dispatch (mvm side)
+
+> Substrate work for the warm-process tier of mvmforge ADR-0011. Adds an
+> opt-in worker pool inside the guest agent so function-entrypoint
+> calls can reuse a long-running wrapper process instead of cold-spawning
+> per `mvmctl invoke`. Sits on top of plan 41 (cold-tier
+> `RunEntrypoint`) and is orthogonal to warm-VM session reuse.
+
+## Context
+
+Plan 41 / Sprint 45 shipped the **cold tier**: `RunEntrypoint` spawns the
+validated wrapper at `/usr/lib/mvm/wrappers/<name>` per call, serialized
+through `RUN_ENTRYPOINT_LOCK` (M12 — one in-flight call per VM). Per-call
+process spawn pays the wrapper's interpreter cold-start (~hundreds of
+milliseconds for Python) on every invoke.
+
+mvmforge ADR-0011 specifies a three-tier concurrency hierarchy. Plan 41
+gave us tier 1 (cold). Tier 2 (warm-process) keeps a pool of wrapper
+processes alive across calls; tier 3 (warm-VM, `mvmctl session`) is
+orthogonal and ships separately. This plan covers tier 2.
+
+The host wire is unchanged — `mvmctl invoke` still sends
+`GuestRequest::RunEntrypoint { stdin, timeout_secs }` and consumes the
+same `EntrypointEvent` stream. Whether the substrate respawns or reuses
+is a guest-side choice driven by `/etc/mvm/runtime.json`, the new
+mvmforge-owned config file. Images without `runtime.json` (or without a
+`concurrency` field) keep the cold path bit-for-bit.
+
+## Trigger config
+
+mvmforge writes `/etc/mvm/runtime.json` at image-build time via
+`mkGuest extraFiles` (existing mechanism, no flake change here):
+
+```json
+{
+  "language": "python",
+  "module": "...", "function": "...", "format": "json",
+  "source_path": "/app",
+  "concurrency": {
+    "kind": "warm_process",
+    "max_calls_per_worker": 1000,
+    "max_rss_mb": 512,
+    "pool_size": 1,
+    "in_process": "serial"
+  }
+}
+```
+
+`concurrency` absent → cold tier. `kind = "warm_process"` → this plan's
+new path. `in_process = "concurrent"` is rejected at parse time (out of
+scope for v0.2 per ADR-0011).
+
+## Architectural decisions
+
+These resolve the contracts ADR-0011 left open:
+
+1. **Backpressure**: FIFO queue with bounded depth. Default
+   `max_queue_depth = 2 * pool_size`, overridable via `runtime.json`.
+   Overflow → `EntrypointEvent::Error { kind: Busy }` — same envelope
+   the cold path returns on M12 contention. The cap is a defensive
+   bound (a host caller that loops `mvmctl invoke` could OOM the agent
+   without it; each queued caller holds its `stdin: Vec<u8>` in memory).
+2. **Worker → agent framing**: one length-prefixed JSON frame per call
+   (4-byte big-endian length + body, 256 KiB cap,
+   `serde(deny_unknown_fields)`). Buffered, not streamed sub-frames —
+   matches the current cold-path emission shape (one `Stdout`, one
+   `Stderr`, one terminal). The agent synthesizes `EntrypointEvent`s
+   from the worker's single response so the host wire stays identical.
+3. **Binary encoding**: base64 over JSON for stdin/stdout/stderr. Single
+   serializer (`serde_json`) across the agent. Bincode is a v0.3 perf knob.
+4. **Malformed runtime.json**: fail loud — agent exits non-zero at boot.
+   mvmforge owns the file; a broken one is a build bug, not a runtime
+   fallback. Missing file → cold tier (no error).
+5. **`in_process = "concurrent"`**: rejected at parse time.
+6. **M12 invariant under warm-process**: bypassed. New invariant: "one
+   in-flight call per worker, up to `pool_size` concurrent." Cold path
+   keeps the existing global mutex untouched.
+7. **No `dev-shell` feature gate**. Warm-process is production code.
+   The CI gate (`scripts/check-prod-agent-no-exec.sh`) only forbids
+   `mvm_guest_agent::do_exec`; new `mvm_guest::worker_pool::*` symbols
+   pass.
+8. **Recycle-after-call only**: RSS sampled from `/proc/<pid>/statm`
+   after the worker returns its response, never mid-dispatch.
+
+## Boundaries
+
+- **Two config files, two owners.** `/etc/mvm/agent.json` (mvm-owned,
+  transport tuning, exists today) vs `/etc/mvm/runtime.json`
+  (mvmforge-owned, per-workload metadata, NEW). Different schemas,
+  different release cadences, kept separate.
+- **One mode per image in v0.2.** No mixed cold+warm in the same image.
+  "Warm with cold overflow" is a v0.3 idea.
+- **Workers don't cross VM boundaries.** Each VM has its own pool;
+  cross-VM call routing is mvmd's concern.
+- **Sync, not async.** Tokio adds binary-size + audit surface to a
+  uid-901 production binary; bounded concurrency (`pool_size ≤ 64`)
+  doesn't motivate it. Thread-per-connection is the right shape.
+
+## Approach
+
+Five phases, each independently committable.
+
+### Phase 1 — Types and config surface
+
+`crates/mvm-guest/src/runtime_config.rs` (new):
+
+```rust
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeConfig {
+    pub language: String,
+    pub module: String,
+    pub function: String,
+    pub format: String,
+    pub source_path: String,
+    #[serde(default)]
+    pub concurrency: Option<ConcurrencyConfig>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields, tag = "kind", rename_all = "snake_case")]
+pub enum ConcurrencyConfig {
+    WarmProcess(WarmProcessConfig),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct WarmProcessConfig {
+    pub max_calls_per_worker: u64,
+    pub max_rss_mb: u64,
+    pub pool_size: usize,
+    pub in_process: InProcessMode,
+    /// Default = 2 * pool_size. Overflow → Busy.
+    #[serde(default)]
+    pub max_queue_depth: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InProcessMode { Serial, Concurrent }
+```
+
+`pub fn load() -> Result<Option<RuntimeConfig>, RuntimeConfigError>`:
+reads `/etc/mvm/runtime.json`. Missing → `Ok(None)`. Malformed → `Err`.
+Validates `pool_size` in `[1, 64]` and rejects `Concurrent`. Path is
+overridable for tests via `load_from(&Path)`.
+
+`crates/mvm-guest/src/worker_protocol.rs` (new):
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerCallRequest {
+    #[serde(with = "base64_bytes")]
+    pub stdin: Vec<u8>,
+    pub timeout_secs: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerCallResponse {
+    #[serde(with = "base64_bytes")]
+    pub stdout: Vec<u8>,
+    #[serde(with = "base64_bytes")]
+    pub stderr: Vec<u8>,
+    pub outcome: WorkerOutcome,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, tag = "kind", rename_all = "snake_case")]
+pub enum WorkerOutcome {
+    Exit { code: i32 },
+    Error { kind: String, message: String },
+}
+
+pub fn write_pipe_frame<W: Write, T: Serialize>(...) -> io::Result<()>;
+pub fn read_pipe_frame<R: Read, T: DeserializeOwned>(...) -> io::Result<T>;
+```
+
+Helpers mirror `vsock.rs:read_frame`/`write_frame` but generic over
+`Read`/`Write` (pipe handles, not `UnixStream`). `MAX_PIPE_FRAME_SIZE =
+256 KiB`. Types are `pub` so mvmforge can depend on `mvm-guest` for the
+wrapper-side schema (single source of truth).
+
+Acceptance: serde roundtrips for every type; deny-unknown rejection
+tests; fuzz cases for truncated / oversized / partial frames.
+
+### Phase 2 — Worker pool module
+
+`crates/mvm-guest/src/worker_pool.rs` (new):
+
+```rust
+struct WorkerHandle {
+    pid: u32,
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    stderr_drain: JoinHandle<Vec<u8>>,
+    call_count: u64,
+    last_rss_bytes: u64,
+}
+
+enum WorkerSlot { Idle(WorkerHandle), Busy, Replacing, Dead }
+
+pub struct WorkerPool {
+    slots: Mutex<Vec<WorkerSlot>>,
+    cv: Condvar,
+    pending_waiters: AtomicUsize,
+    cfg: WarmProcessConfig,
+    entrypoint: Arc<ValidatedEntrypoint>,
+    shutdown: AtomicBool,
+}
+
+impl WorkerPool {
+    pub fn start(cfg: WarmProcessConfig, entry: Arc<ValidatedEntrypoint>) -> io::Result<Arc<Self>>;
+    pub fn dispatch(&self, stdin: Vec<u8>, timeout: Duration) -> DispatchOutcome;
+    pub fn shutdown(&self, grace: Duration);
+}
+```
+
+Worker spawn reuses the validated FD (`/proc/self/fd/<n>` from
+`VALIDATED_ENTRYPOINT`). Same security envelope as plan 41's
+`entrypoint::execute`: `env_clear()`, `process_group(0)`, `pre_exec` to
+zero `RLIMIT_CORE`, stdio piped. The agent's setpriv envelope (W4.5)
+propagates to children.
+
+Dispatch flow:
+1. `acquire_idle_or_wait()` — if `pending_waiters >= max_queue_depth`,
+   return `QueueFull`; otherwise find first `Idle`, swap to `Busy`. If
+   none free, increment waiters, `cv.wait`, decrement on wake.
+2. Spawn watchdog thread that SIGKILLs the worker process group on
+   `timeout_secs` expiry.
+3. `write_pipe_frame(WorkerCallRequest)`.
+4. `read_pipe_frame::<WorkerCallResponse>`. EOF / parse error →
+   `WrapperCrashed`.
+5. Cancel watchdog. Bump `call_count`. Sample RSS.
+6. Recycle if `call_count >= max_calls_per_worker`, RSS over cap, or the
+   call errored — drain (no-op since serial), SIGTERM/grace/SIGKILL,
+   reap, spawn replacement. Otherwise return slot to `Idle` and
+   `cv.notify_one()`.
+
+Replacement failure marks the slot `Dead`; a 1s recovery thread
+periodically retries `Dead → Idle`.
+
+Routing back to `EntrypointEvent` (caller side):
+- `Outcome::Exit { code }` → `Stdout(stdout)`, `Stderr(stderr)`,
+  `Exit { code }`.
+- `Outcome::Error { kind: "wrapper_crash", .. }` → `Error { kind:
+  WrapperCrashed, .. }`.
+- `kind == "timeout"` → `Error { kind: Timeout, .. }`.
+- Other → `Error { kind: InternalError, .. }`.
+
+Acceptance: pool spawn unit tests against `fake_runner`; recycle on
+call-count and RSS; FIFO queue under saturation; PID stability across
+calls without recycle.
+
+### Phase 3 — Wire the agent
+
+`crates/mvm-guest/src/bin/mvm-guest-agent.rs`:
+
+1. **Boot init** after `init_entrypoint_validation()`:
+   ```rust
+   let warm_pool = match runtime_config::load() {
+       Ok(None) => None,
+       Ok(Some(rc)) => match rc.concurrency {
+           Some(ConcurrencyConfig::WarmProcess(wp)) => match VALIDATED_ENTRYPOINT.get() {
+               Some(Ok(entry)) => Some(WorkerPool::start(wp, Arc::new(entry.clone()))?),
+               _ => { eprintln!("warm-process configured but entrypoint validation failed"); std::process::exit(1); }
+           },
+           None => None,
+       },
+       Err(e) => { eprintln!("invalid /etc/mvm/runtime.json: {e}"); std::process::exit(1); }
+   };
+   static WARM_POOL: OnceLock<Option<Arc<WorkerPool>>> = OnceLock::new();
+   let _ = WARM_POOL.set(warm_pool);
+   ```
+
+2. **Branch in `handle_run_entrypoint`** before the M12 try_lock:
+   ```rust
+   if let Some(Some(pool)) = WARM_POOL.get() {
+       return dispatch_via_warm_pool(file, pool, stdin, timeout_secs);
+   }
+   // existing cold path unchanged
+   ```
+   Preserve `#[inline(never)]` on `handle_run_entrypoint` (load-bearing
+   for the W5 symbol gate).
+
+3. **Accept loop**: when warm-process is active, spawn-thread-per-conn
+   so concurrent invokes reach parallel workers. Cold path stays
+   single-threaded — no behavior change for cold-tier images.
+
+4. **Shutdown handler**: install a SIGTERM handler that calls
+   `WorkerPool::shutdown(5s)`. Sets the `shutdown` atomic, drains
+   in-flight calls, SIGTERM/grace/SIGKILL idle workers.
+
+Acceptance: cold-tier regression — existing `runentrypoint` tests pass
+with no `runtime.json`. Warm-tier integration test drives
+`handle_run_entrypoint` end-to-end against `fake_runner`.
+
+### Phase 4 — Tests
+
+**Fixture** `crates/mvm-guest/tests/bin/fake_runner.rs`: Rust binary
+that reads frames via `worker_protocol::read_pipe_frame`. Behavior via
+env: `FAKE_RUNNER_BEHAVIOR=ok|crash|leak_50mib|exit_after_n=N|malformed_frame|sleep_forever`.
+Default: echo stdin → stdout, fixed stderr, `Exit { code: 0 }`.
+
+**Unit tests** in `worker_pool.rs::tests`:
+- `dispatch_one_call_pid_stable` — case 1
+- `recycle_on_call_count_exceeded` — case 2
+- `recycle_on_rss_exceeded` (injectable `RssReader` trait) — case 3
+- `wrapper_crash_returns_error_and_recycles` — case 4
+- `user_code_fault_does_not_recycle` — case 5
+- `pool_4_parallel_dispatches` — case 7
+- `fifo_queue_under_saturation` — case 8
+- `concurrent_mode_rejected_at_load` — case 9 (partial)
+
+**Frame fuzz** in `worker_protocol.rs::tests`:
+- truncated length, oversized length, partial payload — case 6.
+
+**Integration** `crates/mvm-guest/tests/runentrypoint_warm.rs`:
+- writes `runtime.json` to a tempdir
+- builds an `EntrypointPolicy` pointing at `fake_runner`
+- exercises `handle_run_entrypoint` end-to-end via mock vsock stream
+- adds `no_runtime_json_uses_cold_path` regression — case 9
+
+**Symbol-contract gate** `scripts/check-prod-agent-no-exec.sh`: extend
+with positive assertion for `mvm_guest::worker_pool` presence as
+evidence the warm path is wired.
+
+### Phase 5 — Coordination signal to mvmforge
+
+This plan is mvm-side only. After it lands, mvmforge owes:
+
+- Plumb `concurrency` through their IR.
+- Each language factory writes `runtime.json` with the new shape into
+  `mkGuest extraFiles`.
+- The runner wrapper speaks the framed multi-call loop on stdin/stdout
+  (4-byte BE + JSON `WorkerCallRequest`/`WorkerCallResponse`).
+- Wire-format alignment via `mvm-guest::worker_protocol` (re-exported
+  `pub` so mvmforge depends on mvm-guest for the schema).
+
+Until mvmforge ships its side, no image carries `concurrency.kind =
+"warm_process"`, so the warm path is dormant in the wild and the cold
+path is unaffected. We can land this substrate safely and test it via
+`fake_runner` without mvmforge ready.
+
+## Surface area
+
+| Surface | Change | Containment |
+|---|---|---|
+| `runtime.json` parser | New file read at boot | `deny_unknown_fields`, `pool_size ≤ 64`, fail-loud on malformed; rootfs verity-protected (W3) |
+| Wrapper-side stdio pipes | Agent reads JSON frames from a child | 256 KiB frame cap; parse error → recycle; watchdog SIGKILLs on `timeout_secs` |
+| Worker spawn | Child from validated FD | Same `EntrypointPolicy::production()` validation as cold path; FD-held-open defeats TOCTOU |
+| Accept-loop concurrency | Thread-per-connection when warm | Existing shared state is `Arc<Mutex<>>`; explicit `handle_client` audit pass |
+| M12 lock bypass | Per-slot Busy replaces global mutex | Cold path keeps M12; new invariant documented and tested |
+
+**Specifically widened vs cold path**:
+- In-flight `RunEntrypoint` per VM: 1 → up to `pool_size` (cap 64), with
+  `max_queue_depth` (default `2 * pool_size`).
+- Long-running wrapper persists across calls. Cross-call state inside
+  the wrapper is the user's responsibility per ADR-0011 — log loudly at
+  agent boot.
+- Wrapper crash mid-call affects only that call; cold path: process
+  exits per call regardless.
+
+**Specifically NOT widened (verified surface-stable)**:
+- Host-side `mvmctl invoke` argv, stdin/stdout, exit codes.
+- vsock wire types (`GuestRequest`, `GuestResponse`, `EntrypointEvent`).
+- Cold-path behavior when no `runtime.json` is present.
+- Session-mode dispatch (`mvmctl session`, orthogonal).
+- CLI audit-emit gate (CLI-side, untouched).
+
+**Audit pass during implementation**:
+1. Walk every `handle_client` match arm for non-mutex-protected shared
+   state (sleep_prep, drop_caches, port-forward all already safe;
+   paranoia pass).
+2. Run `scripts/check-prod-agent-no-exec.sh` before and after — confirm
+   no new forbidden symbols and the new positive-evidence assertion
+   passes.
+3. Frame fuzz on `read_pipe_frame`: truncated, oversized, partial-read,
+   garbage payload.
+4. 10K-recycle stress test, watch `/proc/<agent>/fd/` for leaks.
+
+**Known limitations**:
+
+- Warm-process opt-in is decided at agent boot. There's no host-side
+  runtime kill-switch to force a warm image back to cold tier; rolling
+  back requires rebuilding. A defense-in-depth runtime override
+  (kernel cmdline or `agent.json` toggle that suppresses warm even
+  when configured) is out of scope for v0.2 — file as v0.3.
+- No SIGTERM handler. The agent has no signal-handling infrastructure
+  today; on VM teardown all processes die abruptly. `WorkerPool::shutdown()`
+  exists for tests / future use, but no handler invokes it. The fallback
+  is the kernel's own teardown — workers receive SIGPIPE on the agent's
+  FD-table tear-down and PID 1 reaps them. Captured as a follow-up in
+  [`44-agent-signal-handling.md`](44-agent-signal-handling.md), which
+  also covers SIGHUP config reload if that becomes relevant.
+
+## Files to touch
+
+**New**:
+- `crates/mvm-guest/src/runtime_config.rs`
+- `crates/mvm-guest/src/worker_protocol.rs`
+- `crates/mvm-guest/src/worker_pool.rs`
+- `crates/mvm-guest/tests/bin/fake_runner.rs`
+- `crates/mvm-guest/tests/runentrypoint_warm.rs`
+
+**Modified**:
+- `crates/mvm-guest/src/lib.rs` — re-export new modules
+- `crates/mvm-guest/src/bin/mvm-guest-agent.rs` — boot init,
+  spawn-per-conn (warm only), `handle_run_entrypoint` branch
+- `crates/mvm-guest/src/entrypoint.rs` — export `spawn_path` and kill
+  helpers as `pub(crate)`
+- `crates/mvm-guest/Cargo.toml` — add `base64` dep; declare
+  `fake_runner` test binary
+- `scripts/check-prod-agent-no-exec.sh` — positive symbol assertion
+
+**Untouched**:
+- `crates/mvm-cli/src/commands/vm/invoke.rs` — host CLI unchanged
+- `crates/mvm-cli/src/commands/vm/exec.rs` — session-mode is orthogonal
+- `crates/mvm-runtime/src/vsock_transport.rs` — host transport unchanged
+- `nix/flake.nix` `mkGuest` — `runtime.json` ships via existing
+  `extraFiles` mechanism
+
+## Risks
+
+1. **Accept-loop concurrency** introduces real parallelism for
+   warm-tier images. Audit `handle_client` match arms (existing
+   `Arc<Mutex<>>` covers integrations / probes / port forwards).
+2. **Pipe writes blocking forever** if a worker stops reading stdin.
+   Watchdog SIGKILL closes the pipe and unblocks the agent.
+3. **FD leaks** on respawn churn. `Child::Drop` handles stdlib pipes;
+   verify with a 10K-recycle stress test.
+4. **`prod-agent-no-exec` CI gate** must keep passing. Run the gate
+   locally before opening the PR.
+
+## Verification
+
+```bash
+cargo test -p mvm-guest worker_pool::tests
+cargo test -p mvm-guest worker_protocol::tests
+cargo test -p mvm-guest --test runentrypoint_warm
+
+cargo test --workspace
+cargo clippy --workspace -- -D warnings
+bash scripts/check-prod-agent-no-exec.sh
+```
+
+Live smoke (requires a warm-process image from mvmforge):
+
+```bash
+mvmctl up warm-py-fn
+for i in {1..100}; do echo '{"x":1}' | mvmctl invoke warm-py-fn; done
+# Expect: ~10 worker recycles in agent stderr with max_calls_per_worker=10.
+# Expect: same N PIDs reused between recycles.
+
+# M12 cold-path regression (no runtime.json):
+mvmctl up cold-py-fn
+( mvmctl invoke cold-py-fn < input1 & mvmctl invoke cold-py-fn < input2 & wait )
+# Second invoke MUST see EntrypointEvent::Error { kind: Busy }.
+
+# Crash recovery: kill -9 a worker mid-call from another shell.
+# Expect: EntrypointEvent::Error { kind: WrapperCrashed }; next invoke succeeds.
+```
+
+## Acceptance
+
+By close of plan 43, mvm should be able to claim:
+
+1. *A `runtime.json`-driven worker pool runs warm-tier function calls
+   from a fixed set of long-lived wrapper processes; cold tier stays
+   bit-identical when `runtime.json` is absent.* (Phases 1–3)
+2. *Worker recycling fires on `max_calls_per_worker`, `max_rss_mb`, and
+   wrapper crash; user-code faults do not recycle.* (Phase 2)
+3. *`prod-agent-no-exec` gate keeps passing; new
+   `worker_pool::dispatch` symbol is required as positive evidence the
+   warm path is wired.* (Phase 4)
+4. *Wire-format types are `pub` for mvmforge to depend on, so the
+   wrapper-side runner stays in lockstep with the agent without
+   schema duplication.* (Phase 1)
+
+mvmforge IR + factory cutover lands in a coordinated PR after; the
+warm path is dormant until then.

--- a/specs/plans/44-agent-signal-handling.md
+++ b/specs/plans/44-agent-signal-handling.md
@@ -1,0 +1,224 @@
+# Plan 44 — Guest agent signal handling
+
+Status: backlog. Sized for a future contributor / agent to pick up
+without re-doing the discovery work.
+
+## Background
+
+The guest agent (`crates/mvm-guest/src/bin/mvm-guest-agent.rs`) has
+no signal handlers. SIGTERM, SIGINT, SIGHUP all hit the default
+disposition — the process dies abruptly without giving any subsystem
+a chance to drain or release resources. Today this is fine because:
+
+- The dominant teardown path is **VM destruction**, not agent
+  shutdown. When Firecracker is killed (host shutdown / container
+  stop), KVM tears down the VM's memory — every process inside,
+  including the agent, vanishes in the same instant. There's no
+  signal to handle because there's no kernel left to deliver one.
+- The agent has no hot-reload or in-place update flow. The
+  unit-of-restart is the whole VM.
+- Cleanup that *would* matter (warm-process worker drain, reaping
+  children) is bounded by the VM's lifetime; the host-side stack
+  doesn't observe in-VM zombies.
+
+## What surfaced this gap
+
+Plan 43 (warm-process function dispatch) added a worker pool that
+spawns long-lived child processes inside the agent. The plan
+called for a SIGTERM handler that would call
+`WorkerPool::shutdown(Duration::from_secs(5))` to:
+
+1. Stop accepting new vsock connections.
+2. Wait for in-flight `RunEntrypoint` calls to drain (bounded by
+   their per-call `timeout_secs`).
+3. SIGTERM each worker, give a grace period, SIGKILL stragglers,
+   `wait()` to reap.
+
+`WorkerPool::shutdown()` was implemented (see
+`crates/mvm-guest/src/worker_pool.rs`) but the handler that calls
+it was deferred. Plan 43's "Known limitation" section names this
+as v0.3 work.
+
+## Why deferring is safe (today)
+
+`WorkerHandle::Drop` already does SIGTERM/SIGKILL/reap when the
+pool is dropped naturally — for example, in tests or if the pool
+were ever replaced at runtime. It does NOT fire on
+`std::process::exit` because Rust skips destructors on hard exit.
+
+When the agent process dies on SIGTERM (default disposition):
+
+- The kernel reparents worker children to PID 1.
+- Workers receive SIGPIPE on their stdin pipe (the agent's FD
+  table tearing down closes the parent end).
+- A correctly-written wrapper exits in response and PID 1 reaps it.
+- Inside the VM PID 1 is typically `init` / `systemd-style` /
+  `mvm-verity-init`'s pivoted real init — which reaps zombies.
+
+So there's no *permanent* leak. The cost is "no orderly drain" —
+in-flight calls die mid-frame and surface to the host as
+`EntrypointEvent::Error` or just connection-closed.
+
+## When this plan should be picked up
+
+Any of these flips the calculus:
+
+1. **Hot-reload / in-place update** — if mvm grows a path that
+   restarts the agent without rebooting the VM (e.g. agent-only
+   security patches), graceful shutdown becomes load-bearing.
+2. **Long-running calls** — if `timeout_secs` defaults grow past
+   ~30 s, killing the agent during a call is increasingly user-visible.
+   A drain window lets in-flight work finish.
+3. **SIGHUP for config reload** — if `runtime.json` / `agent.json`
+   become reloadable, the same signal-handler infrastructure
+   serves both. Adding two handlers at once amortizes the design
+   cost.
+4. **Operator-driven shutdown** — if mvmd starts sending SIGTERM
+   to the agent (rather than killing the VM) for orderly tenant
+   migration, graceful shutdown is required.
+5. **Containerized agent (no microVM)** — Apple Container's PID 1
+   handling differs from a Firecracker microVM; if the agent
+   starts running in non-VM contexts, the orphan-reparent
+   semantics may not apply.
+
+## Approach
+
+Three workstreams. W1 is the substrate; W2 / W3 are the consumers
+that justify shipping it.
+
+### W1 — Signal-handler primitive
+
+Decide on the handling strategy:
+
+- **Option A: raw `libc::sigaction` + atomic flag.** ~30 lines, no
+  new deps. Handler is `extern "C"` and async-signal-safe (only
+  flips an `AtomicBool`). The accept loop polls the flag between
+  iterations; `accept()` returns `EINTR` when a signal lands so
+  the loop wakes up promptly. Matches the codebase's "no extra
+  deps" preference.
+- **Option B: `signal-hook` crate.** Higher-level, supports
+  multiple signals cleanly. Adds a workspace dep.
+
+Recommendation: A for v1. B if W3 (config reload) wants
+multi-signal dispatch.
+
+```rust
+static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+unsafe extern "C" fn on_sigterm(_: libc::c_int) {
+    SHUTDOWN_REQUESTED.store(true, Ordering::Release);
+}
+
+fn install_signal_handlers() {
+    unsafe {
+        let mut sa: libc::sigaction = std::mem::zeroed();
+        sa.sa_sigaction = on_sigterm as usize;
+        libc::sigemptyset(&mut sa.sa_mask);
+        libc::sigaction(libc::SIGTERM, &sa, std::ptr::null_mut());
+        libc::sigaction(libc::SIGINT, &sa, std::ptr::null_mut());
+    }
+}
+```
+
+The accept loop changes:
+
+```rust
+loop {
+    if SHUTDOWN_REQUESTED.load(Ordering::Acquire) {
+        break;
+    }
+    let cfd = unsafe { accept(fd, ...) };
+    if cfd < 0 {
+        // EINTR is expected when a signal lands; the next iteration
+        // sees SHUTDOWN_REQUESTED and breaks.
+        continue;
+    }
+    handle_client(cfd, ...);
+}
+// Post-loop: drain.
+shutdown_subsystems(Duration::from_secs(5));
+```
+
+### W2 — Warm-process pool drain consumer
+
+`shutdown_subsystems` calls
+`WARM_POOL.get().and_then(|p| p.as_ref()).map(|p| p.shutdown(grace))`.
+
+`WorkerPool::shutdown` already exists and does the right thing:
+
+- Sets the `shutdown` atomic so new dispatches return
+  `DispatchError::ShuttingDown`.
+- Replaces idle slots with `Dead` (`Drop` SIGTERMs/SIGKILLs each
+  worker).
+- Sleeps `grace` to let busy slots finish.
+
+Add: a `shutdown_busy` mode that also blocks on busy slots
+finishing (currently relies on natural progression). The simpler
+form for v1: skip this; busy workers see SIGPIPE when the agent
+finally exits.
+
+### W3 — SIGHUP config reload (optional)
+
+If the same plan ships config reload, wire SIGHUP to a separate
+`RELOAD_REQUESTED: AtomicBool`. The accept loop checks both flags;
+on RELOAD, re-read `/etc/mvm/agent.json` and apply the
+hot-reloadable subset. Don't reload `runtime.json` — it pins
+worker-pool sizing decided at boot.
+
+Pre-requisite: an `AgentConfig` reload-safety review. Many fields
+(vsock port, integration drop-in dir) are not safely reloadable.
+Document the reloadable subset before shipping the SIGHUP path.
+
+## Tests
+
+- Unit test the handler installation: install handlers,
+  `kill(self_pid, SIGTERM)`, assert `SHUTDOWN_REQUESTED` flips.
+- Integration test on `WorkerPool::shutdown`: pool with one busy
+  + one idle worker; call `shutdown(1s)`; assert idle is killed
+  immediately, busy completes, all workers reaped.
+- Symbol-contract gate (`scripts/check-prod-agent-no-exec.sh`):
+  add a positive-evidence assertion that
+  `mvm_guest_agent::install_signal_handlers` is present, mirroring
+  the W5/W7 pattern.
+
+## Risks
+
+- **Async-signal-safety violations.** Anything beyond
+  `AtomicBool::store` and `write` to a self-pipe is unsafe in a
+  signal handler. The handler must be trivial; all real work
+  happens in the accept loop after the flag is observed.
+- **EINTR-vs-no-EINTR loops.** Some libc calls retry internally;
+  others don't. The accept loop must check the shutdown flag
+  *outside* the syscall, not inside, so a missing EINTR doesn't
+  wedge shutdown.
+- **Signal mask inheritance.** The agent's own SIGTERM mask is
+  inherited by spawned workers via `process_group(0)` + fork. If
+  workers need to handle their own signals differently, they need
+  to reset the mask in `pre_exec`. Most wrappers don't care, but
+  document the inheritance.
+- **Multiple signals delivered before drain finishes.** A second
+  SIGTERM during drain should escalate to immediate exit, not
+  retrigger the drain. Handler can count: first sets flag, second
+  calls `_exit(128 + SIGTERM)`.
+
+## Acceptance
+
+By close of plan 44, mvm should be able to claim:
+
+1. *The guest agent installs SIGTERM/SIGINT handlers at boot;
+   on signal, new connections are refused, in-flight calls drain
+   to a configurable timeout, the warm-process pool tears down
+   workers cleanly, and the agent exits 0.*
+2. *A second SIGTERM during drain escalates to immediate exit so
+   a wedged drain doesn't strand operators.*
+3. *The symbol-contract gate asserts the handler is wired into
+   the production binary.*
+4. *Plan 43's "Known limitation" can be removed.*
+
+## Cross-references
+
+- Plan 43 §"Known limitation" — names the deferral.
+- `crates/mvm-guest/src/worker_pool.rs::shutdown` — the consumer
+  this handler calls.
+- `crates/mvm-guest/src/bin/mvm-guest-agent.rs` — install site
+  (right after `init_warm_pool` in `main`).


### PR DESCRIPTION
## Summary

Adds an opt-in worker pool inside the guest agent so function-entrypoint
calls can reuse a long-running wrapper across invokes instead of cold-spawning
per `mvmctl invoke`. Implements **tier 2** of mvmforge ADR-0011's
function-entrypoint concurrency hierarchy. Plan 41 / Sprint 45 W1–W5 shipped
the cold tier; this is the warm-process tier on top.

Driven by a new mvmforge-owned `/etc/mvm/runtime.json` carrying
`concurrency.kind = "warm_process"`. When that file or field is absent the
cold path stays bit-identical. Host wire (`RunEntrypoint` request +
`EntrypointEvent` stream) is unchanged.

This PR is **mvm-side only**. mvmforge ships the matching IR + factory +
runner-wrapper changes in a coordinated follow-up — the warm path stays
dormant in the wild until then, so cold-tier images are unaffected by
landing this substrate.

Specs:
- `specs/plans/43-warm-process-function-dispatch.md` — full design + boundaries + surface-area analysis
- `specs/plans/44-agent-signal-handling.md` — sibling backlog plan capturing a deferral that surfaced here (the agent has no SIGTERM handler; not load-bearing today, becomes so under hot-reload / config-reload / operator-driven shutdown)
- Sprint 45 entry updated with W7

## What's in the substrate

New `mvm-guest` modules (all unconditionally compiled, no feature gate):

- `runtime_config` — parses `/etc/mvm/runtime.json`, `deny_unknown_fields`, fail-loud on malformed, rejects `in_process="concurrent"` at parse time.
- `worker_protocol` — `WorkerCallRequest` / `WorkerCallResponse` / `WorkerOutcome` types + generic `read_pipe_frame` / `write_pipe_frame` over `Read` / `Write` (4-byte BE length + JSON body, 256 KiB cap, base64 for binary). `pub` so mvmforge can depend on `mvm-guest` for the wrapper-side schema.
- `worker_pool` — Mutex+Condvar slot machinery, watchdog SIGKILL on per-call timeout, recycle on call-count / RSS / wrapper crash, FIFO queue with `max_queue_depth` (default `2 * pool_size`) returning `EntrypointEvent::Error { kind: Busy }` on overflow.

Agent wiring (`mvm-guest-agent.rs`):

- `WARM_POOL: OnceLock<Option<Arc<WorkerPool>>>` populated at boot, after entrypoint validation.
- `handle_run_entrypoint` branches to `dispatch_via_warm_pool` when the pool is active; cold path otherwise. M12 single-call lock applies to cold tier only (warm tier's per-slot Busy state replaces it with "one in-flight call per worker, ≤ pool_size concurrent").
- Accept loop spawns thread-per-connection only when warm-process is active — cold-tier images keep their single-threaded dispatcher.
- `dispatch_via_warm_pool` is `#[inline(never)]` so the symbol gate can pin it.

Symbol-contract gate (`scripts/check-prod-agent-no-exec.sh`):

- New positive-evidence assertion that `dispatch_via_warm_pool` is present in the prod build, alongside the existing `do_exec`-absent + `handle_run_entrypoint`-present checks. Verified locally; all three pass.

## Test coverage

| Suite | Count | Notes |
|---|---|---|
| `runtime_config::tests` | 11 | parse / deny-unknown / pool-size bounds / concurrent-rejection |
| `worker_protocol::tests` | 10 | roundtrips + frame fuzz (truncated, oversized, partial, garbage, deny-unknown) |
| `worker_pool::tests` | 4 | display strings + smoke |
| `tests/worker_pool_warm.rs` | 7 | integration vs `fake-runner` |

Integration tests cover all 9 user-listed scenarios:

- **happy-path PID stability** (`warm_process_round_trip_pid_stable`)
- **call-count recycle** (`recycle_on_call_count_exceeded`)
- **RSS recycle** (`recycle_on_rss_exceeded`, Linux-only via `cfg`)
- **wrapper crash recycle** (`wrapper_crash_returns_error_and_recycles`)
- **user-code fault stays on same worker** (`user_code_fault_does_not_recycle`)
- **frame fuzz** (`worker_protocol::tests`)
- **pool_size > 1 parallelism** (`pool_size_4_parallel_dispatches`)
- **bounded queue + Busy on overflow** (`fifo_queue_serializes_callers`, `queue_full_returns_error`)
- **cold path unchanged** (existing `runentrypoint` tests pass with no `runtime.json`)

The fake-runner test binary (`tests/bin/fake_runner.rs`) speaks the framed
protocol and selects behavior via env var: `ok`, `user_fault`,
`crash_after_n=N`, `crash_during_call_n=N`, `malformed_frame_on_n=N`,
`leak_50mib_per_call`, `slow_secs=N`. Declared `[[bin]] test = false` so
it never ships in the production guest closure.

## Test plan

- [x] `cargo test -p mvm-guest` — 139 lib + 7 integration green
- [x] `cargo test --workspace` — all green (incl. `code_quality::no_unwrap_in_production_code`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-prod-agent-no-exec.sh` — `do_exec` absent, `handle_run_entrypoint` present, `dispatch_via_warm_pool` present
- [ ] **Live-KVM smoke run** — needs a Linux/KVM host + a warm-tier rootfs from mvmforge (cross-repo dependency). Will land as a follow-up PR alongside the mvmforge IR cutover (mirrors plan 41 W3's deferred live-smoke pattern).

## What this does NOT widen (verified)

- Host-side `mvmctl invoke` argv, stdin/stdout, exit codes — unchanged.
- vsock wire types (`GuestRequest`, `GuestResponse`, `EntrypointEvent`) — unchanged.
- Cold-path behavior when no `runtime.json` is present — bit-identical.
- Session-mode dispatch (`mvmctl session`) — orthogonal.
- CLI audit-emit gate — CLI-side, untouched.

## Known limitations

- **No SIGTERM handler.** The agent has no signal-handling infrastructure today. `WorkerPool::shutdown()` exists for future use, but no handler invokes it. On VM teardown all processes die abruptly anyway, so graceful drain is currently cosmetic. Captured as a follow-up in plan 44.
- **No host-side runtime kill-switch** to force a warm image back to cold tier — rolling back requires rebuilding. Defense-in-depth runtime override is v0.3.

## Cross-repo coordination

mvmforge owes:
- Plumb `concurrency` through their IR.
- Each language factory (`nix/factories/{python,node,…}`) writes `runtime.json` with the new shape into `mkGuest extraFiles`.
- The runner wrapper speaks the framed multi-call loop on stdin/stdout (`WorkerCallRequest`/`WorkerCallResponse`).
- Wire-format alignment via `mvm_guest::worker_protocol` (single source of truth for the schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)