### PR TITLE
feat(bundle): registry replacement + --bundle-pin + audit-kind variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3867,6 +3867,7 @@ version = "0.14.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "chrono",
  "colored",
  "ed25519-dalek",
  "indicatif",
@@ -3878,6 +3879,7 @@ dependencies = [
  "mvm-build",
  "mvm-core",
  "mvm-guest",
+ "mvm-plan",
  "mvm-providers",
  "mvm-security",
  "opendal",

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -38,6 +38,7 @@ inquire.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+tar = "0.4"
 tempfile.workspace = true
 tera.workspace = true
 toml.workspace = true
@@ -53,11 +54,6 @@ assert_cmd.workspace = true
 ed25519-dalek.workspace = true
 predicates.workspace = true
 rand.workspace = true
-# Sprint 52 W2 follow-on: admit-time bundle re-verify tests need
-# to crack open `.mvmpkg` archives to recover the manifest sig
-# for pin construction. tar is the same dep mvm-plan uses
-# production-side.
-tar = "0.4"
 
 [lints]
 workspace = true

--- a/crates/mvm-cli/src/commands/bundle/export.rs
+++ b/crates/mvm-cli/src/commands/bundle/export.rs
@@ -143,6 +143,15 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         (None, None) => None,
     };
 
+    // Bake the template's declared resources into the bundle so
+    // `mvmctl up <bundle-sha>` on another host gets sensible
+    // defaults without re-discovering them. CLI `--cpus` /
+    // `--memory` still override at launch time.
+    let resources = Some(mvm_plan::BundleResources {
+        vcpus: spec.vcpus as u32,
+        mem_mib: spec.mem_mib,
+    });
+
     let manifest = BundleManifest {
         schema_version: BUNDLE_SCHEMA_VERSION,
         publisher: host_signer::host_signer_id(),
@@ -155,6 +164,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         labels: Default::default(),
         artifacts,
         verity,
+        resources,
     };
 
     // ---- 4. Sign + write the archive ----

--- a/crates/mvm-cli/src/commands/bundle/fetch.rs
+++ b/crates/mvm-cli/src/commands/bundle/fetch.rs
@@ -79,6 +79,15 @@ impl BundleSource {
     }
 }
 
+/// Pub variant of [`load_archive_bytes`] for sibling subcommands
+/// (`mvmctl bundle install`) that reuse the same source-parsing +
+/// transport rules. Parses `source` into a [`BundleSource`] and
+/// dispatches.
+pub(in crate::commands) fn load_bundle_bytes(source: &str, allow_http: bool) -> Result<Vec<u8>> {
+    let parsed = BundleSource::parse(source);
+    load_archive_bytes(&parsed, allow_http)
+}
+
 /// Load the archive bytes, honouring the source's transport
 /// rules. HTTPS downloads write to a temp file (via
 /// `crate::http::download_file`) and read back — the temp file is

--- a/crates/mvm-cli/src/commands/bundle/gc.rs
+++ b/crates/mvm-cli/src/commands/bundle/gc.rs
@@ -1,0 +1,132 @@
+//! `mvmctl bundle gc` — prune installed bundles from the local
+//! registry.
+//!
+//! Two modes, mutually exclusive:
+//!
+//! - `mvmctl bundle gc <SHA>` — remove a specific bundle by its
+//!   64-hex sha256.
+//! - `mvmctl bundle gc --all` — remove every installed bundle.
+//!
+//! `--unused` (remove only bundles no plan references) would need
+//! a host-side "last used" tracker — deferred to a future commit.
+//!
+//! Removal is symmetric to `mvmctl bundle install`: both the
+//! cached `<sha>.mvmpkg` and the extracted `<sha>/` directory are
+//! unlinked. Successful sweeps emit a single
+//! `LocalAuditKind::BundleGc` audit line with the removed count
+//! and the truncated sha list.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+
+use mvm_core::user_config::MvmConfig;
+use mvm_plan::BundleRegistry;
+
+use super::super::Cli;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Bundle sha256 to remove (64 lowercase hex chars). Mutually
+    /// exclusive with `--all`.
+    #[arg(value_name = "SHA", conflicts_with = "all")]
+    pub sha: Option<String>,
+    /// Remove every installed bundle.
+    #[arg(long)]
+    pub all: bool,
+    /// Override the bundle registry root. Defaults to
+    /// `~/.mvm/bundles/`.
+    #[arg(long, value_name = "DIR")]
+    pub registry: Option<PathBuf>,
+    /// Skip the "are you sure?" prompt for `--all`. Mirrors the
+    /// pattern other destructive verbs use; in non-interactive
+    /// contexts (CI, scripts) the prompt is suppressed automatically
+    /// so `--yes` is mostly a no-op there.
+    #[arg(long)]
+    pub yes: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    if args.sha.is_none() && !args.all {
+        anyhow::bail!(
+            "specify a bundle sha256 to remove, or pass --all to wipe every installed bundle"
+        );
+    }
+
+    let registry = match args.registry {
+        Some(p) => BundleRegistry::new(p),
+        None => BundleRegistry::default_path()
+            .context("resolving default bundle registry root (~/.mvm/bundles/)")?,
+    };
+
+    let mut removed: Vec<String> = Vec::new();
+
+    if let Some(sha) = args.sha.as_deref() {
+        // Validate the shape up front so an obvious typo doesn't
+        // become a "no such bundle" miss.
+        if sha.len() != 64
+            || !sha
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+        {
+            anyhow::bail!("bundle sha {sha:?} is malformed (expected 64 lowercase hex chars)");
+        }
+        let touched = registry
+            .remove(sha)
+            .with_context(|| format!("removing bundle {sha}"))?;
+        if !touched {
+            anyhow::bail!("no installed bundle for {sha}");
+        }
+        removed.push(sha.to_string());
+    } else {
+        // --all path.
+        let bundles = registry.list().context("listing installed bundles")?;
+        if bundles.is_empty() {
+            println!("No installed bundles to remove.");
+            return Ok(());
+        }
+        if !args.yes && std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+            println!(
+                "About to remove {} installed bundle(s) from {}",
+                bundles.len(),
+                registry.root().display()
+            );
+            for sha in &bundles {
+                println!("  {sha}");
+            }
+            anyhow::bail!(
+                "refusing without confirmation — re-run with --yes to remove these bundles"
+            );
+        }
+        for sha in &bundles {
+            if registry.remove(sha)? {
+                removed.push(sha.clone());
+            }
+        }
+    }
+
+    // Audit emit — single line per `gc` invocation. Detail
+    // truncates the sha list to the first 5 entries so an `--all`
+    // sweep of a large registry doesn't blow out the log line.
+    let detail = {
+        let count = removed.len();
+        let preview: Vec<&str> = removed.iter().take(5).map(String::as_str).collect();
+        let mut s = format!("removed={count},shas={}", preview.join(","));
+        if removed.len() > 5 {
+            s.push_str(",...");
+        }
+        s
+    };
+    mvm_core::audit::emit(
+        mvm_core::audit::LocalAuditKind::BundleGc,
+        None,
+        Some(&detail),
+    );
+
+    println!("Removed {} bundle(s).", removed.len());
+    for sha in &removed {
+        println!("  {sha}");
+    }
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/bundle/install.rs
+++ b/crates/mvm-cli/src/commands/bundle/install.rs
@@ -68,6 +68,15 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         .install(&bytes, &trust, args.force)
         .with_context(|| format!("installing bundle from {}", args.source))?;
 
+    mvm_core::audit::emit(
+        mvm_core::audit::LocalAuditKind::BundleInstall,
+        None,
+        Some(&format!(
+            "bundle_sha256={},key_id={}",
+            installed.sha256, installed.manifest.key_id.0,
+        )),
+    );
+
     println!(
         "Installed bundle {} ({} artifacts, publisher key_id={})",
         installed.sha256,

--- a/crates/mvm-cli/src/commands/bundle/install.rs
+++ b/crates/mvm-cli/src/commands/bundle/install.rs
@@ -1,0 +1,80 @@
+//! `mvmctl bundle install <SOURCE>` — verify a `.mvmpkg` archive
+//! and extract it into the local bundle registry so subsequent
+//! `mvmctl up <bundle-sha256>` calls can launch from it.
+//!
+//! Reuses the source-parsing + transport rules from
+//! [`super::fetch::BundleSource`] (local path or `https://` URL,
+//! plain HTTP refused unless `--allow-http`). After verification
+//! the archive is atomically installed under
+//! `~/.mvm/bundles/<bundle_sha256>/` via
+//! [`mvm_plan::BundleRegistry::install`]; the archive bytes are
+//! also written to `<bundle_sha256>.mvmpkg` so the
+//! `FsBundleResolver` admit-time path finds them too.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+
+use mvm_core::user_config::MvmConfig;
+use mvm_plan::{BundleRegistry, FsTrustStore};
+
+use super::super::Cli;
+use super::fetch::load_bundle_bytes;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Local path to a `.mvmpkg` archive, or an `https://` URL
+    /// (HTTP is opt-in via `--allow-http`).
+    #[arg(value_name = "SOURCE")]
+    pub source: String,
+    /// Override the trust store directory. Defaults to
+    /// `~/.mvm/trusted-publishers/`.
+    #[arg(long, value_name = "DIR")]
+    pub trust_store: Option<PathBuf>,
+    /// Override the bundle registry root. Defaults to
+    /// `~/.mvm/bundles/`.
+    #[arg(long, value_name = "DIR")]
+    pub registry: Option<PathBuf>,
+    /// Allow plain-HTTP downloads. The Ed25519 signature still
+    /// catches tampering, but HTTP exposes traffic metadata. Off
+    /// by default.
+    #[arg(long)]
+    pub allow_http: bool,
+    /// Overwrite an existing install with the same bundle_sha256
+    /// instead of erroring. Bundles are content-addressed so a
+    /// matching sha256 means the contents are byte-identical
+    /// anyway; `--force` just makes that explicit.
+    #[arg(long)]
+    pub force: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let bytes = load_bundle_bytes(&args.source, args.allow_http)
+        .with_context(|| format!("loading bundle archive from {}", args.source))?;
+
+    let trust = match args.trust_store {
+        Some(p) => FsTrustStore::new(p),
+        None => FsTrustStore::default_path()
+            .context("resolving default trust-store path (~/.mvm/trusted-publishers/)")?,
+    };
+    let registry = match args.registry {
+        Some(p) => BundleRegistry::new(p),
+        None => BundleRegistry::default_path()
+            .context("resolving default bundle registry root (~/.mvm/bundles/)")?,
+    };
+
+    let installed = registry
+        .install(&bytes, &trust, args.force)
+        .with_context(|| format!("installing bundle from {}", args.source))?;
+
+    println!(
+        "Installed bundle {} ({} artifacts, publisher key_id={})",
+        installed.sha256,
+        installed.manifest.artifacts.len(),
+        installed.manifest.key_id.0,
+    );
+    println!("  registry root: {}", installed.root.display());
+    println!("  launch with:   mvmctl up --manifest {}", installed.sha256);
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/bundle/mod.rs
+++ b/crates/mvm-cli/src/commands/bundle/mod.rs
@@ -31,7 +31,8 @@ use mvm_core::user_config::MvmConfig;
 use super::Cli;
 
 mod export;
-mod fetch;
+pub(super) mod fetch;
+mod install;
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -49,11 +50,17 @@ pub(in crate::commands) enum BundleAction {
     /// Reports the parsed manifest on success; rejects on any of
     /// the failure modes in `BundleVerifyError`.
     Fetch(fetch::Args),
+    /// Verify and atomically install a `.mvmpkg` archive into the
+    /// local bundle registry (`~/.mvm/bundles/<sha>/`). Once
+    /// installed, `mvmctl up --manifest <sha>` launches from it.
+    /// Sprint 52 W2 registry-replacement substrate.
+    Install(install::Args),
 }
 
 pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
     match args.action {
         BundleAction::Export(a) => export::run(cli, a, cfg),
         BundleAction::Fetch(a) => fetch::run(cli, a, cfg),
+        BundleAction::Install(a) => install::run(cli, a, cfg),
     }
 }

--- a/crates/mvm-cli/src/commands/bundle/mod.rs
+++ b/crates/mvm-cli/src/commands/bundle/mod.rs
@@ -32,6 +32,7 @@ use super::Cli;
 
 mod export;
 pub(super) mod fetch;
+mod gc;
 mod install;
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -55,6 +56,10 @@ pub(in crate::commands) enum BundleAction {
     /// installed, `mvmctl up --manifest <sha>` launches from it.
     /// Sprint 52 W2 registry-replacement substrate.
     Install(install::Args),
+    /// Prune installed bundles from the registry. Either a specific
+    /// `<SHA>` or `--all` to wipe everything. Emits
+    /// `LocalAuditKind::BundleGc` on success.
+    Gc(gc::Args),
 }
 
 pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
@@ -62,5 +67,6 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
         BundleAction::Export(a) => export::run(cli, a, cfg),
         BundleAction::Fetch(a) => fetch::run(cli, a, cfg),
         BundleAction::Install(a) => install::run(cli, a, cfg),
+        BundleAction::Gc(a) => gc::run(cli, a, cfg),
     }
 }

--- a/crates/mvm-cli/src/commands/trust/add.rs
+++ b/crates/mvm-cli/src/commands/trust/add.rs
@@ -72,6 +72,12 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         perms.set_mode(0o644);
         std::fs::set_permissions(&dst, perms)?;
     }
+    mvm_core::audit::emit(
+        mvm_core::audit::LocalAuditKind::TrustAdd,
+        None,
+        Some(&format!("key_id={}", key_id.0)),
+    );
+
     println!("Trusted key_id {}", key_id.0);
     Ok(())
 }

--- a/crates/mvm-cli/src/commands/trust/remove.rs
+++ b/crates/mvm-cli/src/commands/trust/remove.rs
@@ -28,6 +28,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     let path = dir.join(format!("{}.pub", id.0));
     match std::fs::remove_file(&path) {
         Ok(()) => {
+            mvm_core::audit::emit(
+                mvm_core::audit::LocalAuditKind::TrustRemove,
+                None,
+                Some(&format!("key_id={}", id.0)),
+            );
             println!("Removed key_id {}", id.0);
             Ok(())
         }

--- a/crates/mvm-cli/src/commands/vm/plan_admission.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_admission.rs
@@ -446,6 +446,7 @@ mod tests {
                 make_art("rootfs.ext4", ArtifactRole::Rootfs, rootfs),
             ],
             verity: None,
+            resources: None,
         };
         let archive = write_bundle(
             &manifest,

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -17,7 +17,9 @@ use super::Cli;
 use super::audit_chain::AuditEmitter;
 use super::forward::forward_ports;
 use super::host_signer::load_or_init_at;
-use super::plan_admission::{AdmittedPlan, InMemoryNonceLedger, SystemClock, admit_for_run};
+use super::plan_admission::{
+    AdmittedPlan, BundleAdmissionContext, InMemoryNonceLedger, SystemClock, admit_for_run,
+};
 use super::plan_builder::SynthesisInput;
 use super::policy_resolver::{
     LOCAL_DEFAULT, ResolveError, resolve_supervisor_components,
@@ -34,6 +36,61 @@ use super::shared::{
 /// the workspace `clippy::too_many_arguments = "deny"` ceiling and so
 /// future callers (W5 policy slots) can extend the shape without
 /// churning every call site.
+/// In-memory `BundleResolver` scoped to a single admission. Used
+/// when `mvmctl up --bundle-pin <path>` already has the archive
+/// bytes — no need to walk the filesystem registry again.
+struct InMemoryBundleResolver {
+    bytes: Vec<u8>,
+}
+
+impl InMemoryBundleResolver {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+}
+
+impl mvm_plan::BundleResolver for InMemoryBundleResolver {
+    fn resolve(
+        &self,
+        _bundle_sha256: &str,
+    ) -> std::result::Result<Vec<u8>, mvm_plan::BundleResolveError> {
+        Ok(self.bytes.clone())
+    }
+}
+
+/// Build a `PlanArtifact` pin from a verified bundle archive.
+/// Pulls the 64-byte signature out of the `manifest.sig` entry,
+/// hashes the archive for the bundle_sha256 field, and stamps the
+/// publisher's `key_id`.
+fn bundle_pin_from_archive(
+    archive: &[u8],
+    key_id: mvm_plan::KeyId,
+) -> Result<mvm_plan::PlanArtifact> {
+    let mut tar = tar::Archive::new(std::io::Cursor::new(archive));
+    for entry in tar.entries().context("walking archive entries")? {
+        let mut entry = entry.context("reading archive entry")?;
+        let path = entry
+            .path()
+            .context("reading archive entry path")?
+            .to_string_lossy()
+            .into_owned();
+        if path == "manifest.sig" {
+            let mut bytes = Vec::with_capacity(64);
+            std::io::Read::read_to_end(&mut entry, &mut bytes)
+                .context("reading manifest.sig bytes")?;
+            let sig_arr: [u8; 64] = bytes.as_slice().try_into().map_err(|_| {
+                anyhow::anyhow!("manifest.sig is {} bytes; expected 64", bytes.len())
+            })?;
+            return Ok(mvm_plan::PlanArtifact::new(
+                mvm_plan::bundle_sha256(archive),
+                &sig_arr,
+                key_id,
+            ));
+        }
+    }
+    anyhow::bail!("archive has no manifest.sig entry")
+}
+
 struct AdmitPlanForBootParams<'a> {
     pub tenant: &'a str,
     pub vm_name: &'a str,
@@ -56,6 +113,12 @@ struct AdmitPlanForBootParams<'a> {
     /// tempdir so a bogus bundle can be staged without touching the
     /// real user's home.
     pub policy_dir: Option<&'a std::path::Path>,
+    /// Optional path to a `.mvmpkg` bundle archive. When set, the
+    /// archive is read + verified at admit time, the resulting
+    /// `PlanArtifact` is embedded into the plan, and the supervisor's
+    /// admit path re-verifies on every launch. Production callers
+    /// thread `args.bundle_pin`; tests pass `None`.
+    pub bundle_pin: Option<&'a std::path::Path>,
 }
 
 /// Bundle of artifacts produced by a successful admission: the
@@ -122,6 +185,37 @@ fn admit_plan_for_boot(p: AdmitPlanForBootParams<'_>) -> Result<Option<Admission
             p.rootfs_path.display()
         )
     })?;
+
+    // ADR-002 claim 9 — bundle pin (when supplied).
+    //
+    // Read the archive bytes, verify them against the local trust
+    // store, then construct the `PlanArtifact` triple
+    // (bundle_sha256 + manifest_sig + key_id). The supervisor's
+    // admit path re-runs the same verifier against the on-disk
+    // archive — defence in depth between CLI synth and backend
+    // dispatch. Errors surface before admit so the user sees them
+    // without a confusing post-sign rejection.
+    let (bundle_pin, bundle_resolver, bundle_trust) = match p.bundle_pin {
+        Some(path) => {
+            let bytes = std::fs::read(path)
+                .with_context(|| format!("reading bundle archive at {}", path.display()))?;
+            let trust = mvm_plan::FsTrustStore::default_path()
+                .context("resolving default trust-store path (~/.mvm/trusted-publishers/)")?;
+            let verified = mvm_plan::read_and_verify_bundle(&bytes, &trust)
+                .with_context(|| format!("verifying bundle at {}", path.display()))?;
+            let pin =
+                bundle_pin_from_archive(&bytes, verified.key_id.clone()).with_context(|| {
+                    format!("extracting signature from bundle at {}", path.display())
+                })?;
+            // Use an in-memory resolver scoped to this admission —
+            // the caller supplied the path, so we already have the
+            // bytes; no need to walk the FS registry again.
+            let resolver = InMemoryBundleResolver::new(bytes);
+            (Some(pin), Some(resolver), Some(trust))
+        }
+        None => (None, None, None),
+    };
+
     let input = SynthesisInput {
         vm_name: p.vm_name,
         tenant: Some(p.tenant),
@@ -135,16 +229,22 @@ fn admit_plan_for_boot(p: AdmitPlanForBootParams<'_>) -> Result<Option<Admission
         boot_timeout_secs: 60,
         exec_timeout_secs: 0,
         destroy_on_exit: true,
-        // Substrate-only: pin is None today. A follow-up CLI flag
-        // (`--bundle-pin <path>`) will populate this from a fetched
-        // and verified `.mvmpkg` so admit_for_run re-verifies before
-        // backend dispatch. ADR-002 claim 9 — load-bearing at launch.
-        bundle_pin: None,
+        bundle_pin: bundle_pin.clone(),
     };
-    // No bundle pin in v1 — when populated, pass a
-    // `BundleAdmissionContext` with the resolver + trust store. The
-    // admission path refuses if a pin is present without context.
-    let admitted = admit_for_run(&input, &SystemClock, p.ledger, p.keys_dir, None)?;
+    let admission_ctx = match (&bundle_resolver, &bundle_trust) {
+        (Some(r), Some(t)) => Some(BundleAdmissionContext {
+            resolver: r,
+            trust: t,
+        }),
+        _ => None,
+    };
+    let admitted = admit_for_run(
+        &input,
+        &SystemClock,
+        p.ledger,
+        p.keys_dir,
+        admission_ctx.as_ref(),
+    )?;
     tracing::info!(
         plan_id = %admitted.plan_id.0,
         signer_id = %admitted.signer_id,
@@ -378,6 +478,16 @@ pub(in crate::commands) struct Args {
     /// when set. Will be removed once admission is the only path.
     #[arg(long)]
     pub no_supervisor: bool,
+    /// Pin the launch to a specific `.mvmpkg` bundle. The path is
+    /// read at admit time, verified against the local trust store
+    /// (`~/.mvm/trusted-publishers/`), and embedded into the
+    /// `ExecutionPlan` as a `PlanArtifact`. The supervisor's admit
+    /// path then re-verifies the bundle against the pin before
+    /// backend dispatch — claim 9 load-bearing at launch. Use the
+    /// same path you handed to `mvmctl bundle fetch` /
+    /// `mvmctl bundle install`.
+    #[arg(long, value_name = "PATH")]
+    pub bundle_pin: Option<std::path::PathBuf>,
     /// Build-mode override flags (`--dev` / `--prod`). Default: `--prod`.
     #[command(flatten)]
     pub build_mode: super::super::shared::BuildModeFlags,
@@ -519,6 +629,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         auto_resume,
         tenant: &args.tenant,
         no_supervisor: args.no_supervisor,
+        bundle_pin: args.bundle_pin.as_deref(),
         build_mode,
     })
 }
@@ -554,6 +665,10 @@ pub(in crate::commands) struct RunParams<'a> {
     pub(super) tenant: &'a str,
     /// `true` when `--no-supervisor` is set — disables plan-64 admission.
     pub(super) no_supervisor: bool,
+    /// Optional `.mvmpkg` archive path that admit_for_run re-verifies
+    /// against the local trust store before backend dispatch.
+    /// `Some(p)` populates `PlanArtifact` in the synthesised plan.
+    pub(super) bundle_pin: Option<&'a std::path::Path>,
     pub(super) build_mode: mvm_build::pipeline::BuildMode,
 }
 
@@ -584,6 +699,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         auto_resume,
         tenant,
         no_supervisor,
+        bundle_pin,
         build_mode,
     } = params;
     let _span =
@@ -717,6 +833,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             keys_dir: None,
             audit_dir: None,
             policy_dir: None,
+            bundle_pin,
         })?;
 
         let start_config = mvm_core::vm_backend::VmStartConfig {
@@ -1043,6 +1160,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         keys_dir: None,
         audit_dir: None,
         policy_dir: None,
+        bundle_pin,
     })?;
 
     // If a template snapshot exists AND the backend supports snapshots,
@@ -1372,6 +1490,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 keys_dir: None,
                 audit_dir: None,
                 policy_dir: None,
+                bundle_pin,
             }) {
                 Ok(ctx) => ctx,
                 Err(e) => {
@@ -1527,6 +1646,101 @@ mod admit_plan_tests {
         path
     }
 
+    /// Build a signed `.mvmpkg` archive in-memory so the
+    /// `--bundle-pin` test path doesn't need a real fetched bundle.
+    /// Uses mvm_plan's own writer + signing primitives.
+    fn make_bundle_for_pin(sk: &ed25519_dalek::SigningKey) -> (Vec<u8>, mvm_plan::KeyId) {
+        use mvm_plan::{
+            ArtifactRole, BUNDLE_SCHEMA_VERSION, BundleArtifact, BundleManifest, KeyId, sha256_hex,
+            write_bundle,
+        };
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        let kernel = b"kernel-bytes".to_vec();
+        let rootfs = b"rootfs-bytes".to_vec();
+        let manifest = BundleManifest {
+            schema_version: BUNDLE_SCHEMA_VERSION,
+            publisher: "test".to_string(),
+            key_id: key_id.clone(),
+            arch: "aarch64".to_string(),
+            kernel_version: None,
+            profile: None,
+            workload_label: None,
+            created_at: "2026-05-13T00:00:00Z".to_string(),
+            labels: Default::default(),
+            artifacts: vec![
+                BundleArtifact {
+                    name: "vmlinux".to_string(),
+                    role: ArtifactRole::Kernel,
+                    path: "artifacts/vmlinux".to_string(),
+                    sha256: sha256_hex(&kernel),
+                    size_bytes: kernel.len() as u64,
+                },
+                BundleArtifact {
+                    name: "rootfs.ext4".to_string(),
+                    role: ArtifactRole::Rootfs,
+                    path: "artifacts/rootfs.ext4".to_string(),
+                    sha256: sha256_hex(&rootfs),
+                    size_bytes: rootfs.len() as u64,
+                },
+            ],
+            verity: None,
+        };
+        let archive = write_bundle(
+            &manifest,
+            sk,
+            vec![
+                ("artifacts/vmlinux".to_string(), kernel),
+                ("artifacts/rootfs.ext4".to_string(), rootfs),
+            ],
+        )
+        .expect("write_bundle");
+        (archive, key_id)
+    }
+
+    #[test]
+    fn bundle_pin_from_archive_recovers_signature_and_sha() {
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let (archive, key_id) = make_bundle_for_pin(&sk);
+        let pin = bundle_pin_from_archive(&archive, key_id.clone()).expect("recovers pin");
+        assert_eq!(pin.bundle_sha256, mvm_plan::bundle_sha256(&archive));
+        assert_eq!(pin.key_id, key_id);
+        // Signature round-trips through base64 → bytes → verify.
+        let sig_arr = pin.signature_bytes().expect("base64 decodes");
+        assert_eq!(sig_arr.len(), 64);
+    }
+
+    #[test]
+    fn bundle_pin_from_archive_missing_signature_errors() {
+        // Bundle without a `manifest.sig` entry — built by hand so
+        // the helper sees the gap. The function must bail with a
+        // clear message rather than panic.
+        let mut buf = std::io::Cursor::new(Vec::<u8>::new());
+        {
+            let mut tar = tar::Builder::new(&mut buf);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(0);
+            header.set_mode(0o644);
+            header.set_cksum();
+            tar.append_data(&mut header, "manifest.json", std::io::Cursor::new(b""))
+                .unwrap();
+            tar.finish().unwrap();
+        }
+        let archive = buf.into_inner();
+        let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let key_id = mvm_plan::KeyId::from_pubkey(&sk.verifying_key());
+        let err = bundle_pin_from_archive(&archive, key_id).expect_err("must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("manifest.sig"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn in_memory_bundle_resolver_returns_archive_bytes() {
+        let bytes = b"hello-archive".to_vec();
+        let resolver = InMemoryBundleResolver::new(bytes.clone());
+        let out = mvm_plan::BundleResolver::resolve(&resolver, "anything").unwrap();
+        assert_eq!(out, bytes);
+    }
+
     #[test]
     fn no_supervisor_short_circuits_to_none() {
         // The escape hatch must skip admission entirely — no host
@@ -1546,6 +1760,7 @@ mod admit_plan_tests {
             keys_dir: None, // not read — short-circuit returns first
             audit_dir: None,
             policy_dir: None,
+            bundle_pin: None,
         })
         .expect("must succeed");
         assert!(result.is_none(), "no_supervisor must return None");
@@ -1570,6 +1785,7 @@ mod admit_plan_tests {
             keys_dir: Some(keys_dir.path()),
             audit_dir: Some(audit_dir.path()),
             policy_dir: None,
+            bundle_pin: None,
         })
         .expect("admission")
         .expect("Some when admission ran");
@@ -1607,6 +1823,7 @@ mod admit_plan_tests {
             keys_dir: Some(keys_dir.path()),
             audit_dir: Some(audit_dir.path()),
             policy_dir: None,
+            bundle_pin: None,
         })
         .expect_err("missing rootfs must fail");
         assert!(
@@ -1638,6 +1855,7 @@ mod admit_plan_tests {
             keys_dir: Some(keys_dir.path()),
             audit_dir: Some(audit_dir.path()),
             policy_dir: None,
+            bundle_pin: None,
         })
         .unwrap()
         .unwrap();
@@ -1653,6 +1871,7 @@ mod admit_plan_tests {
             keys_dir: Some(keys_dir.path()),
             audit_dir: Some(audit_dir.path()),
             policy_dir: None,
+            bundle_pin: None,
         })
         .unwrap()
         .unwrap();
@@ -1710,6 +1929,7 @@ mod admit_plan_tests {
             keys_dir: Some(keys_dir.path()),
             audit_dir: Some(audit_dir.path()),
             policy_dir: Some(policy_dir.path()),
+            bundle_pin: None,
         })
         .expect("admission")
         .expect("Some when admission ran");

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1684,6 +1684,7 @@ mod admit_plan_tests {
                 },
             ],
             verity: None,
+            resources: None,
         };
         let archive = write_bundle(
             &manifest,

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -202,6 +202,11 @@ pub enum LocalAuditKind {
     /// `mvmctl trust remove <key_id>` — un-enrolled a publisher.
     /// Detail: `key_id=<32hex>`.
     TrustRemove,
+    /// `mvmctl bundle install <source>` — verified + atomically
+    /// extracted a `.mvmpkg` archive into `~/.mvm/bundles/<sha>/`.
+    /// Detail: `bundle_sha256=<64hex>,key_id=<32hex>`. Emitted only
+    /// on the success arm; verify failures don't reach the emit.
+    BundleInstall,
     // --- Plan 47: dm-thin storage pool ops ---
     /// `mvmctl storage gc` removed one or more orphaned thin volumes
     /// from the pool. Detail carries the removed volume names (or a
@@ -651,6 +656,8 @@ mod tests {
             // Sprint 52 W2 trust-store mutations.
             LocalAuditKind::TrustAdd,
             LocalAuditKind::TrustRemove,
+            // Sprint 52 W2 bundle registry mutation.
+            LocalAuditKind::BundleInstall,
         ];
         for kind in kinds {
             let json = serde_json::to_string(&kind).unwrap();
@@ -683,6 +690,8 @@ mod tests {
             // Sprint 52 W2 trust-store mutations.
             (LocalAuditKind::TrustAdd, "trust_add"),
             (LocalAuditKind::TrustRemove, "trust_remove"),
+            // Sprint 52 W2 bundle install.
+            (LocalAuditKind::BundleInstall, "bundle_install"),
         ];
         for (kind, expected) in kinds_and_strings {
             let json = serde_json::to_string(&kind).unwrap();

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -207,6 +207,11 @@ pub enum LocalAuditKind {
     /// Detail: `bundle_sha256=<64hex>,key_id=<32hex>`. Emitted only
     /// on the success arm; verify failures don't reach the emit.
     BundleInstall,
+    /// `mvmctl bundle gc <sha>` or `mvmctl bundle gc --all` —
+    /// pruned one or more installed bundles from the registry.
+    /// Detail: `removed=<count>,shas=<sha1>[,sha2,...]` (truncated
+    /// to the first ~5 shas for sweeps).
+    BundleGc,
     // --- Plan 47: dm-thin storage pool ops ---
     /// `mvmctl storage gc` removed one or more orphaned thin volumes
     /// from the pool. Detail carries the removed volume names (or a
@@ -656,8 +661,9 @@ mod tests {
             // Sprint 52 W2 trust-store mutations.
             LocalAuditKind::TrustAdd,
             LocalAuditKind::TrustRemove,
-            // Sprint 52 W2 bundle registry mutation.
+            // Sprint 52 W2 bundle registry mutations.
             LocalAuditKind::BundleInstall,
+            LocalAuditKind::BundleGc,
         ];
         for kind in kinds {
             let json = serde_json::to_string(&kind).unwrap();
@@ -690,8 +696,9 @@ mod tests {
             // Sprint 52 W2 trust-store mutations.
             (LocalAuditKind::TrustAdd, "trust_add"),
             (LocalAuditKind::TrustRemove, "trust_remove"),
-            // Sprint 52 W2 bundle install.
+            // Sprint 52 W2 bundle registry mutations.
             (LocalAuditKind::BundleInstall, "bundle_install"),
+            (LocalAuditKind::BundleGc, "bundle_gc"),
         ];
         for (kind, expected) in kinds_and_strings {
             let json = serde_json::to_string(&kind).unwrap();

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -190,6 +190,18 @@ pub enum LocalAuditKind {
     /// trusting the per-tenant JSONL rollup file (which the audit
     /// chain authenticates by sealing each bucket here).
     MeteringEpoch,
+    // --- Sprint 52 W2: bundle trust store mutations ---
+    //
+    // `~/.mvm/trusted-publishers/<key_id>.pub` is the host-trust-
+    // boundary state for bundle admission (claim 9). Every add /
+    // remove leaves an audit line so a forensics pass can answer
+    // "which publishers were trusted at the moment of incident."
+    /// `mvmctl trust add <pubkey>` — enrolled a publisher's Ed25519
+    /// pubkey in the trust store. Detail: `key_id=<32hex>`.
+    TrustAdd,
+    /// `mvmctl trust remove <key_id>` — un-enrolled a publisher.
+    /// Detail: `key_id=<32hex>`.
+    TrustRemove,
     // --- Plan 47: dm-thin storage pool ops ---
     /// `mvmctl storage gc` removed one or more orphaned thin volumes
     /// from the pool. Detail carries the removed volume names (or a
@@ -636,6 +648,9 @@ mod tests {
             LocalAuditKind::SessionConsoleOpen,
             LocalAuditKind::SessionKill,
             LocalAuditKind::SessionReap,
+            // Sprint 52 W2 trust-store mutations.
+            LocalAuditKind::TrustAdd,
+            LocalAuditKind::TrustRemove,
         ];
         for kind in kinds {
             let json = serde_json::to_string(&kind).unwrap();
@@ -665,6 +680,9 @@ mod tests {
             (LocalAuditKind::SessionConsoleOpen, "session_console_open"),
             (LocalAuditKind::SessionKill, "session_kill"),
             (LocalAuditKind::SessionReap, "session_reap"),
+            // Sprint 52 W2 trust-store mutations.
+            (LocalAuditKind::TrustAdd, "trust_add"),
+            (LocalAuditKind::TrustRemove, "trust_remove"),
         ];
         for (kind, expected) in kinds_and_strings {
             let json = serde_json::to_string(&kind).unwrap();

--- a/crates/mvm-plan/Cargo.toml
+++ b/crates/mvm-plan/Cargo.toml
@@ -18,11 +18,13 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 tar = "0.4"
+# Used by BundleRegistry::install for atomic-write of the cached
+# `<sha>.mvmpkg` file via `NamedTempFile::persist`.
+tempfile.workspace = true
 thiserror = "1"
 
 [dev-dependencies]
 rand.workspace = true
-tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/mvm-plan/src/bundle.rs
+++ b/crates/mvm-plan/src/bundle.rs
@@ -610,6 +610,84 @@ impl BundleRegistry {
         })
     }
 
+    /// Remove an installed bundle. Best-effort symmetric to
+    /// [`install`](Self::install): unlinks both the
+    /// `<sha>.mvmpkg` cached archive AND the extracted
+    /// `<sha>/` directory. Idempotent on already-absent entries
+    /// (returns `Ok(false)`); returns `Ok(true)` when at least
+    /// one of the two artifacts was found and removed.
+    ///
+    /// Reports IO failures verbatim. Partial cleanup is possible
+    /// (archive removed but directory removal raced an open file);
+    /// the caller's audit log should reflect the *attempt*, not
+    /// the success — the next install of the same sha will refuse
+    /// (or overwrite with `force`) cleanly either way.
+    pub fn remove(&self, bundle_sha256: &str) -> anyhow::Result<bool> {
+        let mut removed_any = false;
+
+        let archive = self.archive_path(bundle_sha256);
+        match std::fs::remove_file(&archive) {
+            Ok(()) => removed_any = true,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "removing archive {}: {e}",
+                    archive.display()
+                ));
+            }
+        }
+
+        let dir = self.install_dir(bundle_sha256);
+        match std::fs::remove_dir_all(&dir) {
+            Ok(()) => removed_any = true,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "removing install dir {}: {e}",
+                    dir.display()
+                ));
+            }
+        }
+
+        Ok(removed_any)
+    }
+
+    /// List the bundle sha256s currently installed under the
+    /// registry root. Returns sorted output so consumers (CLI
+    /// listing, `bundle gc --all`) see deterministic order.
+    /// Skips entries that don't look like a bundle install
+    /// (anything other than a 64-lowercase-hex directory).
+    pub fn list(&self) -> anyhow::Result<Vec<String>> {
+        let mut out = Vec::new();
+        let read_dir = match std::fs::read_dir(&self.root) {
+            Ok(r) => r,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "reading registry root {}: {e}",
+                    self.root.display()
+                ));
+            }
+        };
+        for entry in read_dir.flatten() {
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            // Bundle sha is 64 lowercase hex chars; staging dirs
+            // (`<sha>.partial/`) and archive files don't match.
+            if name.len() == 64
+                && name
+                    .chars()
+                    .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+            {
+                out.push(name);
+            }
+        }
+        out.sort();
+        Ok(out)
+    }
+
     /// Resolve an installed bundle by sha256. Returns `Ok(None)`
     /// when the entry isn't present (the caller often wants to
     /// fall through to a different lookup); errors only on I/O
@@ -2014,6 +2092,83 @@ mod tests {
         assert_eq!(installed.sha256, sha);
         // Staging dir got removed during install (rename consumed it).
         assert!(!staging.exists(), "staging dir survived install");
+    }
+
+    #[test]
+    fn bundle_registry_remove_unlinks_archive_and_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        let sk = fresh_key();
+        let archive = build_bundle(&sk, b"k", b"r");
+        let store = trust(&sk);
+        let installed = registry.install(&archive, &store, false).unwrap();
+        let sha = installed.sha256.clone();
+
+        assert!(registry.archive_path(&sha).exists());
+        assert!(registry.install_dir(&sha).exists());
+
+        let touched = registry.remove(&sha).expect("remove ok");
+        assert!(touched, "should report something was removed");
+        assert!(!registry.archive_path(&sha).exists());
+        assert!(!registry.install_dir(&sha).exists());
+    }
+
+    #[test]
+    fn bundle_registry_remove_idempotent_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        let touched = registry.remove(&"a".repeat(64)).expect("remove ok");
+        assert!(!touched, "no archive + no dir → returns false");
+    }
+
+    #[test]
+    fn bundle_registry_list_returns_installed_shas_sorted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        let sk = fresh_key();
+        let store = trust(&sk);
+        // Two distinct bundles.
+        let a = build_bundle(&sk, b"kA", b"rA");
+        let b = build_bundle(&sk, b"kB", b"rB");
+        let sha_a = registry.install(&a, &store, false).unwrap().sha256;
+        let sha_b = registry.install(&b, &store, false).unwrap().sha256;
+
+        let listed = registry.list().expect("list ok");
+        assert_eq!(listed.len(), 2);
+        // Sorted output.
+        let mut expected = vec![sha_a.clone(), sha_b.clone()];
+        expected.sort();
+        assert_eq!(listed, expected);
+    }
+
+    #[test]
+    fn bundle_registry_list_skips_non_sha_entries() {
+        // Stray files / partial-install staging dirs / arbitrary
+        // dot-files must not appear in the listing.
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        std::fs::write(tmp.path().join("not-a-bundle.txt"), b"junk").unwrap();
+        std::fs::create_dir_all(tmp.path().join("abc.partial")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("XYZ".repeat(22) + "ab")).unwrap(); // wrong case
+        let sk = fresh_key();
+        let store = trust(&sk);
+        let archive = build_bundle(&sk, b"k", b"r");
+        let sha = registry.install(&archive, &store, false).unwrap().sha256;
+
+        let listed = registry.list().expect("list ok");
+        assert_eq!(listed, vec![sha]);
+    }
+
+    #[test]
+    fn bundle_registry_list_empty_when_root_absent() {
+        // Calling list() before any install (root doesn't exist
+        // yet) returns an empty vec rather than erroring — the
+        // gc verb uses this on a fresh host.
+        let tmp = tempfile::tempdir().unwrap();
+        let absent = tmp.path().join("never-created");
+        let registry = BundleRegistry::new(&absent);
+        let listed = registry.list().expect("list ok");
+        assert!(listed.is_empty());
     }
 
     #[test]

--- a/crates/mvm-plan/src/bundle.rs
+++ b/crates/mvm-plan/src/bundle.rs
@@ -359,6 +359,331 @@ impl BundleResolver for FsBundleResolver {
     }
 }
 
+// ---------------------------------------------------------------------------
+// BundleRegistry — content-addressed installed-bundle layout
+// ---------------------------------------------------------------------------
+
+/// A bundle that has been verified and extracted onto disk under
+/// `~/.mvm/bundles/<bundle_sha256>/`. Holds the artifact root path
+/// plus the parsed manifest so callers can resolve per-role
+/// artifact paths without re-reading the JSON.
+///
+/// Returned by [`BundleRegistry::install`] and
+/// [`BundleRegistry::find`]. Drop is a no-op — installs persist
+/// across processes; cleanup is the caller's job (typically a
+/// future `mvmctl bundle gc`).
+#[derive(Debug, Clone)]
+pub struct InstalledBundle {
+    /// Lowercase-hex SHA-256 of the archive bytes the bundle was
+    /// installed from. Equal to the directory name under the
+    /// registry root.
+    pub sha256: String,
+    /// Directory holding the extracted manifest + artifacts. The
+    /// `manifest.json` / `manifest.sig` / `artifacts/*` files live
+    /// inside this directory.
+    pub root: PathBuf,
+    /// Parsed manifest, recovered from the extract. Cheap to clone
+    /// because the manifest is small (kilobytes at most).
+    pub manifest: BundleManifest,
+}
+
+impl InstalledBundle {
+    /// Find an artifact by role inside the install directory.
+    /// Returns the absolute filesystem path; the file existence check
+    /// is the caller's responsibility (the manifest's per-artifact
+    /// sha256 was already verified at install time, so reading the
+    /// file is safe to assume).
+    pub fn path_for_role(&self, role: &ArtifactRole) -> Option<PathBuf> {
+        self.manifest
+            .find_by_role(role)
+            .map(|a| self.root.join(&a.path))
+    }
+
+    /// Same as [`path_for_role`](Self::path_for_role) but keyed by
+    /// the artifact's `name` field. Useful for verity sidecars
+    /// whose role is `VerityHashSidecar` but whose binding to the
+    /// rootfs is named-not-roled.
+    pub fn path_for_name(&self, name: &str) -> Option<PathBuf> {
+        self.manifest
+            .find_by_name(name)
+            .map(|a| self.root.join(&a.path))
+    }
+}
+
+/// Errors specific to bundle install.
+#[derive(Debug, Error)]
+pub enum BundleInstallError {
+    #[error("bundle archive failed verification: {0}")]
+    Verify(#[source] BundleVerifyError),
+
+    #[error("filesystem error installing bundle {bundle_sha256}: {reason}")]
+    Io {
+        bundle_sha256: String,
+        reason: String,
+    },
+
+    #[error("bundle {bundle_sha256} is already installed; pass `force` to overwrite")]
+    AlreadyInstalled { bundle_sha256: String },
+}
+
+/// Content-addressed registry of installed bundles. Each entry is a
+/// directory keyed by `<bundle_sha256>` containing the verified
+/// manifest, signature, and extracted artifacts. The registry sits
+/// next to the archive cache that [`FsBundleResolver`] reads —
+/// installs write both the original `<sha>.mvmpkg` (for re-fetch
+/// /verify) and the unpacked `<sha>/` (for template loading).
+///
+/// Install is atomic: extraction happens into a `<sha>.partial/`
+/// staging dir; only after every artifact landed does the rename
+/// to `<sha>/` happen. Crash mid-install leaves either no entry
+/// or the previous entry — never half an install.
+pub struct BundleRegistry {
+    root: PathBuf,
+}
+
+impl BundleRegistry {
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        Self { root: dir.into() }
+    }
+
+    /// Default path: `~/.mvm/bundles/`. Same root [`FsBundleResolver`]
+    /// uses — the archive (`<sha>.mvmpkg`) and the unpacked
+    /// directory (`<sha>/`) cohabit under one tree.
+    pub fn default_path() -> anyhow::Result<Self> {
+        let home = std::env::var_os("HOME").ok_or_else(|| {
+            anyhow::anyhow!("$HOME is not set; cannot resolve bundle registry root")
+        })?;
+        let p = PathBuf::from(home).join(".mvm").join("bundles");
+        Ok(Self::new(p))
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Absolute path to the archive cache file for a given sha256.
+    pub fn archive_path(&self, bundle_sha256: &str) -> PathBuf {
+        self.root.join(format!("{bundle_sha256}.mvmpkg"))
+    }
+
+    /// Absolute path to the extracted-bundle directory for a given
+    /// sha256.
+    pub fn install_dir(&self, bundle_sha256: &str) -> PathBuf {
+        self.root.join(bundle_sha256)
+    }
+
+    /// Install a verified archive into the registry. Verifies the
+    /// archive against `trust`, extracts every declared artifact
+    /// atomically (stage to `<sha>.partial/`, rename to `<sha>/`),
+    /// and writes the archive bytes to `<sha>.mvmpkg` so a later
+    /// `BundleResolver::resolve` finds them.
+    ///
+    /// Idempotent when `force == false`: if `<sha>/` already exists
+    /// the call returns `AlreadyInstalled`. `force == true` removes
+    /// the existing install and replaces it.
+    pub fn install(
+        &self,
+        archive_bytes: &[u8],
+        trust: &dyn TrustStore,
+        force: bool,
+    ) -> Result<InstalledBundle, BundleInstallError> {
+        let verified =
+            read_and_verify_bundle(archive_bytes, trust).map_err(BundleInstallError::Verify)?;
+        let sha = bundle_sha256(archive_bytes);
+
+        let install_dir = self.install_dir(&sha);
+        if install_dir.exists() {
+            if !force {
+                return Err(BundleInstallError::AlreadyInstalled {
+                    bundle_sha256: sha.clone(),
+                });
+            }
+            std::fs::remove_dir_all(&install_dir).map_err(|e| BundleInstallError::Io {
+                bundle_sha256: sha.clone(),
+                reason: format!(
+                    "removing existing install at {}: {e}",
+                    install_dir.display()
+                ),
+            })?;
+        }
+
+        // Ensure the registry root exists with tight perms — same
+        // shape as the trust store directory.
+        std::fs::create_dir_all(&self.root).map_err(|e| BundleInstallError::Io {
+            bundle_sha256: sha.clone(),
+            reason: format!("creating registry root {}: {e}", self.root.display()),
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(meta) = std::fs::metadata(&self.root) {
+                let mut perms = meta.permissions();
+                perms.set_mode(0o700);
+                let _ = std::fs::set_permissions(&self.root, perms);
+            }
+        }
+
+        // Stage extracts into <sha>.partial/. A previous crash
+        // could have left this dir behind; remove it first.
+        let staging = self.root.join(format!("{sha}.partial"));
+        if staging.exists() {
+            std::fs::remove_dir_all(&staging).map_err(|e| BundleInstallError::Io {
+                bundle_sha256: sha.clone(),
+                reason: format!("removing stale staging at {}: {e}", staging.display()),
+            })?;
+        }
+        std::fs::create_dir_all(&staging).map_err(|e| BundleInstallError::Io {
+            bundle_sha256: sha.clone(),
+            reason: format!("creating staging dir {}: {e}", staging.display()),
+        })?;
+
+        // Write manifest.json + manifest.sig + each artifact into
+        // the staging dir. `verified.artifacts` is keyed by the
+        // archive-relative path the verifier already validated as
+        // safe — direct join is OK.
+        let manifest_bytes =
+            verified
+                .manifest
+                .canonical_bytes()
+                .map_err(|e| BundleInstallError::Io {
+                    bundle_sha256: sha.clone(),
+                    reason: format!("re-serialising manifest: {e:#}"),
+                })?;
+        write_into(&staging, MANIFEST_FILENAME, &manifest_bytes, &sha)?;
+
+        // Recover the signature blob from the original archive —
+        // verified.artifacts doesn't carry it as an entry, but the
+        // tar does.
+        let sig_bytes = read_signature_from_archive(archive_bytes).map_err(|reason| {
+            BundleInstallError::Io {
+                bundle_sha256: sha.clone(),
+                reason,
+            }
+        })?;
+        write_into(&staging, SIGNATURE_FILENAME, &sig_bytes, &sha)?;
+
+        for (rel_path, bytes) in &verified.artifacts {
+            write_into(&staging, rel_path, bytes, &sha)?;
+        }
+
+        // Promote the staging dir to its final name. `rename` is
+        // atomic on POSIX within the same filesystem; the registry
+        // root lives inside `~/.mvm/` so this is always within
+        // `$HOME`'s filesystem in practice.
+        std::fs::rename(&staging, &install_dir).map_err(|e| BundleInstallError::Io {
+            bundle_sha256: sha.clone(),
+            reason: format!(
+                "promoting staging {} → install {}: {e}",
+                staging.display(),
+                install_dir.display()
+            ),
+        })?;
+
+        // Also persist the archive bytes so FsBundleResolver finds
+        // them. Atomic via NamedTempFile + persist.
+        let archive_path = self.archive_path(&sha);
+        let mut tmp =
+            tempfile::NamedTempFile::new_in(&self.root).map_err(|e| BundleInstallError::Io {
+                bundle_sha256: sha.clone(),
+                reason: format!("creating archive tempfile: {e}"),
+            })?;
+        std::io::Write::write_all(tmp.as_file_mut(), archive_bytes).map_err(|e| {
+            BundleInstallError::Io {
+                bundle_sha256: sha.clone(),
+                reason: format!("writing archive bytes: {e}"),
+            }
+        })?;
+        tmp.persist(&archive_path)
+            .map_err(|e| BundleInstallError::Io {
+                bundle_sha256: sha.clone(),
+                reason: format!(
+                    "persisting archive {} → {}: {e}",
+                    e.file.path().display(),
+                    archive_path.display()
+                ),
+            })?;
+
+        Ok(InstalledBundle {
+            sha256: sha,
+            root: install_dir,
+            manifest: verified.manifest,
+        })
+    }
+
+    /// Resolve an installed bundle by sha256. Returns `Ok(None)`
+    /// when the entry isn't present (the caller often wants to
+    /// fall through to a different lookup); errors only on I/O
+    /// or corrupt-manifest cases.
+    pub fn find(&self, bundle_sha256: &str) -> anyhow::Result<Option<InstalledBundle>> {
+        let dir = self.install_dir(bundle_sha256);
+        if !dir.exists() {
+            return Ok(None);
+        }
+        let manifest_path = dir.join(MANIFEST_FILENAME);
+        let bytes = std::fs::read(&manifest_path).map_err(|e| {
+            anyhow::anyhow!(
+                "reading installed bundle manifest at {}: {e}",
+                manifest_path.display()
+            )
+        })?;
+        let manifest: BundleManifest = serde_json::from_slice(&bytes).map_err(|e| {
+            anyhow::anyhow!(
+                "parsing installed bundle manifest at {}: {e}",
+                manifest_path.display()
+            )
+        })?;
+        Ok(Some(InstalledBundle {
+            sha256: bundle_sha256.to_string(),
+            root: dir,
+            manifest,
+        }))
+    }
+}
+
+/// Write a single file under `dir` atomically. Used by
+/// [`BundleRegistry::install`] for every staged artifact + the
+/// manifest + the signature.
+fn write_into(
+    dir: &Path,
+    rel_path: &str,
+    bytes: &[u8],
+    bundle_sha256: &str,
+) -> Result<(), BundleInstallError> {
+    let target = dir.join(rel_path);
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| BundleInstallError::Io {
+            bundle_sha256: bundle_sha256.to_string(),
+            reason: format!("creating {}: {e}", parent.display()),
+        })?;
+    }
+    std::fs::write(&target, bytes).map_err(|e| BundleInstallError::Io {
+        bundle_sha256: bundle_sha256.to_string(),
+        reason: format!("writing {}: {e}", target.display()),
+    })
+}
+
+/// Read just the signature blob from a `.mvmpkg` archive without
+/// going through the full verification pass. Used by
+/// [`BundleRegistry::install`] to copy the signature into the
+/// extracted directory.
+fn read_signature_from_archive(archive: &[u8]) -> Result<Vec<u8>, String> {
+    let mut tar = tar::Archive::new(std::io::Cursor::new(archive));
+    for entry in tar.entries().map_err(|e| e.to_string())? {
+        let mut entry = entry.map_err(|e| e.to_string())?;
+        let path = entry
+            .path()
+            .map_err(|e| e.to_string())?
+            .to_string_lossy()
+            .into_owned();
+        if path == SIGNATURE_FILENAME {
+            let mut bytes = Vec::with_capacity(64);
+            std::io::Read::read_to_end(&mut entry, &mut bytes).map_err(|e| e.to_string())?;
+            return Ok(bytes);
+        }
+    }
+    Err(format!("{SIGNATURE_FILENAME} not present in archive"))
+}
+
 /// Verify a plan's pinned bundle at admit time.
 ///
 /// Runs the full [`read_and_verify_bundle`] rejection ladder against
@@ -1566,6 +1891,160 @@ mod tests {
             Err(PlanBundleError::BundleSha256Mismatch { .. }) => {}
             other => panic!("expected BundleSha256Mismatch, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn bundle_registry_install_roundtrip() {
+        // Install a clean bundle → assert both the archive file
+        // and the extracted dir exist, and that `find` recovers
+        // the parsed manifest.
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        let sk = fresh_key();
+        let archive = build_bundle(&sk, b"kernel-bytes", b"rootfs-bytes");
+        let store = trust(&sk);
+
+        let installed = registry
+            .install(&archive, &store, false)
+            .expect("install succeeds");
+
+        // Archive file landed.
+        let archive_path = registry.archive_path(&installed.sha256);
+        assert!(
+            archive_path.exists(),
+            "archive missing at {:?}",
+            archive_path
+        );
+        let archive_back = std::fs::read(&archive_path).unwrap();
+        assert_eq!(archive_back, archive);
+
+        // Extracted dir landed.
+        let install_dir = registry.install_dir(&installed.sha256);
+        assert!(install_dir.is_dir());
+        assert!(install_dir.join(MANIFEST_FILENAME).exists());
+        assert!(install_dir.join(SIGNATURE_FILENAME).exists());
+        assert!(install_dir.join("artifacts/vmlinux").exists());
+        assert!(install_dir.join("artifacts/rootfs.ext4").exists());
+
+        // find() recovers the same handle.
+        let recovered = registry
+            .find(&installed.sha256)
+            .expect("find succeeds")
+            .expect("entry present");
+        assert_eq!(recovered.sha256, installed.sha256);
+        assert_eq!(recovered.manifest, installed.manifest);
+    }
+
+    #[test]
+    fn bundle_registry_install_rejects_tampered_archive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        let sk = fresh_key();
+        let mut archive = build_bundle(&sk, b"k", b"r");
+        archive[200] ^= 0x01; // tamper
+        let store = trust(&sk);
+
+        let err = registry
+            .install(&archive, &store, false)
+            .expect_err("must refuse tampered bundle");
+        assert!(matches!(err, BundleInstallError::Verify(_)));
+
+        // No partial state left behind. read_dir's first entry — if
+        // any — is unexpected; clippy's `never_loop` lint flags the
+        // explicit for-loop form here so the assertion uses next().
+        if let Some(entry) = std::fs::read_dir(tmp.path()).unwrap().flatten().next() {
+            let name = entry.file_name().into_string().unwrap();
+            panic!("unexpected file in registry after refusal: {name}");
+        }
+    }
+
+    #[test]
+    fn bundle_registry_install_refuses_overwrite_without_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        let sk = fresh_key();
+        let archive = build_bundle(&sk, b"k", b"r");
+        let store = trust(&sk);
+
+        registry
+            .install(&archive, &store, false)
+            .expect("first install");
+        let err = registry
+            .install(&archive, &store, false)
+            .expect_err("second install without force must refuse");
+        assert!(matches!(err, BundleInstallError::AlreadyInstalled { .. }));
+    }
+
+    #[test]
+    fn bundle_registry_install_overwrites_with_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        let sk = fresh_key();
+        let archive = build_bundle(&sk, b"k", b"r");
+        let store = trust(&sk);
+
+        let first = registry.install(&archive, &store, false).unwrap();
+        let second = registry
+            .install(&archive, &store, true)
+            .expect("force install succeeds");
+        assert_eq!(first.sha256, second.sha256);
+        // Re-installable means the extracted dir is fresh — at
+        // minimum the manifest still parses.
+        assert_eq!(first.manifest, second.manifest);
+    }
+
+    #[test]
+    fn bundle_registry_install_cleans_up_stale_staging() {
+        // Simulate a crash mid-install by pre-creating the
+        // `<sha>.partial/` staging dir with junk in it. The next
+        // install must remove it and replace cleanly.
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        let sk = fresh_key();
+        let archive = build_bundle(&sk, b"k", b"r");
+        let store = trust(&sk);
+        let sha = bundle_sha256(&archive);
+        let staging = tmp.path().join(format!("{sha}.partial"));
+        std::fs::create_dir_all(&staging).unwrap();
+        std::fs::write(staging.join("junk"), b"left over from crash").unwrap();
+
+        let installed = registry
+            .install(&archive, &store, false)
+            .expect("install survives stale staging");
+        assert_eq!(installed.sha256, sha);
+        // Staging dir got removed during install (rename consumed it).
+        assert!(!staging.exists(), "staging dir survived install");
+    }
+
+    #[test]
+    fn bundle_registry_find_misses_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        let result = registry.find(&"0".repeat(64)).expect("ok");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn installed_bundle_finds_artifacts_by_role_and_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BundleRegistry::new(tmp.path());
+        let sk = fresh_key();
+        let archive = build_bundle(&sk, b"k", b"r");
+        let store = trust(&sk);
+        let installed = registry.install(&archive, &store, false).unwrap();
+
+        let kernel = installed
+            .path_for_role(&ArtifactRole::Kernel)
+            .expect("kernel role present");
+        assert!(kernel.ends_with("artifacts/vmlinux"));
+        assert!(kernel.exists());
+
+        let by_name = installed
+            .path_for_name("rootfs.ext4")
+            .expect("rootfs by name present");
+        assert!(by_name.exists());
+
+        assert!(installed.path_for_role(&ArtifactRole::Initrd).is_none());
     }
 
     #[test]

--- a/crates/mvm-plan/src/bundle.rs
+++ b/crates/mvm-plan/src/bundle.rs
@@ -65,7 +65,16 @@ use thiserror::Error;
 /// Highest bundle-manifest schema version this build understands.
 /// Verifiers fail closed on a future bump rather than silently
 /// dropping fields they don't know about.
-pub const BUNDLE_SCHEMA_VERSION: u32 = 1;
+///
+/// Bumped 1 → 2 in Sprint 52 W2 residual C when `BundleManifest`
+/// gained the optional `resources: Option<BundleResources>`
+/// field. Older verifiers `#[serde(deny_unknown_fields)]` would
+/// refuse v2 bundles on the field alone, but the version sniff
+/// runs first and surfaces a clear `UnsupportedSchema` error.
+/// Newer verifiers reading a v1 bundle accept the missing field
+/// via `#[serde(default)]` and fall back to operator-config
+/// defaults at launch time.
+pub const BUNDLE_SCHEMA_VERSION: u32 = 2;
 
 /// Filename inside the archive for the canonical-JSON manifest.
 pub const MANIFEST_FILENAME: &str = "manifest.json";
@@ -148,6 +157,25 @@ pub struct BundleArtifact {
     pub size_bytes: u64,
 }
 
+/// Resource expectations the bundle publisher recorded at build
+/// time. Optional on the wire (`#[serde(default)]` via the parent
+/// struct's `Option<BundleResources>`), present in v2+ bundles.
+/// Old (`schema_version = 1`) bundles deserialise with `None` and
+/// the template loader defaults to operator config.
+///
+/// Both fields are advisory: `mvmctl up --cpus / --memory`
+/// overrides them. The point is to let a bundle ship with sensible
+/// resource expectations baked in so dev-laptop users don't have
+/// to remember the right values.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BundleResources {
+    /// vCPU count the workload was sized for at build time.
+    pub vcpus: u32,
+    /// Memory cap in MiB the workload was sized for at build time.
+    pub mem_mib: u32,
+}
+
 /// dm-verity binding for the rootfs. Present when the workload was
 /// built with `verifiedBoot = true` (ADR-002 §W3).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -207,6 +235,14 @@ pub struct BundleManifest {
     /// dm-verity binding, when the rootfs was built verified.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verity: Option<VerityInfo>,
+    /// Advisory resource expectations recorded by the publisher at
+    /// build time. `Some(...)` in v2+ bundles; `None` for v1
+    /// bundles (handled via `#[serde(default)]`). The template
+    /// loader uses these to set defaults when `mvmctl up` doesn't
+    /// pass `--cpus` / `--memory` explicitly. ADR-002 claim 9
+    /// re-verify still re-hashes the field as part of the manifest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources: Option<BundleResources>,
 }
 
 impl BundleManifest {
@@ -1328,6 +1364,7 @@ mod tests {
             labels: BTreeMap::new(),
             artifacts,
             verity: None,
+            resources: None,
         }
     }
 
@@ -2221,6 +2258,71 @@ mod tests {
             Err(BundleResolveError::MissingBundle { .. }) => {}
             other => panic!("expected MissingBundle, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn bundle_manifest_resources_round_trip_when_set() {
+        let sk = fresh_key();
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        let mut manifest = make_manifest(key_id, Vec::new());
+        manifest.resources = Some(BundleResources {
+            vcpus: 4,
+            mem_mib: 2048,
+        });
+        let bytes = manifest.canonical_bytes().unwrap();
+        let parsed: BundleManifest = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed.resources, manifest.resources);
+        let json = String::from_utf8(bytes).unwrap();
+        assert!(json.contains("\"resources\""), "got: {json}");
+    }
+
+    #[test]
+    fn bundle_manifest_resources_omitted_when_none() {
+        // Backwards compat: v2-built bundles whose publisher chose
+        // not to declare resources still emit the manifest WITHOUT
+        // an empty "resources":null object, so a v1 verifier doing
+        // a "would this parse as v1?" check sees a clean wire.
+        let sk = fresh_key();
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        let manifest = make_manifest(key_id, Vec::new()); // resources: None
+        let bytes = manifest.canonical_bytes().unwrap();
+        let json = String::from_utf8(bytes).unwrap();
+        assert!(
+            !json.contains("resources"),
+            "skip_serializing_if must elide the field: {json}"
+        );
+    }
+
+    #[test]
+    fn bundle_manifest_v1_loads_with_no_resources_field() {
+        // Round-trip a hand-rolled v1 manifest (no `resources`
+        // field) and assert it parses cleanly into the v2 struct
+        // with `resources = None`. Protects against a future
+        // accidental drop of `#[serde(default)]` on the field.
+        let sk = fresh_key();
+        let key_id = KeyId::from_pubkey(&sk.verifying_key());
+        let v1_json = format!(
+            r#"{{
+                "schema_version": 1,
+                "publisher": "test",
+                "key_id": "{}",
+                "arch": "aarch64",
+                "created_at": "2026-05-01T00:00:00Z",
+                "artifacts": []
+            }}"#,
+            key_id.0
+        );
+        let parsed: BundleManifest = serde_json::from_str(&v1_json).expect("v1 parses");
+        assert_eq!(parsed.schema_version, 1);
+        assert!(parsed.resources.is_none());
+        assert!(parsed.verity.is_none());
+    }
+
+    #[test]
+    fn bundle_schema_version_is_two() {
+        // Pin the current version constant — bumps are deliberate;
+        // a silent rev should trip this test.
+        assert_eq!(BUNDLE_SCHEMA_VERSION, 2);
     }
 
     #[test]

--- a/crates/mvm-plan/src/lib.rs
+++ b/crates/mvm-plan/src/lib.rs
@@ -34,10 +34,11 @@ pub mod types;
 pub mod validity;
 
 pub use bundle::{
-    ArtifactRole, BUNDLE_SCHEMA_VERSION, BundleArtifact, BundleManifest, BundleResolveError,
-    BundleResolver, BundleVerifyError, FsBundleResolver, FsTrustStore, KeyId, PlanArtifact,
-    PlanBundleError, TrustStore, VerifiedBundle, VerityInfo, bundle_sha256, read_and_verify_bundle,
-    sha256_hex, signature_from_base64, signature_to_base64, verify_plan_bundle, write_bundle,
+    ArtifactRole, BUNDLE_SCHEMA_VERSION, BundleArtifact, BundleInstallError, BundleManifest,
+    BundleRegistry, BundleResolveError, BundleResolver, BundleVerifyError, FsBundleResolver,
+    FsTrustStore, InstalledBundle, KeyId, PlanArtifact, PlanBundleError, TrustStore,
+    VerifiedBundle, VerityInfo, bundle_sha256, read_and_verify_bundle, sha256_hex,
+    signature_from_base64, signature_to_base64, verify_plan_bundle, write_bundle,
 };
 pub use plan::{ExecutionPlan, SCHEMA_VERSION};
 pub use signing::{PlanVerifyError, SignedExecutionPlan, sign_plan, verify_plan};

--- a/crates/mvm-plan/src/lib.rs
+++ b/crates/mvm-plan/src/lib.rs
@@ -35,9 +35,9 @@ pub mod validity;
 
 pub use bundle::{
     ArtifactRole, BUNDLE_SCHEMA_VERSION, BundleArtifact, BundleInstallError, BundleManifest,
-    BundleRegistry, BundleResolveError, BundleResolver, BundleVerifyError, FsBundleResolver,
-    FsTrustStore, InstalledBundle, KeyId, PlanArtifact, PlanBundleError, TrustStore,
-    VerifiedBundle, VerityInfo, bundle_sha256, read_and_verify_bundle, sha256_hex,
+    BundleRegistry, BundleResolveError, BundleResolver, BundleResources, BundleVerifyError,
+    FsBundleResolver, FsTrustStore, InstalledBundle, KeyId, PlanArtifact, PlanBundleError,
+    TrustStore, VerifiedBundle, VerityInfo, bundle_sha256, read_and_verify_bundle, sha256_hex,
     signature_from_base64, signature_to_base64, verify_plan_bundle, write_bundle,
 };
 pub use plan::{ExecutionPlan, SCHEMA_VERSION};

--- a/crates/mvm/Cargo.toml
+++ b/crates/mvm/Cargo.toml
@@ -11,6 +11,7 @@ autobins = false
 
 [dependencies]
 mvm-core.workspace = true
+mvm-plan.workspace = true
 mvm-security.workspace = true
 mvm-guest.workspace = true
 mvm-build.workspace = true
@@ -18,6 +19,7 @@ mvm-backend.workspace = true
 mvm-base.workspace = true
 anyhow.workspace = true
 base64.workspace = true
+chrono.workspace = true
 colored.workspace = true
 ed25519-dalek.workspace = true
 rand.workspace = true

--- a/crates/mvm/src/vm/template/lifecycle.rs
+++ b/crates/mvm/src/vm/template/lifecycle.rs
@@ -459,10 +459,16 @@ fn bundle_artifacts_for_sha(
         .path_for_role(&ArtifactRole::Initrd)
         .map(|p| p.to_string_lossy().into_owned());
 
-    // Operator-config-defaulted resources. Bundle manifest doesn't
-    // currently declare vcpus/mem; the CLI's `--cpus` / `--memory`
-    // override these at `mvmctl up` time.
+    // Resource resolution: bundle manifest's `resources` field
+    // wins when set (BUNDLE_SCHEMA_VERSION 2+ bundles ship this).
+    // Falls back to operator config for v1 bundles or when the
+    // publisher chose to omit. CLI `--cpus` / `--memory` still
+    // overrides both at `mvmctl up` time.
     let user_cfg = mvm_core::user_config::load(None);
+    let (vcpus_u32, mem_mib) = match installed.manifest.resources.as_ref() {
+        Some(r) => (r.vcpus, r.mem_mib),
+        None => (user_cfg.default_cpus, user_cfg.default_memory_mib),
+    };
     let now = chrono::Utc::now().to_rfc3339();
     let spec = TemplateSpec {
         schema_version: mvm_core::template::CURRENT_SCHEMA_VERSION,
@@ -470,8 +476,8 @@ fn bundle_artifacts_for_sha(
         flake_ref: format!("bundle:{bundle_sha256}"),
         profile: installed.manifest.profile.clone().unwrap_or_default(),
         role: String::new(),
-        vcpus: u8::try_from(user_cfg.default_cpus.min(u32::from(u8::MAX))).unwrap_or(u8::MAX),
-        mem_mib: user_cfg.default_memory_mib,
+        vcpus: u8::try_from(vcpus_u32.min(u32::from(u8::MAX))).unwrap_or(u8::MAX),
+        mem_mib,
         mem_initial_mib: None,
         data_disk_mib: 0,
         created_at: installed.manifest.created_at.clone(),

--- a/crates/mvm/src/vm/template/lifecycle.rs
+++ b/crates/mvm/src/vm/template/lifecycle.rs
@@ -361,9 +361,17 @@ fn persisted_to_synthetic_spec(p: &PersistedManifest) -> TemplateSpec {
     }
 }
 
-/// Unified entry point that dispatches to the slot-keyed function when
-/// `id_or_slot` looks like a 64-char lowercase-hex slot hash, or to
-/// the legacy name-keyed function otherwise.
+/// Unified entry point that dispatches by id/key shape:
+///
+/// 1. **Legacy name** (e.g. `claude-code-vm`) → `template_artifacts`.
+/// 2. **Slot hash** (`sha256(canonical_manifest_path)`, 64-char hex,
+///    and the slot dir exists under `~/.mvm/templates/`) →
+///    `template_artifacts_for_slot`.
+/// 3. **Bundle sha256** (also 64-char hex, but the slot dir doesn't
+///    exist; the bundle registry under `~/.mvm/bundles/<sha>/` does)
+///    → [`bundle_artifacts_for_sha`]. Sprint 52 W2 registry-
+///    replacement substrate — bundles are content-addressed images
+///    fetched + installed via `mvmctl bundle install`.
 ///
 /// Used by `mvmctl up` / `mvmctl exec` so the CLI can resolve a
 /// `--manifest <PATH>` argument to a slot hash and pass it through
@@ -373,45 +381,161 @@ pub fn template_artifacts_dispatched(
     id_or_slot: &str,
 ) -> Result<(TemplateSpec, String, Option<String>, String, String)> {
     if is_slot_hash_dirname(id_or_slot) {
-        let (persisted, vmlinux, initrd, rootfs, rev) = template_artifacts_for_slot(id_or_slot)?;
-        Ok((
-            persisted_to_synthetic_spec(&persisted),
-            vmlinux,
-            initrd,
-            rootfs,
-            rev,
-        ))
+        // A 64-char hex string is ambiguous: it could be a templates/
+        // slot hash OR a bundle sha256. Resolve by checking which
+        // directory actually exists. Templates-slot wins when both
+        // are present (legacy build-on-this-host stays the primary
+        // path).
+        let slot_path = std::path::Path::new(&slot_dir(id_or_slot)).to_path_buf();
+        if slot_path.exists() {
+            let (persisted, vmlinux, initrd, rootfs, rev) =
+                template_artifacts_for_slot(id_or_slot)?;
+            Ok((
+                persisted_to_synthetic_spec(&persisted),
+                vmlinux,
+                initrd,
+                rootfs,
+                rev,
+            ))
+        } else {
+            bundle_artifacts_for_sha(id_or_slot)
+        }
     } else {
         template_artifacts(id_or_slot)
     }
 }
 
+/// Resolve a bundle-sha256 reference through
+/// [`mvm_plan::BundleRegistry`] (default path
+/// `~/.mvm/bundles/<sha>/`). Returns the same shape as
+/// [`template_artifacts`] / [`template_artifacts_for_slot`] so the
+/// dispatch fan-in is uniform.
+///
+/// `revision_hash` for a bundle equals the bundle sha — bundles are
+/// content-addressed, so the "revision" of a content-addressed unit
+/// is just its hash. `TemplateSpec.template_id` is set the same way.
+///
+/// `vcpus` / `mem_mib` come from operator config defaults because
+/// the bundle manifest doesn't carry resources today (a future
+/// schema bump would let bundles declare them; for now `mvmctl up`
+/// `--cpus` / `--memory` override). The CLI surfaces this as a
+/// "bundle X uses default resources" info line so users aren't
+/// surprised when no per-template defaults flow through.
+fn bundle_artifacts_for_sha(
+    bundle_sha256: &str,
+) -> Result<(TemplateSpec, String, Option<String>, String, String)> {
+    use mvm_plan::ArtifactRole;
+
+    let registry = mvm_plan::BundleRegistry::default_path()
+        .context("resolving default bundle registry root")?;
+    let installed = registry
+        .find(bundle_sha256)
+        .with_context(|| format!("looking up bundle {bundle_sha256} in registry"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no installed bundle for {bundle_sha256} — run `mvmctl bundle install` first"
+            )
+        })?;
+
+    let kernel = installed
+        .path_for_role(&ArtifactRole::Kernel)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "bundle {bundle_sha256} has no Kernel artifact — manifest is missing a vmlinux entry"
+            )
+        })?
+        .to_string_lossy()
+        .into_owned();
+    let rootfs = installed
+        .path_for_role(&ArtifactRole::Rootfs)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "bundle {bundle_sha256} has no Rootfs artifact — manifest is missing a rootfs entry"
+            )
+        })?
+        .to_string_lossy()
+        .into_owned();
+    let initrd = installed
+        .path_for_role(&ArtifactRole::Initrd)
+        .map(|p| p.to_string_lossy().into_owned());
+
+    // Operator-config-defaulted resources. Bundle manifest doesn't
+    // currently declare vcpus/mem; the CLI's `--cpus` / `--memory`
+    // override these at `mvmctl up` time.
+    let user_cfg = mvm_core::user_config::load(None);
+    let now = chrono::Utc::now().to_rfc3339();
+    let spec = TemplateSpec {
+        schema_version: mvm_core::template::CURRENT_SCHEMA_VERSION,
+        template_id: bundle_sha256.to_string(),
+        flake_ref: format!("bundle:{bundle_sha256}"),
+        profile: installed.manifest.profile.clone().unwrap_or_default(),
+        role: String::new(),
+        vcpus: u8::try_from(user_cfg.default_cpus.min(u32::from(u8::MAX))).unwrap_or(u8::MAX),
+        mem_mib: user_cfg.default_memory_mib,
+        mem_initial_mib: None,
+        data_disk_mib: 0,
+        created_at: installed.manifest.created_at.clone(),
+        updated_at: now,
+        default_network_policy: None,
+    };
+
+    // Bundle sha == revision, since bundles are content-addressed.
+    Ok((spec, kernel, initrd, rootfs, bundle_sha256.to_string()))
+}
+
 /// Dispatched variant of [`template_load`] / [`template_load_slot`].
 /// Returns a [`TemplateSpec`] regardless of which key shape was used.
+///
+/// Bundle-sha256 fallthrough mirrors `template_artifacts_dispatched`:
+/// when the 64-char hex name doesn't have a templates/ slot dir,
+/// look it up in the bundle registry.
 pub fn template_load_dispatched(id_or_slot: &str) -> Result<TemplateSpec> {
     if is_slot_hash_dirname(id_or_slot) {
-        let persisted = template_load_slot(id_or_slot)?;
-        Ok(persisted_to_synthetic_spec(&persisted))
+        let slot_path = std::path::Path::new(&slot_dir(id_or_slot)).to_path_buf();
+        if slot_path.exists() {
+            let persisted = template_load_slot(id_or_slot)?;
+            Ok(persisted_to_synthetic_spec(&persisted))
+        } else {
+            // Reuse the artifact-resolver to derive a TemplateSpec
+            // from an installed bundle — same fields, same defaults.
+            let (spec, _vm, _ir, _rf, _rev) = bundle_artifacts_for_sha(id_or_slot)?;
+            Ok(spec)
+        }
     } else {
         template_load(id_or_slot)
     }
 }
 
 /// Dispatched variant of [`template_snapshot_info`] /
-/// [`template_snapshot_info_for_slot`].
+/// [`template_snapshot_info_for_slot`]. Bundles don't ship
+/// snapshots today (the snapshot is a per-host FC artifact tied to
+/// the machine that built it); the bundle fallthrough returns
+/// `None` rather than erroring.
 pub fn template_snapshot_info_dispatched(id_or_slot: &str) -> Result<Option<SnapshotInfo>> {
     if is_slot_hash_dirname(id_or_slot) {
-        template_snapshot_info_for_slot(id_or_slot)
+        let slot_path = std::path::Path::new(&slot_dir(id_or_slot)).to_path_buf();
+        if slot_path.exists() {
+            template_snapshot_info_for_slot(id_or_slot)
+        } else {
+            Ok(None)
+        }
     } else {
         template_snapshot_info(id_or_slot)
     }
 }
 
 /// Dispatched variant of [`template_has_snapshot`] /
-/// [`template_has_snapshot_for_slot`].
+/// [`template_has_snapshot_for_slot`]. Same bundle-fallthrough
+/// shape as `template_snapshot_info_dispatched`: bundles never
+/// have snapshots in v1.
 pub fn template_has_snapshot_dispatched(id_or_slot: &str) -> Result<bool> {
     if is_slot_hash_dirname(id_or_slot) {
-        template_has_snapshot_for_slot(id_or_slot)
+        let slot_path = std::path::Path::new(&slot_dir(id_or_slot)).to_path_buf();
+        if slot_path.exists() {
+            template_has_snapshot_for_slot(id_or_slot)
+        } else {
+            Ok(false)
+        }
     } else {
         template_has_snapshot(id_or_slot)
     }

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1417,19 +1417,46 @@ Shipped in the W2 admit-time re-verify commit:
   `verify_plan_bundle` tests covering every PlanBundleError
   variant.
 
-Outstanding (deferred follow-ups):
+Shipped in the W2 follow-on (registry replacement + bundle-pin
+CLI + audit-kind variants):
 
-- `mvmctl up --bundle-pin <path>` (or a manifest field) so the
-  CLI side populates `SynthesisInput.bundle_pin`. Today the
-  substrate is there; production callers just need to point at
-  a real bundle.
-- Registry replacement: replace
-  `~/.mvm/templates/<sha256(manifest_path)>/...` keying with
-  bundle-sha256 directories so a fetched bundle slots into the
-  template flow directly.
-- `LocalAuditKind::TrustAdd` / `TrustRemove` variants + emitter
-  wiring so `trust add/remove` flips from `InteractiveOrControl`
-  to `Emits(...)` in the posture table.
+- **Bundle registry** at `~/.mvm/bundles/<sha>/`. New
+  `BundleRegistry::install` atomically extracts a verified
+  `.mvmpkg` (stage to `<sha>.partial/`, rename to `<sha>/`),
+  also persists the archive bytes at `<sha>.mvmpkg` so
+  `FsBundleResolver` continues to find them. `find(sha)` returns
+  an `InstalledBundle` with `path_for_role()` / `path_for_name()`
+  helpers. `template_artifacts_dispatched` and the three other
+  `_dispatched` variants now disambiguate 64-char hex ids:
+  templates-slot wins when present, fall through to bundle
+  registry otherwise. Bundle-served templates default vcpus/mem
+  from operator config (manifest doesn't carry resources today).
+- **`mvmctl bundle install <SOURCE> [--force]`** verb. Reuses
+  `BundleSource` parser from fetch.rs (local path or `https://`);
+  runs the verification ladder, atomically installs, prints
+  `Installed bundle <sha> (N artifacts, key_id=...)`.
+- **`mvmctl up --bundle-pin <PATH>`** flag. Reads the archive,
+  verifies via `FsTrustStore::default_path()`, derives the
+  `PlanArtifact` triple via `bundle_pin_from_archive`, hands an
+  in-memory `BundleAdmissionContext` to `admit_for_run`. Claim 9
+  re-verify fires on every launch.
+- **`LocalAuditKind::TrustAdd` / `TrustRemove`** added to the
+  audit-kind enum + casing pins + serde round-trip test.
+  `mvmctl trust add/remove` now emit via
+  `mvm_core::audit::emit`; `AUDIT_POSTURE` TRUST_SUB flipped from
+  `InteractiveOrControl` → `Emits(...)`.
+- `BUNDLE_SUB::install` row added with posture
+  `InteractiveOrControl` (will flip to `Emits("BundleInstall")`
+  once the install audit hook ships).
+
+Outstanding (deferred, none blocking):
+
+- `BundleInstall` audit-kind + emitter wiring (flips the install
+  row to `Emits(...)`). Small follow-up.
+- Bundle manifest could carry vcpus/mem_mib so the synthetic
+  TemplateSpec stops defaulting from operator config (bundle-
+  schema bump).
+- `mvmctl bundle gc` to prune installed bundles by sha.
 
 ### W3 — Network default flip (deny-by-default)  ✅ shipped
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1449,14 +1449,27 @@ CLI + audit-kind variants):
   `InteractiveOrControl` (will flip to `Emits("BundleInstall")`
   once the install audit hook ships).
 
-Outstanding (deferred, none blocking):
+Closed out in the W2 final commits (`90cef3d`, `ad3f52c`,
+TBD-resources):
 
-- `BundleInstall` audit-kind + emitter wiring (flips the install
-  row to `Emits(...)`). Small follow-up.
-- Bundle manifest could carry vcpus/mem_mib so the synthetic
-  TemplateSpec stops defaulting from operator config (bundle-
-  schema bump).
-- `mvmctl bundle gc` to prune installed bundles by sha.
+- `LocalAuditKind::BundleInstall` variant + emit from
+  `mvmctl bundle install` + AUDIT_POSTURE flipped to
+  `Emits("BundleInstall")`.
+- `mvmctl bundle gc <SHA>` and `--all` verbs +
+  `BundleRegistry::remove` + `list` + new
+  `LocalAuditKind::BundleGc`. Interactive --all confirms unless
+  `--yes` (or non-TTY).
+- `BundleResources { vcpus, mem_mib }` optional field on
+  `BundleManifest`. **BUNDLE_SCHEMA_VERSION bumped 1 → 2.** v1
+  bundles deserialise cleanly with `resources = None`; v2 with
+  resources are the new default for `mvmctl bundle export`.
+  Older verifiers see `schema_version = 2` and refuse with
+  `UnsupportedSchema` (deliberate fail-closed).
+  `bundle_artifacts_for_sha` prefers manifest resources over
+  operator config when present; CLI `--cpus` / `--memory` still
+  override.
+
+W2 is now fully shipped end-to-end with no outstanding follow-ups.
 
 ### W3 — Network default flip (deny-by-default)  ✅ shipped
 

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -176,16 +176,14 @@ const BUNDLE_SUB: &[(&str, AuditPosture)] = &[
     ("install", AuditPosture::InteractiveOrControl),
 ];
 
-// trust add/remove mutate `~/.mvm/trusted-publishers/` but the
-// audit chain integration (new `LocalAuditKind::TrustAdd /
-// TrustRemove` variants + emitter wiring) hasn't landed yet —
-// same staged shape `policy update` used while waiting on plan
-// 60 Phase 8. Bumping these to `Emits("TrustAdd"/"TrustRemove")`
-// is the follow-up that goes with the audit-chain hook-up.
+// trust add/remove mutate `~/.mvm/trusted-publishers/` and emit
+// `LocalAuditKind::{TrustAdd, TrustRemove}` via
+// `mvm_core::audit::emit`. Sprint 52 W2 phase-3 close-out
+// promoted these from `InteractiveOrControl` to `Emits(...)`.
 const TRUST_SUB: &[(&str, AuditPosture)] = &[
-    ("add", AuditPosture::InteractiveOrControl),
+    ("add", AuditPosture::Emits("TrustAdd")),
     ("list", AuditPosture::ReadOnly),
-    ("remove", AuditPosture::InteractiveOrControl),
+    ("remove", AuditPosture::Emits("TrustRemove")),
 ];
 
 /// Every top-level `mvmctl` subcommand keyed by its clap name.
@@ -414,6 +412,8 @@ fn audit_posture_emits_entries_reference_known_audit_kinds() {
         "VmProcSignal",
         "VmProcStart",
         "VmProcStdin",
+        "TrustAdd",
+        "TrustRemove",
         "VmStart",
         "VmStop",
         "VmTtlSet",

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -170,6 +170,10 @@ const SNAPSHOT_SUB: &[(&str, AuditPosture)] = &[
 const BUNDLE_SUB: &[(&str, AuditPosture)] = &[
     ("export", AuditPosture::InteractiveOrControl),
     ("fetch", AuditPosture::ReadOnly),
+    // `bundle install` mutates the local bundle registry under
+    // `~/.mvm/bundles/<sha>/`. Substrate posture for now; once the
+    // audit-chain hook ships, this flips to Emits("BundleInstall").
+    ("install", AuditPosture::InteractiveOrControl),
 ];
 
 // trust add/remove mutate `~/.mvm/trusted-publishers/` but the

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -171,9 +171,9 @@ const BUNDLE_SUB: &[(&str, AuditPosture)] = &[
     ("export", AuditPosture::InteractiveOrControl),
     ("fetch", AuditPosture::ReadOnly),
     // `bundle install` mutates the local bundle registry under
-    // `~/.mvm/bundles/<sha>/`. Substrate posture for now; once the
-    // audit-chain hook ships, this flips to Emits("BundleInstall").
-    ("install", AuditPosture::InteractiveOrControl),
+    // `~/.mvm/bundles/<sha>/` and emits
+    // `LocalAuditKind::BundleInstall` via `mvm_core::audit::emit`.
+    ("install", AuditPosture::Emits("BundleInstall")),
 ];
 
 // trust add/remove mutate `~/.mvm/trusted-publishers/` and emit
@@ -412,6 +412,7 @@ fn audit_posture_emits_entries_reference_known_audit_kinds() {
         "VmProcSignal",
         "VmProcStart",
         "VmProcStdin",
+        "BundleInstall",
         "TrustAdd",
         "TrustRemove",
         "VmStart",

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -174,6 +174,9 @@ const BUNDLE_SUB: &[(&str, AuditPosture)] = &[
     // `~/.mvm/bundles/<sha>/` and emits
     // `LocalAuditKind::BundleInstall` via `mvm_core::audit::emit`.
     ("install", AuditPosture::Emits("BundleInstall")),
+    // `bundle gc` removes one (or all) installed bundles and emits
+    // `LocalAuditKind::BundleGc` on the success arm.
+    ("gc", AuditPosture::Emits("BundleGc")),
 ];
 
 // trust add/remove mutate `~/.mvm/trusted-publishers/` and emit
@@ -412,6 +415,7 @@ fn audit_posture_emits_entries_reference_known_audit_kinds() {
         "VmProcSignal",
         "VmProcStart",
         "VmProcStdin",
+        "BundleGc",
         "BundleInstall",
         "TrustAdd",
         "TrustRemove",


### PR DESCRIPTION
## Summary

Sprint 52 W2 close-out across six coherent commits. Bundles become a first-class template unit, fully usable end-to-end through CLI verbs, with the registry, audit coverage, and resource sizing all in place.

## Commits

- `384164a` — **Phase 1**: `BundleRegistry` + atomic install + template dispatch fallthrough + `mvmctl bundle install` (7 new tests)
- `8a4c30e` — **Phase 2**: `mvmctl up --bundle-pin <path>` wires `PlanArtifact` end-to-end (3 new tests)
- `f3e7dc6` — **Phase 3**: `LocalAuditKind::TrustAdd/TrustRemove` variants + emit from trust verbs + `AUDIT_POSTURE` flip
- `90cef3d` — **Residual A**: `LocalAuditKind::BundleInstall` + emit from install verb + `AUDIT_POSTURE` flip
- `ad3f52c` — **Residual B**: `mvmctl bundle gc <sha>` / `--all` + `BundleRegistry::remove` / `list` + `BundleGc` audit kind (4 new tests)
- `2c970d1` — **Residual C**: `BundleResources { vcpus, mem_mib }` field + **`BUNDLE_SCHEMA_VERSION` 1 → 2** + `bundle_artifacts_for_sha` prefers manifest resources + `bundle export` populates them (4 new tests)

## End-to-end flow now possible

```
# Machine A — author + publish
mvmctl bundle export <template> --out ./foo.mvmpkg

# Machine B — consume
mvmctl trust add ./publisher.pub
mvmctl bundle install ./foo.mvmpkg         # verifies, atomically installs, emits BundleInstall
mvmctl up --manifest <sha>                 # bundle_artifacts_for_sha resolves resources from the manifest
mvmctl up --manifest <sha> --bundle-pin ./foo.mvmpkg
                                           # admit-time re-verify fires every launch (claim 9)
mvmctl bundle gc --all --yes               # cleanup; emits BundleGc
```

## Trust + audit posture

Every state-changing verb in the bundle/trust namespace now emits a typed `LocalAuditKind`:

| Verb | Audit kind |
|---|---|
| `bundle install` | `BundleInstall` |
| `bundle gc` | `BundleGc` |
| `trust add` | `TrustAdd` |
| `trust remove` | `TrustRemove` |

`AUDIT_POSTURE` table in `tests/audit_total_coverage.rs` was extended with each variant + their `KNOWN_TOKENS` entries.

## Wire-format change disclosure

`BUNDLE_SCHEMA_VERSION` bumped 1 → 2 to accommodate the new optional `resources` field. v1 bundles deserialise into v2 verifiers cleanly (resources = None). v2 bundles refuse to deserialise in v1 verifiers — the schema sniff fires first with a clear `UnsupportedSchema` error. Deliberate fail-closed, same shape the earlier `valid_from/valid_until/nonce` bump used on `ExecutionPlan`.

## Test plan

- [ ] `cargo test --workspace --lib -- --test-threads=1` — 334 supervisor + 44 mvm-plan bundle (15 new across the 6 commits) + 13 admit_plan + every other crate green
- [ ] `cargo test --test audit_total_coverage` — 3 pass; BundleInstall, BundleGc, TrustAdd, TrustRemove all expected as Emits rows
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Walk the schema-version probe order in `read_and_verify_bundle` to confirm v1→v2 compat handling: schema sniff runs before deserialise, so a v3-from-future build will refuse with UnsupportedSchema rather than `deny_unknown_fields` panic.
- [ ] Atomic-extract crash safety: `BundleRegistry::install` stages to `<sha>.partial/`, rename promotes to `<sha>/`. Crash mid-install leaves no half-state.
- [ ] Confirm `mvmctl bundle gc --all` in a TTY refuses without `--yes`; non-TTY (CI) skips the prompt automatically.
- [ ] `bundle export` round-trip with resources: build a template with cpus=4 / mem=2G, export, install on a fresh registry, confirm `mvmctl up --manifest <sha>` picks up 4/2G defaults without explicit CLI flags.

## SPRINT.md

W2 fully shipped — no remaining follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)