### PR TITLE
plan-69: MVM_UPDATE_API_URL + httpmock live UpdateInstall coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +189,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,15 +230,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -247,6 +287,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,9 +339,18 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
 ]
 
 [[package]]
@@ -281,14 +359,14 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-lite",
  "rustix 1.1.4",
 ]
@@ -320,6 +398,34 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -463,6 +569,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +617,21 @@ dependencies = [
  "shlex",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -558,7 +690,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1534,6 +1666,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,8 +1683,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1685,6 +1838,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1941,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -1794,7 +1962,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -1836,6 +2004,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -2199,7 +2373,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -2439,6 +2613,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2458,12 +2643,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2474,8 +2670,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2484,6 +2680,40 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "humansize"
@@ -2505,6 +2735,29 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -2514,8 +2767,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2531,8 +2784,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2552,14 +2805,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2850,7 +3103,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2",
+ "socket2 0.6.2",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -2896,6 +3149,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -3106,6 +3368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "kvm-bindings"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3398,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph 0.6.5",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3140,6 +3442,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "lexical"
@@ -3353,6 +3661,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -4180,6 +4491,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "httpmock",
  "mimalloc",
  "mvm",
  "mvm-backend",
@@ -4208,6 +4520,12 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "newline-converter"
@@ -4450,7 +4768,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
- "http",
+ "http 1.4.0",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
@@ -4535,7 +4853,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-auth",
  "jwt",
  "lazy_static",
@@ -4561,7 +4879,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-auth",
  "jsonwebtoken",
  "lazy_static",
@@ -4670,7 +4988,7 @@ dependencies = [
  "flagset",
  "futures",
  "getrandom 0.2.17",
- "http",
+ "http 1.4.0",
  "log",
  "md-5",
  "once_cell",
@@ -4695,7 +5013,7 @@ dependencies = [
  "dyn-clone",
  "ed25519-dalek",
  "hmac",
- "http",
+ "http 1.4.0",
  "itertools 0.10.5",
  "log",
  "oauth2",
@@ -4952,11 +5270,21 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
 ]
@@ -4998,6 +5326,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -5160,6 +5494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5305,7 +5645,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
@@ -5404,7 +5744,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5442,7 +5782,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5582,6 +5922,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -5667,7 +6018,7 @@ dependencies = [
  "hex",
  "hmac",
  "home",
- "http",
+ "http 1.4.0",
  "log",
  "percent-encoding",
  "quick-xml 0.37.5",
@@ -5692,10 +6043,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -5736,10 +6087,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -6379,6 +6730,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6635,6 +6996,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6714,6 +7081,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -6766,7 +7143,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -6948,6 +7325,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7118,6 +7507,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7270,7 +7670,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -7450,8 +7850,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -7710,7 +8110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -7769,6 +8169,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -8753,7 +9159,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-sink",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,9 @@ chrono.workspace = true
 # `clap::Command` tree returned by `mvm_cli::commands::cli_command()`
 # to enforce that every subcommand has a declared audit posture.
 clap.workspace = true
+# Plan 69: local mock HTTP server for the `mvmctl update` live test.
+# Avoids reaching the real GitHub release API in CI / on dev machines.
+httpmock = "0.7"
 predicates.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -62,6 +62,18 @@ impl MockBackend {
     pub fn count(&self) -> usize {
         self.state.lock().map(|s| s.len()).unwrap_or(0)
     }
+
+    /// Host-side per-VM directory for a mock VM. Lives under
+    /// `<mvm_data_dir>/mock-vms/<name>/` so it never collides with
+    /// the Lima-era `~/microvm/vms/<name>` path that
+    /// `resolve_running_vm_dir` expects for real Firecracker VMs.
+    /// Plan 65 W1: `pause.rs` and `resume.rs` read the snapshot
+    /// directory through here when `--hypervisor mock` is set.
+    pub fn vm_dir(name: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from(mvm_core::config::mvm_data_dir())
+            .join("mock-vms")
+            .join(name)
+    }
 }
 
 impl VmBackend for MockBackend {
@@ -87,6 +99,13 @@ impl VmBackend for MockBackend {
         if state.contains_key(&config.name) {
             bail!("mock: VM '{}' already running", config.name);
         }
+        // Plan 65 W1: create a host-side per-VM directory so the
+        // verbs that probe `<vm_dir>/...` paths (pause/resume's
+        // snapshot dir; future fs/proc/volume work) find something
+        // real. Best-effort — a failure here doesn't abort start
+        // because not every consumer needs the directory.
+        let vm_dir = Self::vm_dir(&config.name);
+        let _ = std::fs::create_dir_all(&vm_dir);
         state.insert(
             config.name.clone(),
             MockVm {

--- a/crates/mvm-cli/src/commands/vm/pause.rs
+++ b/crates/mvm-cli/src/commands/vm/pause.rs
@@ -18,7 +18,9 @@ use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
 
-use mvm::vm::instance_snapshot::{FirecrackerIO, pause_and_seal, verify_and_resume};
+use mvm::vm::instance_snapshot::{
+    CannedIO, FirecrackerIO, SnapshotIO, pause_and_seal, verify_and_resume,
+};
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
 
@@ -30,6 +32,14 @@ pub(in crate::commands) struct PauseArgs {
     /// Name of the VM to pause
     #[arg(value_parser = clap_vm_name)]
     pub name: String,
+    /// Hypervisor to drive the snapshot through. Defaults to
+    /// `firecracker`. `--hypervisor mock` swaps the FirecrackerIO
+    /// snapshot transport for `CannedIO` (writes deterministic
+    /// stub bytes to vmstate.bin + mem.bin), letting plan 65's
+    /// live tests exercise `WorkloadSleep` without a real
+    /// Firecracker socket.
+    #[arg(long, default_value = "firecracker")]
+    pub hypervisor: String,
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -37,17 +47,48 @@ pub(in crate::commands) struct ResumeArgs {
     /// Name of the VM to resume
     #[arg(value_parser = clap_vm_name)]
     pub name: String,
+    /// Hypervisor to drive the restore through. Defaults to
+    /// `firecracker`. See `pause --help` for the `mock` variant.
+    #[arg(long, default_value = "firecracker")]
+    pub hypervisor: String,
+}
+
+/// Pick the `SnapshotIO` impl matching the hypervisor selector.
+/// Plan 65 W2: `mock` swaps in `CannedIO` for hermetic
+/// `WorkloadSleep` / `WorkloadWake` audit-emit coverage; every
+/// other selector uses `FirecrackerIO` against the running VM's
+/// UDS socket.
+fn snapshot_io_for(hypervisor: &str, vm_name: &str) -> Result<Box<dyn SnapshotIO>> {
+    if hypervisor == "mock" {
+        // The mock VM's per-VM directory lives at
+        // `<mvm_data_dir>/mock-vms/<name>/` and is created by
+        // `MockBackend::start_with_mode`. Nothing to validate here
+        // beyond its existence — `pause_and_seal` writes the
+        // snapshot files into a sibling `snapshot/` directory.
+        let dir = mvm_backend::MockBackend::vm_dir(vm_name);
+        if !dir.exists() {
+            bail!(
+                "mock VM {vm_name:?} is not running (no directory at {})",
+                dir.display()
+            );
+        }
+        return Ok(Box::new(CannedIO {
+            vmstate_bytes: b"mock-vmstate".to_vec(),
+            mem_bytes: b"mock-mem".to_vec(),
+        }));
+    }
+    let vm_dir = mvm_backend::microvm::resolve_running_vm_dir(vm_name)
+        .with_context(|| format!("VM {vm_name:?} is not running"))?;
+    let socket = firecracker_socket(&vm_dir);
+    Ok(Box::new(FirecrackerIO::new(socket)))
 }
 
 pub(in crate::commands) fn run_pause(_cli: &Cli, args: PauseArgs, _cfg: &MvmConfig) -> Result<()> {
     validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
-    let vm_dir = mvm_backend::microvm::resolve_running_vm_dir(&args.name)
-        .with_context(|| format!("VM {:?} is not running", args.name))?;
-    let socket = firecracker_socket(&vm_dir);
-    let io = FirecrackerIO::new(socket);
+    let io = snapshot_io_for(&args.hypervisor, &args.name)?;
 
     let sidecar =
-        pause_and_seal(&args.name, &io).with_context(|| format!("pausing VM {:?}", args.name))?;
+        pause_and_seal(&args.name, &*io).with_context(|| format!("pausing VM {:?}", args.name))?;
 
     let registry_path = mvm::vm::name_registry::registry_path();
     if let Ok(mut registry) = mvm::vm::name_registry::VmNameRegistry::load(&registry_path) {
@@ -58,7 +99,7 @@ pub(in crate::commands) fn run_pause(_cli: &Cli, args: PauseArgs, _cfg: &MvmConf
         "{}: paused (epoch {}, vmstate {} B, mem {} B)",
         args.name, sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
-    mvm_core::audit_emit!(WorkloadSleep, vm: args.name, "epoch={} vmstate={} mem={}" ,
+    mvm_core::audit_emit!(WorkloadSleep, vm: &args.name, "epoch={} vmstate={} mem={}" ,
         sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
     Ok(())
@@ -76,19 +117,13 @@ pub(in crate::commands) fn run_resume(
     // requires the user to have already started a fresh VM
     // shell that's waiting for the snapshot load (Firecracker's
     // restore-into-empty-VMM workflow). The substrate is
-    // ready; the launcher integration is a follow-up.
-    let vm_dir = mvm_backend::microvm::resolve_running_vm_dir(&args.name).with_context(|| {
-        format!(
-            "VM {:?} has no running Firecracker shell; resume currently \
-                 requires a fresh `mvmctl up --resume-from-snapshot` (follow-up). \
-                 Substrate verifies, the launcher integration is pending.",
-            args.name
-        )
-    })?;
-    let socket = firecracker_socket(&vm_dir);
-    let io = FirecrackerIO::new(socket);
+    // ready; the launcher integration is a follow-up. Plan 65
+    // W2: `--hypervisor mock` swaps in `CannedIO` so the
+    // verify-resume path can land its `WorkloadWake` audit emit
+    // without a live Firecracker socket.
+    let io = snapshot_io_for(&args.hypervisor, &args.name)?;
 
-    let sidecar = verify_and_resume(&args.name, &io)
+    let sidecar = verify_and_resume(&args.name, &*io)
         .with_context(|| format!("resuming VM {:?}", args.name))?;
 
     let registry_path = mvm::vm::name_registry::registry_path();
@@ -100,7 +135,7 @@ pub(in crate::commands) fn run_resume(
         "{}: resumed (epoch {}, vmstate {} B, mem {} B)",
         args.name, sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
-    mvm_core::audit_emit!(WorkloadWake, vm: args.name, "epoch={} vmstate={} mem={}" ,
+    mvm_core::audit_emit!(WorkloadWake, vm: &args.name, "epoch={} vmstate={} mem={}" ,
         sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
     Ok(())

--- a/crates/mvm-cli/src/update.rs
+++ b/crates/mvm-cli/src/update.rs
@@ -41,10 +41,42 @@ fn detect_target() -> Result<&'static str> {
     );
 }
 
+/// Base URL for the GitHub releases query.
+///
+/// Defaults to `https://api.github.com`. `MVM_UPDATE_API_URL` overrides
+/// for hermetic tests (plan 69) — the env-var supplies the bare host
+/// (e.g. `http://127.0.0.1:8080`) and the existing path suffix
+/// `/repos/<repo>/releases/latest` is appended. The override path
+/// emits a warning so the bypass is visible in stderr.
+fn github_api_base() -> String {
+    if let Ok(base) = std::env::var("MVM_UPDATE_API_URL")
+        && !base.trim().is_empty()
+    {
+        eprintln!("[mvm] MVM_UPDATE_API_URL set; using {base} (test path).");
+        return base.trim().trim_end_matches('/').to_string();
+    }
+    String::from("https://api.github.com")
+}
+
+/// Base URL for GitHub release-asset downloads.
+///
+/// Defaults to `https://github.com`. `MVM_UPDATE_DOWNLOAD_URL` overrides
+/// for hermetic tests — same shape as `MVM_UPDATE_API_URL`.
+fn github_download_base() -> String {
+    if let Ok(base) = std::env::var("MVM_UPDATE_DOWNLOAD_URL")
+        && !base.trim().is_empty()
+    {
+        eprintln!("[mvm] MVM_UPDATE_DOWNLOAD_URL set; using {base} (test path).");
+        return base.trim().trim_end_matches('/').to_string();
+    }
+    String::from("https://github.com")
+}
+
 /// Query the GitHub releases API for the latest release tag name.
 fn fetch_latest_version() -> Result<String> {
     let url = format!(
-        "https://api.github.com/repos/{}/releases/latest",
+        "{}/repos/{}/releases/latest",
+        github_api_base(),
         GITHUB_REPO
     );
 
@@ -90,8 +122,10 @@ fn parse_checksum_line(line: &str) -> Result<[u8; 32]> {
 /// and confirms it matches the digest of the file at `archive_path`.
 fn verify_checksum(version: &str, archive_name: &str, archive_path: &Path) -> Result<()> {
     let checksum_url = format!(
-        "https://github.com/{}/releases/download/{}/checksums-sha256.txt",
-        GITHUB_REPO, version
+        "{}/{}/releases/download/{}/checksums-sha256.txt",
+        github_download_base(),
+        GITHUB_REPO,
+        version
     );
 
     let checksum_text = http::fetch_text(&checksum_url)
@@ -140,8 +174,11 @@ fn hex_encode(bytes: &[u8]) -> String {
 fn download_release(version: &str, target: &str, tmp_dir: &Path) -> Result<()> {
     let archive_name = format!("mvmctl-{}.tar.gz", target);
     let download_url = format!(
-        "https://github.com/{}/releases/download/{}/{}",
-        GITHUB_REPO, version, archive_name
+        "{}/{}/releases/download/{}/{}",
+        github_download_base(),
+        GITHUB_REPO,
+        version,
+        archive_name
     );
     let dest = tmp_dir.join(&archive_name);
 
@@ -428,8 +465,11 @@ fn verify_signature(version: &str, archive_name: &str, archive_path: &Path) -> R
 
     let bundle_name = format!("{}.bundle", archive_name);
     let bundle_url = format!(
-        "https://github.com/{}/releases/download/{}/{}",
-        GITHUB_REPO, version, bundle_name
+        "{}/{}/releases/download/{}/{}",
+        github_download_base(),
+        GITHUB_REPO,
+        version,
+        bundle_name
     );
     let bundle_path = archive_path
         .parent()

--- a/crates/mvm/src/vm/instance_snapshot.rs
+++ b/crates/mvm/src/vm/instance_snapshot.rs
@@ -117,7 +117,7 @@ pub trait SnapshotIO {
 /// 3. Tighten file modes to 0600.
 /// 4. Bump the per-instance epoch counter.
 /// 5. Seal the HMAC envelope with the new epoch.
-pub fn pause_and_seal<IO: SnapshotIO>(vm_name: &str, io: &IO) -> Result<IntegritySidecar> {
+pub fn pause_and_seal<IO: SnapshotIO + ?Sized>(vm_name: &str, io: &IO) -> Result<IntegritySidecar> {
     let dir = prepare_instance_snapshot_dir(vm_name)?;
     io.create_snapshot(&dir)
         .with_context(|| format!("Firecracker create_snapshot({})", dir.display()))?;
@@ -159,7 +159,10 @@ pub fn pause_and_seal<IO: SnapshotIO>(vm_name: &str, io: &IO) -> Result<Integrit
 ///
 /// Returns the verified sidecar so the caller can audit it before
 /// resuming Firecracker.
-pub fn verify_and_resume<IO: SnapshotIO>(vm_name: &str, io: &IO) -> Result<IntegritySidecar> {
+pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
+    vm_name: &str,
+    io: &IO,
+) -> Result<IntegritySidecar> {
     let dir = snapshot_dir(vm_name);
     if !dir.exists() {
         bail!(

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -75,6 +75,11 @@
 //!   entry (the `ATTEST` leaves are all ReadOnly)
 //! - `mvmctl session ls` / `volume ls <vm>` → **no** audit entry
 //!   (SESSION ls and VOLUME ls leaves are both ReadOnly)
+//! - `mvmctl volume mount <vm> ...` → `VmVolumeAdd` (Plan 67:
+//!   the verb operates purely on the host-side
+//!   `~/.mvm/instances/<vm>/volume_mounts.json` registry — no
+//!   virtio-fs daemon attach, no backend dispatch)
+//! - `mvmctl volume unmount <vm> <guest>` → `VmVolumeRemove`
 //! - `mvmctl ls` / `metrics` / `catalog list` → **no** audit entry
 //!   (top-level ReadOnly verbs — three more rows from
 //!   `AUDIT_POSTURE` pinned against a future regression that
@@ -1333,6 +1338,105 @@ fn volume_ls_does_not_emit_audit_entry() {
         log.is_empty(),
         "read-only `volume ls` must not write to the LocalAudit \
          stream. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn volume_mount_emits_vm_volume_add_audit_entry() {
+    // Plan 67: `volume mount` operates purely on the host-side
+    // `~/.mvm/instances/<vm>/volume_mounts.json` registry — no
+    // virtio-fs daemon attach, no Firecracker socket. The audit
+    // emit fires after the registry write. Hermetic out of the box.
+    let sandbox = AuditSandbox::new();
+    let host_share = sandbox.home_path().join("share");
+    std::fs::create_dir_all(&host_share).expect("mkdir host share");
+
+    let output = sandbox
+        .mvmctl()
+        .args([
+            "volume",
+            "mount",
+            "vol-test-vm",
+            "--volume",
+            "mydata",
+            "--host",
+            host_share.to_str().expect("utf-8 path"),
+            "--guest",
+            "/mnt/data",
+        ])
+        .output()
+        .expect("spawn mvmctl volume mount");
+    assert!(
+        output.status.success(),
+        "mvmctl volume mount failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_volume_add");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_volume_add entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"vol-test-vm\""),
+        "vm_volume_add must carry vm_name=vol-test-vm. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("guest=/mnt/data"),
+        "vm_volume_add detail must record guest=/mnt/data. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn volume_unmount_emits_vm_volume_remove_audit_entry() {
+    // Plan 67: mount-then-unmount round-trip. Both emits land in
+    // the LocalAudit stream; this test pins the remove half.
+    let sandbox = AuditSandbox::new();
+    let host_share = sandbox.home_path().join("share");
+    std::fs::create_dir_all(&host_share).expect("mkdir host share");
+
+    let mount = sandbox
+        .mvmctl()
+        .args([
+            "volume",
+            "mount",
+            "vol-rm-vm",
+            "--volume",
+            "mydata",
+            "--host",
+            host_share.to_str().expect("utf-8 path"),
+            "--guest",
+            "/mnt/data",
+        ])
+        .output()
+        .expect("spawn mvmctl volume mount");
+    assert!(
+        mount.status.success(),
+        "mvmctl volume mount failed: stderr={}",
+        String::from_utf8_lossy(&mount.stderr)
+    );
+
+    let unmount = sandbox
+        .mvmctl()
+        .args(["volume", "unmount", "vol-rm-vm", "/mnt/data"])
+        .output()
+        .expect("spawn mvmctl volume unmount");
+    assert!(
+        unmount.status.success(),
+        "mvmctl volume unmount failed: stderr={}",
+        String::from_utf8_lossy(&unmount.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_volume_remove");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_volume_remove entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"vol-rm-vm\""),
+        "vm_volume_remove must carry vm_name=vol-rm-vm. Full log:\n{log}"
     );
 }
 

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -50,6 +50,15 @@
 //! - `mvmctl set-ttl <vm> <duration>` (after `up --hypervisor mock`)
 //!   → `VmTtlSet` (chains off the up-via-mock fixture; the verb
 //!   operates on the persistent name registry that `up` populates)
+//! - `mvmctl pause <vm> --hypervisor mock` (after `up`) →
+//!   `WorkloadSleep` (Plan 65: pause routes through the SnapshotIO
+//!   trait; `--hypervisor mock` swaps in `CannedIO` so the seal
+//!   step writes deterministic 12-byte vmstate + 8-byte mem stubs
+//!   instead of talking to a real Firecracker UDS)
+//! - `mvmctl resume <vm> --hypervisor mock` (after `pause`) →
+//!   `WorkloadWake` (mirrors; verify-and-resume against the sealed
+//!   sidecar succeeds because the seal was written under
+//!   deterministic-stubs round-trip)
 //! - `mvmctl down` (no args, empty sandbox) → `VmStop`
 //!   (`stop_all` is tolerant of an empty VM registry and emits
 //!   with `detail=stop_all_ok`)
@@ -900,6 +909,86 @@ fn set_ttl_clear_emits_vm_ttl_set_with_cleared_detail() {
     assert!(
         log.contains("expires_at=cleared"),
         "set-ttl --clear must record expires_at=cleared. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn pause_emits_workload_sleep_audit_entry() {
+    // Plan 65 W3: `mvmctl pause --hypervisor mock` exercises the
+    // snapshot-and-seal path against `CannedIO` (deterministic
+    // 12-byte vmstate + 8-byte mem stubs). Pre-Plan-65 the verb
+    // would have bailed on `resolve_running_vm_dir` because the
+    // mock VM has no Lima-shaped vm_dir; the `--hypervisor mock`
+    // selector routes through `MockBackend::vm_dir(name)` instead.
+    let sandbox = AuditSandbox::new();
+    bring_up_mock_vm(&sandbox, "pause-vm");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["pause", "pause-vm", "--hypervisor", "mock"])
+        .output()
+        .expect("spawn mvmctl pause");
+    assert!(
+        output.status.success(),
+        "mvmctl pause failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "workload_sleep");
+    assert!(
+        hits >= 1,
+        "expected ≥1 workload_sleep entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"pause-vm\""),
+        "workload_sleep must carry vm_name=pause-vm. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("epoch="),
+        "workload_sleep detail must record the epoch. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn resume_emits_workload_wake_audit_entry() {
+    // Plan 65 W3: pause-then-resume against the mock backend.
+    // The seal-and-verify round-trip works because `CannedIO`
+    // writes its stubs to disk and `verify_and_resume` reads
+    // them back through the same HMAC-sealed sidecar.
+    let sandbox = AuditSandbox::new();
+    bring_up_mock_vm(&sandbox, "resume-vm");
+
+    let pause = sandbox
+        .mvmctl()
+        .args(["pause", "resume-vm", "--hypervisor", "mock"])
+        .output()
+        .expect("spawn mvmctl pause");
+    assert!(
+        pause.status.success(),
+        "mvmctl pause failed: stderr={}",
+        String::from_utf8_lossy(&pause.stderr)
+    );
+    let resume = sandbox
+        .mvmctl()
+        .args(["resume", "resume-vm", "--hypervisor", "mock"])
+        .output()
+        .expect("spawn mvmctl resume");
+    assert!(
+        resume.status.success(),
+        "mvmctl resume failed: stderr={}",
+        String::from_utf8_lossy(&resume.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "workload_wake");
+    assert!(
+        hits >= 1,
+        "expected ≥1 workload_wake entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"resume-vm\""),
+        "workload_wake must carry vm_name=resume-vm. Full log:\n{log}"
     );
 }
 

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -84,6 +84,14 @@
 //!   (top-level ReadOnly verbs — three more rows from
 //!   `AUDIT_POSTURE` pinned against a future regression that
 //!   adds an emit to a read-only path)
+//! - `mvmctl update` (against an `httpmock` server returning the
+//!   current version) → `UpdateInstall` (Plan 69: the
+//!   `MVM_UPDATE_API_URL` env-var redirects the
+//!   `https://api.github.com/.../releases/latest` query to a local
+//!   mock that returns the current binary's own version.
+//!   `update::update` exits early with "already up to date" and
+//!   the outer wrapper emits `UpdateInstall`. No real network, no
+//!   binary swap.)
 //! - `mvmctl uninstall --yes --dry-run` → **no** audit entry
 //!   (the positive `Uninstall` path is real-system-destructive
 //!   and not safely-hermetic, but the dry-run path is read-only
@@ -1255,6 +1263,84 @@ fn catalog_list_does_not_emit_audit_entry() {
         log.is_empty(),
         "read-only `mvmctl catalog list` must not write to the \
          LocalAudit stream. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn update_emits_update_install_audit_entry_against_mocked_github() {
+    // Plan 69: `mvmctl update` reaches `api.github.com/releases/latest`
+    // by default. The `MVM_UPDATE_API_URL` env-var redirects the
+    // base URL to a local `httpmock` server, which returns the
+    // current binary's own version. `update::update` then exits
+    // early on the "already up to date" branch — Ok(()) without
+    // swapping the binary — and the outer wrapper at
+    // `commands/env/update.rs` emits `UpdateInstall`. No real
+    // network, no binary swap, no install dance.
+    let server = httpmock::MockServer::start();
+    let current_version = env!("CARGO_PKG_VERSION");
+    let _api_mock = server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path_contains("/releases/latest");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(format!(r#"{{"tag_name":"v{current_version}"}}"#));
+    });
+
+    let sandbox = AuditSandbox::new();
+    let output = sandbox
+        .mvmctl()
+        .env("MVM_UPDATE_API_URL", server.base_url())
+        .args(["update"])
+        .output()
+        .expect("spawn mvmctl update");
+    assert!(
+        output.status.success(),
+        "mvmctl update failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "update_install");
+    assert!(
+        hits >= 1,
+        "expected ≥1 update_install entry, got {hits}. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn update_check_does_not_emit_audit_entry() {
+    // Negative: `update --check` short-circuits before the install
+    // path AND before the outer wrapper's audit-emit branch
+    // (`!args.check` guard at `commands/env/update.rs`). Read-only;
+    // pins that against a future regression that emits on check.
+    let server = httpmock::MockServer::start();
+    let _api_mock = server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path_contains("/releases/latest");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(r#"{"tag_name":"v0.999.0"}"#);
+    });
+
+    let sandbox = AuditSandbox::new();
+    let output = sandbox
+        .mvmctl()
+        .env("MVM_UPDATE_API_URL", server.base_url())
+        .args(["update", "--check"])
+        .output()
+        .expect("spawn mvmctl update --check");
+    assert!(
+        output.status.success(),
+        "mvmctl update --check failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "update_install");
+    assert_eq!(
+        hits, 0,
+        "read-only `update --check` must not emit; got {hits}. \
+         Full log:\n{log}"
     );
 }
 


### PR DESCRIPTION
## Summary

Plan 69. Two env-var overrides + an `httpmock` fixture pin the `UpdateInstall` Emits row without reaching the real GitHub release API.

### What lands

1. **`MVM_UPDATE_API_URL`** — overrides the GitHub releases API base (default `https://api.github.com`). The path suffix `/repos/<repo>/releases/latest` is appended.
2. **`MVM_UPDATE_DOWNLOAD_URL`** — overrides the asset download base (default `https://github.com`). Wired for symmetry; tests don't reach the download path because the mock returns the current binary's own version.
3. Both overrides log a stderr warning when set.
4. **`httpmock = "0.7"`** added to `[dev-dependencies]` only.
5. **Two live tests**:
   - `update_emits_update_install_audit_entry_against_mocked_github` — mock returns `tag_name = "v<CARGO_PKG_VERSION>"`, `update::update` takes the "already up to date" branch (returns Ok without downloading), outer wrapper emits `UpdateInstall`.
   - `update_check_does_not_emit_audit_entry` — pins the negative for `--check` mode.

### Why the "already up to date" branch

Driving the install path end-to-end would require:
- A tarball download mock returning real `mvmctl-<target>.tar.gz` bytes
- A matching `checksums-sha256.txt` mock
- A `cosign` bundle mock (or `--skip-verify`)
- The `extract_and_install` step would then rename into `current_exe`, **overwriting the test runner's mvmctl binary**.

The "already up to date" branch is exactly the no-op-but-still-emits case Plan 37 §6 covers. It exercises every URL the test cares about (the API query) and lands the audit emit without the destructive install step.

## Verification

- [x] `cargo test -p mvmctl --test audit_emissions_live`: 46 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean
- [x] `cargo run -p xtask -- check-audit-positional`: clean

## Notes

- **Targets** `feat/plan-67-volume-mock` (PR #116). Merge order: #106 → #107 → #108 → #114 → #116 → this PR.
- Live test count: 44 → 46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)