### PR TITLE
feat: virtio-balloon elasticity + portable signed bundles substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4146,6 +4146,7 @@ dependencies = [
 name = "mvm-supervisor"
 version = "0.14.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.22.1",
  "chrono",
@@ -4162,6 +4163,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sysinfo",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -4315,6 +4317,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -5607,7 +5618,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -7024,6 +7035,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "windows 0.52.0",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8125,12 +8150,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -8141,7 +8176,16 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8163,7 +8207,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
 ]
@@ -8202,7 +8246,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,12 +4056,17 @@ dependencies = [
 name = "mvm-plan"
 version = "0.14.0"
 dependencies = [
+ "anyhow",
+ "base64 0.22.1",
  "chrono",
  "ed25519-dalek",
  "mvm-core",
  "rand 0.8.6",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "tar",
+ "tempfile",
  "thiserror 1.0.69",
 ]
 

--- a/crates/mvm-backend/src/apple_container.rs
+++ b/crates/mvm-backend/src/apple_container.rs
@@ -66,6 +66,12 @@ impl VmBackend for AppleContainerBackend {
             snapshots: false,
             vsock: true,
             tap_networking: false,
+            // Apple's Virtualization framework does not expose
+            // virtio-balloon to guests; memory ballooning is handled
+            // by the host kernel via macOS memory pressure, not by
+            // an in-guest device. Declared `false` so the host-side
+            // reclaim controller skips this backend cleanly.
+            balloon: false,
         }
     }
 

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -47,6 +47,7 @@ impl FirecrackerConfig {
             profile: config.profile.clone(),
             cpus: config.cpus,
             memory: config.memory_mib,
+            mem_initial: config.mem_initial_mib,
             volumes: config
                 .volumes
                 .iter()
@@ -102,11 +103,17 @@ impl VmBackend for FirecrackerBackend {
     }
 
     fn capabilities(&self) -> VmCapabilities {
+        // Firecracker ships a virtio-balloon device with PATCH-able
+        // target via `/balloon`; the start path attaches it whenever
+        // `VmStartConfig::mem_initial_mib` is `Some`. Capability is
+        // advertised unconditionally so the host-side controller can
+        // discover support before deciding to plumb a workload.
         VmCapabilities {
             pause_resume: true,
             snapshots: true,
             vsock: true,
             tap_networking: true,
+            balloon: true,
         }
     }
 
@@ -137,6 +144,28 @@ impl VmBackend for FirecrackerBackend {
 
     fn resume(&self, id: &VmId) -> Result<()> {
         microvm::resume_vm(&id.0)
+    }
+
+    fn balloon_set_target(&self, id: &VmId, target_inflate_mib: u32) -> Result<()> {
+        microvm::balloon_set_target(&id.0, target_inflate_mib)
+    }
+
+    fn balloon_state(&self, id: &VmId) -> Result<mvm_core::vm_backend::BalloonState> {
+        let inflated = microvm::balloon_state(&id.0)?;
+        // FC reports the inflation amount via /balloon; the cap is
+        // tracked host-side in the VM's runtime metadata (RunInfo).
+        // List the VM to recover its declared cap.
+        let vms = microvm::list_vms()?;
+        let info = vms
+            .into_iter()
+            .find(|i| i.name.as_deref() == Some(&*id.0))
+            .ok_or_else(|| anyhow::anyhow!("balloon_state: VM '{}' not found in list", id.0))?;
+        let max_mib = info.memory;
+        Ok(mvm_core::vm_backend::BalloonState {
+            max_mib,
+            inflated_mib: inflated,
+            host_committed_mib: max_mib.saturating_sub(inflated),
+        })
     }
 
     fn status(&self, id: &VmId) -> Result<VmStatus> {
@@ -403,6 +432,17 @@ impl AnyBackend {
     /// Resume a paused VM. See [`VmBackend::resume`].
     pub fn resume(&self, id: &VmId) -> Result<()> {
         self.inner().resume(id)
+    }
+
+    /// Set the virtio-balloon inflation target. See
+    /// [`VmBackend::balloon_set_target`].
+    pub fn balloon_set_target(&self, id: &VmId, target_inflate_mib: u32) -> Result<()> {
+        self.inner().balloon_set_target(id, target_inflate_mib)
+    }
+
+    /// Read the current balloon state. See [`VmBackend::balloon_state`].
+    pub fn balloon_state(&self, id: &VmId) -> Result<mvm_core::vm_backend::BalloonState> {
+        self.inner().balloon_state(id)
     }
 
     pub fn status(&self, id: &VmId) -> Result<VmStatus> {

--- a/crates/mvm-backend/src/ch_runtime.rs
+++ b/crates/mvm-backend/src/ch_runtime.rs
@@ -153,6 +153,32 @@ pub(crate) fn api_put_empty(socket: &str, endpoint: &str) -> Result<()> {
     run_curl_put_with_file(socket, endpoint, None)
 }
 
+/// GET a CH API endpoint, returning the response body as a string.
+///
+/// Used by read-only endpoints like `/api/v1/vm.info` (and via that,
+/// the balloon-state path). Same defensive quoting rules as `api_put`;
+/// the endpoint argument is a compile-time constant at call sites.
+pub(crate) fn api_get(socket: &str, endpoint: &str) -> Result<String> {
+    let q_socket = shell_quote(socket);
+    let url = format!("http://localhost{endpoint}");
+    let q_url = shell_quote(&url);
+    let q_endpoint = shell_quote(endpoint);
+    let script = format!(
+        r#"
+        set -eu
+        response=$(sudo curl -s -w "\n%{{http_code}}" --unix-socket {q_socket} {q_url})
+        code=$(printf '%s' "$response" | tail -n1)
+        out=$(printf '%s' "$response" | sed '$d')
+        if [ "$code" -ge 400 ]; then
+            echo "[mvm] ERROR: CH GET $(printf '%s' {q_endpoint}) returned $code: $out" >&2
+            exit 1
+        fi
+        printf '%s' "$out"
+        "#,
+    );
+    run_in_vm_stdout(&script)
+}
+
 /// Shared curl shell-out for both PUT variants.
 ///
 /// The socket path is `shell_quote`d defensively even though it
@@ -215,6 +241,20 @@ pub(crate) fn build_vm_config(args: &VmConfigArgs<'_>) -> String {
         Some(c) => format!(", \"cmdline\": {{ \"args\": {} }}", json_str(c)),
         None => String::new(),
     };
+    // Cloud-hypervisor expresses the virtio-balloon device through
+    // the top-level `balloon` field: `size` is the *initial balloon
+    // inflation* in bytes (memory the guest hands back at boot).
+    // Same semantics as Firecracker's `amount_mib`. We only emit the
+    // field when the workload opted in; absent = no balloon device.
+    let balloon = match args.balloon_mib {
+        Some(mib) if mib > 0 => {
+            let bytes = u64::from(mib) * 1024 * 1024;
+            // `deflate_on_oom: true` matches the FC mandatory shape —
+            // guest must be able to take pages back under pressure.
+            format!(r#", "balloon": {{ "size": {bytes}, "deflate_on_oom": true }}"#,)
+        }
+        _ => String::new(),
+    };
     format!(
         r#"{{
           "cpus": {{ "boot_vcpus": {cpus}, "max_vcpus": {cpus} }},
@@ -225,7 +265,7 @@ pub(crate) fn build_vm_config(args: &VmConfigArgs<'_>) -> String {
           ],
           "vsock": {{ "cid": {vsock_cid}, "socket": {vsock_socket} }},
           "console": {{ "mode": "Off" }},
-          "serial": {{ "mode": "Tty" }}
+          "serial": {{ "mode": "Tty" }}{balloon}
         }}"#,
         cpus = args.cpus,
         memory_bytes = memory_bytes,
@@ -235,6 +275,7 @@ pub(crate) fn build_vm_config(args: &VmConfigArgs<'_>) -> String {
         rootfs = json_str(args.rootfs_path),
         vsock_cid = args.vsock_cid,
         vsock_socket = json_str(&args.vsock_socket_path),
+        balloon = balloon,
     )
 }
 
@@ -247,6 +288,11 @@ pub(crate) struct VmConfigArgs<'a> {
     pub cmdline: Option<&'a str>,
     pub cpus: u32,
     pub memory_mib: u32,
+    /// Initial balloon inflation in MiB. `None` (or `Some(0)`) omits
+    /// the balloon device entirely. When `Some(n)` with `n > 0`, CH
+    /// attaches a balloon pre-inflated to `n` MiB; the host commits
+    /// `memory_mib - n` MiB at boot. Equivalent to FC's `amount_mib`.
+    pub balloon_mib: Option<u32>,
     pub vsock_cid: u32,
     pub vsock_socket_path: String,
 }
@@ -362,6 +408,7 @@ mod tests {
             cmdline: Some("console=ttyS0 root=/dev/vda"),
             cpus: 4,
             memory_mib: 2048,
+            balloon_mib: None,
             vsock_cid: 3,
             vsock_socket_path: "/tmp/v.sock".to_string(),
         };
@@ -395,6 +442,7 @@ mod tests {
             cmdline: None,
             cpus: 1,
             memory_mib: 256,
+            balloon_mib: None,
             vsock_cid: 3,
             vsock_socket_path: "/tmp/v.sock".to_string(),
         };
@@ -412,11 +460,76 @@ mod tests {
             cmdline: None,
             cpus: 1,
             memory_mib: 256,
+            balloon_mib: None,
             vsock_cid: 3,
             vsock_socket_path: "/tmp/v.sock".to_string(),
         };
         let json = build_vm_config(&args);
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert!(parsed["payload"]["initramfs"].is_null());
+    }
+
+    #[test]
+    fn build_vm_config_omits_balloon_when_unset() {
+        let args = VmConfigArgs {
+            kernel_path: "/k/vmlinux",
+            rootfs_path: "/k/rootfs.ext4",
+            initrd_path: None,
+            cmdline: None,
+            cpus: 1,
+            memory_mib: 1024,
+            balloon_mib: None,
+            vsock_cid: 3,
+            vsock_socket_path: "/tmp/v.sock".to_string(),
+        };
+        let json = build_vm_config(&args);
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert!(
+            parsed["balloon"].is_null(),
+            "no balloon device emitted when balloon_mib is None: {json}"
+        );
+    }
+
+    #[test]
+    fn build_vm_config_omits_balloon_when_zero() {
+        // Zero is a defensive "user opted in but to nothing useful";
+        // the CH config builder treats it the same as None.
+        let args = VmConfigArgs {
+            kernel_path: "/k/vmlinux",
+            rootfs_path: "/k/rootfs.ext4",
+            initrd_path: None,
+            cmdline: None,
+            cpus: 1,
+            memory_mib: 1024,
+            balloon_mib: Some(0),
+            vsock_cid: 3,
+            vsock_socket_path: "/tmp/v.sock".to_string(),
+        };
+        let json = build_vm_config(&args);
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert!(parsed["balloon"].is_null(), "balloon: 0 should be omitted");
+    }
+
+    #[test]
+    fn build_vm_config_emits_balloon_when_present() {
+        // mem 1024 MiB, balloon 256 MiB → host commits 768 MiB.
+        let args = VmConfigArgs {
+            kernel_path: "/k/vmlinux",
+            rootfs_path: "/k/rootfs.ext4",
+            initrd_path: None,
+            cmdline: None,
+            cpus: 1,
+            memory_mib: 1024,
+            balloon_mib: Some(256),
+            vsock_cid: 3,
+            vsock_socket_path: "/tmp/v.sock".to_string(),
+        };
+        let json = build_vm_config(&args);
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        // CH expects balloon size in bytes.
+        assert_eq!(parsed["balloon"]["size"], 256u64 * 1024 * 1024);
+        assert_eq!(parsed["balloon"]["deflate_on_oom"], true);
+        // Memory cap stays unchanged.
+        assert_eq!(parsed["memory"]["size"], 1024u64 * 1024 * 1024);
     }
 }

--- a/crates/mvm-backend/src/cloud_hypervisor.rs
+++ b/crates/mvm-backend/src/cloud_hypervisor.rs
@@ -99,6 +99,12 @@ impl VmBackend for CloudHypervisorBackend {
             snapshots: true,
             vsock: true,
             tap_networking: false,
+            // Cloud-hypervisor exposes virtio-balloon via the
+            // `balloon` field on `VmConfig` and the
+            // `/api/v1/vm.resize` endpoint for runtime adjustment.
+            // Same opt-in shape as Firecracker — present only when
+            // `VmStartConfig::mem_initial_mib` is `Some`.
+            balloon: true,
         }
     }
 
@@ -126,6 +132,27 @@ impl VmBackend for CloudHypervisorBackend {
         // Spawn the daemon. Waits for the API socket.
         ch_runtime::start_ch_daemon(&abs_dir, &api_socket)?;
 
+        let memory_mib = if config.memory_mib == 0 {
+            256
+        } else {
+            config.memory_mib
+        };
+        // Balloon opt-in. CH validates `mem_initial < memory` for us
+        // at vm.create, but we mirror Firecracker's defensive check
+        // so the misuse surfaces with a clearer host-side message.
+        let balloon_mib = match config.mem_initial_mib {
+            Some(0) => {
+                anyhow::bail!("cloud-hypervisor: mem_initial_mib must be > 0 when set");
+            }
+            Some(initial) if initial >= memory_mib => {
+                anyhow::bail!(
+                    "cloud-hypervisor: mem_initial_mib ({initial}) must be < memory_mib ({memory_mib})"
+                );
+            }
+            Some(initial) => Some(memory_mib - initial),
+            None => None,
+        };
+
         // Configure the VM. CH ignores fields we omit; only the
         // required shape is sent.
         let args = ch_runtime::VmConfigArgs {
@@ -134,11 +161,8 @@ impl VmBackend for CloudHypervisorBackend {
             initrd_path: config.initrd_path.as_deref(),
             cmdline: Some(DEFAULT_CMDLINE),
             cpus: config.cpus.max(1),
-            memory_mib: if config.memory_mib == 0 {
-                256
-            } else {
-                config.memory_mib
-            },
+            memory_mib,
+            balloon_mib,
             vsock_cid: 3,
             vsock_socket_path: vsock_socket,
         };
@@ -181,6 +205,56 @@ impl VmBackend for CloudHypervisorBackend {
         let api_socket = ch_runtime::ch_api_socket(&abs_dir);
         ch_runtime::api_put_empty(&api_socket, "/api/v1/vm.resume")
             .with_context(|| format!("PUT /api/v1/vm.resume for VM '{}'", id.0))
+    }
+
+    fn balloon_set_target(&self, id: &VmId, target_inflate_mib: u32) -> Result<()> {
+        let abs_dir = ch_runtime::ch_vm_dir(&id.0)
+            .with_context(|| format!("resolving per-VM dir for {}", id.0))?;
+        let api_socket = ch_runtime::ch_api_socket(&abs_dir);
+        let bytes = u64::from(target_inflate_mib) * 1024 * 1024;
+        // CH's resize endpoint accepts `desired_vcpus`, `desired_ram`,
+        // and `desired_balloon` (all optional). Sending only the
+        // balloon field leaves vcpus + ram alone.
+        let body = format!(r#"{{"desired_balloon": {bytes}}}"#);
+        ch_runtime::api_put(&abs_dir, &api_socket, "/api/v1/vm.resize", &body).with_context(|| {
+            format!(
+                "PUT /api/v1/vm.resize (desired_balloon={bytes}) for VM '{}'; \
+                     VM may have been launched without `mem_initial_mib` (no balloon device)",
+                id.0
+            )
+        })
+    }
+
+    fn balloon_state(&self, id: &VmId) -> Result<mvm_core::vm_backend::BalloonState> {
+        let abs_dir = ch_runtime::ch_vm_dir(&id.0)
+            .with_context(|| format!("resolving per-VM dir for {}", id.0))?;
+        let api_socket = ch_runtime::ch_api_socket(&abs_dir);
+        let body = ch_runtime::api_get(&api_socket, "/api/v1/vm.info")
+            .with_context(|| format!("GET /api/v1/vm.info for VM '{}'", id.0))?;
+        let parsed: serde_json::Value = serde_json::from_str(body.trim())
+            .with_context(|| format!("parse vm.info response: {body:?}"))?;
+
+        // Memory cap comes from `config.memory.size` (bytes); CH
+        // doesn't echo a separate "max balloon" so we derive it.
+        // Current balloon inflation is at `config.balloon.size` —
+        // CH keeps the live size up-to-date there after resize.
+        let memory_bytes = parsed
+            .pointer("/config/memory/size")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| anyhow::anyhow!("vm.info missing /config/memory/size: {body}"))?;
+        let balloon_bytes = parsed
+            .pointer("/config/balloon/size")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+
+        let mib = |b: u64| (b / (1024 * 1024)) as u32;
+        let max_mib = mib(memory_bytes);
+        let inflated_mib = mib(balloon_bytes);
+        Ok(mvm_core::vm_backend::BalloonState {
+            max_mib,
+            inflated_mib,
+            host_committed_mib: max_mib.saturating_sub(inflated_mib),
+        })
     }
 
     fn stop_all(&self) -> Result<()> {

--- a/crates/mvm-backend/src/docker.rs
+++ b/crates/mvm-backend/src/docker.rs
@@ -116,6 +116,11 @@ impl VmBackend for DockerBackend {
             snapshots: false,
             vsock: false,
             tap_networking: false,
+            // Docker uses cgroup memory caps, not virtio-balloon —
+            // the reclaim mechanic is fundamentally different (OOM
+            // kill / swap, not an in-guest driver returning pages).
+            // The reclaim controller treats this as no-balloon.
+            balloon: false,
         }
     }
 

--- a/crates/mvm-backend/src/image.rs
+++ b/crates/mvm-backend/src/image.rs
@@ -113,6 +113,13 @@ pub struct RuntimeConfig {
     pub cpus: Option<u32>,
     #[serde(default)]
     pub memory: Option<u32>,
+    /// Initial host commitment in MiB when opting into virtio-balloon.
+    /// `None` keeps the legacy "commit `memory` at boot" behaviour.
+    /// When `Some(n)`, the workload boots with `memory - n` MiB worth
+    /// of balloon pre-inflated and the host reclaim controller adjusts
+    /// over the VM's lifetime.
+    #[serde(default)]
+    pub mem_initial: Option<u32>,
     #[serde(default)]
     pub volumes: Vec<RuntimeVolume>,
 }

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -42,6 +42,10 @@ impl VmBackend for LibkrunBackend {
             snapshots: false,
             vsock: true,
             tap_networking: false,
+            // libkrun's C API doesn't expose virtio-balloon control
+            // today; the upstream crate carries no `.balloon(...)`
+            // builder. Declared `false` until wiring lands.
+            balloon: false,
         }
     }
 

--- a/crates/mvm-backend/src/microsandbox.rs
+++ b/crates/mvm-backend/src/microsandbox.rs
@@ -141,6 +141,11 @@ impl VmBackend for MicrosandboxBackend {
             snapshots: false,
             vsock: true,
             tap_networking: false,
+            // Inherits libkrun's stance: no balloon control surfaced
+            // by the upstream microsandbox builder. Track libkrun's
+            // capability flag; flip both together when the upstream
+            // crate gains a `.balloon(...)` method.
+            balloon: false,
         }
     }
 

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -532,8 +532,15 @@ pub struct FlakeRunConfig {
     pub profile: Option<String>,
     /// Number of vCPUs.
     pub cpus: u32,
-    /// Memory in MiB.
+    /// Memory cap in MiB.
     pub memory: u32,
+    /// Initial host commitment in MiB when opting into virtio-balloon.
+    /// `None` = full commitment at boot (legacy default). `Some(n)`
+    /// attaches a virtio-balloon device pre-inflated to
+    /// `memory - n` MiB so the host commits only `n` MiB at boot;
+    /// the host-side controller can PATCH the balloon target at
+    /// runtime via Firecracker's `/balloon` endpoint.
+    pub mem_initial: Option<u32>,
     /// Extra volumes to attach (mounted via config drive, not SSH).
     pub volumes: Vec<RuntimeVolume>,
     /// Extra files to write onto the config drive.
@@ -557,6 +564,25 @@ impl FlakeRunConfig {
                 "memory must be between 128 and 65536 MiB (got {})",
                 self.memory
             );
+        }
+        if let Some(initial) = self.mem_initial {
+            // The balloon device must leave the guest with some
+            // headroom; 0-byte commitment doesn't boot, and a value
+            // >= memory is nonsensical (balloon would claim 0 or
+            // negative pages). The CLI clamps these via filter() but
+            // backends are the second line of defence.
+            if initial == 0 {
+                anyhow::bail!(
+                    "mem_initial must be > 0 when set; got 0 (use None to opt out of balloon)"
+                );
+            }
+            if initial >= self.memory {
+                anyhow::bail!(
+                    "mem_initial ({initial}) must be strictly less than memory ({}); \
+                     the balloon needs a non-zero inflation target",
+                    self.memory
+                );
+            }
         }
         if self.name.is_empty() {
             anyhow::bail!("VM name must not be empty");
@@ -891,6 +917,78 @@ pub fn resume_vm(name: &str) -> Result<()> {
 
 /// Stop a specific named VM.
 #[instrument(skip_all, fields(name))]
+/// Adjust the virtio-balloon inflation target for a running FC VM.
+///
+/// `target_inflate_mib` is the amount the balloon should claim back
+/// from the guest. The guest's effective commitment is `memory -
+/// target_inflate_mib`. Firecracker expresses this through its
+/// `PATCH /balloon` endpoint with `amount_mib`.
+///
+/// Returns an error if the VM was started without
+/// `mem_initial.is_some()` — no balloon device exists to PATCH.
+/// Firecracker surfaces this as HTTP 400 with a clear message.
+pub fn balloon_set_target(name: &str, target_inflate_mib: u32) -> Result<()> {
+    require_linux_env()?;
+
+    let abs_vms = run_in_vm_stdout(&format!("echo {}", VMS_DIR))?;
+    let abs_dir = format!("{}/{}", abs_vms.trim(), name);
+    let pid_file = format!("{}/fc.pid", abs_dir);
+    let socket = format!("{}/fc.socket", abs_dir);
+
+    if !firecracker::is_vm_running(&pid_file)? {
+        anyhow::bail!("VM '{}' is not running", name);
+    }
+
+    let q_socket = shell_quote(&socket);
+    run_in_vm(&format!(
+        r#"sudo curl -fsS -X PATCH --unix-socket {q_socket} \
+            -H 'Content-Type: application/json' \
+            -d '{{"amount_mib":{target}}}' \
+            'http://localhost/balloon'"#,
+        target = target_inflate_mib,
+    ))
+    .with_context(|| {
+        format!(
+            "PATCH /balloon (amount_mib={target_inflate_mib}) for VM '{name}'; \
+             VM may have been launched without `mem_initial` (no balloon device)"
+        )
+    })?;
+    Ok(())
+}
+
+/// Read the current balloon state of a running FC VM.
+///
+/// Returns the inflation amount in MiB. `0` means the balloon is
+/// fully deflated (guest has all of `memory`). Combined with the
+/// VM's declared `memory` cap (e.g. from `list_vms()`), the host
+/// reclaim controller derives the effective commitment.
+pub fn balloon_state(name: &str) -> Result<u32> {
+    require_linux_env()?;
+
+    let abs_vms = run_in_vm_stdout(&format!("echo {}", VMS_DIR))?;
+    let abs_dir = format!("{}/{}", abs_vms.trim(), name);
+    let pid_file = format!("{}/fc.pid", abs_dir);
+    let socket = format!("{}/fc.socket", abs_dir);
+
+    if !firecracker::is_vm_running(&pid_file)? {
+        anyhow::bail!("VM '{}' is not running", name);
+    }
+
+    let q_socket = shell_quote(&socket);
+    let body = run_in_vm_stdout(&format!(
+        r#"sudo curl -fsS --unix-socket {q_socket} 'http://localhost/balloon'"#,
+    ))
+    .with_context(|| format!("GET /balloon for VM '{name}'"))?;
+
+    let parsed: serde_json::Value = serde_json::from_str(body.trim())
+        .with_context(|| format!("parse /balloon response: {body:?}"))?;
+    let amount = parsed
+        .get("amount_mib")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| anyhow::anyhow!("/balloon response missing amount_mib: {body}"))?;
+    Ok(amount as u32)
+}
+
 pub fn stop_vm(name: &str) -> Result<()> {
     require_linux_env()?;
 
@@ -1672,6 +1770,33 @@ pub fn configure_flake_microvm_with_drives_dir(
         ),
     )?;
 
+    // Virtio-balloon. Only attached when the workload opted in via
+    // `mem_initial`. The device boots pre-inflated to `memory -
+    // mem_initial` MiB so the host commits only `mem_initial` MiB
+    // until the reclaim controller deflates the balloon.
+    //
+    // `deflate_on_oom = true` is mandatory: under guest memory
+    // pressure the device must yield pages back, otherwise the guest
+    // OOM-kills the workload while the host still has memory it
+    // could give back. `stats_polling_interval_s = 1` lets the host
+    // controller poll real guest commitment without driving the
+    // guest's stat refresh too aggressively.
+    if let Some(initial) = config.mem_initial {
+        let amount_mib = config.memory.saturating_sub(initial);
+        ui::info(&format!(
+            "Attaching virtio-balloon (cap {} MiB, initial commit {} MiB, balloon {} MiB)",
+            config.memory, initial, amount_mib
+        ));
+        api_put_socket(
+            socket,
+            "/balloon",
+            &format!(
+                r#"{{"amount_mib": {amount}, "deflate_on_oom": true, "stats_polling_interval_s": 1}}"#,
+                amount = amount_mib,
+            ),
+        )?;
+    }
+
     Ok(())
 }
 
@@ -1868,6 +1993,66 @@ mod tests {
         assert!(f.name.is_empty());
         assert!(f.content.is_empty());
         assert_eq!(f.mode, 0o444);
+    }
+
+    fn baseline_run_config(mem_initial: Option<u32>) -> FlakeRunConfig {
+        FlakeRunConfig {
+            name: "v".to_string(),
+            slot: VmSlot::new("v", 0),
+            vmlinux_path: "/k/vmlinux".to_string(),
+            initrd_path: None,
+            rootfs_path: "/k/rootfs.ext4".to_string(),
+            verity_path: None,
+            roothash: None,
+            revision_hash: "abc".to_string(),
+            flake_ref: "/p".to_string(),
+            profile: None,
+            cpus: 2,
+            memory: 1024,
+            mem_initial,
+            volumes: Vec::new(),
+            config_files: Vec::new(),
+            secret_files: Vec::new(),
+            ports: Vec::new(),
+            network_policy: mvm_core::network_policy::NetworkPolicy::default(),
+        }
+    }
+
+    #[test]
+    fn flake_run_config_validate_accepts_none_mem_initial() {
+        baseline_run_config(None).validate().unwrap();
+    }
+
+    #[test]
+    fn flake_run_config_validate_accepts_valid_mem_initial() {
+        // 256 < 1024 → balloon device gets `1024 - 256 = 768` MiB
+        // inflation, host commits 256 MiB.
+        baseline_run_config(Some(256)).validate().unwrap();
+    }
+
+    #[test]
+    fn flake_run_config_validate_rejects_zero_mem_initial() {
+        let err = baseline_run_config(Some(0))
+            .validate()
+            .expect_err("rejects zero mem_initial");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("mem_initial"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn flake_run_config_validate_rejects_mem_initial_equal_to_memory() {
+        let err = baseline_run_config(Some(1024))
+            .validate()
+            .expect_err("rejects mem_initial == memory");
+        assert!(format!("{err:#}").contains("strictly less than"));
+    }
+
+    #[test]
+    fn flake_run_config_validate_rejects_mem_initial_above_memory() {
+        let err = baseline_run_config(Some(2048))
+            .validate()
+            .expect_err("rejects mem_initial > memory");
+        assert!(format!("{err:#}").contains("strictly less than"));
     }
 
     #[test]

--- a/crates/mvm-backend/src/microvm_nix.rs
+++ b/crates/mvm-backend/src/microvm_nix.rs
@@ -73,6 +73,11 @@ impl VmBackend for MicrovmNixBackend {
             snapshots: false,
             vsock: true,
             tap_networking: true,
+            // microvm.nix-launched runners delegate to whichever VMM
+            // the flake picked (qemu / firecracker / cloud-hypervisor /
+            // crosvm). Surfacing balloon honestly would require
+            // peeking at the runner script — leave `false` for now.
+            balloon: false,
         }
     }
 

--- a/crates/mvm-cli/src/commands/bundle/export.rs
+++ b/crates/mvm-cli/src/commands/bundle/export.rs
@@ -1,0 +1,181 @@
+//! `mvmctl bundle export <template> --out <path>` — seal a built
+//! template into a signed `.mvmpkg`.
+//!
+//! Reads the template's current revision artifacts (kernel,
+//! rootfs, optional initrd, optional dm-verity sidecar), hashes
+//! each, builds a [`BundleManifest`], signs it under the host
+//! signer, and writes the archive bytes to `--out`.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use clap::Args as ClapArgs;
+use mvm_plan::bundle::{
+    ARTIFACTS_DIR, ArtifactRole, BUNDLE_SCHEMA_VERSION, BundleArtifact, BundleManifest, KeyId,
+    VerityInfo, sha256_hex, write_bundle,
+};
+
+use mvm::vm::template::lifecycle as tmpl;
+use mvm_core::user_config::MvmConfig;
+
+use super::super::Cli;
+use super::super::vm::host_signer;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Template name or 64-char slot hash to export.
+    #[arg(value_name = "TEMPLATE")]
+    pub template: String,
+    /// Output path for the `.mvmpkg` archive. Parent directory must
+    /// exist; the file is overwritten if it already exists.
+    #[arg(long, value_name = "PATH")]
+    pub out: PathBuf,
+    /// Optional human-readable workload label baked into the
+    /// manifest. Surfaced by `mvmctl bundle fetch` for diagnostics.
+    #[arg(long)]
+    pub label: Option<String>,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    // ---- 1. Resolve the template's artifact paths ----
+    let (spec, vmlinux, initrd, rootfs, _rev) = tmpl::template_artifacts_dispatched(&args.template)
+        .with_context(|| {
+            format!(
+                "loading template {:?} — does it exist? Try `mvmctl manifest ls`",
+                args.template
+            )
+        })?;
+
+    // Verity sidecar lives next to the rootfs by convention; the
+    // backend's probe is the source of truth.
+    let (verity_path, roothash) = mvm_backend::microvm::probe_verity_sidecar(&rootfs);
+
+    // ---- 2. Load every artifact byte blob ----
+    //
+    // Today bundles hold the bytes in memory; multi-GiB rootfs
+    // streaming is a v2 concern. The `read_and_verify_bundle`
+    // counterpart has the same shape.
+    let kernel_bytes =
+        std::fs::read(&vmlinux).with_context(|| format!("reading kernel at {vmlinux}"))?;
+    let rootfs_bytes =
+        std::fs::read(&rootfs).with_context(|| format!("reading rootfs at {rootfs}"))?;
+    let initrd_bytes = match initrd.as_deref() {
+        Some(p) => Some(std::fs::read(p).with_context(|| format!("reading initrd at {p}"))?),
+        None => None,
+    };
+    let verity_bytes = match verity_path.as_deref() {
+        Some(p) => {
+            Some(std::fs::read(p).with_context(|| format!("reading verity sidecar at {p}"))?)
+        }
+        None => None,
+    };
+
+    // ---- 3. Build the BundleManifest ----
+    let signer = host_signer::load_or_init().context("loading host signer for bundle sign")?;
+    let key_id = KeyId::from_pubkey(&signer.verifying);
+
+    let mut artifacts: Vec<BundleArtifact> = Vec::new();
+    let mut payload: Vec<(String, Vec<u8>)> = Vec::new();
+
+    let push = |artifacts: &mut Vec<BundleArtifact>,
+                payload: &mut Vec<(String, Vec<u8>)>,
+                name: &str,
+                role: ArtifactRole,
+                bytes: Vec<u8>| {
+        let path = format!("{ARTIFACTS_DIR}/{name}");
+        artifacts.push(BundleArtifact {
+            name: name.to_string(),
+            role,
+            path: path.clone(),
+            sha256: sha256_hex(&bytes),
+            size_bytes: bytes.len() as u64,
+        });
+        payload.push((path, bytes));
+    };
+
+    push(
+        &mut artifacts,
+        &mut payload,
+        "vmlinux",
+        ArtifactRole::Kernel,
+        kernel_bytes,
+    );
+    push(
+        &mut artifacts,
+        &mut payload,
+        "rootfs.ext4",
+        ArtifactRole::Rootfs,
+        rootfs_bytes,
+    );
+    if let Some(b) = initrd_bytes {
+        push(
+            &mut artifacts,
+            &mut payload,
+            "initrd",
+            ArtifactRole::Initrd,
+            b,
+        );
+    }
+    let verity = match (verity_bytes, roothash) {
+        (Some(b), Some(roothash)) => {
+            push(
+                &mut artifacts,
+                &mut payload,
+                "rootfs.verity",
+                ArtifactRole::VerityHashSidecar,
+                b,
+            );
+            Some(VerityInfo {
+                roothash,
+                sidecar_artifact: "rootfs.verity".to_string(),
+            })
+        }
+        // Sidecar without a roothash is a misbuild — the backend's
+        // probe returns paired Some/Some or paired None/None.
+        // Surface inconsistency loudly rather than dropping the
+        // sidecar silently.
+        (Some(_), None) | (None, Some(_)) => {
+            anyhow::bail!(
+                "template carries an incomplete dm-verity binding (sidecar without roothash, or vice versa); rebuild before exporting"
+            );
+        }
+        (None, None) => None,
+    };
+
+    let manifest = BundleManifest {
+        schema_version: BUNDLE_SCHEMA_VERSION,
+        publisher: host_signer::host_signer_id(),
+        key_id: key_id.clone(),
+        arch: std::env::consts::ARCH.to_string(),
+        kernel_version: None,
+        profile: Some(spec.profile.clone()),
+        workload_label: args.label,
+        created_at: Utc::now().to_rfc3339(),
+        labels: Default::default(),
+        artifacts,
+        verity,
+    };
+
+    // ---- 4. Sign + write the archive ----
+    let archive_bytes = write_bundle(&manifest, &signer.signing, payload)
+        .context("sealing bundle (manifest + signature + artifacts)")?;
+
+    if let Some(parent) = args.out.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent dir {}", parent.display()))?;
+    }
+    std::fs::write(&args.out, &archive_bytes)
+        .with_context(|| format!("writing bundle to {}", args.out.display()))?;
+
+    println!(
+        "Exported bundle to {} ({} bytes, key_id={})",
+        args.out.display(),
+        archive_bytes.len(),
+        key_id.0,
+    );
+
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/bundle/fetch.rs
+++ b/crates/mvm-cli/src/commands/bundle/fetch.rs
@@ -1,0 +1,102 @@
+//! `mvmctl bundle fetch <path>` — verify a `.mvmpkg` archive
+//! against the local trust store.
+//!
+//! Scope for the substrate close-out is verification only: reads
+//! the archive, looks the publisher pubkey up via
+//! [`FsTrustStore`], re-verifies the signature, and re-hashes
+//! every artifact against the signed manifest. Reports the parsed
+//! manifest on success.
+//!
+//! Replacing the local template registry's manifest-path-hash
+//! keying with bundle-sha256 directories is a follow-up — it
+//! interacts with the existing `~/.mvm/templates/<hash>/...` flow
+//! and deserves its own commit.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+
+use mvm_core::user_config::MvmConfig;
+use mvm_plan::bundle::{FsTrustStore, bundle_sha256, read_and_verify_bundle};
+
+use super::super::Cli;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Path to a `.mvmpkg` archive on disk. (HTTP URLs are a
+    /// follow-up — see module docs.)
+    #[arg(value_name = "PATH")]
+    pub path: PathBuf,
+    /// Override the trust store directory. Defaults to
+    /// `~/.mvm/trusted-publishers/`.
+    #[arg(long, value_name = "DIR")]
+    pub trust_store: Option<PathBuf>,
+    /// Output the verified manifest as JSON instead of a
+    /// human-readable summary.
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let bytes = std::fs::read(&args.path)
+        .with_context(|| format!("reading bundle archive at {}", args.path.display()))?;
+
+    let trust = match args.trust_store {
+        Some(p) => FsTrustStore::new(p),
+        None => FsTrustStore::default_path()
+            .context("resolving default trust-store path (~/.mvm/trusted-publishers/)")?,
+    };
+
+    let verified = read_and_verify_bundle(&bytes, &trust)
+        .with_context(|| format!("verifying bundle at {}", args.path.display()))?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&verified.manifest)?);
+    } else {
+        let summary = BundleSummary {
+            bundle_sha256: bundle_sha256(&bytes),
+            key_id: verified.key_id.0.clone(),
+            publisher: verified.manifest.publisher.clone(),
+            arch: verified.manifest.arch.clone(),
+            profile: verified.manifest.profile.clone(),
+            workload_label: verified.manifest.workload_label.clone(),
+            artifact_count: verified.manifest.artifacts.len(),
+            has_verity: verified.manifest.verity.is_some(),
+        };
+        summary.render();
+    }
+    Ok(())
+}
+
+struct BundleSummary {
+    bundle_sha256: String,
+    key_id: String,
+    publisher: String,
+    arch: String,
+    profile: Option<String>,
+    workload_label: Option<String>,
+    artifact_count: usize,
+    has_verity: bool,
+}
+
+impl BundleSummary {
+    fn render(&self) {
+        println!("Bundle verified");
+        println!("  sha256:    {}", self.bundle_sha256);
+        println!("  key_id:    {}", self.key_id);
+        println!("  publisher: {}", self.publisher);
+        println!("  arch:      {}", self.arch);
+        if let Some(p) = &self.profile {
+            println!("  profile:   {p}");
+        }
+        if let Some(l) = &self.workload_label {
+            println!("  label:     {l}");
+        }
+        println!("  artifacts: {}", self.artifact_count);
+        println!(
+            "  verity:    {}",
+            if self.has_verity { "yes" } else { "no" }
+        );
+    }
+}

--- a/crates/mvm-cli/src/commands/bundle/fetch.rs
+++ b/crates/mvm-cli/src/commands/bundle/fetch.rs
@@ -1,16 +1,21 @@
-//! `mvmctl bundle fetch <path>` — verify a `.mvmpkg` archive
+//! `mvmctl bundle fetch <SOURCE>` — verify a `.mvmpkg` archive
 //! against the local trust store.
 //!
-//! Scope for the substrate close-out is verification only: reads
-//! the archive, looks the publisher pubkey up via
-//! [`FsTrustStore`], re-verifies the signature, and re-hashes
-//! every artifact against the signed manifest. Reports the parsed
-//! manifest on success.
+//! `SOURCE` is either a path on disk or an `https://` URL. HTTPS
+//! downloads use the workspace's existing reqwest-blocking helper
+//! ([`crate::http::download_file`]) with the system trust store
+//! via rustls + webpki-roots. Plain `http://` URLs are refused by
+//! default — the trust model (Ed25519 signature) catches a tampered
+//! bundle, but plain HTTP makes traffic observable, and consumers
+//! often have no idea they typed the wrong scheme. `--allow-http`
+//! opts in explicitly with a loud launch-time warning.
 //!
-//! Replacing the local template registry's manifest-path-hash
-//! keying with bundle-sha256 directories is a follow-up — it
-//! interacts with the existing `~/.mvm/templates/<hash>/...` flow
-//! and deserves its own commit.
+//! Scope for this commit is download + verify. Extracting the
+//! verified bundle into the local template registry (replacing
+//! the manifest-path-hash keying with bundle-sha256 directories)
+//! is its own follow-up — it interacts with the existing
+//! `~/.mvm/templates/<hash>/...` flow and deserves a separate
+//! commit.
 
 use std::path::PathBuf;
 
@@ -24,10 +29,10 @@ use super::super::Cli;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
-    /// Path to a `.mvmpkg` archive on disk. (HTTP URLs are a
-    /// follow-up — see module docs.)
-    #[arg(value_name = "PATH")]
-    pub path: PathBuf,
+    /// Local path to a `.mvmpkg` archive, or an `https://` URL
+    /// (HTTP is opt-in via `--allow-http`).
+    #[arg(value_name = "SOURCE")]
+    pub source: String,
     /// Override the trust store directory. Defaults to
     /// `~/.mvm/trusted-publishers/`.
     #[arg(long, value_name = "DIR")]
@@ -36,11 +41,87 @@ pub(in crate::commands) struct Args {
     /// human-readable summary.
     #[arg(long)]
     pub json: bool,
+    /// Allow plain-HTTP downloads. The Ed25519 signature still
+    /// catches tampering, but HTTP exposes traffic metadata
+    /// (e.g. which bundle a host is pulling). Off by default.
+    #[arg(long)]
+    pub allow_http: bool,
+}
+
+/// Parsed source — file path or URL. Kept narrow so the dispatch
+/// fn below stays a small `match`.
+#[derive(Debug, PartialEq, Eq)]
+enum BundleSource {
+    /// Path on the local filesystem.
+    File(PathBuf),
+    /// `https://…` URL — verified TLS at the wire layer.
+    HttpsUrl(String),
+    /// `http://…` URL — refused unless `--allow-http` is set.
+    HttpUrl(String),
+}
+
+impl BundleSource {
+    /// Parse a user-supplied string into the right variant.
+    ///
+    /// Scheme detection is intentionally tiny — no URL crate dep
+    /// for this. An `https://` prefix wins; an `http://` prefix
+    /// wins next; anything else is a file path. (A relative path
+    /// that happens to begin with `https//` without the colon is
+    /// a file path, as intended.)
+    fn parse(s: &str) -> Self {
+        if s.starts_with("https://") {
+            Self::HttpsUrl(s.to_string())
+        } else if s.starts_with("http://") {
+            Self::HttpUrl(s.to_string())
+        } else {
+            Self::File(PathBuf::from(s))
+        }
+    }
+}
+
+/// Load the archive bytes, honouring the source's transport
+/// rules. HTTPS downloads write to a temp file (via
+/// `crate::http::download_file`) and read back — the temp file is
+/// in a `tempfile::NamedTempFile` so it's cleaned on drop even if
+/// verification fails.
+fn load_archive_bytes(src: &BundleSource, allow_http: bool) -> Result<Vec<u8>> {
+    match src {
+        BundleSource::File(path) => std::fs::read(path)
+            .with_context(|| format!("reading bundle archive at {}", path.display())),
+        BundleSource::HttpsUrl(url) => download_to_bytes(url),
+        BundleSource::HttpUrl(url) => {
+            if !allow_http {
+                anyhow::bail!(
+                    "refusing to fetch over plain HTTP: {url}\n   \
+                     The Ed25519 signature still catches tampering, but HTTP exposes traffic \
+                     metadata. Pass --allow-http to override (with a launch-time warning), or \
+                     use the https:// URL if the publisher offers one."
+                );
+            }
+            crate::ui::warn(&format!(
+                "⚠ Downloading bundle over plain HTTP from {url}\n   \
+                 Signature verification still applies; traffic metadata is visible to anyone \
+                 on the wire."
+            ));
+            download_to_bytes(url)
+        }
+    }
+}
+
+fn download_to_bytes(url: &str) -> Result<Vec<u8>> {
+    // Write to a temp file then read back. Two passes is fine for
+    // v1 — bundles are modest in size, and the second read covers
+    // the disk-cache-warm path the verifier would walk anyway.
+    let tmp = tempfile::NamedTempFile::new().context("creating temp file for bundle download")?;
+    crate::http::download_file(url, tmp.path())
+        .with_context(|| format!("downloading bundle from {url}"))?;
+    std::fs::read(tmp.path())
+        .with_context(|| format!("reading downloaded bundle from {}", tmp.path().display()))
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
-    let bytes = std::fs::read(&args.path)
-        .with_context(|| format!("reading bundle archive at {}", args.path.display()))?;
+    let source = BundleSource::parse(&args.source);
+    let bytes = load_archive_bytes(&source, args.allow_http)?;
 
     let trust = match args.trust_store {
         Some(p) => FsTrustStore::new(p),
@@ -49,7 +130,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     };
 
     let verified = read_and_verify_bundle(&bytes, &trust)
-        .with_context(|| format!("verifying bundle at {}", args.path.display()))?;
+        .with_context(|| format!("verifying bundle from {}", args.source))?;
 
     if args.json {
         println!("{}", serde_json::to_string_pretty(&verified.manifest)?);
@@ -98,5 +179,87 @@ impl BundleSummary {
             "  verity:    {}",
             if self.has_verity { "yes" } else { "no" }
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_https_url() {
+        let s = BundleSource::parse("https://registry.example.com/foo.mvmpkg");
+        assert_eq!(
+            s,
+            BundleSource::HttpsUrl("https://registry.example.com/foo.mvmpkg".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_http_url() {
+        let s = BundleSource::parse("http://registry.example.com/foo.mvmpkg");
+        assert_eq!(
+            s,
+            BundleSource::HttpUrl("http://registry.example.com/foo.mvmpkg".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_relative_file_path() {
+        let s = BundleSource::parse("./bundles/foo.mvmpkg");
+        assert_eq!(s, BundleSource::File(PathBuf::from("./bundles/foo.mvmpkg")));
+    }
+
+    #[test]
+    fn parse_absolute_file_path() {
+        let s = BundleSource::parse("/tmp/foo.mvmpkg");
+        assert_eq!(s, BundleSource::File(PathBuf::from("/tmp/foo.mvmpkg")));
+    }
+
+    #[test]
+    fn parse_scheme_lookalike_is_still_a_path() {
+        // A path that happens to begin with "https" but no "://"
+        // separator is a file path, not a URL. This protects against
+        // accidental misinterpretation of cwd-relative names.
+        let s = BundleSource::parse("https-mirror/foo.mvmpkg");
+        assert_eq!(
+            s,
+            BundleSource::File(PathBuf::from("https-mirror/foo.mvmpkg"))
+        );
+    }
+
+    #[test]
+    fn parse_scheme_is_case_sensitive() {
+        // Match the conventional URL grammar — lowercase only. An
+        // uppercase prefix is more likely a filename than a real
+        // URL on a filesystem.
+        let s = BundleSource::parse("HTTPS://registry.example.com/foo");
+        assert_eq!(
+            s,
+            BundleSource::File(PathBuf::from("HTTPS://registry.example.com/foo"))
+        );
+    }
+
+    #[test]
+    fn load_archive_bytes_refuses_http_without_allow_http() {
+        let src = BundleSource::HttpUrl("http://example.com/foo.mvmpkg".to_string());
+        let err = load_archive_bytes(&src, false).expect_err("must refuse");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("refusing to fetch over plain HTTP"),
+            "got: {msg}"
+        );
+        // The escape hatch hint should appear in the same message so
+        // users know exactly how to recover.
+        assert!(msg.contains("--allow-http"), "got: {msg}");
+    }
+
+    #[test]
+    fn load_archive_bytes_reads_a_local_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"hello-bundle").unwrap();
+        let src = BundleSource::File(tmp.path().to_path_buf());
+        let bytes = load_archive_bytes(&src, false).expect("reads");
+        assert_eq!(bytes, b"hello-bundle");
     }
 }

--- a/crates/mvm-cli/src/commands/bundle/mod.rs
+++ b/crates/mvm-cli/src/commands/bundle/mod.rs
@@ -1,0 +1,59 @@
+//! `mvmctl bundle` — content-addressed, publisher-signed
+//! `.mvmpkg` portable image archives.
+//!
+//! Sprint 52 W2: a bundle pairs `manifest.json` + `manifest.sig` +
+//! the artifact bytes inside one tar archive. The manifest declares
+//! a per-artifact SHA-256, an architecture, the publisher's
+//! `key_id`, and a workload label. The signature is detached
+//! Ed25519 over the canonical-JSON manifest bytes.
+//!
+//! Trust model lives at the consumer: the publisher pubkey is
+//! looked up via `~/.mvm/trusted-publishers/<key_id>.pub` (managed
+//! by `mvmctl trust`). An unknown `key_id` is refused before
+//! reading artifact bytes; a tampered manifest fails signature
+//! verification; a tampered artifact fails the post-signature
+//! sha256 re-check. See `mvm_plan::bundle` module rustdoc for the
+//! full rejection ladder.
+//!
+//! ## Scope (this commit)
+//!
+//! `export` and `fetch` over local filesystem paths. HTTP fetch
+//! and supervisor admit-time re-verify (`ExecutionPlan::PlanArtifact`)
+//! are deferred follow-ups — both touch larger surfaces (a wire
+//! client and an `ExecutionPlan` schema bump respectively) that
+//! shouldn't sneak into the substrate-close-out commit.
+
+use anyhow::Result;
+use clap::{Args as ClapArgs, Subcommand};
+
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+
+mod export;
+mod fetch;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub action: BundleAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum BundleAction {
+    /// Seal a built template into a signed `.mvmpkg` archive.
+    /// Signs with the host signer at `~/.mvm/keys/host-signer.ed25519`
+    /// (the same key that signs `ExecutionPlan` envelopes).
+    Export(export::Args),
+    /// Verify a `.mvmpkg` archive against the local trust store.
+    /// Reports the parsed manifest on success; rejects on any of
+    /// the failure modes in `BundleVerifyError`.
+    Fetch(fetch::Args),
+}
+
+pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
+    match args.action {
+        BundleAction::Export(a) => export::run(cli, a, cfg),
+        BundleAction::Fetch(a) => fetch::run(cli, a, cfg),
+    }
+}

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -173,6 +173,8 @@ impl Commands {
             Commands::Secret(_) => "secret",
             Commands::Attest(_) => "attest",
             Commands::Policy(_) => "policy",
+            Commands::Bundle(_) => "bundle",
+            Commands::Trust(_) => "trust",
         }
     }
 }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod build;
+mod bundle;
 mod catalog;
 mod cmd_audit;
 mod env;
@@ -6,6 +7,7 @@ mod manifest;
 mod ops;
 mod shared;
 mod storage;
+mod trust;
 mod vm;
 
 #[cfg(test)]
@@ -177,6 +179,16 @@ pub(in crate::commands) enum Commands {
     /// `mvmctl policy update` is stubbed in v0 — production updates
     /// require an mvmd-signed plan (Phase 8). Plan 60 Phase 3 Slice D.
     Policy(ops::policy::Args),
+    /// Seal a built template into a portable, signed `.mvmpkg`
+    /// archive — or verify one against the local trust store.
+    /// Sprint 52 W2 close-out. Bundles are content-addressed and
+    /// signed by the host signer; consumers verify via
+    /// `mvmctl trust`-managed publisher pubkeys.
+    Bundle(bundle::Args),
+    /// Manage the bundle-publisher trust store at
+    /// `~/.mvm/trusted-publishers/`. `mvmctl bundle fetch` looks
+    /// pubkeys up via this store before verifying signatures.
+    Trust(trust::Args),
 }
 
 // ============================================================================
@@ -304,6 +316,8 @@ pub fn run() -> Result<()> {
         Commands::Secret(a) => ops::secret::run(&cli, a, &cfg),
         Commands::Attest(a) => ops::attest::run(&cli, a, &cfg),
         Commands::Policy(a) => ops::policy::run(&cli, a, &cfg),
+        Commands::Bundle(a) => bundle::run(&cli, a, &cfg),
+        Commands::Trust(a) => trust::run(&cli, a, &cfg),
     };
 
     cmd_audit::emit_cmd_outcome(cmd_recorder.as_ref(), verb, &result);

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -153,6 +153,7 @@ impl ExecDispatcher {
             image: crate::exec::ImageSource::Template(env.to_string()),
             cpus: DEFAULT_VM_CPUS,
             memory_mib: DEFAULT_VM_MEM_MIB,
+            mem_initial_mib: None,
             add_dirs: Vec::new(),
             env: Vec::new(),
             target: crate::exec::ExecTarget::Inline { argv },

--- a/crates/mvm-cli/src/commands/shared/start.rs
+++ b/crates/mvm-cli/src/commands/shared/start.rs
@@ -22,6 +22,10 @@ pub struct VmStartParams<'a> {
     pub profile: Option<String>,
     pub cpus: u32,
     pub memory_mib: u32,
+    /// Opt into virtio-balloon: when `Some(n)`, the host commits `n`
+    /// MiB at boot and the balloon claws back `memory_mib - n` MiB.
+    /// `None` keeps the legacy "commit memory_mib at boot" behaviour.
+    pub mem_initial_mib: Option<u32>,
     pub volumes: &'a [image::RuntimeVolume],
     pub config_files: &'a [microvm::DriveFile],
     pub secret_files: &'a [microvm::DriveFile],
@@ -42,6 +46,7 @@ impl VmStartParams<'_> {
             profile: self.profile,
             cpus: self.cpus,
             memory_mib: self.memory_mib,
+            mem_initial_mib: self.mem_initial_mib,
             ports: self
                 .port_mappings
                 .iter()

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1160,9 +1160,17 @@ fn test_run_cli_flag_overrides_config_memory() {
 }
 
 #[test]
-fn test_resolve_network_policy_default() {
+fn test_resolve_network_policy_default_is_deny_all() {
+    // ADR-002 claim 10: the safe default is deny-all. Workloads
+    // that need network access opt in explicitly. Pre-Sprint 52
+    // this test asserted `is_unrestricted()` — flipped here as
+    // part of the default flip.
     let policy = resolve_network_policy(None, &[]).unwrap();
-    assert!(policy.is_unrestricted());
+    assert!(!policy.is_unrestricted());
+    let rules = policy
+        .resolve_rules()
+        .expect("default resolves to a concrete rule set");
+    assert!(rules.is_empty(), "deny-all should yield no allow rules");
 }
 
 #[test]

--- a/crates/mvm-cli/src/commands/trust/add.rs
+++ b/crates/mvm-cli/src/commands/trust/add.rs
@@ -1,0 +1,77 @@
+//! `mvmctl trust add <PUBKEY>` — enrol a publisher's Ed25519
+//! public key as trusted.
+//!
+//! Reads 32 raw bytes from the path, validates that they form a
+//! valid Ed25519 verifying key, derives `key_id =
+//! sha256(pubkey)[..32hex]`, and writes the bytes to
+//! `~/.mvm/trusted-publishers/<key_id>.pub`. Refuses to overwrite
+//! an existing entry without `--force` — a publisher key
+//! collision under truncation would still need a full Ed25519
+//! collision to forge a signature, but loud-failing surfaces the
+//! mistake.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use ed25519_dalek::VerifyingKey;
+
+use mvm_core::user_config::MvmConfig;
+use mvm_plan::bundle::KeyId;
+
+use super::super::Cli;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Path to a 32-byte Ed25519 public-key file. No PEM, no
+    /// headers — raw bytes only. Bundles publish this format via
+    /// `~/.mvm/keys/host-signer.pub` after `host_signer::load_or_init`.
+    #[arg(value_name = "PUBKEY")]
+    pub pubkey: PathBuf,
+    /// Overwrite an existing entry with the same `key_id`.
+    #[arg(long)]
+    pub force: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let bytes = std::fs::read(&args.pubkey)
+        .with_context(|| format!("reading pubkey at {}", args.pubkey.display()))?;
+    if bytes.len() != 32 {
+        anyhow::bail!(
+            "pubkey at {} is {} bytes; expected exactly 32 (raw Ed25519)",
+            args.pubkey.display(),
+            bytes.len()
+        );
+    }
+    let arr: [u8; 32] = bytes.as_slice().try_into().expect("checked length");
+    let vk = VerifyingKey::from_bytes(&arr).with_context(|| {
+        format!(
+            "pubkey bytes at {} do not decode as a valid Ed25519 verifying key",
+            args.pubkey.display()
+        )
+    })?;
+    let key_id = KeyId::from_pubkey(&vk);
+
+    let dir = super::ensure_trust_dir()?;
+    let dst = dir.join(format!("{}.pub", key_id.0));
+    if dst.exists() && !args.force {
+        anyhow::bail!(
+            "trust store already has an entry for key_id {}; pass --force to overwrite",
+            key_id.0
+        );
+    }
+    std::fs::write(&dst, vk.to_bytes())
+        .with_context(|| format!("writing pubkey to {}", dst.display()))?;
+    // World-readable is fine — public keys are not secrets — but
+    // mirror the existing host-signer.pub mode (0644) for
+    // consistency with the rest of `~/.mvm/keys/`.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&dst)?.permissions();
+        perms.set_mode(0o644);
+        std::fs::set_permissions(&dst, perms)?;
+    }
+    println!("Trusted key_id {}", key_id.0);
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/trust/list.rs
+++ b/crates/mvm-cli/src/commands/trust/list.rs
@@ -1,0 +1,56 @@
+//! `mvmctl trust list` — enumerate the local trust store.
+
+use anyhow::Result;
+use clap::Args as ClapArgs;
+
+use mvm_core::user_config::MvmConfig;
+use mvm_plan::bundle::KeyId;
+
+use super::super::Cli;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Output as JSON (array of `key_id` strings).
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let dir = super::ensure_trust_dir()?;
+    let mut key_ids: Vec<String> = Vec::new();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => {
+            // ensure_trust_dir creates the dir, so a read_dir miss
+            // here means the directory was deleted between the two
+            // syscalls — treat as empty rather than erroring.
+            print_result(&[], args.json)?;
+            return Ok(());
+        }
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if let Some(stem) = name.strip_suffix(".pub") {
+            let id = KeyId(stem.to_string());
+            if id.is_well_formed() {
+                key_ids.push(id.0);
+            }
+        }
+    }
+    key_ids.sort();
+    print_result(&key_ids, args.json)?;
+    Ok(())
+}
+
+fn print_result(ids: &[String], json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(ids)?);
+    } else if ids.is_empty() {
+        println!("(no trusted publishers)");
+    } else {
+        for id in ids {
+            println!("{id}");
+        }
+    }
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/trust/mod.rs
+++ b/crates/mvm-cli/src/commands/trust/mod.rs
@@ -1,0 +1,77 @@
+//! `mvmctl trust` — manage the local bundle-publisher trust store
+//! at `~/.mvm/trusted-publishers/<key_id>.pub`.
+//!
+//! Sprint 52 W2: a bundle's publisher key never lives in the
+//! bundle itself; consumers establish trust out-of-band by
+//! enrolling a publisher's Ed25519 public key under a derived
+//! `key_id` filename. This command makes that enrolment a
+//! first-class verb instead of a "drop bytes at a path" trick.
+//!
+//! Pubkey files hold 32 raw Ed25519 public-key bytes (no PEM, no
+//! header). `<key_id>.pub` filenames are derived from the key
+//! itself (sha256 of pubkey bytes, truncated to 32 hex chars) so
+//! a malicious publisher can't fake another publisher's `key_id`
+//! at the filesystem level.
+
+use anyhow::Result;
+use clap::{Args as ClapArgs, Subcommand};
+
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+
+mod add;
+mod list;
+mod remove;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub action: TrustAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum TrustAction {
+    /// Enrol a publisher's Ed25519 public key as trusted. Reads
+    /// 32 raw bytes from `<PUBKEY>` and writes them to
+    /// `~/.mvm/trusted-publishers/<key_id>.pub` (mode 0644).
+    Add(add::Args),
+    /// List currently-trusted publisher key_ids.
+    #[command(alias = "ls")]
+    List(list::Args),
+    /// Remove a publisher by `key_id`. The file is unlinked but
+    /// not zeroed — pubkeys aren't secrets, just lookup tokens.
+    #[command(alias = "rm")]
+    Remove(remove::Args),
+}
+
+pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
+    match args.action {
+        TrustAction::Add(a) => add::run(cli, a, cfg),
+        TrustAction::List(a) => list::run(cli, a, cfg),
+        TrustAction::Remove(a) => remove::run(cli, a, cfg),
+    }
+}
+
+/// Resolve the trust-store directory, creating it (mode 0700) if
+/// it doesn't already exist. Centralised so add/list/remove agree
+/// on the path and on the create-on-first-use behaviour.
+pub(super) fn ensure_trust_dir() -> Result<std::path::PathBuf> {
+    use mvm_plan::bundle::FsTrustStore;
+    let store = FsTrustStore::default_path()?;
+    let dir = store.root().to_path_buf();
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir).map_err(anyhow::Error::from)?;
+        // Tighten parent permissions on POSIX. Tests on macOS/Linux
+        // hit this path; on platforms without unix perms (Windows
+        // CI someday) the cfg-gate makes it a no-op.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&dir)?.permissions();
+            perms.set_mode(0o700);
+            std::fs::set_permissions(&dir, perms)?;
+        }
+    }
+    Ok(dir)
+}

--- a/crates/mvm-cli/src/commands/trust/remove.rs
+++ b/crates/mvm-cli/src/commands/trust/remove.rs
@@ -1,0 +1,39 @@
+//! `mvmctl trust remove <KEY_ID>` — unlink a trusted publisher.
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+
+use mvm_core::user_config::MvmConfig;
+use mvm_plan::bundle::KeyId;
+
+use super::super::Cli;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// 32-char hex `key_id` to remove. Get the list via
+    /// `mvmctl trust list`.
+    #[arg(value_name = "KEY_ID")]
+    pub key_id: String,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let id = KeyId(args.key_id.clone());
+    if !id.is_well_formed() {
+        anyhow::bail!(
+            "key_id {:?} is malformed (expected 32 lowercase hex characters)",
+            args.key_id
+        );
+    }
+    let dir = super::ensure_trust_dir()?;
+    let path = dir.join(format!("{}.pub", id.0));
+    match std::fs::remove_file(&path) {
+        Ok(()) => {
+            println!("Removed key_id {}", id.0);
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            anyhow::bail!("no trusted entry for key_id {}", id.0)
+        }
+        Err(e) => Err(e).with_context(|| format!("removing {}", path.display())),
+    }
+}

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -116,6 +116,10 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         image,
         cpus: args.cpus,
         memory_mib,
+        // mvmctl exec is a one-shot transient; no balloon plumbing
+        // here yet. The manifest-driven path on mvmctl up is where
+        // mem_initial gets sourced for long-running workloads.
+        mem_initial_mib: None,
         add_dirs,
         env: env_pairs,
         target,

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -406,7 +406,8 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
     // this field; manifest-keyed slots don't — runtime policy moves
     // to `mvmctl up` flags / `~/.mvm/config.toml` / mvmd per plan 38
     // §"Manifest scope"). Explicit CLI flags always win.
-    let network_policy = if args.network_preset.is_some() || !args.network_allow.is_empty() {
+    let explicit_cli_network = args.network_preset.is_some() || !args.network_allow.is_empty();
+    let network_policy = if explicit_cli_network {
         resolve_network_policy(args.network_preset.as_deref(), &args.network_allow)?
     } else if let Some(id_or_slot) = resolved_template_arg.as_deref()
         && let Ok(spec) = mvm::vm::template::lifecycle::template_load_dispatched(id_or_slot)
@@ -419,6 +420,33 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
     } else {
         resolve_network_policy(None, &[])?
     };
+
+    // ADR-002 claim 10 — deny-by-default network. When the resolved
+    // policy is `unrestricted`, the user (or a template they
+    // selected) explicitly opted out of the safe default. Surface
+    // that as a one-line warning so operators are never surprised
+    // by wide-open egress. Suppressible via
+    // `MVM_ACK_UNRESTRICTED_NETWORK=1` for CI / scripted use that
+    // already knows what it's doing.
+    if network_policy.is_unrestricted()
+        && std::env::var_os("MVM_ACK_UNRESTRICTED_NETWORK").is_none()
+    {
+        let source = if explicit_cli_network {
+            "--network-preset unrestricted (CLI flag)"
+        } else {
+            "template's default_network_policy (baked at build time)"
+        };
+        // vm_name isn't bound at this point in the flow; use the
+        // user-supplied --name (or "(unnamed)" placeholder) which
+        // matches what the rest of the boot log shows.
+        let label = args.name.as_deref().unwrap_or("(unnamed)");
+        crate::ui::warn(&format!(
+            "⚠ VM '{label}' will boot with UNRESTRICTED network egress (source: {source}).\n   \
+             ADR-002 claim 10 sets deny-all as the safe default; \
+             this workload opted out. Set MVM_ACK_UNRESTRICTED_NETWORK=1 \
+             to suppress this warning."
+        ));
+    }
     let seccomp_tier: mvm_security::seccomp::SeccompTier =
         args.seccomp.parse().context("Invalid --seccomp value")?;
     let secret_bindings: Vec<mvm_core::secret_binding::SecretBinding> = args

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -751,6 +751,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         source_profile,
         tmpl_cpus,
         tmpl_mem,
+        tmpl_mem_initial,
         snapshot_info,
     ) = if let Some(tmpl) = template_name {
         ui::step(
@@ -777,6 +778,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             Some(spec.profile.clone()),
             Some(spec.vcpus as u32),
             Some(spec.mem_mib),
+            spec.mem_initial_mib,
             snap_info,
         )
     } else if let Some(flake) = flake_ref {
@@ -816,6 +818,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             profile.map(|s| s.to_string()),
             None,
             None,
+            None, // tmpl_mem_initial — flake builds don't carry it
             None, // No snapshot for flake builds
         )
     } else {
@@ -837,6 +840,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             None,
             None,
             None,
+            None, // tmpl_mem_initial
             None,
         )
     };
@@ -898,11 +902,17 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         .or(rt_config.memory)
         .or(tmpl_mem)
         .unwrap_or(user_cfg.default_memory_mib);
-    // Balloon opt-in: when the manifest declares `mem_initial`, the
-    // backend creates a pre-inflated balloon and only commits this
-    // amount at boot. `None` preserves the historical behaviour.
+    // Balloon opt-in resolution. Precedence:
+    //   1. `--config` runtime override (`rt_config.mem_initial`)
+    //   2. Template-baked value (manifest's `mem_initial` from the
+    //      slot's PersistedManifest, via TemplateSpec.mem_initial_mib)
+    //   3. Off (legacy commit-mem_mib-at-boot shape)
+    // The final value must be strictly inside `(0, final_memory)`;
+    // anything else gets filtered to `None` so the FC + CH backends
+    // never see a value they'd reject anyway.
     let final_mem_initial = rt_config
         .mem_initial
+        .or(tmpl_mem_initial)
         .filter(|n| *n > 0 && *n < final_memory);
 
     // Parse port mappings and inject as config drive file

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -898,6 +898,12 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         .or(rt_config.memory)
         .or(tmpl_mem)
         .unwrap_or(user_cfg.default_memory_mib);
+    // Balloon opt-in: when the manifest declares `mem_initial`, the
+    // backend creates a pre-inflated balloon and only commits this
+    // amount at boot. `None` preserves the historical behaviour.
+    let final_mem_initial = rt_config
+        .mem_initial
+        .filter(|n| *n > 0 && *n < final_memory);
 
     // Parse port mappings and inject as config drive file
     let port_mappings = parse_port_specs(ports)?;
@@ -1018,6 +1024,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             profile: source_profile,
             cpus: final_cpus,
             memory: final_memory,
+            mem_initial: final_mem_initial,
             volumes: volume_cfg,
             config_files,
             secret_files,
@@ -1060,6 +1067,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             profile: source_profile,
             cpus: final_cpus,
             memory_mib: final_memory,
+            mem_initial_mib: final_mem_initial,
             volumes: &volume_cfg,
             config_files: &config_files,
             secret_files: &secret_files,
@@ -1339,6 +1347,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 profile: profile.map(|s| s.to_string()),
                 cpus: final_cpus,
                 memory_mib: final_memory,
+                mem_initial_mib: final_mem_initial,
                 volumes: &w_volume_cfg,
                 config_files: &w_config_files,
                 secret_files: &w_secret_files,

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use anyhow::Result;
 use serde::Serialize;
 
@@ -44,6 +46,12 @@ struct SecurityPostureReport {
 struct DoctorReport {
     checks: Vec<Check>,
     security_posture: SecurityPostureReport,
+    /// Per-backend virtio-balloon capability surfaced by
+    /// `VmBackend::capabilities`. Lets users predict which backend
+    /// will honour `mem_initial` in their manifest before launching.
+    /// Ordered by `BTreeMap`'s natural backend-name order so JSON
+    /// output is deterministic.
+    balloon_support: BTreeMap<String, bool>,
     all_ok: bool,
 }
 
@@ -111,11 +119,15 @@ pub fn run(json: bool) -> Result<()> {
     // ── Active backend security posture (ADR-002 / plan 53) ──────
     let security_posture = collect_security_posture();
 
+    // ── Balloon capability per backend ────────────────────────────
+    let balloon_support = collect_balloon_support();
+
     // ── Render ────────────────────────────────────────────────────
     let all_ok = checks.iter().all(|c| c.ok);
     let report = DoctorReport {
         checks,
         security_posture,
+        balloon_support,
         all_ok,
     };
 
@@ -176,6 +188,55 @@ fn render_text(report: &DoctorReport) {
         );
     }
     render_security_posture(&report.security_posture);
+    render_balloon_support(&report.balloon_support);
+}
+
+/// Enumerate every backend's `capabilities().balloon`. The doctor
+/// surfaces this so a user authoring `mem_initial` in `mvm.toml`
+/// can see at a glance which backend will honour the opt-in (vs.
+/// which will silently ignore it because the underlying VMM doesn't
+/// support virtio-balloon).
+///
+/// Keyed by `&str` rather than `&'static str` so JSON serialisation
+/// gets a stable BTreeMap ordering. Names match `VmBackend::name`.
+fn collect_balloon_support() -> BTreeMap<String, bool> {
+    // Hypervisor selectors mirror `AnyBackend::from_hypervisor`. The
+    // list is hand-maintained because there's no general "iterate
+    // every backend" helper today; adding a new backend means
+    // adding it here so doctor surfaces it without lying.
+    let names = [
+        "firecracker",
+        "cloud-hypervisor",
+        "apple-container",
+        "docker",
+        "libkrun",
+        "microsandbox",
+        "qemu",
+    ];
+    let mut out = BTreeMap::new();
+    for name in names {
+        let backend = AnyBackend::from_hypervisor(name);
+        out.insert(backend.name().to_string(), backend.capabilities().balloon);
+    }
+    out
+}
+
+/// Print the balloon-support matrix in `mvmctl doctor` text mode.
+/// Stays concise — one section, one line per backend.
+fn render_balloon_support(support: &BTreeMap<String, bool>) {
+    let title = "Memory ballooning (virtio-balloon)";
+    println!("\n{}", title);
+    println!("{}", "-".repeat(title.len()));
+    for (backend, ok) in support {
+        let mark = if *ok { "yes" } else { "no" };
+        ui::status_line(&format!("  {backend}:"), mark);
+    }
+    if !support.values().any(|v| *v) {
+        ui::warn(
+            "  · No backend on this host advertises virtio-balloon. \
+             `mem_initial` in mvm.toml will be ignored at boot.",
+        );
+    }
 }
 
 // ── Active backend security posture (ADR-002 / plan 53) ──────
@@ -1272,6 +1333,19 @@ mod tests {
     }
 
     #[test]
+    fn collect_balloon_support_advertises_fc_and_ch() {
+        let support = collect_balloon_support();
+        // The hand-maintained list in collect_balloon_support must
+        // include both rust-vmm backends. If a future refactor drops
+        // one, this fails loudly.
+        assert_eq!(support.get("firecracker"), Some(&true));
+        assert_eq!(support.get("cloud-hypervisor"), Some(&true));
+        // And honestly-`false` backends should not be silently dropped.
+        assert_eq!(support.get("docker"), Some(&false));
+        assert_eq!(support.get("apple-container"), Some(&false));
+    }
+
+    #[test]
     fn doctor_report_serializes_to_json() {
         let report = DoctorReport {
             checks: vec![Check {
@@ -1281,6 +1355,7 @@ mod tests {
                 info: "v1.0".to_string(),
             }],
             security_posture: collect_security_posture(),
+            balloon_support: collect_balloon_support(),
             all_ok: true,
         };
         let json = serde_json::to_string(&report).unwrap();

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -146,6 +146,14 @@ pub struct ExecRequest {
     pub image: ImageSource,
     pub cpus: u32,
     pub memory_mib: u32,
+    /// Opt into virtio-balloon. `None` keeps the legacy "commit
+    /// memory_mib at boot" behaviour; `Some(n)` commits only `n` MiB
+    /// initially and lets the host-side reclaim controller adjust.
+    /// See [`VmStartConfig::mem_initial_mib`].
+    ///
+    /// [`VmStartConfig::mem_initial_mib`]:
+    ///     mvm_core::vm_backend::VmStartConfig::mem_initial_mib
+    pub mem_initial_mib: Option<u32>,
     pub add_dirs: Vec<AddDir>,
     pub env: Vec<(String, String)>,
     pub target: ExecTarget,
@@ -552,6 +560,7 @@ fn run_inner(req: ExecRequest, capture: bool) -> Result<Either<i32, ExecOutput>>
         profile: profile.clone(),
         cpus: req.cpus,
         memory_mib: req.memory_mib,
+        mem_initial_mib: req.mem_initial_mib,
         ports: Vec::new(),
         volumes: volumes
             .iter()
@@ -668,6 +677,12 @@ fn restore_via_snapshot(
         profile: start_config.profile.clone(),
         cpus: start_config.cpus,
         memory: start_config.memory_mib,
+        // Inherit the balloon decision from the start_config. The
+        // snapshot path is rare for balloon-enabled workloads (FC
+        // snapshots don't checkpoint balloon state cleanly), but
+        // we preserve the field so a future fix doesn't have to
+        // re-thread it.
+        mem_initial: start_config.mem_initial_mib,
         // Snapshot-eligible callers have no extra volumes; if that ever
         // changes the snapshot layout will mismatch and Firecracker will
         // refuse to load — `snapshot_eligible` enforces this.
@@ -807,6 +822,9 @@ pub fn boot_session_vm(
         profile: Some(spec.profile),
         cpus,
         memory_mib,
+        // Session VMs are short-lived MCP-driven boots; balloon
+        // elasticity isn't useful here, so leave commit at boot.
+        mem_initial_mib: None,
         ports: vec![],
         volumes: vec![],
         config_files: vec![],
@@ -856,6 +874,7 @@ pub fn dispatch_in_session(vm: &SessionVm, code: String, timeout_secs: u64) -> R
         image: ImageSource::Template(String::new()),
         cpus: 0,
         memory_mib: 0,
+        mem_initial_mib: None,
         add_dirs: vec![],
         env: vec![],
         target: ExecTarget::Inline {
@@ -1032,6 +1051,7 @@ mod tests {
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
+            mem_initial_mib: None,
             add_dirs: Vec::new(),
             env: Vec::new(),
             target: ExecTarget::Inline {
@@ -1048,6 +1068,7 @@ mod tests {
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
+            mem_initial_mib: None,
             add_dirs: Vec::new(),
             env: Vec::new(),
             target: ExecTarget::Inline {
@@ -1068,6 +1089,7 @@ mod tests {
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
+            mem_initial_mib: None,
             add_dirs: vec![AddDir {
                 host_path: "/h".into(),
                 guest_path: "/g".into(),
@@ -1092,6 +1114,7 @@ mod tests {
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
+            mem_initial_mib: None,
             add_dirs: vec![AddDir {
                 host_path: "/h".into(),
                 guest_path: "/g".into(),
@@ -1320,6 +1343,7 @@ mod tests {
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
+            mem_initial_mib: None,
             add_dirs: Vec::new(),
             env: Vec::new(),
             target: ExecTarget::LaunchPlan {
@@ -1343,6 +1367,7 @@ mod tests {
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
+            mem_initial_mib: None,
             add_dirs: Vec::new(),
             env: vec![("CLI_OVER".to_string(), "wins".to_string())],
             target: ExecTarget::LaunchPlan {
@@ -1381,6 +1406,7 @@ mod tests {
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
+            mem_initial_mib: None,
             add_dirs: Vec::new(),
             env: Vec::new(),
             target: ExecTarget::Inline {

--- a/crates/mvm-core/src/domain/manifest.rs
+++ b/crates/mvm-core/src/domain/manifest.rs
@@ -94,9 +94,20 @@ pub struct Manifest {
     #[serde(default = "default_vcpus")]
     pub vcpus: u8,
 
-    /// Human-readable memory size (`512M`, `1G`, `1024`, …).
+    /// Human-readable memory size (`512M`, `1G`, `1024`, …). Acts as
+    /// the *cap* on guest memory; when [`mem_initial`](Self::mem_initial)
+    /// is also set, this is the upper bound the balloon can deflate to.
     #[serde(default = "default_mem")]
     pub mem: String,
+
+    /// Optional initial host commitment (e.g. `256M`, `1G`). When set,
+    /// opts the workload into virtio-balloon: the backend attaches a
+    /// balloon device pre-inflated to `mem - mem_initial`, so the host
+    /// commits only this amount at boot. The reclaim controller can
+    /// adjust the balloon over the VM's life. Must parse to a value
+    /// strictly between zero and `mem`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mem_initial: Option<String>,
 
     /// Human-readable data disk size; `"0"` means no data disk.
     #[serde(default = "default_data_disk")]
@@ -151,6 +162,23 @@ impl Manifest {
                 "manifest field `mem` must be >= {MIN_MEM_MIB} MiB (got {mem} MiB)"
             ));
         }
+        if let Some(mi) = self.mem_initial.as_deref() {
+            let mi_mib = parse_human_size(mi)
+                .with_context(|| format!("invalid `mem_initial` field: {mi:?}"))?;
+            if mi_mib == 0 {
+                return Err(anyhow!(
+                    "manifest field `mem_initial` must be > 0 when set; \
+                     omit it to opt out of virtio-balloon"
+                ));
+            }
+            if mi_mib >= mem {
+                return Err(anyhow!(
+                    "manifest field `mem_initial` ({mi_mib} MiB) must be \
+                     strictly less than `mem` ({mem} MiB); the balloon needs \
+                     a non-zero inflation target"
+                ));
+            }
+        }
         let _ = parse_human_size(&self.data_disk)
             .with_context(|| format!("invalid `data_disk` field: {:?}", self.data_disk))?;
         if let Some(name) = self.name.as_deref() {
@@ -160,9 +188,21 @@ impl Manifest {
         Ok(())
     }
 
-    /// Memory in MiB, parsed from the human-readable string.
+    /// Memory cap in MiB, parsed from the human-readable string.
     pub fn mem_mib(&self) -> Result<u32> {
         parse_human_size(&self.mem).with_context(|| format!("invalid `mem` field: {:?}", self.mem))
+    }
+
+    /// Initial host commitment in MiB, when the workload opted into
+    /// virtio-balloon. Returns `Ok(None)` when the field is unset
+    /// (legacy "commit `mem` at boot" behaviour).
+    pub fn mem_initial_mib(&self) -> Result<Option<u32>> {
+        match self.mem_initial.as_deref() {
+            Some(s) => parse_human_size(s)
+                .map(Some)
+                .with_context(|| format!("invalid `mem_initial` field: {s:?}")),
+            None => Ok(None),
+        }
     }
 
     /// Data disk in MiB.
@@ -645,6 +685,76 @@ mod tests {
         let m = Manifest::from_toml_str(minimal_manifest_toml()).unwrap();
         assert_eq!(m.mem_mib().unwrap(), 1024);
         assert_eq!(m.data_disk_mib().unwrap(), 0);
+    }
+
+    #[test]
+    fn mem_initial_absent_means_no_balloon_opt_in() {
+        let m = Manifest::from_toml_str(minimal_manifest_toml()).unwrap();
+        assert!(m.mem_initial.is_none());
+        assert!(m.mem_initial_mib().unwrap().is_none());
+    }
+
+    #[test]
+    fn mem_initial_set_parses_and_validates() {
+        let toml = r#"
+            flake = "."
+            profile = "default"
+            vcpus = 2
+            mem = "1024M"
+            mem_initial = "256M"
+        "#;
+        let m = Manifest::from_toml_str(toml).expect("parses");
+        assert_eq!(m.mem_initial.as_deref(), Some("256M"));
+        assert_eq!(m.mem_initial_mib().unwrap(), Some(256));
+    }
+
+    #[test]
+    fn mem_initial_zero_rejected() {
+        let toml = r#"
+            flake = "."
+            profile = "default"
+            vcpus = 2
+            mem = "1024M"
+            mem_initial = "0"
+        "#;
+        let err = Manifest::from_toml_str(toml).expect_err("rejects zero mem_initial");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("mem_initial"), "msg was {msg}");
+    }
+
+    #[test]
+    fn mem_initial_at_least_mem_rejected() {
+        // mem_initial >= mem leaves no headroom for the balloon to inflate.
+        let toml = r#"
+            flake = "."
+            profile = "default"
+            vcpus = 2
+            mem = "1024M"
+            mem_initial = "1024M"
+        "#;
+        let err = Manifest::from_toml_str(toml).expect_err("rejects >=mem mem_initial");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("strictly less than"), "msg was {msg}");
+    }
+
+    #[test]
+    fn mem_initial_unparseable_rejected() {
+        let toml = r#"
+            flake = "."
+            profile = "default"
+            vcpus = 2
+            mem = "1024M"
+            mem_initial = "spuds"
+        "#;
+        let err = Manifest::from_toml_str(toml).expect_err("rejects junk mem_initial");
+        assert!(format!("{err:#}").contains("mem_initial"));
+    }
+
+    #[test]
+    fn serde_skips_omitted_mem_initial() {
+        let m = Manifest::from_toml_str(minimal_manifest_toml()).unwrap();
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(!json.contains("mem_initial"));
     }
 
     #[test]

--- a/crates/mvm-core/src/domain/manifest.rs
+++ b/crates/mvm-core/src/domain/manifest.rs
@@ -425,6 +425,13 @@ pub struct PersistedManifest {
 
     pub vcpus: u8,
     pub mem_mib: u32,
+    /// Initial host commitment in MiB when the source manifest opted
+    /// into virtio-balloon (`mem_initial = "256M"`). `None` keeps the
+    /// historical commit-mem_mib-at-boot shape. Backward-compat:
+    /// missing field deserialises to `None` so older slot records
+    /// keep working without a rebuild.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mem_initial_mib: Option<u32>,
     pub data_disk_mib: u32,
 
     /// Display name from the manifest (NOT the registry key).
@@ -464,6 +471,7 @@ impl PersistedManifest {
             .to_string();
         let manifest_hash = canonical_key_for_path(canonical_path)?;
         let mem_mib = manifest.mem_mib()?;
+        let mem_initial_mib = manifest.mem_initial_mib()?;
         let data_disk_mib = manifest.data_disk_mib()?;
         let now = provenance.built_at.clone();
         Ok(Self {
@@ -474,6 +482,7 @@ impl PersistedManifest {
             profile: manifest.profile.clone(),
             vcpus: manifest.vcpus,
             mem_mib,
+            mem_initial_mib,
             data_disk_mib,
             name: manifest.name.clone(),
             backend: backend.to_string(),
@@ -1031,11 +1040,58 @@ mod tests {
         let p = fixture_persisted(&tmp);
         assert_eq!(p.vcpus, 2);
         assert_eq!(p.mem_mib, 1024);
+        // Minimal manifest fixture has no `mem_initial` set.
+        assert_eq!(p.mem_initial_mib, None);
         assert_eq!(p.data_disk_mib, 0);
         assert_eq!(p.flake_ref, ".");
         assert_eq!(p.profile, "default");
         assert_eq!(p.backend, "firecracker");
         assert_eq!(p.schema_version, MANIFEST_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn persisted_from_manifest_carries_mem_initial_when_set() {
+        let tmp = TempDir::new().unwrap();
+        let toml = r#"
+            flake = "."
+            profile = "default"
+            vcpus = 2
+            mem = "1024M"
+            mem_initial = "256M"
+        "#;
+        write(tmp.path(), "mvm.toml", toml);
+        let manifest = Manifest::read_file(&tmp.path().join("mvm.toml")).unwrap();
+        let canonical = std::fs::canonicalize(tmp.path().join("mvm.toml")).unwrap();
+        let p = PersistedManifest::from_manifest(
+            &manifest,
+            &canonical,
+            "firecracker",
+            Provenance {
+                toolchain_version: "0.13.0".to_string(),
+                builder_image_digest: None,
+                host_arch: "x86_64-linux".to_string(),
+                built_at: "2026-04-30T12:00:00Z".to_string(),
+                ir_hash: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(p.mem_initial_mib, Some(256));
+        // Schema-skip rule: a None mem_initial_mib must NOT serialise
+        // (older verifiers don't know the field). A Some value MUST
+        // serialise — verifiers need to see the balloon opt-in.
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(json.contains("\"mem_initial_mib\":256"), "got: {json}");
+    }
+
+    #[test]
+    fn persisted_manifest_serde_skips_omitted_mem_initial() {
+        let tmp = TempDir::new().unwrap();
+        let p = fixture_persisted(&tmp);
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(
+            !json.contains("mem_initial_mib"),
+            "field with None value must not appear in JSON: {json}"
+        );
     }
 
     #[test]

--- a/crates/mvm-core/src/domain/template.rs
+++ b/crates/mvm-core/src/domain/template.rs
@@ -53,6 +53,14 @@ pub struct TemplateSpec {
     pub role: String,
     pub vcpus: u8,
     pub mem_mib: u32,
+    /// Initial host commitment in MiB when the template opts into
+    /// virtio-balloon. `None` keeps the legacy "commit `mem_mib` at
+    /// boot" behaviour; `Some(n)` sources `VmStartConfig::mem_initial_mib`
+    /// from the template when `mvmctl up` doesn't override it on the
+    /// CLI or via `--config`. Backward-compat: missing field
+    /// deserialises to `None` for templates that predate the schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mem_initial_mib: Option<u32>,
     pub data_disk_mib: u32,
     pub created_at: String,
     pub updated_at: String,
@@ -420,6 +428,7 @@ mod tests {
             role: "agent".to_string(),
             vcpus: 2,
             mem_mib: 1024,
+            mem_initial_mib: None,
             data_disk_mib: 0,
             created_at: "2025-01-01T00:00:00Z".to_string(),
             updated_at: "2025-01-01T00:00:00Z".to_string(),

--- a/crates/mvm-core/src/policy/network_policy.rs
+++ b/crates/mvm-core/src/policy/network_policy.rs
@@ -360,8 +360,24 @@ impl NetworkPolicy {
 }
 
 impl Default for NetworkPolicy {
+    /// Deny-all is the safe default.
+    ///
+    /// Pre-Sprint 52, `Default` returned `unrestricted()`. The old
+    /// posture contradicted the rest of the ADR-002 security model
+    /// (claims 1–9 confine the guest at every other layer; an
+    /// unrestricted egress default undermined the claim that
+    /// untrusted code can't reach arbitrary network destinations).
+    /// Sprint 52 flipped the default to `deny_all` so the safe
+    /// posture is the one workloads get without opting in.
+    ///
+    /// Migration shape: `mvmctl up` callers who relied on the old
+    /// default get a warning if they explicitly pass
+    /// `--network-preset unrestricted`. Template authors who want
+    /// open egress declare it in the template's
+    /// `default_network_policy`. The escape hatch is named, never
+    /// silent.
     fn default() -> Self {
-        Self::unrestricted()
+        Self::deny_all()
     }
 }
 
@@ -593,8 +609,19 @@ mod tests {
     }
 
     #[test]
-    fn policy_default_is_unrestricted() {
-        assert!(NetworkPolicy::default().is_unrestricted());
+    fn policy_default_is_deny_all() {
+        // ADR-002 claim 10: the safe default is deny-all. Workloads
+        // that need network access opt in explicitly via
+        // `--network-preset` or a template's
+        // `default_network_policy`. The escape hatch is
+        // `--network-preset unrestricted`, which mvmctl warns about
+        // at launch.
+        let default = NetworkPolicy::default();
+        assert!(!default.is_unrestricted());
+        let rules = default
+            .resolve_rules()
+            .expect("default resolves to a concrete rule set");
+        assert!(rules.is_empty(), "deny-all should yield no allow rules");
     }
 
     #[test]

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -52,8 +52,21 @@ pub struct VmStartConfig {
     pub profile: Option<String>,
     /// Number of vCPUs.
     pub cpus: u32,
-    /// Memory in MiB.
+    /// Memory cap in MiB. The guest may not allocate beyond this. When
+    /// [`mem_initial_mib`](Self::mem_initial_mib) is `None`, this is
+    /// also the host-committed amount at boot (the historical mvm
+    /// shape). When `mem_initial_mib` is `Some`, this becomes a cap
+    /// rather than a commitment — see that field's docs.
     pub memory_mib: u32,
+    /// Optional initial host commitment in MiB, opting the workload
+    /// into virtio-balloon elasticity. When `Some(n)`, the backend
+    /// creates a virtio-balloon device pre-inflated to
+    /// `memory_mib - n` MiB so the host only commits `n` MiB at boot;
+    /// the host-side reclaim controller adjusts the balloon over the
+    /// VM's life. Must satisfy `0 < n <= memory_mib`. When `None`,
+    /// no balloon is attached and the full `memory_mib` is committed
+    /// at boot (backward-compatible default).
+    pub mem_initial_mib: Option<u32>,
     /// Declared port mappings (host:guest) for forwarding and guest config.
     pub ports: Vec<VmPortMapping>,
     /// Extra volumes to mount in the guest.
@@ -289,6 +302,35 @@ pub struct VmCapabilities {
     pub vsock: bool,
     /// Supports TAP-based networking (Firecracker/Docker: yes, WASM: no).
     pub tap_networking: bool,
+    /// Supports a virtio-balloon device with runtime inflate/deflate.
+    /// When `true`, [`VmBackend::balloon_set_target`] is wired and the
+    /// host-side reclaim controller can adjust guest commitment
+    /// without rebooting the VM. cgroup-style memory limiting (Docker)
+    /// is **not** a balloon and stays `false`.
+    pub balloon: bool,
+}
+
+/// Snapshot of a VM's virtio-balloon state, returned by
+/// [`VmBackend::balloon_state`].
+///
+/// All values are in MiB. The reclaim controller compares
+/// `host_committed_mib` against host memory pressure to decide
+/// whether to call [`VmBackend::balloon_set_target`] up or down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BalloonState {
+    /// The cap declared by the workload — equal to
+    /// `VmStartConfig::memory_mib` at boot. Useful as the upper bound
+    /// for `inflated_mib` (the balloon cannot inflate past this).
+    pub max_mib: u32,
+    /// Current balloon inflation, i.e. memory the guest has handed
+    /// back to the host. Increases under host pressure; decreases
+    /// when the guest needs the pages.
+    pub inflated_mib: u32,
+    /// Effective host commitment after subtracting the balloon —
+    /// `max_mib - inflated_mib`. Tracked separately because some
+    /// VMMs report it directly and the subtraction may not be
+    /// perfectly exact across the wire.
+    pub host_committed_mib: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -576,6 +618,39 @@ pub trait VmBackend: Send + Sync {
         anyhow::bail!("{} does not provide guest channel info", self.name())
     }
 
+    /// Set the virtio-balloon inflation target (in MiB).
+    ///
+    /// `target_inflate_mib` is the number of MiB the guest should
+    /// hand back to the host. `0` deflates the balloon completely;
+    /// `VmStartConfig::memory_mib` would (in principle) reclaim
+    /// everything but is rejected by sensible backends since the
+    /// guest needs *some* memory to function.
+    ///
+    /// Only meaningful when [`VmCapabilities::balloon`] is `true`
+    /// **and** the VM was started with `VmStartConfig::mem_initial_mib`
+    /// set — otherwise the backend never created a balloon device and
+    /// this call has nothing to operate on.
+    ///
+    /// The default impl bails so backends that don't support balloon
+    /// surface a clear error to the reclaim controller.
+    fn balloon_set_target(&self, _id: &VmId, _target_inflate_mib: u32) -> Result<()> {
+        anyhow::bail!(
+            "{}: virtio-balloon is not supported by this backend",
+            self.name()
+        )
+    }
+
+    /// Read the current balloon state of a VM.
+    ///
+    /// Same support contract as
+    /// [`balloon_set_target`](Self::balloon_set_target).
+    fn balloon_state(&self, _id: &VmId) -> Result<BalloonState> {
+        anyhow::bail!(
+            "{}: virtio-balloon is not supported by this backend",
+            self.name()
+        )
+    }
+
     /// Return the ADR-002 security profile for this backend.
     ///
     /// Each backend declares which of the seven CI-enforced claims hold,
@@ -654,6 +729,19 @@ mod tests {
         assert!(!caps.snapshots);
         assert!(!caps.vsock);
         assert!(!caps.tap_networking);
+        assert!(!caps.balloon);
+    }
+
+    #[test]
+    fn test_balloon_state_serde_roundtrip() {
+        let s = BalloonState {
+            max_mib: 2048,
+            inflated_mib: 512,
+            host_committed_mib: 1536,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let parsed: BalloonState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, s);
     }
 
     #[test]
@@ -705,6 +793,9 @@ mod tests {
         assert!(config.initrd_path.is_none());
         assert_eq!(config.cpus, 0);
         assert_eq!(config.memory_mib, 0);
+        // Default opts out of balloon — preserves the historical
+        // "memory_mib is committed at boot" contract.
+        assert!(config.mem_initial_mib.is_none());
         assert!(config.ports.is_empty());
         assert!(config.volumes.is_empty());
         assert!(config.config_files.is_empty());

--- a/crates/mvm-plan/Cargo.toml
+++ b/crates/mvm-plan/Cargo.toml
@@ -9,15 +9,20 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
+anyhow.workspace = true
+base64.workspace = true
 mvm-core.workspace = true
 chrono.workspace = true
 ed25519-dalek.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
+tar = "0.4"
 thiserror = "1"
 
 [dev-dependencies]
 rand.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/mvm-plan/src/bundle.rs
+++ b/crates/mvm-plan/src/bundle.rs
@@ -1,0 +1,1176 @@
+//! Portable image bundle (`.mvmpkg`) — content-addressed, signed
+//! archive of the artifacts needed to launch one microVM workload.
+//!
+//! ## Trust model (sigstore/cosign-style)
+//!
+//! A bundle ships a `manifest.json` listing every artifact + its
+//! SHA-256, plus a detached `manifest.sig` over the canonical
+//! manifest bytes. The signature is checked against a publisher
+//! pubkey looked up *out of band* — concretely, from
+//! `~/.mvm/trusted-publishers/<key_id>.pub` on the consumer. The
+//! pubkey **never lives inside the bundle**; an attacker swapping
+//! the bundle's `key_id` cannot make the bundle verify because the
+//! consumer won't have that key_id in its trust store.
+//!
+//! `key_id` is content-derived from the publisher pubkey
+//! (`sha256(pubkey_bytes)`, truncated to 32 hex chars). Truncation
+//! is cosmetic: collisions in the truncated form still demand a
+//! full Ed25519 key collision to subvert verification. The full
+//! pubkey is what the verifier checks against.
+//!
+//! ## Verification flow
+//!
+//! 1. Read `manifest.json` + `manifest.sig` from the archive.
+//! 2. Look up `<key_id>.pub` in the consumer's trust store.
+//!    *Unknown `key_id` → reject before reading any artifact bytes.*
+//! 3. Ed25519-verify the signature over the canonical manifest
+//!    bytes. *Mismatch → reject.*
+//! 4. For each artifact, re-hash its bytes and compare against the
+//!    SHA-256 declared in the signed manifest. *Mismatch → reject.*
+//! 5. dm-verity (ADR-002 §W3) gives independent per-block integrity
+//!    inside the rootfs at boot — the bundle layer covers tamper
+//!    detection at extract time.
+//!
+//! ## What lives in the bundle archive
+//!
+//! ```text
+//! bundle.mvmpkg (tar)
+//! ├── manifest.json       # canonical JSON, BundleManifest
+//! ├── manifest.sig        # 64 raw Ed25519 signature bytes
+//! └── artifacts/
+//!     ├── vmlinux         # kernel
+//!     ├── rootfs.ext4     # root filesystem
+//!     ├── rootfs.verity   # optional dm-verity sidecar (W3)
+//!     ├── fc_base_config.json
+//!     └── initrd          # optional NixOS stage-1
+//! ```
+//!
+//! The archive layout is plain tar (no gzip) because the rootfs and
+//! kernel are already binary blobs that compress poorly; gzip would
+//! buy little and add a transitive dep. A future `.mvmpkg.gz`
+//! wrapper can layer on if size becomes a real concern.
+
+use std::collections::BTreeMap;
+use std::io::{Cursor, Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Highest bundle-manifest schema version this build understands.
+/// Verifiers fail closed on a future bump rather than silently
+/// dropping fields they don't know about.
+pub const BUNDLE_SCHEMA_VERSION: u32 = 1;
+
+/// Filename inside the archive for the canonical-JSON manifest.
+pub const MANIFEST_FILENAME: &str = "manifest.json";
+
+/// Filename inside the archive for the detached Ed25519 signature.
+/// 64 raw bytes — no header, no encoding.
+pub const SIGNATURE_FILENAME: &str = "manifest.sig";
+
+/// Directory inside the archive that holds the actual artifact
+/// bytes (kernel, rootfs, verity sidecar, ...).
+pub const ARTIFACTS_DIR: &str = "artifacts";
+
+/// Content-derived identifier for a publisher's Ed25519 key. Equals
+/// `sha256(pubkey_bytes)` truncated to 32 hex characters.
+///
+/// `key_id` is the lookup token a consumer uses to find the matching
+/// pubkey in its trust store. It is **not a substitute for the
+/// pubkey itself**: verification always uses the full key loaded
+/// from `~/.mvm/trusted-publishers/<key_id>.pub`. Truncation is for
+/// filesystem readability, not cryptographic strength.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct KeyId(pub String);
+
+impl KeyId {
+    /// Derive the key_id from a verifying-key's bytes.
+    pub fn from_pubkey(pk: &VerifyingKey) -> Self {
+        let bytes = pk.to_bytes();
+        let digest = Sha256::digest(bytes);
+        let hex = format!("{digest:x}");
+        Self(hex[..32].to_string())
+    }
+
+    /// Validation: 32 lowercase hex characters. Anything else
+    /// indicates a tampered or malformed manifest.
+    pub fn is_well_formed(&self) -> bool {
+        self.0.len() == 32
+            && self
+                .0
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+    }
+}
+
+/// Role of an artifact inside a bundle. Verifiers + launchers use
+/// this to find the kernel, rootfs, verity sidecar, etc. without
+/// pinning to specific filenames.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactRole {
+    /// Linux kernel image (`vmlinux`).
+    Kernel,
+    /// Root filesystem block image (ext4 or squashfs).
+    Rootfs,
+    /// dm-verity Merkle-hash sidecar paired with `Rootfs`. ADR-002 §W3.
+    VerityHashSidecar,
+    /// Firecracker base VM config JSON.
+    FirecrackerBaseConfig,
+    /// Initial ramdisk (NixOS stage-1 or similar).
+    Initrd,
+    /// Catch-all for backend-specific extras. The role consumer
+    /// must inspect `name` to know what it's looking at.
+    Other,
+}
+
+/// One file inside the bundle. The `path` is relative to the
+/// archive root (e.g. `artifacts/vmlinux`). `sha256` is the
+/// lowercase-hex digest of the file bytes — verifiers re-hash at
+/// extract time and reject on mismatch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BundleArtifact {
+    pub name: String,
+    pub role: ArtifactRole,
+    /// Archive-relative path, forward-slash separated. The verifier
+    /// rejects absolute paths, `..` traversal, and `\` separators.
+    pub path: String,
+    /// Lowercase hex SHA-256 of the file bytes.
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+/// dm-verity binding for the rootfs. Present when the workload was
+/// built with `verifiedBoot = true` (ADR-002 §W3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VerityInfo {
+    /// 64-char lowercase-hex Merkle-tree root hash. Baked into the
+    /// kernel cmdline as `dm-mod.create=`.
+    pub roothash: String,
+    /// `name` of the `VerityHashSidecar` artifact inside this
+    /// bundle. Verifier matches on `name`, not `path`, so a later
+    /// re-layout of the archive doesn't break the binding.
+    pub sidecar_artifact: String,
+}
+
+/// Top-level signed bundle manifest. Serialised as canonical JSON
+/// (via `serde_json::to_vec`); the signed bytes are exactly those.
+///
+/// `deny_unknown_fields` keeps the wire format strict: a future
+/// field added in v2 will fail to parse in a v1 verifier. The
+/// `schema_version` sniff happens *after* signature check (same
+/// pattern as `ExecutionPlan`), so an attacker who flips
+/// `schema_version` doesn't slip in a v2 plan past a v1 build.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BundleManifest {
+    pub schema_version: u32,
+    /// Human-readable name for the publisher (not authoritative —
+    /// trust derives from `key_id` lookup, not from this string).
+    pub publisher: String,
+    /// Lookup token for the publisher's Ed25519 pubkey. The full
+    /// pubkey lives at `~/.mvm/trusted-publishers/<key_id>.pub` on
+    /// the consumer side.
+    pub key_id: KeyId,
+    /// Target architecture (`x86_64`, `aarch64`). Verifiers refuse
+    /// to launch a bundle whose arch doesn't match the host.
+    pub arch: String,
+    /// Optional kernel version string, e.g. `6.6.39`. Surfaced in
+    /// `mvmctl bundle inspect` and `mvmctl doctor`; not authoritative.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kernel_version: Option<String>,
+    /// Optional flake profile name the bundle was built for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    /// Optional human-readable workload label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workload_label: Option<String>,
+    /// ISO-8601 timestamp the bundle was sealed at.
+    pub created_at: String,
+    /// Free-form metadata key/value pairs. Reserved for publisher
+    /// annotations; verifiers must not interpret these.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
+    /// Every artifact inside the archive. Order is preserved in the
+    /// JSON for determinism; consumers find artifacts by `role` or
+    /// `name`, not by index.
+    pub artifacts: Vec<BundleArtifact>,
+    /// dm-verity binding, when the rootfs was built verified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verity: Option<VerityInfo>,
+}
+
+impl BundleManifest {
+    /// Find an artifact by role. Returns the first match — manifests
+    /// shouldn't carry two artifacts with the same role, but the
+    /// schema doesn't enforce uniqueness so consumers should treat
+    /// duplicates as undefined.
+    pub fn find_by_role(&self, role: &ArtifactRole) -> Option<&BundleArtifact> {
+        self.artifacts.iter().find(|a| &a.role == role)
+    }
+
+    /// Find an artifact by exact name.
+    pub fn find_by_name(&self, name: &str) -> Option<&BundleArtifact> {
+        self.artifacts.iter().find(|a| a.name == name)
+    }
+
+    /// Canonical JSON bytes used as the signing input. Pure function;
+    /// the same bytes round-trip from sign → verify.
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>> {
+        serde_json::to_vec(self).context("serialise BundleManifest to canonical JSON")
+    }
+}
+
+/// Compute lowercase-hex SHA-256 of arbitrary bytes. Mirrors the
+/// hex-digest pattern used in `mvm-core::manifest::canonical_key_for_path`.
+pub fn sha256_hex(data: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(data))
+}
+
+/// Pin from an `ExecutionPlan` to a specific signed bundle. Captures
+/// the three quantities the supervisor needs to re-verify on admit:
+///
+/// 1. **`bundle_sha256`** — SHA-256 of the entire archive bytes. The
+///    plan's pin is "I authorise launching this exact byte string."
+/// 2. **`manifest_sig_base64`** — the publisher's signature over the
+///    bundle's manifest. Held in the plan so the verifier can refuse
+///    the launch without trusting whatever copy of the manifest the
+///    archive on disk contains.
+/// 3. **`key_id`** — the publisher's key_id. Lets admission reject
+///    plans whose pinning publisher isn't in the local trust store
+///    *before* opening the archive.
+///
+/// `serde(deny_unknown_fields)` keeps the wire format strict — a
+/// future field added in v2 fails closed in older builds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlanArtifact {
+    /// Lowercase-hex SHA-256 of the entire `.mvmpkg` archive.
+    pub bundle_sha256: String,
+    /// Base64-encoded 64-byte Ed25519 signature over the bundle's
+    /// `manifest.json` bytes. Use [`signature_from_base64`] to decode.
+    pub manifest_sig_base64: String,
+    /// Publisher key_id the bundle was signed under.
+    pub key_id: KeyId,
+}
+
+impl PlanArtifact {
+    /// Construct from raw signature bytes + bundle hash + key_id.
+    pub fn new(bundle_sha256: String, sig: &[u8; 64], key_id: KeyId) -> Self {
+        Self {
+            bundle_sha256,
+            manifest_sig_base64: signature_to_base64(sig),
+            key_id,
+        }
+    }
+
+    /// Decode the base64-encoded signature back to raw bytes.
+    /// Returns `None` when the field is malformed.
+    pub fn signature_bytes(&self) -> Option<[u8; 64]> {
+        signature_from_base64(&self.manifest_sig_base64)
+    }
+}
+
+/// Errors that can fall out of bundle verification.
+///
+/// Each variant carries enough detail to debug a specific failure
+/// without exposing artifact bytes to log sinks.
+#[derive(Debug, Error)]
+pub enum BundleVerifyError {
+    #[error("trust store has no entry for key_id {key_id}")]
+    UnknownKey { key_id: String },
+
+    #[error("publisher key file at {path} is malformed: {reason}")]
+    MalformedPubkey { path: PathBuf, reason: String },
+
+    #[error("signature does not verify under trusted key {key_id}: {reason}")]
+    SignatureInvalid { key_id: String, reason: String },
+
+    #[error("schema version {found} is newer than this build supports ({supported})")]
+    UnsupportedSchema { found: u32, supported: u32 },
+
+    #[error("manifest JSON parse failed: {0}")]
+    ManifestParse(String),
+
+    #[error("manifest declares key_id {declared} but trust store entry is for {actual}")]
+    KeyIdMismatch { declared: String, actual: String },
+
+    #[error("artifact {name} sha256 mismatch: manifest says {declared}, actual {actual}")]
+    ArtifactSha256Mismatch {
+        name: String,
+        declared: String,
+        actual: String,
+    },
+
+    #[error("artifact {name} size mismatch: manifest says {declared}, actual {actual}")]
+    ArtifactSizeMismatch {
+        name: String,
+        declared: u64,
+        actual: u64,
+    },
+
+    #[error(
+        "archive entry path is unsafe: {path:?} (absolute paths, `..` traversal, and \
+         backslash separators are rejected)"
+    )]
+    UnsafePath { path: String },
+
+    #[error("manifest references artifact {name} but it is missing from the archive")]
+    ArtifactMissing { name: String },
+
+    #[error("signature blob is the wrong size: expected 64 bytes, got {got}")]
+    MalformedSignature { got: usize },
+}
+
+/// Validate that an archive-relative path is safe to extract: no
+/// absolute roots, no `..` traversal, no backslash separators.
+///
+/// Returns `Ok(())` if safe; `BundleVerifyError::UnsafePath`
+/// otherwise. Surfaced as a free function so the archive reader and
+/// the manifest validator both apply the same rule.
+pub fn ensure_safe_path(path: &str) -> Result<(), BundleVerifyError> {
+    if path.is_empty()
+        || path.starts_with('/')
+        || path.contains('\\')
+        || path.split('/').any(|seg| seg == ".." || seg == ".")
+    {
+        return Err(BundleVerifyError::UnsafePath {
+            path: path.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Build a sealed bundle archive from manifest + artifact byte blobs.
+///
+/// The caller supplies the manifest (already populated with per-
+/// artifact sha256s and sizes) and an iterator yielding
+/// `(archive_relative_path, bytes)` pairs for each artifact. The
+/// manifest is signed inside this function so the signature lines up
+/// exactly with the canonical bytes that get written.
+///
+/// Returns the full archive bytes as a `Vec<u8>` — the caller is
+/// responsible for writing them out. In-memory representation
+/// matches the on-disk archive byte-for-byte.
+pub fn write_bundle(
+    manifest: &BundleManifest,
+    signing_key: &SigningKey,
+    mut artifacts: Vec<(String, Vec<u8>)>,
+) -> Result<Vec<u8>> {
+    // Defensive: the manifest must declare the same key_id the
+    // signing key would derive. Mismatch is a publisher bug, not a
+    // verifier concern, but catching it at write-time stops bad
+    // bundles from ever leaving the build host.
+    let derived = KeyId::from_pubkey(&signing_key.verifying_key());
+    anyhow::ensure!(
+        manifest.key_id == derived,
+        "manifest key_id ({}) does not match signing key derivation ({})",
+        manifest.key_id.0,
+        derived.0
+    );
+
+    // Same defensive check for declared sha256 vs actual bytes.
+    for (path, bytes) in &artifacts {
+        let art = manifest
+            .artifacts
+            .iter()
+            .find(|a| a.path == *path)
+            .with_context(|| {
+                format!("archive contains {path:?} not declared in manifest.artifacts")
+            })?;
+        let actual = sha256_hex(bytes);
+        anyhow::ensure!(
+            art.sha256 == actual,
+            "artifact {} sha256 mismatch at write time: manifest {}, actual {}",
+            art.name,
+            art.sha256,
+            actual,
+        );
+        anyhow::ensure!(
+            art.size_bytes == bytes.len() as u64,
+            "artifact {} size mismatch at write time: manifest {}, actual {}",
+            art.name,
+            art.size_bytes,
+            bytes.len(),
+        );
+        ensure_safe_path(path).context("artifact path validation")?;
+    }
+
+    let manifest_bytes = manifest.canonical_bytes()?;
+    let sig: Signature = signing_key.sign(&manifest_bytes);
+    let sig_bytes = sig.to_bytes();
+
+    let mut tar_buf = Cursor::new(Vec::<u8>::new());
+    {
+        let mut tar = tar::Builder::new(&mut tar_buf);
+
+        // manifest.json first so a partial-read consumer can find it
+        // without scanning the whole archive.
+        append_bytes(&mut tar, MANIFEST_FILENAME, &manifest_bytes)?;
+        append_bytes(&mut tar, SIGNATURE_FILENAME, &sig_bytes)?;
+
+        // Artifacts in manifest order — deterministic output.
+        artifacts.sort_by(|(a, _), (b, _)| a.cmp(b));
+        for (path, bytes) in &artifacts {
+            append_bytes(&mut tar, path, bytes)?;
+        }
+        tar.finish().context("finalise tar archive")?;
+    }
+
+    Ok(tar_buf.into_inner())
+}
+
+fn append_bytes<W: Write>(tar: &mut tar::Builder<W>, path: &str, bytes: &[u8]) -> Result<()> {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    tar.append_data(&mut header, path, Cursor::new(bytes))
+        .with_context(|| format!("write tar entry {path:?}"))
+}
+
+/// Lookup interface for finding a publisher's verifying key by `key_id`.
+///
+/// Production impl reads `~/.mvm/trusted-publishers/<key_id>.pub`;
+/// tests inject an in-memory map. Kept narrow so the verifier
+/// doesn't grow a filesystem dependency.
+pub trait TrustStore {
+    /// Return the verifying key for `key_id`, or `None` if the
+    /// consumer has not enrolled this publisher.
+    fn lookup(&self, key_id: &KeyId) -> Option<VerifyingKey>;
+}
+
+/// Filesystem-backed trust store rooted at `~/.mvm/trusted-publishers/`
+/// (or any directory). Pubkey files are named `<key_id>.pub` and
+/// hold the 32 raw Ed25519 public-key bytes (no PEM, no headers).
+///
+/// Production consumers populate this via `mvmctl trust add`
+/// (shipped in a follow-up). For now the format is documented here
+/// so out-of-band enrolment via plain file copy works too.
+pub struct FsTrustStore {
+    root: PathBuf,
+}
+
+impl FsTrustStore {
+    /// Construct rooted at `dir`.
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        Self { root: dir.into() }
+    }
+
+    /// Default path: `~/.mvm/trusted-publishers/`. Errors when
+    /// `$HOME` is unset.
+    pub fn default_path() -> Result<Self> {
+        let home = std::env::var_os("HOME")
+            .ok_or_else(|| anyhow::anyhow!("$HOME is not set; cannot resolve trust store"))?;
+        let p = PathBuf::from(home).join(".mvm").join("trusted-publishers");
+        Ok(Self::new(p))
+    }
+
+    /// Underlying directory.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl TrustStore for FsTrustStore {
+    fn lookup(&self, key_id: &KeyId) -> Option<VerifyingKey> {
+        if !key_id.is_well_formed() {
+            return None;
+        }
+        let path = self.root.join(format!("{}.pub", key_id.0));
+        let bytes = std::fs::read(&path).ok()?;
+        let arr: [u8; 32] = bytes.as_slice().try_into().ok()?;
+        VerifyingKey::from_bytes(&arr).ok()
+    }
+}
+
+/// Verified bundle handle: the parsed manifest, the bytes for each
+/// artifact, and the `key_id` that signed it.
+///
+/// Returned by [`read_and_verify_bundle`]. Holding this value is
+/// proof the signature checked and every artifact's hash matched
+/// the manifest — consumers can use the contents directly without
+/// re-verifying.
+#[derive(Debug)]
+pub struct VerifiedBundle {
+    pub manifest: BundleManifest,
+    pub artifacts: BTreeMap<String, Vec<u8>>,
+    pub key_id: KeyId,
+}
+
+/// Read a bundle archive, look the publisher up in the trust store,
+/// verify the signature, then re-hash every artifact against the
+/// signed manifest. Returns a [`VerifiedBundle`] on success.
+///
+/// All four failure modes ([`BundleVerifyError::UnknownKey`],
+/// `SignatureInvalid`, `ArtifactSha256Mismatch`, `UnsafePath`)
+/// reject *before* the artifact bytes are exposed to anything
+/// outside this function's local scope. The bytes ARE held in
+/// memory during the size+hash pass; production callers that need
+/// streaming verification of multi-GiB rootfs files will want a
+/// chunked extractor (Phase 2).
+pub fn read_and_verify_bundle(
+    archive_bytes: &[u8],
+    trust_store: &dyn TrustStore,
+) -> Result<VerifiedBundle, BundleVerifyError> {
+    // Pass 1: pull every entry into memory. Bundles for v1 are
+    // modest in size (≤ a few hundred MiB); a chunked impl can come
+    // when that stops being true.
+    let mut entries: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    let mut archive = tar::Archive::new(Cursor::new(archive_bytes));
+    for entry in archive
+        .entries()
+        .map_err(|e| BundleVerifyError::ManifestParse(format!("tar entries() failed: {e}")))?
+    {
+        let mut entry =
+            entry.map_err(|e| BundleVerifyError::ManifestParse(format!("tar entry read: {e}")))?;
+        let path = entry
+            .path()
+            .map_err(|e| BundleVerifyError::ManifestParse(format!("tar entry path: {e}")))?
+            .to_string_lossy()
+            .into_owned();
+        ensure_safe_path(&path)?;
+        let mut buf = Vec::new();
+        entry
+            .read_to_end(&mut buf)
+            .map_err(|e| BundleVerifyError::ManifestParse(format!("tar entry body read: {e}")))?;
+        entries.insert(path, buf);
+    }
+
+    let manifest_bytes = entries
+        .get(MANIFEST_FILENAME)
+        .ok_or_else(|| BundleVerifyError::ManifestParse(format!("{MANIFEST_FILENAME} missing")))?
+        .clone();
+    let sig_bytes = entries
+        .get(SIGNATURE_FILENAME)
+        .ok_or_else(|| BundleVerifyError::ManifestParse(format!("{SIGNATURE_FILENAME} missing")))?
+        .clone();
+
+    // ----- Step 1: schema version sniff (pre-signature) -----
+    //
+    // We deliberately read schema_version *before* checking the
+    // signature. If a v2 bundle ever shows up, an older verifier
+    // should refuse with UnsupportedSchema, not parse-fail with a
+    // misleading deny_unknown_fields error. The signature check
+    // still happens before we expose any parsed plan-level fields.
+    #[derive(Deserialize)]
+    struct SchemaProbe {
+        schema_version: u32,
+    }
+    let probe: SchemaProbe = serde_json::from_slice(&manifest_bytes).map_err(|e| {
+        BundleVerifyError::ManifestParse(format!("schema_version probe failed: {e}"))
+    })?;
+    if probe.schema_version > BUNDLE_SCHEMA_VERSION {
+        return Err(BundleVerifyError::UnsupportedSchema {
+            found: probe.schema_version,
+            supported: BUNDLE_SCHEMA_VERSION,
+        });
+    }
+
+    // ----- Step 2: pull key_id (still pre-signature) -----
+    #[derive(Deserialize)]
+    struct KeyIdProbe {
+        key_id: KeyId,
+    }
+    let key_probe: KeyIdProbe = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| BundleVerifyError::ManifestParse(format!("key_id probe failed: {e}")))?;
+    let declared_key_id = key_probe.key_id;
+
+    // ----- Step 3: trust-store lookup -----
+    let pubkey =
+        trust_store
+            .lookup(&declared_key_id)
+            .ok_or_else(|| BundleVerifyError::UnknownKey {
+                key_id: declared_key_id.0.clone(),
+            })?;
+
+    // Defensive: confirm the pubkey we got back actually derives to
+    // the declared key_id. Defends against a misnamed file in the
+    // trust store; the trust-store file naming convention is the
+    // verifier's only link from declared id to actual key.
+    let actual_id = KeyId::from_pubkey(&pubkey);
+    if actual_id != declared_key_id {
+        return Err(BundleVerifyError::KeyIdMismatch {
+            declared: declared_key_id.0,
+            actual: actual_id.0,
+        });
+    }
+
+    // ----- Step 4: signature check -----
+    if sig_bytes.len() != 64 {
+        return Err(BundleVerifyError::MalformedSignature {
+            got: sig_bytes.len(),
+        });
+    }
+    let sig_arr: [u8; 64] = sig_bytes.as_slice().try_into().expect("checked above");
+    let signature = Signature::from_bytes(&sig_arr);
+    pubkey.verify(&manifest_bytes, &signature).map_err(|e| {
+        BundleVerifyError::SignatureInvalid {
+            key_id: declared_key_id.0.clone(),
+            reason: e.to_string(),
+        }
+    })?;
+
+    // ----- Step 5: full manifest parse, now that the bytes are
+    // proven authentic -----
+    let manifest: BundleManifest = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| BundleVerifyError::ManifestParse(e.to_string()))?;
+
+    // ----- Step 6: per-artifact hash + size check -----
+    let mut artifacts_out: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    for art in &manifest.artifacts {
+        ensure_safe_path(&art.path)?;
+        let bytes = entries
+            .get(&art.path)
+            .ok_or_else(|| BundleVerifyError::ArtifactMissing {
+                name: art.name.clone(),
+            })?;
+        let actual_size = bytes.len() as u64;
+        if actual_size != art.size_bytes {
+            return Err(BundleVerifyError::ArtifactSizeMismatch {
+                name: art.name.clone(),
+                declared: art.size_bytes,
+                actual: actual_size,
+            });
+        }
+        let actual_sha = sha256_hex(bytes);
+        if actual_sha != art.sha256 {
+            return Err(BundleVerifyError::ArtifactSha256Mismatch {
+                name: art.name.clone(),
+                declared: art.sha256.clone(),
+                actual: actual_sha,
+            });
+        }
+        artifacts_out.insert(art.path.clone(), bytes.clone());
+    }
+
+    Ok(VerifiedBundle {
+        manifest,
+        artifacts: artifacts_out,
+        key_id: declared_key_id,
+    })
+}
+
+/// Convenience: SHA-256 of the entire archive bytes, encoded as
+/// lowercase hex. The `bundle_sha256` field on
+/// [`crate::types::PlanArtifact`] holds this exact value, so an
+/// `ExecutionPlan` can pin a specific bundle without trusting any
+/// publisher metadata.
+pub fn bundle_sha256(archive_bytes: &[u8]) -> String {
+    sha256_hex(archive_bytes)
+}
+
+/// Base64-encode a signature for transport on a JSON wire (e.g.
+/// inside an `ExecutionPlan`). Round-trips via [`signature_from_base64`].
+pub fn signature_to_base64(sig: &[u8; 64]) -> String {
+    B64.encode(sig)
+}
+
+/// Inverse of [`signature_to_base64`]. Returns `None` for malformed
+/// input; the verifier surfaces this as `MalformedSignature`.
+pub fn signature_from_base64(s: &str) -> Option<[u8; 64]> {
+    let bytes = B64.decode(s).ok()?;
+    bytes.as_slice().try_into().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+    use std::collections::HashMap;
+
+    /// In-memory trust store for tests. Production uses
+    /// [`FsTrustStore`]; the trait split keeps the verifier free of
+    /// filesystem I/O when exercised in unit tests.
+    struct MapTrustStore(HashMap<KeyId, VerifyingKey>);
+    impl TrustStore for MapTrustStore {
+        fn lookup(&self, key_id: &KeyId) -> Option<VerifyingKey> {
+            self.0.get(key_id).copied()
+        }
+    }
+
+    fn fresh_key() -> SigningKey {
+        SigningKey::generate(&mut OsRng)
+    }
+
+    fn make_manifest(key_id: KeyId, artifacts: Vec<BundleArtifact>) -> BundleManifest {
+        BundleManifest {
+            schema_version: BUNDLE_SCHEMA_VERSION,
+            publisher: "test-publisher".to_string(),
+            key_id,
+            arch: "aarch64".to_string(),
+            kernel_version: Some("6.6.0".to_string()),
+            profile: Some("worker".to_string()),
+            workload_label: None,
+            created_at: "2026-05-12T00:00:00Z".to_string(),
+            labels: BTreeMap::new(),
+            artifacts,
+            verity: None,
+        }
+    }
+
+    fn art(name: &str, role: ArtifactRole, path: &str, bytes: &[u8]) -> BundleArtifact {
+        BundleArtifact {
+            name: name.to_string(),
+            role,
+            path: path.to_string(),
+            sha256: sha256_hex(bytes),
+            size_bytes: bytes.len() as u64,
+        }
+    }
+
+    fn build_bundle(sk: &SigningKey, kernel: &[u8], rootfs: &[u8]) -> Vec<u8> {
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        let manifest = make_manifest(
+            key_id,
+            vec![
+                art("vmlinux", ArtifactRole::Kernel, "artifacts/vmlinux", kernel),
+                art(
+                    "rootfs.ext4",
+                    ArtifactRole::Rootfs,
+                    "artifacts/rootfs.ext4",
+                    rootfs,
+                ),
+            ],
+        );
+        write_bundle(
+            &manifest,
+            sk,
+            vec![
+                ("artifacts/vmlinux".to_string(), kernel.to_vec()),
+                ("artifacts/rootfs.ext4".to_string(), rootfs.to_vec()),
+            ],
+        )
+        .expect("write_bundle should succeed")
+    }
+
+    fn trust(sk: &SigningKey) -> MapTrustStore {
+        let mut m = HashMap::new();
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        m.insert(key_id, sk.verifying_key());
+        MapTrustStore(m)
+    }
+
+    #[test]
+    fn key_id_is_32_hex_chars() {
+        let sk = fresh_key();
+        let id = KeyId::from_pubkey(&sk.verifying_key());
+        assert_eq!(id.0.len(), 32);
+        assert!(id.is_well_formed());
+    }
+
+    #[test]
+    fn well_formed_rejects_wrong_length_and_case() {
+        assert!(!KeyId("abc".to_string()).is_well_formed());
+        assert!(!KeyId("X".repeat(32)).is_well_formed());
+        assert!(!KeyId("g".repeat(32)).is_well_formed());
+    }
+
+    #[test]
+    fn round_trip_verifies_clean() {
+        let sk = fresh_key();
+        let bundle = build_bundle(&sk, b"kernel-bytes", b"rootfs-bytes");
+        let trust_store = trust(&sk);
+        let verified = read_and_verify_bundle(&bundle, &trust_store).expect("verifies");
+        assert_eq!(verified.manifest.publisher, "test-publisher");
+        assert_eq!(verified.manifest.artifacts.len(), 2);
+        assert_eq!(
+            verified.artifacts.get("artifacts/vmlinux").unwrap(),
+            b"kernel-bytes"
+        );
+        assert_eq!(
+            verified.artifacts.get("artifacts/rootfs.ext4").unwrap(),
+            b"rootfs-bytes"
+        );
+    }
+
+    #[test]
+    fn unknown_key_rejected_before_signature_work() {
+        let sk = fresh_key();
+        let bundle = build_bundle(&sk, b"k", b"r");
+        let empty = MapTrustStore(HashMap::new());
+        match read_and_verify_bundle(&bundle, &empty) {
+            Err(BundleVerifyError::UnknownKey { .. }) => {}
+            other => panic!("expected UnknownKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tampered_manifest_fails_signature() {
+        let sk = fresh_key();
+        let mut bundle = build_bundle(&sk, b"k", b"r");
+        // Flip a byte deep inside the archive — likely lands inside
+        // the manifest.json entry. Some randomly-flipped byte
+        // positions may instead invalidate the tar header itself,
+        // in which case `read_and_verify_bundle` will surface a
+        // ManifestParse error rather than SignatureInvalid; either
+        // outcome is a *rejection* (the test asserts that), which
+        // is the property that matters for the trust model.
+        bundle[200] ^= 0x01;
+        match read_and_verify_bundle(&bundle, &trust(&sk)) {
+            Err(BundleVerifyError::SignatureInvalid { .. })
+            | Err(BundleVerifyError::ManifestParse(_)) => {}
+            other => panic!("expected rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_key_in_trust_store_rejected_as_keyid_mismatch() {
+        // Publisher A signs the bundle; trust store has key A under
+        // the wrong key_id (matching key B). The KeyIdMismatch guard
+        // catches this before the signature check would succeed.
+        let sk_a = fresh_key();
+        let sk_b = fresh_key();
+        let bundle = build_bundle(&sk_a, b"k", b"r");
+        let mut m = HashMap::new();
+        let key_id_a = KeyId::from_pubkey(&sk_a.verifying_key());
+        m.insert(key_id_a, sk_b.verifying_key()); // wrong key under A's id
+        let bad_store = MapTrustStore(m);
+        match read_and_verify_bundle(&bundle, &bad_store) {
+            Err(BundleVerifyError::KeyIdMismatch { .. }) => {}
+            other => panic!("expected KeyIdMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tampered_artifact_fails_hash_check() {
+        // Sign cleanly, but post-sign rewrite the rootfs bytes by
+        // surgically constructing an archive whose manifest declares
+        // sha256(X) but whose `rootfs.ext4` entry contains Y.
+        let sk = fresh_key();
+        let kernel = b"kernel-bytes".to_vec();
+        let real_rootfs = b"rootfs-bytes".to_vec();
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        let manifest = make_manifest(
+            key_id,
+            vec![
+                art(
+                    "vmlinux",
+                    ArtifactRole::Kernel,
+                    "artifacts/vmlinux",
+                    &kernel,
+                ),
+                art(
+                    "rootfs.ext4",
+                    ArtifactRole::Rootfs,
+                    "artifacts/rootfs.ext4",
+                    &real_rootfs,
+                ),
+            ],
+        );
+        // Sign over the canonical manifest bytes.
+        let manifest_bytes = manifest.canonical_bytes().unwrap();
+        let sig = sk.sign(&manifest_bytes);
+
+        // Hand-roll the archive with a *different* rootfs body.
+        let mut buf = Cursor::new(Vec::<u8>::new());
+        {
+            let mut tar = tar::Builder::new(&mut buf);
+            append_bytes(&mut tar, MANIFEST_FILENAME, &manifest_bytes).unwrap();
+            append_bytes(&mut tar, SIGNATURE_FILENAME, &sig.to_bytes()).unwrap();
+            append_bytes(&mut tar, "artifacts/vmlinux", &kernel).unwrap();
+            // 12 bytes — same length as the real rootfs, so the
+            // size-check passes and the sha256 check is what
+            // catches the tamper.
+            append_bytes(&mut tar, "artifacts/rootfs.ext4", b"XXXXXXXXXXXX").unwrap();
+            tar.finish().unwrap();
+        }
+        let archive = buf.into_inner();
+        match read_and_verify_bundle(&archive, &trust(&sk)) {
+            Err(BundleVerifyError::ArtifactSha256Mismatch { name, .. }) => {
+                assert_eq!(name, "rootfs.ext4");
+            }
+            other => panic!("expected ArtifactSha256Mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_artifact_rejected() {
+        let sk = fresh_key();
+        let kernel = b"kernel-bytes".to_vec();
+        let rootfs = b"rootfs-bytes".to_vec();
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        let manifest = make_manifest(
+            key_id,
+            vec![
+                art(
+                    "vmlinux",
+                    ArtifactRole::Kernel,
+                    "artifacts/vmlinux",
+                    &kernel,
+                ),
+                art(
+                    "rootfs.ext4",
+                    ArtifactRole::Rootfs,
+                    "artifacts/rootfs.ext4",
+                    &rootfs,
+                ),
+            ],
+        );
+        let manifest_bytes = manifest.canonical_bytes().unwrap();
+        let sig = sk.sign(&manifest_bytes);
+
+        // Archive omits rootfs.ext4 — manifest still lists it.
+        let mut buf = Cursor::new(Vec::<u8>::new());
+        {
+            let mut tar = tar::Builder::new(&mut buf);
+            append_bytes(&mut tar, MANIFEST_FILENAME, &manifest_bytes).unwrap();
+            append_bytes(&mut tar, SIGNATURE_FILENAME, &sig.to_bytes()).unwrap();
+            append_bytes(&mut tar, "artifacts/vmlinux", &kernel).unwrap();
+            tar.finish().unwrap();
+        }
+        match read_and_verify_bundle(&buf.into_inner(), &trust(&sk)) {
+            Err(BundleVerifyError::ArtifactMissing { name }) => {
+                assert_eq!(name, "rootfs.ext4");
+            }
+            other => panic!("expected ArtifactMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unsafe_path_rejected_in_manifest() {
+        // The path validator runs both at write time and at read
+        // time. Build the archive by hand to exercise the read-time
+        // branch.
+        let sk = fresh_key();
+        let kernel = b"k".to_vec();
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        let manifest = make_manifest(
+            key_id,
+            vec![BundleArtifact {
+                name: "evil".to_string(),
+                role: ArtifactRole::Other,
+                path: "../etc/passwd".to_string(),
+                sha256: sha256_hex(&kernel),
+                size_bytes: kernel.len() as u64,
+            }],
+        );
+        let manifest_bytes = manifest.canonical_bytes().unwrap();
+        let sig = sk.sign(&manifest_bytes);
+
+        let mut buf = Cursor::new(Vec::<u8>::new());
+        {
+            let mut tar = tar::Builder::new(&mut buf);
+            append_bytes(&mut tar, MANIFEST_FILENAME, &manifest_bytes).unwrap();
+            append_bytes(&mut tar, SIGNATURE_FILENAME, &sig.to_bytes()).unwrap();
+            // The tar `append_bytes` would reject `../`-prefixed
+            // paths through its own validation, so we don't even
+            // get to write the entry — but the manifest-declared
+            // path is what we're testing.
+        }
+        match read_and_verify_bundle(&buf.into_inner(), &trust(&sk)) {
+            Err(BundleVerifyError::UnsafePath { .. }) => {}
+            // Some tar entry layouts surface this as ArtifactMissing
+            // before the path scan reaches the manifest's bad path
+            // (the entry was never written). Either rejection is
+            // acceptable — the property is "no extraction happens
+            // to ../etc/passwd."
+            Err(BundleVerifyError::ArtifactMissing { .. }) => {}
+            other => panic!("expected rejection of unsafe path, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn future_schema_version_rejected_after_load() {
+        let sk = fresh_key();
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+
+        // Hand-roll a manifest at SCHEMA_VERSION + 1 and sign it.
+        // Use serde_json::Value so we can bump the version field
+        // without changing the struct.
+        let valid_manifest = make_manifest(key_id, vec![]);
+        let mut value: serde_json::Value = serde_json::to_value(&valid_manifest).unwrap();
+        value["schema_version"] = serde_json::Value::Number((BUNDLE_SCHEMA_VERSION + 1).into());
+        let manifest_bytes = serde_json::to_vec(&value).unwrap();
+        let sig = sk.sign(&manifest_bytes);
+
+        let mut buf = Cursor::new(Vec::<u8>::new());
+        {
+            let mut tar = tar::Builder::new(&mut buf);
+            append_bytes(&mut tar, MANIFEST_FILENAME, &manifest_bytes).unwrap();
+            append_bytes(&mut tar, SIGNATURE_FILENAME, &sig.to_bytes()).unwrap();
+            tar.finish().unwrap();
+        }
+        match read_and_verify_bundle(&buf.into_inner(), &trust(&sk)) {
+            Err(BundleVerifyError::UnsupportedSchema { found, supported }) => {
+                assert_eq!(found, BUNDLE_SCHEMA_VERSION + 1);
+                assert_eq!(supported, BUNDLE_SCHEMA_VERSION);
+            }
+            other => panic!("expected UnsupportedSchema, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn manifest_canonical_bytes_round_trip() {
+        let sk = fresh_key();
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        let m = make_manifest(
+            key_id,
+            vec![art("k", ArtifactRole::Kernel, "artifacts/k", b"X")],
+        );
+        let bytes = m.canonical_bytes().unwrap();
+        let parsed: BundleManifest = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn fs_trust_store_loads_pubkey() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sk = fresh_key();
+        let vk = sk.verifying_key();
+        let key_id = KeyId::from_pubkey(&vk);
+        std::fs::write(tmp.path().join(format!("{}.pub", key_id.0)), vk.to_bytes()).unwrap();
+        let store = FsTrustStore::new(tmp.path());
+        let recovered = store.lookup(&key_id).expect("found");
+        assert_eq!(recovered.to_bytes(), vk.to_bytes());
+    }
+
+    #[test]
+    fn fs_trust_store_misses_for_unknown_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FsTrustStore::new(tmp.path());
+        let bogus = KeyId("0".repeat(32));
+        assert!(store.lookup(&bogus).is_none());
+    }
+
+    #[test]
+    fn fs_trust_store_rejects_malformed_key_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FsTrustStore::new(tmp.path());
+        // A "key_id" that's the right length but wrong shape never
+        // gets a filesystem lookup — the well-formedness check
+        // short-circuits.
+        assert!(
+            store
+                .lookup(&KeyId("not-hex-but-32-characters-aaaa".to_string()))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn write_bundle_rejects_signing_key_keyid_mismatch() {
+        // Manifest says key_id X but we hand a signing key for Y.
+        // Caught at write time so a misconfigured publisher can't
+        // ship an unverifiable bundle.
+        let sk_a = fresh_key();
+        let sk_b = fresh_key();
+        let key_id_a = KeyId::from_pubkey(&sk_a.verifying_key());
+        let manifest = make_manifest(key_id_a, vec![]);
+        let err = write_bundle(&manifest, &sk_b, vec![]).expect_err("rejects");
+        assert!(format!("{err:#}").contains("does not match"));
+    }
+
+    #[test]
+    fn write_bundle_rejects_artifact_sha256_drift() {
+        let sk = fresh_key();
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        let manifest = make_manifest(
+            key_id,
+            vec![BundleArtifact {
+                name: "kernel".to_string(),
+                role: ArtifactRole::Kernel,
+                path: "artifacts/vmlinux".to_string(),
+                // Wrong sha256 vs the bytes we'll hand to write_bundle.
+                sha256: "0".repeat(64),
+                size_bytes: 5,
+            }],
+        );
+        let err = write_bundle(
+            &manifest,
+            &sk,
+            vec![("artifacts/vmlinux".to_string(), b"abcde".to_vec())],
+        )
+        .expect_err("rejects");
+        assert!(format!("{err:#}").contains("sha256 mismatch"));
+    }
+
+    #[test]
+    fn bundle_sha256_is_lowercase_hex() {
+        let h = bundle_sha256(b"abc");
+        assert_eq!(
+            h,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn signature_base64_round_trips() {
+        let sk = fresh_key();
+        let sig = sk.sign(b"some message");
+        let s = signature_to_base64(&sig.to_bytes());
+        let recovered = signature_from_base64(&s).unwrap();
+        assert_eq!(recovered, sig.to_bytes());
+    }
+
+    #[test]
+    fn plan_artifact_round_trips_and_pins_to_bundle() {
+        // End-to-end: build a bundle, derive a PlanArtifact pin from
+        // its hash + signature + key_id, and confirm an external
+        // re-verify with just those three quantities succeeds.
+        let sk = fresh_key();
+        let kernel = b"kernel-bytes";
+        let rootfs = b"rootfs-bytes";
+        let bundle = build_bundle(&sk, kernel, rootfs);
+        let store = trust(&sk);
+
+        let verified = read_and_verify_bundle(&bundle, &store).expect("verifies");
+        let key_id = verified.key_id.clone();
+
+        // Re-extract the signature bytes from the archive so the
+        // pin doesn't depend on internals.
+        let mut archive = tar::Archive::new(Cursor::new(&bundle));
+        let mut sig_bytes = Vec::new();
+        for entry in archive.entries().unwrap() {
+            let mut e = entry.unwrap();
+            if e.path().unwrap().to_string_lossy() == SIGNATURE_FILENAME {
+                e.read_to_end(&mut sig_bytes).unwrap();
+            }
+        }
+        let sig_arr: [u8; 64] = sig_bytes.as_slice().try_into().unwrap();
+
+        let pin = PlanArtifact::new(bundle_sha256(&bundle), &sig_arr, key_id.clone());
+
+        // The pin can be JSON-roundtripped and still verifies its
+        // signature against the archive's manifest.json.
+        let json = serde_json::to_string(&pin).unwrap();
+        let parsed: PlanArtifact = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, pin);
+        assert_eq!(parsed.signature_bytes().unwrap(), sig_arr);
+        assert_eq!(parsed.bundle_sha256, bundle_sha256(&bundle));
+        assert_eq!(parsed.key_id, key_id);
+    }
+
+    #[test]
+    fn plan_artifact_rejects_bad_base64_signature() {
+        let pin = PlanArtifact {
+            bundle_sha256: "0".repeat(64),
+            manifest_sig_base64: "not-base64-!!".to_string(),
+            key_id: KeyId("0".repeat(32)),
+        };
+        assert!(pin.signature_bytes().is_none());
+    }
+
+    #[test]
+    fn plan_artifact_deny_unknown_fields() {
+        // Defence in depth: an attacker bumping the schema must
+        // fail closed in older verifiers.
+        let json = serde_json::json!({
+            "bundle_sha256": "0".repeat(64),
+            "manifest_sig_base64": "AA==",
+            "key_id": "0".repeat(32),
+            "extra_future_field": 42,
+        });
+        let result: Result<PlanArtifact, _> = serde_json::from_value(json);
+        assert!(result.is_err(), "deny_unknown_fields must reject");
+    }
+}

--- a/crates/mvm-plan/src/lib.rs
+++ b/crates/mvm-plan/src/lib.rs
@@ -27,11 +27,17 @@
 //!   the validity check answers "should we accept this otherwise-
 //!   valid plan now".
 
+pub mod bundle;
 pub mod plan;
 pub mod signing;
 pub mod types;
 pub mod validity;
 
+pub use bundle::{
+    ArtifactRole, BUNDLE_SCHEMA_VERSION, BundleArtifact, BundleManifest, BundleVerifyError,
+    FsTrustStore, KeyId, PlanArtifact, TrustStore, VerifiedBundle, VerityInfo, bundle_sha256,
+    read_and_verify_bundle, sha256_hex, signature_from_base64, signature_to_base64, write_bundle,
+};
 pub use plan::{ExecutionPlan, SCHEMA_VERSION};
 pub use signing::{PlanVerifyError, SignedExecutionPlan, sign_plan, verify_plan};
 pub use types::{

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -16,10 +16,15 @@ mvm-policy.workspace = true
 # Heavy dep, but the supervisor's eventual job is to drive runtime
 # operations anyway, so we'd be importing it shortly regardless.
 mvm.workspace = true
+anyhow.workspace = true
 async-trait = "0.1"
 base64.workspace = true
 chrono.workspace = true
 ed25519-dalek.workspace = true
+# Used by the balloon reclaim controller as a cross-platform memory-
+# pressure source. PSI on Linux and `vm_pressure` on macOS are
+# stronger signals — wiring those in is a follow-up.
+sysinfo = { version = "0.30", default-features = false }
 # Plan 60 Phase 3 Slice B — L4 egress policy CIDR matching.
 ipnet.workspace = true
 # Plan 60 Phase 3 Slice B — pure-Rust DNS resolver, alternative to

--- a/crates/mvm-supervisor/src/balloon.rs
+++ b/crates/mvm-supervisor/src/balloon.rs
@@ -16,6 +16,8 @@
 //! [`VmStartConfig::mem_initial_mib`]:
 //!     mvm_core::vm_backend::VmStartConfig::mem_initial_mib
 
+use std::sync::Mutex;
+
 use mvm_core::vm_backend::{BalloonState, VmId};
 
 /// Action to take on a single VM after a controller tick.
@@ -131,6 +133,160 @@ impl BalloonPolicy {
         }
 
         BalloonAction::Hold
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HostPressureSource — pluggable platform reader
+// ---------------------------------------------------------------------------
+
+/// Pluggable provider of host memory pressure.
+///
+/// Production wiring uses [`SysinfoPressureSource`]. Linux PSI
+/// (`/proc/pressure/memory`) and macOS `vm_pressure` are stronger
+/// signals; wiring them as alternative implementations behind the
+/// same trait is a deliberate follow-up (the controller doesn't
+/// need to change, only the source).
+pub trait HostPressureSource: Send + Sync {
+    /// Read the current pressure. Errors propagate; the controller
+    /// surfaces them as `TickOutcome::error` rather than panicking.
+    fn current(&self) -> anyhow::Result<HostPressure>;
+}
+
+/// Cross-platform pressure source backed by the `sysinfo` crate.
+///
+/// Reports `used_memory / total_memory` as the pressure value. This
+/// is a coarse signal — it doesn't distinguish "host actively
+/// pressured" from "host has caches it could drop." Good enough for
+/// v1 ergonomics on dev laptops; not good enough for production
+/// scheduling decisions, where PSI is the right answer on Linux.
+pub struct SysinfoPressureSource {
+    sys: Mutex<sysinfo::System>,
+}
+
+impl SysinfoPressureSource {
+    /// Construct with a fresh `sysinfo::System` ready for memory
+    /// reads. Cheap; safe to keep one per process.
+    pub fn new() -> Self {
+        Self {
+            sys: Mutex::new(sysinfo::System::new()),
+        }
+    }
+}
+
+impl Default for SysinfoPressureSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HostPressureSource for SysinfoPressureSource {
+    fn current(&self) -> anyhow::Result<HostPressure> {
+        // sysinfo's API mutates the System on refresh, hence the
+        // Mutex. The mutation is bounded — we hold the lock just
+        // long enough to refresh + read.
+        let mut sys = self
+            .sys
+            .lock()
+            .map_err(|e| anyhow::anyhow!("sysinfo mutex poisoned: {e}"))?;
+        sys.refresh_memory();
+        let total = sys.total_memory() as f64;
+        if total <= 0.0 {
+            return Ok(HostPressure(0.0));
+        }
+        let used = sys.used_memory() as f64;
+        let ratio = (used / total) as f32;
+        Ok(HostPressure::clamped(ratio))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BalloonController — pressure-driven reclaim tick
+// ---------------------------------------------------------------------------
+
+/// Outcome of a single VM's tick. Surfaces both the decision and
+/// whether application succeeded so the host can log + react.
+#[derive(Debug, Clone)]
+pub struct TickOutcome {
+    pub vm: VmId,
+    pub action: BalloonAction,
+    /// Whether `apply` was actually called. `Hold` actions don't
+    /// call apply; non-`Hold` actions do — `applied=true` here means
+    /// the apply call returned Ok.
+    pub applied: bool,
+    /// Stringified error from the apply call. Held as a String (not
+    /// `anyhow::Error`) so `TickOutcome` can derive `Clone`.
+    pub error: Option<String>,
+}
+
+/// Pressure-driven balloon reclaim controller. Owns a `BalloonPolicy`
+/// plus a `HostPressureSource`; produces decisions per-VM and (when
+/// the caller hands it an apply fn) executes them.
+///
+/// Generic over the pressure source so tests can inject a fixed
+/// pressure value without going through sysinfo. Production code
+/// wires `SysinfoPressureSource` (or, once landed,
+/// `PsiPressureSource` / `MacVmPressureSource`).
+pub struct BalloonController<P: HostPressureSource> {
+    pub policy: BalloonPolicy,
+    pub pressure: P,
+}
+
+impl<P: HostPressureSource> BalloonController<P> {
+    /// Construct with an explicit policy + pressure source.
+    pub fn new(policy: BalloonPolicy, pressure: P) -> Self {
+        Self { policy, pressure }
+    }
+
+    /// Single tick. For each `(vm, state)`, decide an action and
+    /// apply it via the caller-provided `apply` closure. Pressure is
+    /// read once at the start of the tick — same value drives every
+    /// VM's decision for fairness.
+    ///
+    /// `apply(vm, target_inflate_mib)` is what the caller wires to
+    /// `AnyBackend::balloon_set_target`. Splitting the apply out as
+    /// a closure keeps the tick logic testable without a real
+    /// backend.
+    ///
+    /// On pressure-read failure, returns an error before evaluating
+    /// any VM — better to skip the whole tick than apply with a
+    /// stale value.
+    pub fn tick<A>(
+        &self,
+        vm_states: &[(VmId, BalloonState)],
+        mut apply: A,
+    ) -> anyhow::Result<Vec<TickOutcome>>
+    where
+        A: FnMut(&VmId, u32) -> anyhow::Result<()>,
+    {
+        let pressure = self.pressure.current()?;
+        let mut out = Vec::with_capacity(vm_states.len());
+        for (vm, state) in vm_states {
+            let action = self.policy.decide(vm, *state, pressure);
+            let target = match &action {
+                BalloonAction::Hold => None,
+                BalloonAction::Inflate {
+                    target_inflate_mib, ..
+                }
+                | BalloonAction::Deflate {
+                    target_inflate_mib, ..
+                } => Some(*target_inflate_mib),
+            };
+            let (applied, error) = match target {
+                None => (false, None),
+                Some(t) => match apply(vm, t) {
+                    Ok(()) => (true, None),
+                    Err(e) => (false, Some(format!("{e:#}"))),
+                },
+            };
+            out.push(TickOutcome {
+                vm: vm.clone(),
+                action,
+                applied,
+                error,
+            });
+        }
+        Ok(out)
     }
 }
 
@@ -268,5 +424,142 @@ mod tests {
         assert!(p.deflate_below < p.inflate_above);
         assert!(p.step_mib > 0);
         assert!(p.guest_floor_mib > 0);
+    }
+
+    // ── Pressure source + controller tests ───────────────────────
+
+    /// Test-only fixed-value pressure source. The controller is
+    /// generic over the source trait so this stays out of the
+    /// production code path.
+    struct FixedPressure(HostPressure);
+    impl HostPressureSource for FixedPressure {
+        fn current(&self) -> anyhow::Result<HostPressure> {
+            Ok(self.0)
+        }
+    }
+
+    /// Pressure source that always errors. Exercises the
+    /// "skip-whole-tick on read failure" guarantee.
+    struct ErroringPressure;
+    impl HostPressureSource for ErroringPressure {
+        fn current(&self) -> anyhow::Result<HostPressure> {
+            anyhow::bail!("pretend the platform reader failed")
+        }
+    }
+
+    #[test]
+    fn sysinfo_pressure_source_returns_in_range_value() {
+        let src = SysinfoPressureSource::new();
+        let p = src.current().expect("sysinfo read");
+        // Used / total memory is always within [0, 1] after the
+        // clamp; this asserts the impl plumbs through to a sane
+        // number rather than a panic.
+        assert!((0.0..=1.0).contains(&p.0), "got {}", p.0);
+    }
+
+    #[test]
+    fn controller_tick_holds_in_dead_band() {
+        let c = BalloonController::new(BalloonPolicy::default(), FixedPressure(HostPressure(0.70)));
+        // No calls should happen — Hold doesn't fire `apply`.
+        let mut apply_calls = 0;
+        let outcomes = c
+            .tick(&[(vm(), state(1024, 256))], |_, _| {
+                apply_calls += 1;
+                Ok(())
+            })
+            .expect("tick succeeds");
+        assert_eq!(apply_calls, 0);
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].action, BalloonAction::Hold);
+        assert!(!outcomes[0].applied);
+        assert!(outcomes[0].error.is_none());
+    }
+
+    #[test]
+    fn controller_tick_applies_inflate_under_high_pressure() {
+        let c = BalloonController::new(BalloonPolicy::default(), FixedPressure(HostPressure(0.95)));
+        let mut applied_targets: Vec<(VmId, u32)> = Vec::new();
+        let outcomes = c
+            .tick(&[(vm(), state(1024, 0))], |v, t| {
+                applied_targets.push((v.clone(), t));
+                Ok(())
+            })
+            .expect("tick succeeds");
+        assert_eq!(applied_targets.len(), 1);
+        assert_eq!(applied_targets[0].0, vm());
+        assert_eq!(applied_targets[0].1, BalloonPolicy::default().step_mib);
+        assert!(outcomes[0].applied);
+        assert!(matches!(outcomes[0].action, BalloonAction::Inflate { .. }));
+    }
+
+    #[test]
+    fn controller_tick_applies_deflate_under_low_pressure() {
+        let c = BalloonController::new(BalloonPolicy::default(), FixedPressure(HostPressure(0.30)));
+        let mut targets: Vec<u32> = Vec::new();
+        c.tick(&[(vm(), state(1024, 512))], |_, t| {
+            targets.push(t);
+            Ok(())
+        })
+        .expect("tick succeeds");
+        assert_eq!(targets, vec![512 - BalloonPolicy::default().step_mib]);
+    }
+
+    #[test]
+    fn controller_tick_records_apply_error_per_vm() {
+        let c = BalloonController::new(BalloonPolicy::default(), FixedPressure(HostPressure(0.95)));
+        let outcomes = c
+            .tick(&[(vm(), state(1024, 0))], |_, _| {
+                anyhow::bail!("backend.balloon_set_target failed")
+            })
+            .expect("tick itself succeeds even when apply errors");
+        assert_eq!(outcomes.len(), 1);
+        assert!(!outcomes[0].applied);
+        let err = outcomes[0].error.as_deref().expect("error captured");
+        assert!(err.contains("balloon_set_target failed"), "got: {err}");
+    }
+
+    #[test]
+    fn controller_tick_skips_whole_tick_on_pressure_read_failure() {
+        let c = BalloonController::new(BalloonPolicy::default(), ErroringPressure);
+        // apply must never get called when pressure read fails —
+        // a stale-value tick is worse than a missed tick.
+        let mut apply_calls = 0;
+        let result = c.tick(&[(vm(), state(1024, 0))], |_, _| {
+            apply_calls += 1;
+            Ok(())
+        });
+        assert!(result.is_err(), "tick must error when pressure errors");
+        assert_eq!(apply_calls, 0, "apply must not run when pressure errors");
+    }
+
+    #[test]
+    fn controller_tick_pressure_read_is_per_tick_not_per_vm() {
+        // Drive a controller with two VMs through one tick — the
+        // pressure source should be consulted once, not twice. A
+        // counting source enforces this; AtomicU32 keeps the source
+        // Sync without an unsafe impl.
+        use std::sync::atomic::{AtomicU32, Ordering};
+        struct CountingPressure(AtomicU32, HostPressure);
+        impl HostPressureSource for CountingPressure {
+            fn current(&self) -> anyhow::Result<HostPressure> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(self.1)
+            }
+        }
+        let src = CountingPressure(AtomicU32::new(0), HostPressure(0.95));
+        let c = BalloonController::new(BalloonPolicy::default(), src);
+        c.tick(
+            &[
+                (VmId("a".into()), state(1024, 0)),
+                (VmId("b".into()), state(1024, 0)),
+            ],
+            |_, _| Ok(()),
+        )
+        .expect("tick");
+        assert_eq!(
+            c.pressure.0.load(Ordering::SeqCst),
+            1,
+            "pressure should be read once per tick, not once per VM"
+        );
     }
 }

--- a/crates/mvm-supervisor/src/balloon.rs
+++ b/crates/mvm-supervisor/src/balloon.rs
@@ -1,0 +1,272 @@
+//! Virtio-balloon reclaim controller.
+//!
+//! Workloads that opt into [`VmStartConfig::mem_initial_mib`] boot
+//! with a pre-inflated balloon and only commit a fraction of their
+//! cap. The host-side reclaim controller adjusts the balloon over
+//! the VM's life so the host commits more when it has slack and
+//! less when it's under pressure.
+//!
+//! This module ships the *policy* — a pure decision function that
+//! takes a snapshot and returns an action. The wiring to a real
+//! poller (sysinfo / Linux PSI / macOS memorystatus) plus the call
+//! to `VmBackend::balloon_set_target` lives at the integration site
+//! (the supervisor's main loop). Keeping policy and integration
+//! separable makes the policy testable without spinning up a VMM.
+//!
+//! [`VmStartConfig::mem_initial_mib`]:
+//!     mvm_core::vm_backend::VmStartConfig::mem_initial_mib
+
+use mvm_core::vm_backend::{BalloonState, VmId};
+
+/// Action to take on a single VM after a controller tick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BalloonAction {
+    /// No change required — the current target stays.
+    Hold,
+    /// Inflate the balloon (reclaim from guest). `target_inflate_mib`
+    /// is the new absolute target, not a delta.
+    Inflate { vm: VmId, target_inflate_mib: u32 },
+    /// Deflate the balloon (return memory to guest). `target_inflate_mib`
+    /// is the new absolute target.
+    Deflate { vm: VmId, target_inflate_mib: u32 },
+}
+
+/// Host memory pressure, normalised to 0.0..=1.0. Higher = more
+/// pressure (more of host memory is in use). Exact source depends
+/// on the host platform; the controller treats this as opaque.
+///
+/// Reasonable mappings:
+/// - Linux: `MemAvailable / MemTotal` inverted (1 − available_ratio).
+/// - Linux PSI: the 10-second `memory.pressure.full.avg10` is a
+///   stronger signal than a flat used-fraction.
+/// - macOS: vm_pressure (translate the qualitative state to a
+///   numeric).
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct HostPressure(pub f32);
+
+impl HostPressure {
+    /// Construct, clamping to `[0.0, 1.0]`. Defensive against
+    /// platform shims that return out-of-range values under odd
+    /// edge cases.
+    pub fn clamped(p: f32) -> Self {
+        Self(p.clamp(0.0, 1.0))
+    }
+}
+
+/// Two-threshold band policy for v1. Above `inflate_above`, claim
+/// pages from idle guests; below `deflate_below`, hand them back.
+/// Between the two, hold the current target so we don't thrash.
+#[derive(Debug, Clone, Copy)]
+pub struct BalloonPolicy {
+    /// Inflate when host pressure rises above this fraction.
+    pub inflate_above: f32,
+    /// Deflate when host pressure falls below this fraction.
+    pub deflate_below: f32,
+    /// MiB to adjust per tick. Keeping the step modest avoids
+    /// thrashing the guest's allocator under marginal pressure.
+    pub step_mib: u32,
+    /// Floor for guest commitment in MiB. The balloon is never
+    /// inflated past `max_mib - guest_floor_mib` — under-provisioned
+    /// guests OOM-kill workloads, which is worse than the host
+    /// taking the pressure.
+    pub guest_floor_mib: u32,
+}
+
+impl Default for BalloonPolicy {
+    fn default() -> Self {
+        // Defaults tuned for dev-laptop ergonomics: inflate when the
+        // host is at 80% memory (a real squeeze), deflate when it's
+        // back below 60% (we have headroom). 64 MiB step + 64 MiB
+        // guest floor balances responsiveness against thrash.
+        Self {
+            inflate_above: 0.80,
+            deflate_below: 0.60,
+            step_mib: 64,
+            guest_floor_mib: 64,
+        }
+    }
+}
+
+impl BalloonPolicy {
+    /// Decide the action for a single VM. Pure function: no I/O,
+    /// no clock, no allocator state. The caller is responsible for
+    /// reading `state` from the backend and `pressure` from the host
+    /// before each invocation.
+    ///
+    /// Invariants:
+    /// - Returns `Hold` when no progress can be made (already at
+    ///   ceiling or floor in the relevant direction).
+    /// - Never produces a target that would push the guest below
+    ///   `guest_floor_mib` of commitment.
+    /// - The dead-band between `deflate_below` and `inflate_above`
+    ///   prevents pressure oscillations from thrashing the balloon.
+    pub fn decide(&self, vm: &VmId, state: BalloonState, pressure: HostPressure) -> BalloonAction {
+        // Inflate path — claim more pages back from the guest.
+        if pressure.0 >= self.inflate_above {
+            // Ceiling: leave at least `guest_floor_mib` to the guest.
+            let max_inflate = state.max_mib.saturating_sub(self.guest_floor_mib);
+            let new_target = state
+                .inflated_mib
+                .saturating_add(self.step_mib)
+                .min(max_inflate);
+            if new_target > state.inflated_mib {
+                return BalloonAction::Inflate {
+                    vm: vm.clone(),
+                    target_inflate_mib: new_target,
+                };
+            }
+            return BalloonAction::Hold;
+        }
+
+        // Deflate path — return pages to the guest.
+        if pressure.0 <= self.deflate_below {
+            let new_target = state.inflated_mib.saturating_sub(self.step_mib);
+            if new_target < state.inflated_mib {
+                return BalloonAction::Deflate {
+                    vm: vm.clone(),
+                    target_inflate_mib: new_target,
+                };
+            }
+            return BalloonAction::Hold;
+        }
+
+        BalloonAction::Hold
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(max_mib: u32, inflated_mib: u32) -> BalloonState {
+        BalloonState {
+            max_mib,
+            inflated_mib,
+            host_committed_mib: max_mib.saturating_sub(inflated_mib),
+        }
+    }
+
+    fn vm() -> VmId {
+        VmId("test-vm".to_string())
+    }
+
+    #[test]
+    fn high_pressure_inflates_by_step() {
+        let p = BalloonPolicy::default();
+        let action = p.decide(&vm(), state(1024, 0), HostPressure(0.85));
+        assert_eq!(
+            action,
+            BalloonAction::Inflate {
+                vm: vm(),
+                target_inflate_mib: p.step_mib,
+            }
+        );
+    }
+
+    #[test]
+    fn low_pressure_deflates_by_step() {
+        let p = BalloonPolicy::default();
+        let action = p.decide(&vm(), state(1024, 512), HostPressure(0.40));
+        assert_eq!(
+            action,
+            BalloonAction::Deflate {
+                vm: vm(),
+                target_inflate_mib: 512 - p.step_mib,
+            }
+        );
+    }
+
+    #[test]
+    fn dead_band_holds_position() {
+        let p = BalloonPolicy::default();
+        // 0.70 is between 0.60 and 0.80.
+        let action = p.decide(&vm(), state(1024, 256), HostPressure(0.70));
+        assert_eq!(action, BalloonAction::Hold);
+    }
+
+    #[test]
+    fn inflate_caps_at_guest_floor() {
+        let p = BalloonPolicy {
+            inflate_above: 0.80,
+            deflate_below: 0.60,
+            step_mib: 64,
+            guest_floor_mib: 64,
+        };
+        // 1024 - 64 floor = 960 ceiling. Inflated already at 940;
+        // adding step (64) would land at 1004, but we cap at 960.
+        let action = p.decide(&vm(), state(1024, 940), HostPressure(0.95));
+        assert_eq!(
+            action,
+            BalloonAction::Inflate {
+                vm: vm(),
+                target_inflate_mib: 960,
+            }
+        );
+    }
+
+    #[test]
+    fn inflate_at_ceiling_holds() {
+        let p = BalloonPolicy::default();
+        // Already at the ceiling — no more headroom.
+        let ceiling = 1024 - p.guest_floor_mib;
+        let action = p.decide(&vm(), state(1024, ceiling), HostPressure(0.95));
+        assert_eq!(action, BalloonAction::Hold);
+    }
+
+    #[test]
+    fn deflate_at_zero_holds() {
+        let p = BalloonPolicy::default();
+        // Balloon already fully deflated — nothing to return.
+        let action = p.decide(&vm(), state(1024, 0), HostPressure(0.10));
+        assert_eq!(action, BalloonAction::Hold);
+    }
+
+    #[test]
+    fn deflate_saturates_at_zero() {
+        let p = BalloonPolicy {
+            inflate_above: 0.80,
+            deflate_below: 0.60,
+            step_mib: 256,
+            guest_floor_mib: 64,
+        };
+        // Only 32 MiB inflated; step is 256 — deflating must
+        // saturate at 0, not underflow.
+        let action = p.decide(&vm(), state(1024, 32), HostPressure(0.10));
+        assert_eq!(
+            action,
+            BalloonAction::Deflate {
+                vm: vm(),
+                target_inflate_mib: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn host_pressure_clamps_out_of_range_input() {
+        // Defensive clamping on the wire: a platform shim returning
+        // 1.5 or -0.1 must not break the policy.
+        let high = HostPressure::clamped(1.5);
+        let low = HostPressure::clamped(-0.1);
+        assert!((high.0 - 1.0).abs() < f32::EPSILON);
+        assert!(low.0.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn exact_threshold_is_inclusive() {
+        // At exactly inflate_above and deflate_below, behave as the
+        // boundary direction. (`>=` / `<=` semantics.)
+        let p = BalloonPolicy::default();
+        let inflate = p.decide(&vm(), state(1024, 0), HostPressure(0.80));
+        assert!(matches!(inflate, BalloonAction::Inflate { .. }));
+        let deflate = p.decide(&vm(), state(1024, 256), HostPressure(0.60));
+        assert!(matches!(deflate, BalloonAction::Deflate { .. }));
+    }
+
+    #[test]
+    fn default_policy_sanity_band() {
+        let p = BalloonPolicy::default();
+        assert!(p.deflate_below < p.inflate_above);
+        assert!(p.step_mib > 0);
+        assert!(p.guest_floor_mib > 0);
+    }
+}

--- a/crates/mvm-supervisor/src/lib.rs
+++ b/crates/mvm-supervisor/src/lib.rs
@@ -37,6 +37,7 @@ pub mod audit_dedup;
 pub mod audit_file;
 pub mod audit_recorder;
 pub mod backend;
+pub mod balloon;
 pub mod circuit_breaker;
 pub mod destination;
 pub mod egress;

--- a/crates/mvm/src/vm/template/lifecycle.rs
+++ b/crates/mvm/src/vm/template/lifecycle.rs
@@ -353,6 +353,7 @@ fn persisted_to_synthetic_spec(p: &PersistedManifest) -> TemplateSpec {
         role: String::new(),
         vcpus: p.vcpus,
         mem_mib: p.mem_mib,
+        mem_initial_mib: p.mem_initial_mib,
         data_disk_mib: p.data_disk_mib,
         created_at: p.created_at.clone(),
         updated_at: p.updated_at.clone(),

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1211,14 +1211,12 @@ Sprint 51 closes when:
 5. CHANGELOG.md `[Unreleased]` section captures every shipped
    plan with date, commit SHAs, and links to ADRs.
 
-## Sprint 52 — smolvm gap-closing (in flight)
+## Sprint 52 — elastic memory + portable signed bundles (in flight)
 
-Scope: pick the ideas mvm is missing from smolvm
-([smolmachines.com](https://smolmachines.com/)) that close real UX
-or perf gaps without compromising the eight ADR-002 security
-claims. The decision document
-(`/Users/auser/.claude/plans/is-there-anything-mvm-giggly-bear.md`)
-ranks eight candidates; this sprint lands the top two:
+Two ergonomics + reach gaps in the platform that need closing
+without compromising the eight ADR-002 security claims. The
+decision document outside the repo enumerates eight candidates;
+this sprint lands the top two:
 
 1. **Virtio-balloon elasticity** — "mem cap, not commitment."
 2. **Portable image bundles + per-artifact attestation in a signed

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1393,6 +1393,59 @@ Outstanding (deferred follow-ups):
   wiring so `trust add/remove` flips from `InteractiveOrControl`
   to `Emits(...)` in the posture table.
 
+### W3 — Network default flip (deny-by-default)  ✅ shipped
+
+Pre-Sprint 52 `NetworkPolicy::default()` returned `unrestricted()`
+— the entire rest of the ADR-002 model confined the guest at every
+other layer, but egress was wide open. W3 flips the safe default
+to `deny_all()`. Workloads that need network access opt in
+explicitly via `--network-preset` / `--network-allow` /
+`mvmctl trust`-provisioned template policies.
+
+Shipped:
+
+- `NetworkPolicy::default()` in
+  `crates/mvm-core/src/policy/network_policy.rs` returns
+  `Self::deny_all()` (was `Self::unrestricted()`).
+- `mvmctl up` warning when the resolved policy is unrestricted —
+  both for the explicit-CLI-flag path
+  (`--network-preset unrestricted`) and for templates whose baked
+  `default_network_policy` is unrestricted. Names the source so
+  the user knows where the opt-out came from. Suppressible via
+  `MVM_ACK_UNRESTRICTED_NETWORK=1` for CI / scripted use.
+- ADR-002 10th claim shipped: *no untrusted workload reaches the
+  network unless explicitly admitted by policy.* Framework refs
+  added (ATT&CK T1071 / T1041; D3FEND Network Traffic Filtering;
+  CREF Privilege Restriction).
+- Tests updated:
+  - `policy_default_is_deny_all` (renamed from
+    `policy_default_is_unrestricted`) asserts the deny-all shape.
+  - `test_resolve_network_policy_default_is_deny_all` flipped to
+    match. Comment notes the pre-Sprint-52 expectation.
+- 334 supervisor + all-crate lib tests green;
+  `cargo test --test audit_total_coverage` green; clippy clean.
+
+Breaking change disclosure for release notes:
+
+> **Breaking:** `mvmctl up` and the rest of mvm now refuse network
+> egress by default. Workloads that previously relied on
+> implicit unrestricted egress must pass
+> `--network-preset unrestricted` (which emits a launch-time
+> warning) or one of the safer presets (`dev`, `agent`,
+> `registries`). The escape hatch
+> `MVM_ACK_UNRESTRICTED_NETWORK=1` suppresses the warning.
+
+Outstanding (deferred follow-ups):
+
+- CI lane `network-default-is-deny` — a black-box assertion that
+  `mvmctl up` with no flags refuses outbound connectivity from
+  inside the guest. Needs a live-KVM smoke harness mvm doesn't
+  have today; the unit-level guarantee shipped in this commit.
+- `mvmctl doctor` could surface the network default visibly in
+  its security-posture section as a corollary of claim 10. The
+  posture section reads from `BackendSecurityProfile`; teaching
+  it about runtime policy defaults is a small follow-on.
+
 ### Sprint 52 success criteria
 
 1. *A workload with `mem_initial = "256M"` and `mem = "1024M"`

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1296,7 +1296,7 @@ Outstanding (deferred to follow-ups):
   loop. Today the controller is a library piece; wiring it into
   the supervisor's lifecycle is the integration follow-up.
 
-### W2 — Portable image bundles + per-artifact attestation  🟡 substrate landed
+### W2 — Portable image bundles + per-artifact attestation  🟢 CLI surface shipped
 
 Sigstore-style trust model: bundle ships a signed `manifest.json`
 with per-artifact SHA-256s; the publisher's public key lives
@@ -1339,23 +1339,59 @@ Shipped (`mvm-plan::bundle`):
   trust-store file load + miss + malformed-key-id short circuit,
   PlanArtifact JSON round-trip + signature re-decode + deny-unknown-fields.
 
-Outstanding (this sprint):
+Shipped in the W2 close-out commit:
 
-- `mvmctl bundle export <template> --out <path>` — build pipeline
-  emits `.mvmpkg` archives keyed by content (not manifest-path
-  hash).
-- `mvmctl bundle fetch <url-or-path>` — download + verify + extract
-  into the local template registry, replacing the
-  `~/.mvm/templates/<sha256(manifest_path)>/...` keying scheme with
-  bundle-sha256 directories.
-- `mvmctl trust add/list/remove` — manage
-  `~/.mvm/trusted-publishers/` from the CLI rather than file copy.
-- Supervisor admit path: when an `ExecutionPlan` carries a
-  `PlanArtifact`, re-run `read_and_verify_bundle` against the
-  on-disk archive before backend dispatch; chain-sign the
-  admission outcome to the audit log.
-- 9th security claim drafted in ADR-002: *every published bundle
-  is content-addressed, key_id-pinned, and re-verified at admit.*
+- `mvmctl bundle export <TEMPLATE> --out <PATH> [--label]`:
+  resolves the template's current revision (kernel + rootfs +
+  optional initrd + optional dm-verity sidecar), hashes each
+  artifact, builds a `BundleManifest`, signs with the host signer
+  (same key that signs `ExecutionPlan` envelopes), and writes the
+  archive. Refuses to ship a bundle whose declared sha256/size or
+  key_id doesn't match the signing key / actual bytes — caught at
+  write time so misconfigured publishers never ship unverifiable
+  bundles.
+- `mvmctl bundle fetch <PATH> [--trust-store <DIR>] [--json]`:
+  reads the archive, looks the publisher pubkey up via
+  `FsTrustStore` (defaults to `~/.mvm/trusted-publishers/`), runs
+  the full 6-step rejection ladder, prints a verified-bundle
+  summary (sha256, key_id, publisher, arch, profile, label,
+  artifact count, verity yes/no) or full manifest JSON. Refuses
+  on any verification failure before extraction.
+- `mvmctl trust add <PUBKEY> [--force]`: reads 32 raw Ed25519
+  pubkey bytes, derives `key_id`, writes `<key_id>.pub` to the
+  trust store (mode 0644). Refuses to overwrite without `--force`.
+  Trust-store directory created at mode 0700 on first use.
+- `mvmctl trust list [--json]`: enumerates the store, filters to
+  well-formed `<key_id>.pub` entries, sorted output.
+- `mvmctl trust remove <KEY_ID>`: unlinks by key_id; refuses if
+  the key_id is malformed (32 hex chars expected).
+- `cmd_audit::verb_name` + `AUDIT_POSTURE` table extended with
+  `bundle` (DelegatesToSub: export = `InteractiveOrControl`,
+  fetch = `ReadOnly`) and `trust` (DelegatesToSub: add/remove =
+  `InteractiveOrControl` until the audit-chain emitter wiring
+  lands; list = `ReadOnly`).
+- ADR-002 9th claim shipped: *every published bundle is
+  content-addressed, key_id-pinned, and re-verified at fetch.*
+  Backed by `mvm_plan::bundle::read_and_verify_bundle` rejection-
+  ladder tests. ADR-002 also caught up to document claim 8
+  (signed `ExecutionPlan`, already shipped in plan 64 / ADR-041
+  but never previously in the ADR table).
+
+Outstanding (deferred follow-ups):
+
+- HTTP `mvmctl bundle fetch <url>` — adds a wire client; out of
+  scope for the substrate-close-out commit.
+- Supervisor admit-time bundle re-verify wired into
+  `ExecutionPlan::PlanArtifact`. Requires a plan schema bump
+  (carries `bundle_sha256` + `manifest_sig_base64` + `key_id`),
+  which is its own ADR-touching change.
+- Registry replacement: replace
+  `~/.mvm/templates/<sha256(manifest_path)>/...` keying with
+  bundle-sha256 directories so a fetched bundle slots into the
+  template flow directly.
+- `LocalAuditKind::TrustAdd` / `TrustRemove` variants + emitter
+  wiring so `trust add/remove` flips from `InteractiveOrControl`
+  to `Emits(...)` in the posture table.
 
 ### Sprint 52 success criteria
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1211,6 +1211,98 @@ Sprint 51 closes when:
 5. CHANGELOG.md `[Unreleased]` section captures every shipped
    plan with date, commit SHAs, and links to ADRs.
 
+## Sprint 52 — smolvm gap-closing (in flight)
+
+Scope: pick the ideas mvm is missing from smolvm
+([smolmachines.com](https://smolmachines.com/)) that close real UX
+or perf gaps without compromising the eight ADR-002 security
+claims. The decision document
+(`/Users/auser/.claude/plans/is-there-anything-mvm-giggly-bear.md`)
+ranks eight candidates; this sprint lands the top two:
+
+1. **Virtio-balloon elasticity** — "mem cap, not commitment."
+2. **Portable image bundles + per-artifact attestation in a signed
+   envelope** — content-addressed `.mvmpkg` replaces the
+   manifest-path-hash registry keying.
+
+### W1 — Virtio-balloon elasticity  🟡 substrate landed
+
+Workloads opting into `mem_initial_mib` boot with a pre-inflated
+balloon and only commit a fraction of `memory_mib`; a host-side
+reclaim controller adjusts the balloon over the VM's life.
+
+Shipped:
+
+- `mvm-core` — `VmStartConfig::mem_initial_mib`,
+  `VmCapabilities::balloon`, `BalloonState`,
+  `VmBackend::balloon_set_target` + `balloon_state` trait methods.
+- `mvm-backend::microvm` — `FlakeRunConfig::mem_initial` +
+  validate(); FC start path PUTs `/balloon` with
+  `deflate_on_oom: true`; new `balloon_set_target` / `balloon_state`
+  free functions wrap the FC PATCH + GET endpoints.
+- `mvm-backend::cloud_hypervisor` — `VmConfigArgs::balloon_mib`,
+  emits the top-level `"balloon"` field in vm.create JSON, and
+  `balloon_set_target` posts to `/api/v1/vm.resize`
+  (`desired_balloon`); `balloon_state` parses `/api/v1/vm.info`.
+- `mvm-backend::{apple_container, docker, libkrun, microsandbox,
+  microvm_nix}` — `VmCapabilities::balloon = false` declared
+  honestly with rationale next to each (Apple's VZ has no
+  virtio-balloon; Docker is cgroup-mem not balloon; libkrun's C
+  API + microsandbox builder don't surface balloon control today).
+- `mvm-core::manifest` — `mem_initial: Option<String>` field with
+  `parse_human_size`-backed validation (rejects zero, rejects
+  `>= mem`); `Manifest::mem_initial_mib()` helper.
+- `mvm-backend::image::RuntimeConfig.mem_initial` for the
+  `--config` flow.
+- `mvm-cli::commands::shared::start::VmStartParams.mem_initial_mib`
+  threading through both `up.rs` call sites.
+- `mvm-cli::exec::ExecRequest.mem_initial_mib` threading;
+  short-lived session VM and `mvmctl exec` default to `None`
+  (no balloon).
+- `mvm-supervisor::balloon` — pure-function `BalloonPolicy`
+  (two-threshold band + guest floor) returning `BalloonAction`
+  decisions. Defaults: inflate above 0.80, deflate below 0.60,
+  step 64 MiB, guest floor 64 MiB. Fully unit-tested.
+
+Outstanding (this sprint):
+
+- Host-pressure poller integration — turn `BalloonPolicy` into a
+  running tick by reading PSI/sysinfo and calling
+  `AnyBackend::balloon_set_target` against the live VM registry.
+- `mvmctl doctor` surfaces per-backend `balloon` capability.
+- Live-KVM smoke: assert host RSS climbs/falls as the controller
+  inflates/deflates against a real Firecracker guest.
+- Thread `Manifest::mem_initial_mib()` into the template-baked
+  `tmpl_mem_initial` resolution path so manifest-declared
+  `mem_initial` flows to `mvmctl up` without `--config`.
+
+### W2 — Portable image bundles + per-artifact attestation  ⚪ next
+
+Sigstore-style trust model: bundle ships a signed `manifest.json`
+with per-artifact SHA-256s; the publisher's public key lives
+out-of-band at `~/.mvm/trusted-publishers/<key_id>.pub`. dm-verity
+(claim 3) gives independent per-block integrity inside the rootfs.
+Bundle hash + `key_id` pin into `ExecutionPlan::PlanArtifact` so
+admission re-verifies on every launch.
+
+Not started.
+
+### Sprint 52 success criteria
+
+1. *A workload with `mem_initial = "256M"` and `mem = "1024M"`
+   boots on Firecracker and cloud-hypervisor with the balloon
+   pre-inflated to 768 MiB; the host commits 256 MiB.*
+2. *`AnyBackend::balloon_set_target` adjusts a running FC VM's
+   commitment without reboot, observable through `balloon_state`.*
+3. *A `.mvmpkg` bundle built on machine A round-trips through the
+   registry, fetches to machine B, and `mvmctl up` succeeds; a
+   tampered manifest fails admission with a clear error.*
+4. *`mvm_plan::verify_plan` refuses an `ExecutionPlan` pinned to
+   a bundle whose `key_id` is not in the consumer's trust store.*
+5. *Backwards compatibility: every existing workspace test plus
+   `cargo clippy --workspace --all-targets -- -D warnings` stays
+   green throughout.*
+
 ## Completed Sprints
 
 - [01-foundation.md](sprints/01-foundation.md)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1350,13 +1350,20 @@ Shipped in the W2 close-out commit:
   key_id doesn't match the signing key / actual bytes — caught at
   write time so misconfigured publishers never ship unverifiable
   bundles.
-- `mvmctl bundle fetch <PATH> [--trust-store <DIR>] [--json]`:
-  reads the archive, looks the publisher pubkey up via
+- `mvmctl bundle fetch <SOURCE> [--trust-store <DIR>] [--json] [--allow-http]`:
+  reads the archive (from a local path **or** an `https://` URL —
+  HTTPS uses rustls + webpki-roots through the existing
+  `crate::http::download_file` helper, written to a temp file
+  that drops on scope exit), looks the publisher pubkey up via
   `FsTrustStore` (defaults to `~/.mvm/trusted-publishers/`), runs
   the full 6-step rejection ladder, prints a verified-bundle
   summary (sha256, key_id, publisher, arch, profile, label,
-  artifact count, verity yes/no) or full manifest JSON. Refuses
-  on any verification failure before extraction.
+  artifact count, verity yes/no) or full manifest JSON. Plain
+  `http://` URLs are refused by default — the Ed25519 signature
+  still catches tampering, but HTTP exposes traffic metadata, so
+  the user must opt in explicitly via `--allow-http` (with a
+  launch-time warning). Refuses on any verification failure
+  before extraction.
 - `mvmctl trust add <PUBKEY> [--force]`: reads 32 raw Ed25519
   pubkey bytes, derives `key_id`, writes `<key_id>.pub` to the
   trust store (mode 0644). Refuses to overwrite without `--force`.
@@ -1379,8 +1386,6 @@ Shipped in the W2 close-out commit:
 
 Outstanding (deferred follow-ups):
 
-- HTTP `mvmctl bundle fetch <url>` — adds a wire client; out of
-  scope for the substrate-close-out commit.
 - Supervisor admit-time bundle re-verify wired into
   `ExecutionPlan::PlanArtifact`. Requires a plan schema bump
   (carries `bundle_sha256` + `manifest_sig_base64` + `key_id`),

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1223,7 +1223,7 @@ this sprint lands the top two:
    envelope** — content-addressed `.mvmpkg` replaces the
    manifest-path-hash registry keying.
 
-### W1 — Virtio-balloon elasticity  🟡 substrate landed
+### W1 — Virtio-balloon elasticity  ✅ shipped
 
 Workloads opting into `mem_initial_mib` boot with a pre-inflated
 balloon and only commit a fraction of `memory_mib`; a host-side
@@ -1262,17 +1262,39 @@ Shipped:
   decisions. Defaults: inflate above 0.80, deflate below 0.60,
   step 64 MiB, guest floor 64 MiB. Fully unit-tested.
 
-Outstanding (this sprint):
+Shipped in the W1 close-out commit:
 
-- Host-pressure poller integration — turn `BalloonPolicy` into a
-  running tick by reading PSI/sysinfo and calling
-  `AnyBackend::balloon_set_target` against the live VM registry.
-- `mvmctl doctor` surfaces per-backend `balloon` capability.
+- `HostPressureSource` trait + `SysinfoPressureSource` cross-
+  platform impl. Linux PSI (`/proc/pressure/memory`) and macOS
+  `vm_pressure` are stronger signals; alternative impls behind the
+  same trait are the natural next refinement.
+- `BalloonController<P>` with a pure `tick(vm_states, apply)`
+  method: reads pressure once per tick (not per VM), decides each
+  VM's action via `BalloonPolicy`, applies via the caller's
+  closure. `TickOutcome` per VM carries the decision + applied
+  flag + per-VM error. Pressure-read failure aborts the whole
+  tick rather than applying with a stale value.
+- `mvmctl doctor` "Memory ballooning (virtio-balloon)" section
+  enumerates every backend's `capabilities().balloon`; surfaces a
+  warning when no backend on the host advertises support.
+- `Manifest::mem_initial` flows end-to-end:
+  `Manifest::mem_initial_mib()` → `PersistedManifest.mem_initial_mib`
+  → `TemplateSpec.mem_initial_mib` → `up.rs` resolves
+  `final_mem_initial = rt_config.or(tmpl_mem_initial).filter(0 < n < final_memory)`.
+  Old slot records that predate the field deserialise as `None`
+  (no behaviour change).
+
+Outstanding (deferred to follow-ups):
+
 - Live-KVM smoke: assert host RSS climbs/falls as the controller
-  inflates/deflates against a real Firecracker guest.
-- Thread `Manifest::mem_initial_mib()` into the template-baked
-  `tmpl_mem_initial` resolution path so manifest-declared
-  `mem_initial` flows to `mvmctl up` without `--config`.
+  inflates/deflates against a real Firecracker guest. Needs CI
+  infrastructure that mvm doesn't have today.
+- PSI / `vm_pressure` `HostPressureSource` impls. The current
+  sysinfo-based source is "used/total" — fine for dev-laptop
+  ergonomics, too coarse for production scheduling.
+- Spawn the tick into a real loop inside the supervisor's main
+  loop. Today the controller is a library piece; wiring it into
+  the supervisor's lifecycle is the integration follow-up.
 
 ### W2 — Portable image bundles + per-artifact attestation  🟡 substrate landed
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1276,16 +1276,66 @@ Outstanding (this sprint):
   `tmpl_mem_initial` resolution path so manifest-declared
   `mem_initial` flows to `mvmctl up` without `--config`.
 
-### W2 — Portable image bundles + per-artifact attestation  ⚪ next
+### W2 — Portable image bundles + per-artifact attestation  🟡 substrate landed
 
 Sigstore-style trust model: bundle ships a signed `manifest.json`
 with per-artifact SHA-256s; the publisher's public key lives
 out-of-band at `~/.mvm/trusted-publishers/<key_id>.pub`. dm-verity
 (claim 3) gives independent per-block integrity inside the rootfs.
-Bundle hash + `key_id` pin into `ExecutionPlan::PlanArtifact` so
-admission re-verifies on every launch.
+Bundle hash + `key_id` pin into `PlanArtifact` so admission
+re-verifies on every launch.
 
-Not started.
+Shipped (`mvm-plan::bundle`):
+
+- `BundleManifest` (canonical-JSON, `deny_unknown_fields`),
+  `BundleArtifact`, `ArtifactRole` enum, `VerityInfo` binding.
+- `KeyId` — content-derived identifier (sha256(pubkey) truncated to
+  32 hex chars). Well-formedness validator.
+- `write_bundle()` — emits a tar archive of `manifest.json` +
+  `manifest.sig` + `artifacts/*`. Pre-flight asserts the signing
+  key matches the manifest's declared `key_id` and that every
+  artifact byte-blob matches its declared sha256 + size_bytes.
+- `read_and_verify_bundle()` — 6-step verification sequence:
+  schema-version sniff (pre-sig) → key_id probe (pre-sig) →
+  trust-store lookup → Ed25519 verify → full manifest parse →
+  per-artifact sha256 + size + path-safety re-check. All four
+  failure modes (UnknownKey, SignatureInvalid,
+  ArtifactSha256Mismatch, UnsafePath) reject before extraction.
+- `TrustStore` trait + `FsTrustStore` rooted at
+  `~/.mvm/trusted-publishers/<key_id>.pub`. Pubkey files are 32
+  raw Ed25519 bytes — no PEM, no headers; populated out-of-band
+  for now (`mvmctl trust add` is the follow-up).
+- `PlanArtifact` (re-exported from `mvm_plan::PlanArtifact`):
+  `bundle_sha256` + base64 `manifest_sig` + `key_id`. Sized for
+  inlining inside an `ExecutionPlan`; the supervisor's admit path
+  re-verifies in a follow-up.
+- 18 new unit tests covering: clean round-trip, unknown-key
+  rejection, tampered manifest rejection (sig fail or parse fail),
+  wrong key under correct key_id (KeyIdMismatch), tampered
+  artifact byte rejection (with same-length tamper to exercise the
+  hash path), missing-artifact rejection, unsafe-path rejection
+  (`..`), schema-version-bump rejection, write-time key/key_id
+  mismatch detection, write-time artifact sha256 drift detection,
+  trust-store file load + miss + malformed-key-id short circuit,
+  PlanArtifact JSON round-trip + signature re-decode + deny-unknown-fields.
+
+Outstanding (this sprint):
+
+- `mvmctl bundle export <template> --out <path>` — build pipeline
+  emits `.mvmpkg` archives keyed by content (not manifest-path
+  hash).
+- `mvmctl bundle fetch <url-or-path>` — download + verify + extract
+  into the local template registry, replacing the
+  `~/.mvm/templates/<sha256(manifest_path)>/...` keying scheme with
+  bundle-sha256 directories.
+- `mvmctl trust add/list/remove` — manage
+  `~/.mvm/trusted-publishers/` from the CLI rather than file copy.
+- Supervisor admit path: when an `ExecutionPlan` carries a
+  `PlanArtifact`, re-run `read_and_verify_bundle` against the
+  on-disk archive before backend dispatch; chain-sign the
+  admission outcome to the audit log.
+- 9th security claim drafted in ADR-002: *every published bundle
+  is content-addressed, key_id-pinned, and re-verified at admit.*
 
 ### Sprint 52 success criteria
 

--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -127,6 +127,7 @@ both.
 | 7 | Cargo deps are audited on every PR | cross-cutting (supply chain) | W5.2 | `cargo-deny` + `cargo-audit` jobs; reproducibility double-build (W5.3) |
 | 8 | Every workload runs from a signed, audited `ExecutionPlan` | cross-cutting (policy + audit) | plan 64 W1–W4, ADR-041 | `synthesize_plan` / `host_signer::load_or_init_at` / `admit_for_run` / `AuditEmitter` round-trip + tamper rejection tests; `xtask check-no-display-on-secret-types` |
 | 9 | Every published bundle is content-addressed, key_id-pinned, and re-verified at fetch | cross-cutting (supply chain + integrity) | Sprint 52 W2 | `mvm_plan::bundle::read_and_verify_bundle` rejection-ladder tests: unknown-key, tampered manifest, key_id mismatch, tampered artifact, missing artifact, unsafe path, schema bump; `mvmctl bundle fetch` round-trip against a signed fixture |
+| 10 | No untrusted workload reaches the network unless explicitly admitted by policy | cross-cutting (data containment) | Sprint 52 W3 | `policy_default_is_deny_all` + `test_resolve_network_policy_default_is_deny_all`; `mvmctl up` emits an opt-in warning when the resolved policy is `unrestricted` (escape hatch is `MVM_ACK_UNRESTRICTED_NETWORK=1`) |
 
 L1 (host + hypervisor) has no claim of its own — the host is trusted
 by definition (see Threat model). L1 *enables* claim 3 (verified boot
@@ -151,6 +152,7 @@ only — the CI gate is the source of truth, not the framework code.
 | 7 | T1195.001 (Compromise Software Dependencies and Development Tools) | D3FEND: Software Composition Analysis · CREF: Substantiated Integrity |
 | 8 | T1565 (Data Manipulation), T1574 (Hijack Execution Flow — policy substitution variant) | D3FEND: Authentication, Authorization · CREF: Substantiated Integrity (every launch traces back to a signed, validity-windowed plan) |
 | 9 | T1195.002 (Compromise Software Supply Chain — image variant), T1565.001 (Stored Data Manipulation) | D3FEND: Authentication, Executable Integrity · CREF: Substantiated Integrity (manifest-signed + per-artifact hash + key_id-pinned trust establishment) |
+| 10 | T1071 (Application Layer Protocol — data exfiltration channel), T1041 (Exfiltration Over C2 Channel) | D3FEND: Network Traffic Filtering, Outbound Traffic Filtering · CREF: Privilege Restriction (deny-all default; egress is an explicit opt-in) |
 
 The cold-state guarantee (per-workload fresh boot, no warm pools — see
 CLAUDE.md and the `mvmctl run` lifecycle) is not in the seven-claim

--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -103,12 +103,18 @@ adaptation is that L5 is enforced *inside* the guest by uid/seccomp
 (plan 26), so even a guest-kernel compromise (L3 fall) doesn't grant
 arbitrary access to other in-guest services.
 
-## The seven CI-enforced claims
+## The CI-enforced claims
 
 Each claim is backed by a CI gate that fails the build if the claim
 ceases to hold. Claims are mapped to the trust layer they *primarily*
 defend; many claims have ripple effects across multiple layers, but
 the primary defended layer is the one the gate fails first.
+
+The original ADR shipped with seven claims. Claim 8 (signed
+`ExecutionPlan`) was added by plan 64 / ADR-041 and named in
+CLAUDE.md but not in this table until now. Claim 9 (signed
+bundles) is Sprint 52 W2 — this commit catches the table up to
+both.
 
 | # | Claim | Primary layer | Workstream | CI gate |
 |---|---|---|---|---|
@@ -119,6 +125,8 @@ the primary defended layer is the one the gate fails first.
 | 5 | Vsock framing is fuzzed | L2/L4 | W4.1, W4.2 | `cargo-fuzz` targets in `crates/mvm-guest/fuzz/`; `deny_unknown_fields` audit |
 | 6 | Pre-built dev image is hash-verified | cross-cutting (supply chain) | W5.1 | `download_dev_image` SHA-256 check; `MVM_SKIP_HASH_VERIFY` only documented escape |
 | 7 | Cargo deps are audited on every PR | cross-cutting (supply chain) | W5.2 | `cargo-deny` + `cargo-audit` jobs; reproducibility double-build (W5.3) |
+| 8 | Every workload runs from a signed, audited `ExecutionPlan` | cross-cutting (policy + audit) | plan 64 W1–W4, ADR-041 | `synthesize_plan` / `host_signer::load_or_init_at` / `admit_for_run` / `AuditEmitter` round-trip + tamper rejection tests; `xtask check-no-display-on-secret-types` |
+| 9 | Every published bundle is content-addressed, key_id-pinned, and re-verified at fetch | cross-cutting (supply chain + integrity) | Sprint 52 W2 | `mvm_plan::bundle::read_and_verify_bundle` rejection-ladder tests: unknown-key, tampered manifest, key_id mismatch, tampered artifact, missing artifact, unsafe path, schema bump; `mvmctl bundle fetch` round-trip against a signed fixture |
 
 L1 (host + hypervisor) has no claim of its own — the host is trusted
 by definition (see Threat model). L1 *enables* claim 3 (verified boot
@@ -141,6 +149,8 @@ only — the CI gate is the source of truth, not the framework code.
 | 5 | T1190-class (Exploit of host↔guest interface) | CREF: Substantiated Integrity (deser path proven via fuzzing + `deny_unknown_fields`) |
 | 6 | T1195.002 (Compromise Software Supply Chain) | D3FEND: Executable Integrity (hash + cosign signature verification) · CREF: Substantiated Integrity |
 | 7 | T1195.001 (Compromise Software Dependencies and Development Tools) | D3FEND: Software Composition Analysis · CREF: Substantiated Integrity |
+| 8 | T1565 (Data Manipulation), T1574 (Hijack Execution Flow — policy substitution variant) | D3FEND: Authentication, Authorization · CREF: Substantiated Integrity (every launch traces back to a signed, validity-windowed plan) |
+| 9 | T1195.002 (Compromise Software Supply Chain — image variant), T1565.001 (Stored Data Manipulation) | D3FEND: Authentication, Executable Integrity · CREF: Substantiated Integrity (manifest-signed + per-artifact hash + key_id-pinned trust establishment) |
 
 The cold-state guarantee (per-workload fresh boot, no warm pools — see
 CLAUDE.md and the `mvmctl run` lifecycle) is not in the seven-claim

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -150,6 +150,40 @@ const SNAPSHOT_SUB: &[(&str, AuditPosture)] = &[
     ("rm", AuditPosture::Emits("SnapshotDelete")),
 ];
 
+// Sprint 52 W2 — bundle / trust subcommand tables.
+//
+// `bundle export` writes a `.mvmpkg` archive to disk under the
+// host's `--out` path; that's a local artifact, not host-side
+// state that the audit chain tracks, so it shipped as
+// `InteractiveOrControl` rather than `Emits` for now. Bumping it
+// to a `BundleExport` emission is the natural follow-up when the
+// host-side bundle registry lands.
+//
+// `bundle fetch` is verify-only in this commit (no extraction),
+// so it's `ReadOnly`. When the registry-replacement flow lands
+// and fetch starts mutating `~/.mvm/templates/<bundle-sha256>/`,
+// this row flips to `Emits("BundleFetch")`.
+//
+// `trust` mutates `~/.mvm/trusted-publishers/`. add/remove emit
+// audit entries (publisher trust is host-trust-boundary state);
+// list is `ReadOnly`.
+const BUNDLE_SUB: &[(&str, AuditPosture)] = &[
+    ("export", AuditPosture::InteractiveOrControl),
+    ("fetch", AuditPosture::ReadOnly),
+];
+
+// trust add/remove mutate `~/.mvm/trusted-publishers/` but the
+// audit chain integration (new `LocalAuditKind::TrustAdd /
+// TrustRemove` variants + emitter wiring) hasn't landed yet —
+// same staged shape `policy update` used while waiting on plan
+// 60 Phase 8. Bumping these to `Emits("TrustAdd"/"TrustRemove")`
+// is the follow-up that goes with the audit-chain hook-up.
+const TRUST_SUB: &[(&str, AuditPosture)] = &[
+    ("add", AuditPosture::InteractiveOrControl),
+    ("list", AuditPosture::ReadOnly),
+    ("remove", AuditPosture::InteractiveOrControl),
+];
+
 /// Every top-level `mvmctl` subcommand keyed by its clap name.
 ///
 /// Order matches the `Commands` enum in
@@ -202,6 +236,9 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     ("secret", AuditPosture::DelegatesToSub(SECRET_SUB)),
     ("attest", AuditPosture::DelegatesToSub(ATTEST_SUB)),
     ("policy", AuditPosture::DelegatesToSub(POLICY_SUB)),
+    // Sprint 52 W2 — bundles + trust store.
+    ("bundle", AuditPosture::DelegatesToSub(BUNDLE_SUB)),
+    ("trust", AuditPosture::DelegatesToSub(TRUST_SUB)),
 ];
 
 // ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Sprint 52 substrate for two ergonomics + reach gaps. Both shipped as opt-in plumbing with their CLI surfaces / integration loops called out as follow-ups in `specs/SPRINT.md`.

- **Virtio-balloon — mem cap, not commitment.** Workloads opting into `VmStartConfig::mem_initial_mib` boot with a pre-inflated balloon; the host commits only the initial fraction. Firecracker (PUT `/balloon`, PATCH for retarget, GET for state) and cloud-hypervisor (top-level `balloon` field, PUT `/api/v1/vm.resize`, GET `/api/v1/vm.info`) wired. Other backends declare `balloon: false` honestly. New `BalloonPolicy` in mvm-supervisor is a pure decide function — host-pressure poller integration is the remaining W1 item.
- **Portable image bundles + sigstore-style trust.** New `mvm-plan::bundle` ships `BundleManifest` + `KeyId` + `write_bundle` / `read_and_verify_bundle` with a 6-step rejection ladder (schema sniff, key_id probe, trust-store lookup, Ed25519 verify, manifest parse, per-artifact sha256/size/path re-check). Pubkey never lives in the bundle — `FsTrustStore` rooted at `~/.mvm/trusted-publishers/<key_id>.pub`. `PlanArtifact` pins (bundle_sha256, base64 sig, key_id) sized for inlining into `ExecutionPlan`. Supervisor admit-time re-verify is the W2 follow-up.

## Commits

- `45ad87f` — `feat(balloon): virtio-balloon substrate — mem cap, not commitment`
- `a5078c9` — `feat(bundle): portable .mvmpkg bundles with sigstore-style trust`
- `6ae49c4` — `docs(SPRINT): reword Sprint 52 banner without naming external reference design`

## Test plan

- [ ] `cargo test --workspace --lib -- --test-threads=1` — 327 supervisor + 129 mvm-backend + 29 mvm-plan tests green (single-threaded works around a pre-existing \$HOME-mocking flake in `microsandbox::tests::record_start_mode_from_rootfs_*` unrelated to this PR)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Read \`specs/SPRINT.md\` Sprint 52 section to confirm scope + follow-ups match expectations
- [ ] Sanity-check the balloon JSON shape Firecracker emits — `PUT /balloon { amount_mib, deflate_on_oom: true, stats_polling_interval_s: 1 }` only present when `mem_initial_mib` is `Some`
- [ ] Sanity-check the cloud-hypervisor balloon shape — top-level \`"balloon": { "size": <bytes>, "deflate_on_oom": true }\` only when opted in
- [ ] Review the trust model in `crates/mvm-plan/src/bundle.rs` module rustdoc — confirm "pubkey never lives in the bundle" is the intended posture
- [ ] Confirm the new `BundleManifest`, `BundleArtifact`, `PlanArtifact` all carry `#[serde(deny_unknown_fields)]`
- [ ] Walk the 6-step verification ladder in `read_and_verify_bundle` against the unit tests to satisfy that rejection happens *before* artifact extraction

## Notes for follow-up

`specs/SPRINT.md` lists the close-outs that turn each substrate into a productive feature: host-pressure poller integration + `mvmctl doctor` surfacing for W1; `mvmctl bundle export/fetch` + `mvmctl trust add/list/remove` + supervisor admit-time re-verify + ADR-002 9th claim for W2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)