### PR TITLE
plan-66 W3+W4: fs/proc mock-VM routing + 10 live tests

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -50,6 +50,12 @@ jobs:
   #   5. Ephemeral port discovery — `TcpListener::bind("127.0.0.1:0")`
   #      in `crates/mvm-cli/src/template_cmd.rs`. Binds to find a free
   #      port; drops the listener immediately. Not a daemon.
+  #   6. Test-only mock guest-agent
+  #      (`crates/mvm-backend/src/mock_guest_agent.rs`). Mirrors the
+  #      in-guest vsock agent on the host side via Unix-domain socket
+  #      so `mvmctl fs *` / `proc *` are hermetically testable against
+  #      `MockBackend`. Tier-3 / test-only; never selected by
+  #      `AnyBackend::auto_select`. Production callers can't reach it.
   #
   # The in-guest vsock agent in `mvm-guest` is also excluded — it
   # runs *inside* the microVM, not on the host.
@@ -96,6 +102,7 @@ jobs:
               --glob '!crates/mvm-providers/src/apple_container/**' \
               --glob '!crates/mvm-cli/src/metrics_server.rs' \
               --glob '!crates/mvm-cli/src/template_cmd.rs' \
+              --glob '!crates/mvm-backend/src/mock_guest_agent.rs' \
               -e "$PATTERNS" \
               crates/ src/ \
               || true)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +189,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,15 +230,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -247,6 +287,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,9 +339,18 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
 ]
 
 [[package]]
@@ -281,14 +359,14 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-lite",
  "rustix 1.1.4",
 ]
@@ -320,6 +398,34 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -463,6 +569,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +617,21 @@ dependencies = [
  "shlex",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -558,7 +690,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1534,6 +1666,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,8 +1683,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1685,6 +1838,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1941,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -1794,7 +1962,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -1836,6 +2004,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -2199,7 +2373,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -2439,6 +2613,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2458,12 +2643,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2474,8 +2670,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2484,6 +2680,40 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "humansize"
@@ -2505,6 +2735,29 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -2514,8 +2767,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2531,8 +2784,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2552,14 +2805,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2850,7 +3103,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2",
+ "socket2 0.6.2",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -2896,6 +3149,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -3106,6 +3368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "kvm-bindings"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3398,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph 0.6.5",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3140,6 +3442,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "lexical"
@@ -3353,6 +3661,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -4180,6 +4491,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "httpmock",
  "mimalloc",
  "mvm",
  "mvm-backend",
@@ -4208,6 +4520,12 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "newline-converter"
@@ -4450,7 +4768,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
- "http",
+ "http 1.4.0",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
@@ -4535,7 +4853,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-auth",
  "jwt",
  "lazy_static",
@@ -4561,7 +4879,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-auth",
  "jsonwebtoken",
  "lazy_static",
@@ -4670,7 +4988,7 @@ dependencies = [
  "flagset",
  "futures",
  "getrandom 0.2.17",
- "http",
+ "http 1.4.0",
  "log",
  "md-5",
  "once_cell",
@@ -4695,7 +5013,7 @@ dependencies = [
  "dyn-clone",
  "ed25519-dalek",
  "hmac",
- "http",
+ "http 1.4.0",
  "itertools 0.10.5",
  "log",
  "oauth2",
@@ -4952,11 +5270,21 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
 ]
@@ -4998,6 +5326,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -5160,6 +5494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5305,7 +5645,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
@@ -5404,7 +5744,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5442,7 +5782,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5582,6 +5922,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -5667,7 +6018,7 @@ dependencies = [
  "hex",
  "hmac",
  "home",
- "http",
+ "http 1.4.0",
  "log",
  "percent-encoding",
  "quick-xml 0.37.5",
@@ -5692,10 +6043,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -5736,10 +6087,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -6379,6 +6730,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6635,6 +6996,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6714,6 +7081,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -6766,7 +7143,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -6948,6 +7325,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7118,6 +7507,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7270,7 +7670,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -7450,8 +7850,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -7710,7 +8110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -7769,6 +8169,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -8753,7 +9159,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-sink",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,9 @@ chrono.workspace = true
 # `clap::Command` tree returned by `mvm_cli::commands::cli_command()`
 # to enforce that every subcommand has a declared audit posture.
 clap.workspace = true
+# Plan 69: local mock HTTP server for the `mvmctl update` live test.
+# Avoids reaching the real GitHub release API in CI / on dev machines.
+httpmock = "0.7"
 predicates.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -47,6 +47,7 @@ pub mod libkrun;
 pub mod microvm;
 pub mod microvm_nix;
 pub mod mock;
+pub mod mock_guest_agent;
 pub mod network;
 
 // `microsandbox` is the only self-contained backend integration that

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -30,6 +30,8 @@ use mvm_core::vm_backend::{
     VmCapabilities, VmExitStatus, VmId, VmInfo, VmNetworkInfo, VmStartConfig, VmStatus,
 };
 
+use crate::mock_guest_agent::MockGuestAgent;
+
 /// Per-VM state held by [`MockBackend`].
 #[derive(Debug, Clone)]
 struct MockVm {
@@ -47,9 +49,15 @@ struct MockVm {
 /// The interior `Mutex<HashMap>` is wrapped in an `Arc` so cloning the
 /// backend (e.g. across an `AnyBackend::Mock(MockBackend)` enum copy)
 /// shares state. The `Default` impl returns an empty registry.
+///
+/// `agents` holds one [`MockGuestAgent`] per VM. Plan 66 W1/W2 — the
+/// agent listens on `<vm_dir>/runtime/v.sock` so host-side `fs` and
+/// `proc` callers find a working endpoint at the same path
+/// Firecracker exposes for the real vsock UDS.
 #[derive(Debug, Default, Clone)]
 pub struct MockBackend {
     state: std::sync::Arc<Mutex<HashMap<String, MockVm>>>,
+    agents: std::sync::Arc<Mutex<HashMap<String, MockGuestAgent>>>,
 }
 
 impl MockBackend {
@@ -106,6 +114,25 @@ impl VmBackend for MockBackend {
         // because not every consumer needs the directory.
         let vm_dir = Self::vm_dir(&config.name);
         let _ = std::fs::create_dir_all(&vm_dir);
+        // Plan 66 W1/W2: spawn the mock vsock guest-agent on
+        // `<vm_dir>/runtime/v.sock`. Failure to start the agent is
+        // *not* fatal — the audit-emit tests that don't touch
+        // fs/proc still want the VM to come up. The fs/proc tests
+        // will see a clearer "connect failed" error than they
+        // would from a missing agent.
+        match MockGuestAgent::start(&vm_dir) {
+            Ok(agent) => {
+                if let Ok(mut agents) = self.agents.lock() {
+                    agents.insert(config.name.clone(), agent);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "mock: failed to start MockGuestAgent for '{}': {e}",
+                    config.name
+                );
+            }
+        }
         state.insert(
             config.name.clone(),
             MockVm {
@@ -134,6 +161,17 @@ impl VmBackend for MockBackend {
             .lock()
             .map_err(|_| anyhow::anyhow!("mock backend state mutex poisoned"))?;
         state.remove(&id.0);
+        // Drop the agent (which joins its thread + removes the socket)
+        // and the on-disk VM dir. Plan 66 W1/W2.
+        if let Ok(mut agents) = self.agents.lock()
+            && let Some(agent) = agents.remove(&id.0)
+        {
+            agent.stop();
+        }
+        let vm_dir = Self::vm_dir(&id.0);
+        if vm_dir.exists() {
+            let _ = std::fs::remove_dir_all(&vm_dir);
+        }
         Ok(())
     }
 
@@ -142,7 +180,19 @@ impl VmBackend for MockBackend {
             .state
             .lock()
             .map_err(|_| anyhow::anyhow!("mock backend state mutex poisoned"))?;
+        let names: Vec<String> = state.keys().cloned().collect();
         state.clear();
+        if let Ok(mut agents) = self.agents.lock() {
+            for (_, agent) in agents.drain() {
+                agent.stop();
+            }
+        }
+        for name in names {
+            let vm_dir = Self::vm_dir(&name);
+            if vm_dir.exists() {
+                let _ = std::fs::remove_dir_all(&vm_dir);
+            }
+        }
         Ok(())
     }
 

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -62,6 +62,18 @@ impl MockBackend {
     pub fn count(&self) -> usize {
         self.state.lock().map(|s| s.len()).unwrap_or(0)
     }
+
+    /// Host-side per-VM directory for a mock VM. Lives under
+    /// `<mvm_data_dir>/mock-vms/<name>/` so it never collides with
+    /// the Lima-era `~/microvm/vms/<name>` path that
+    /// `resolve_running_vm_dir` expects for real Firecracker VMs.
+    /// Plan 65 W1: `pause.rs` and `resume.rs` read the snapshot
+    /// directory through here when `--hypervisor mock` is set.
+    pub fn vm_dir(name: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from(mvm_core::config::mvm_data_dir())
+            .join("mock-vms")
+            .join(name)
+    }
 }
 
 impl VmBackend for MockBackend {
@@ -87,6 +99,13 @@ impl VmBackend for MockBackend {
         if state.contains_key(&config.name) {
             bail!("mock: VM '{}' already running", config.name);
         }
+        // Plan 65 W1: create a host-side per-VM directory so the
+        // verbs that probe `<vm_dir>/...` paths (pause/resume's
+        // snapshot dir; future fs/proc/volume work) find something
+        // real. Best-effort — a failure here doesn't abort start
+        // because not every consumer needs the directory.
+        let vm_dir = Self::vm_dir(&config.name);
+        let _ = std::fs::create_dir_all(&vm_dir);
         state.insert(
             config.name.clone(),
             MockVm {

--- a/crates/mvm-backend/src/mock_guest_agent.rs
+++ b/crates/mvm-backend/src/mock_guest_agent.rs
@@ -1,0 +1,512 @@
+//! In-process mock of the in-guest `mvm-guest-agent` vsock surface.
+//!
+//! Plan 66 W2. Pairs with [`crate::mock::MockBackend`]: every mock VM
+//! gets its own `MockGuestAgent` listening on `<vm_dir>/runtime/v.sock`,
+//! the same Unix-domain socket path Firecracker exposes for the
+//! vsock UDS multiplexer. The host-side fs/proc helpers in
+//! `mvm_guest::vsock` connect to that path, send the
+//! `CONNECT <port>\n` line, then exchange length-prefixed JSON
+//! `GuestRequest` / `GuestResponse` frames. The mock implements that
+//! protocol faithfully enough for the audit-emit live tests in
+//! `tests/audit_emissions_live.rs` to exercise `mvmctl fs *` and
+//! `mvmctl proc *` end-to-end without a real microVM.
+//!
+//! ## What the mock answers
+//!
+//! - **Fs verbs** (`FsWrite`, `FsMkdir`, `FsRemove`, `FsMove`) return
+//!   the matching success variant of [`FsResult`]. Byte counts and
+//!   entry counts reflect the input so audit-detail strings (`bytes=N`,
+//!   `entries=N`) line up with what a real agent would emit.
+//! - **Proc verbs** (`ProcStart`, `ProcSignal`, `ProcSendInput`,
+//!   `ProcKill`) return the matching success variant of [`ProcResult`].
+//!   `ProcStart` mints a deterministic `proc-<N>` token from an atomic
+//!   counter.
+//! - **Read-only verbs** (`FsRead`, `FsStat`, `FsList`, `ProcList`,
+//!   `ProcWait`) return empty / zero-state responses — they exist to
+//!   keep the wire surface complete for the pinned no-emit tests in
+//!   plan 66 W4, not to model real filesystem / proc state.
+//! - **Everything else** comes back as `GuestResponse::Error` so a
+//!   future verb that lands without a matching mock arm fails loud
+//!   instead of hanging.
+//!
+//! ## Security profile
+//!
+//! Tier 3 / test-only. The mock accepts every request, never
+//! validates signatures, and never enforces policy. It mirrors
+//! [`MockBackend`]'s posture — never selectable from
+//! `AnyBackend::auto_select`, only via `--hypervisor mock`.
+
+use std::io::{Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use mvm_guest::vsock::{
+    FsErrorKind, FsResult, GuestRequest, GuestResponse, ProcResult, ProcWaitEvent,
+};
+
+/// Maximum frame size accepted by the mock agent — matches the
+/// host-side `MAX_FRAME_SIZE` (256 KiB) so the mock breaks loud
+/// rather than silent if a caller exceeds the production cap.
+const MAX_FRAME_SIZE: usize = 256 * 1024;
+
+/// How long the accept loop waits between shutdown-flag checks.
+/// Short enough that `MockGuestAgent::stop()` returns promptly,
+/// long enough to keep idle CPU near zero.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Per-VM mock agent. Owns the listener thread and shuts it down
+/// when dropped or when [`stop`](Self::stop) is called.
+pub struct MockGuestAgent {
+    socket_path: PathBuf,
+    shutdown: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for MockGuestAgent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MockGuestAgent")
+            .field("socket_path", &self.socket_path)
+            .field("running", &!self.shutdown.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+impl MockGuestAgent {
+    /// Start a new mock agent listening on `<vm_dir>/runtime/v.sock`.
+    ///
+    /// Creates the `runtime` subdirectory if missing and removes any
+    /// stale socket file at the target path. The accept loop runs
+    /// on a background thread; callers must hold the returned handle
+    /// for the agent's lifetime.
+    pub fn start(vm_dir: &Path) -> Result<Self> {
+        let runtime_dir = vm_dir.join("runtime");
+        std::fs::create_dir_all(&runtime_dir)
+            .with_context(|| format!("creating runtime dir at {}", runtime_dir.display()))?;
+        let socket_path = runtime_dir.join("v.sock");
+        // Stale socket from a previous run would make `bind` fail
+        // with EADDRINUSE. Best-effort removal.
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path)
+            .with_context(|| format!("binding mock agent at {}", socket_path.display()))?;
+        listener
+            .set_nonblocking(true)
+            .with_context(|| "setting listener non-blocking")?;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = Arc::clone(&shutdown);
+        let next_token = Arc::new(AtomicU64::new(1));
+        let next_token_clone = Arc::clone(&next_token);
+
+        let thread = std::thread::Builder::new()
+            .name(format!(
+                "mock-guest-agent-{}",
+                vm_dir.file_name().and_then(|s| s.to_str()).unwrap_or("vm")
+            ))
+            .spawn(move || run_accept_loop(listener, shutdown_clone, next_token_clone))
+            .with_context(|| "spawning mock guest-agent thread")?;
+
+        Ok(Self {
+            socket_path,
+            shutdown,
+            thread: Some(thread),
+        })
+    }
+
+    /// Path of the Unix socket the agent is listening on.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    /// Signal the accept loop to exit, join the thread, and remove
+    /// the socket file. Idempotent — subsequent calls are no-ops.
+    pub fn stop(mut self) {
+        self.shutdown_inner();
+    }
+
+    fn shutdown_inner(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+impl Drop for MockGuestAgent {
+    fn drop(&mut self) {
+        self.shutdown_inner();
+    }
+}
+
+fn run_accept_loop(listener: UnixListener, shutdown: Arc<AtomicBool>, next_token: Arc<AtomicU64>) {
+    while !shutdown.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((stream, _addr)) => {
+                // The listener is non-blocking (so accept can return
+                // WouldBlock for the shutdown poll). On some
+                // platforms the accepted socket inherits non-blocking
+                // mode; force it back to blocking + a generous read
+                // timeout so a misbehaving client can't wedge the
+                // worker forever.
+                if let Err(e) = stream.set_nonblocking(false) {
+                    tracing::warn!("mock-guest-agent: set_nonblocking(false) failed: {e}");
+                    continue;
+                }
+                let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+                let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
+                let token_counter = Arc::clone(&next_token);
+                // One worker per connection. Tests bring up at most
+                // a handful of VMs with one in-flight call each;
+                // unbounded spawn is fine at this scale.
+                let _ = std::thread::Builder::new()
+                    .name("mock-guest-agent-worker".to_string())
+                    .spawn(move || handle_connection(stream, token_counter));
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(_) => {
+                // Listener dropped (socket file removed during stop)
+                // or other unrecoverable error — exit cleanly.
+                break;
+            }
+        }
+    }
+}
+
+/// Handle one client connection: CONNECT handshake, then one
+/// request/response cycle, then close. Matches the host-side
+/// `connect_to_port` + `send_request` shape.
+fn handle_connection(mut stream: UnixStream, next_token: Arc<AtomicU64>) {
+    // Read the CONNECT line one byte at a time. A `BufReader` would
+    // be more idiomatic but it pre-buffers from the underlying
+    // stream, which means it can swallow the length-prefix bytes
+    // the client immediately writes after `CONNECT <port>\n`. The
+    // byte-by-byte loop guarantees the next read on `stream`
+    // starts exactly at the length-prefix.
+    let connect_line = match read_line_byte_by_byte(&mut stream) {
+        Some(line) => line,
+        None => return,
+    };
+    let port = parse_connect_line(&connect_line).unwrap_or(0);
+
+    if writeln!(stream, "OK {}", port).is_err() {
+        return;
+    }
+    if stream.flush().is_err() {
+        return;
+    }
+
+    // Read one length-prefixed JSON request.
+    let mut len_buf = [0u8; 4];
+    if stream.read_exact(&mut len_buf).is_err() {
+        return;
+    }
+    let frame_len = u32::from_be_bytes(len_buf) as usize;
+    if frame_len == 0 || frame_len > MAX_FRAME_SIZE {
+        return;
+    }
+    let mut body = vec![0u8; frame_len];
+    if stream.read_exact(&mut body).is_err() {
+        return;
+    }
+    let req: GuestRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(_) => {
+            let _ = write_error(&mut stream, "mock: failed to deserialize GuestRequest");
+            return;
+        }
+    };
+
+    let resp = dispatch(req, &next_token);
+    let _ = write_frame(&mut stream, &resp);
+}
+
+fn parse_connect_line(line: &str) -> Option<u32> {
+    let trimmed = line.trim();
+    let rest = trimmed.strip_prefix("CONNECT ")?;
+    rest.parse().ok()
+}
+
+/// Read a single line (terminated by `\n`) from `stream` one byte at
+/// a time. Used in place of `BufReader::read_line` so the worker
+/// can switch to length-prefixed framing on the next read without
+/// any pre-buffered bytes left over. Caps at 128 bytes — the line
+/// the client sends is `"CONNECT <decimal-u32>\n"`, comfortably
+/// shorter than that.
+fn read_line_byte_by_byte(stream: &mut UnixStream) -> Option<String> {
+    let mut out = Vec::with_capacity(32);
+    let mut byte = [0u8; 1];
+    while out.len() < 128 {
+        match stream.read_exact(&mut byte) {
+            Ok(()) => {
+                out.push(byte[0]);
+                if byte[0] == b'\n' {
+                    return String::from_utf8(out).ok();
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+    None
+}
+
+fn write_frame(stream: &mut UnixStream, resp: &GuestResponse) -> Result<()> {
+    let data = serde_json::to_vec(resp).context("serialize GuestResponse")?;
+    let len = (data.len() as u32).to_be_bytes();
+    stream.write_all(&len)?;
+    stream.write_all(&data)?;
+    stream.flush()?;
+    Ok(())
+}
+
+fn write_error(stream: &mut UnixStream, message: &str) -> Result<()> {
+    write_frame(
+        stream,
+        &GuestResponse::Error {
+            message: message.to_string(),
+        },
+    )
+}
+
+/// Translate one `GuestRequest` into the matching success-shaped
+/// `GuestResponse`. Centralised so the protocol surface is auditable
+/// in one place.
+fn dispatch(req: GuestRequest, next_token: &AtomicU64) -> GuestResponse {
+    match req {
+        // ── Filesystem verbs ────────────────────────────────────────
+        GuestRequest::FsWrite { content, .. } => GuestResponse::FsResult(FsResult::Write {
+            bytes_written: content.len() as u64,
+        }),
+        GuestRequest::FsMkdir { .. } => GuestResponse::FsResult(FsResult::Mkdir),
+        GuestRequest::FsRemove { .. } => {
+            // Real agent reports actual entry count; the mock has no
+            // tree to walk, so always report a single entry removed.
+            // The audit emit only asserts `entries=<N>` exists, not
+            // the value.
+            GuestResponse::FsResult(FsResult::Remove { entries_removed: 1 })
+        }
+        GuestRequest::FsMove { .. } => GuestResponse::FsResult(FsResult::Move),
+        GuestRequest::FsList { .. } => GuestResponse::FsResult(FsResult::List {
+            entries: Vec::new(),
+            truncated: false,
+        }),
+        GuestRequest::FsRead { .. } | GuestRequest::FsStat { .. } => {
+            GuestResponse::FsResult(FsResult::Error {
+                kind: FsErrorKind::Other,
+                message: "mock guest-agent: read/stat not implemented".to_string(),
+            })
+        }
+
+        // ── Process verbs ───────────────────────────────────────────
+        GuestRequest::ProcStart { .. } => {
+            let n = next_token.fetch_add(1, Ordering::Relaxed);
+            GuestResponse::ProcResult(ProcResult::Started {
+                pid_token: format!("proc-{n}"),
+            })
+        }
+        GuestRequest::ProcSignal { .. } => GuestResponse::ProcResult(ProcResult::Signaled),
+        GuestRequest::ProcSendInput { bytes, .. } => {
+            GuestResponse::ProcResult(ProcResult::InputAccepted {
+                bytes_accepted: bytes.len() as u64,
+            })
+        }
+        GuestRequest::ProcKill { .. } => GuestResponse::ProcResult(ProcResult::Killed),
+        GuestRequest::ProcList => GuestResponse::ProcResult(ProcResult::List {
+            processes: Vec::new(),
+        }),
+        GuestRequest::ProcWait { .. } => {
+            GuestResponse::ProcWaitEvent(ProcWaitEvent::Exit { code: 0 })
+        }
+
+        // ── Catch-all: every other verb fails loud ──────────────────
+        other => GuestResponse::Error {
+            message: format!(
+                "mock guest-agent: verb {:?} is not implemented",
+                std::mem::discriminant(&other)
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_guest::vsock::{send_fs_request, send_proc_request};
+    use std::collections::BTreeMap;
+    use tempfile::TempDir;
+
+    fn make_vm_dir() -> TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn write_file_round_trip() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent; // keep alive
+
+        let req = GuestRequest::FsWrite {
+            path: "/tmp/hello".to_string(),
+            content: b"hi there".to_vec(),
+            mode: 0o644,
+            create_parents: false,
+            follow_symlinks: false,
+        };
+        let result = send_fs_request(&dir.path().to_string_lossy(), req).expect("send_fs_request");
+        match result {
+            FsResult::Write { bytes_written } => assert_eq!(bytes_written, 8),
+            other => panic!("expected Write, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mkdir_and_remove_round_trip() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+        let mk = send_fs_request(
+            &dir.path().to_string_lossy(),
+            GuestRequest::FsMkdir {
+                path: "/tmp/x".to_string(),
+                mode: 0o755,
+                parents: false,
+            },
+        )
+        .expect("mkdir");
+        assert!(matches!(mk, FsResult::Mkdir));
+        let rm = send_fs_request(
+            &dir.path().to_string_lossy(),
+            GuestRequest::FsRemove {
+                path: "/tmp/x".to_string(),
+                recursive: false,
+                follow_symlinks: false,
+            },
+        )
+        .expect("remove");
+        assert!(matches!(rm, FsResult::Remove { entries_removed: 1 }));
+    }
+
+    #[test]
+    fn proc_start_assigns_deterministic_tokens() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+
+        let req = || GuestRequest::ProcStart {
+            argv: vec!["/bin/true".to_string()],
+            env: BTreeMap::new(),
+            cwd: None,
+            stdin: Vec::new(),
+            timeout_secs: None,
+        };
+        let path = dir.path().to_string_lossy();
+        let r1 = send_proc_request(&path, req()).expect("start 1");
+        let r2 = send_proc_request(&path, req()).expect("start 2");
+        match (r1, r2) {
+            (ProcResult::Started { pid_token: t1 }, ProcResult::Started { pid_token: t2 }) => {
+                assert_eq!(t1, "proc-1");
+                assert_eq!(t2, "proc-2");
+            }
+            other => panic!("expected Started + Started, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn proc_signal_and_kill_return_success_variants() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+        let path = dir.path().to_string_lossy();
+        let sig = send_proc_request(
+            &path,
+            GuestRequest::ProcSignal {
+                pid_token: "proc-anything".to_string(),
+                signum: 15,
+            },
+        )
+        .expect("signal");
+        assert!(matches!(sig, ProcResult::Signaled));
+        let kill = send_proc_request(
+            &path,
+            GuestRequest::ProcKill {
+                pid_token: "proc-anything".to_string(),
+            },
+        )
+        .expect("kill");
+        assert!(matches!(kill, ProcResult::Killed));
+    }
+
+    #[test]
+    fn proc_send_input_reports_accepted_bytes() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+        let result = send_proc_request(
+            &dir.path().to_string_lossy(),
+            GuestRequest::ProcSendInput {
+                pid_token: "proc-1".to_string(),
+                bytes: vec![1, 2, 3, 4, 5],
+            },
+        )
+        .expect("send input");
+        match result {
+            ProcResult::InputAccepted { bytes_accepted } => assert_eq!(bytes_accepted, 5),
+            other => panic!("expected InputAccepted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stop_removes_socket() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let socket = agent.socket_path().to_path_buf();
+        assert!(socket.exists(), "socket must exist while agent is up");
+        agent.stop();
+        assert!(
+            !socket.exists(),
+            "socket must be removed by MockGuestAgent::stop"
+        );
+    }
+
+    #[test]
+    fn two_agents_on_separate_vm_dirs_do_not_collide() {
+        let dir_a = make_vm_dir();
+        let dir_b = make_vm_dir();
+        let agent_a = MockGuestAgent::start(dir_a.path()).expect("start a");
+        let agent_b = MockGuestAgent::start(dir_b.path()).expect("start b");
+        let _ = (&agent_a, &agent_b);
+
+        let write_a = send_fs_request(
+            &dir_a.path().to_string_lossy(),
+            GuestRequest::FsWrite {
+                path: "/tmp/a".to_string(),
+                content: b"a".to_vec(),
+                mode: 0o644,
+                create_parents: false,
+                follow_symlinks: false,
+            },
+        )
+        .expect("write a");
+        let write_b = send_fs_request(
+            &dir_b.path().to_string_lossy(),
+            GuestRequest::FsWrite {
+                path: "/tmp/b".to_string(),
+                content: b"bb".to_vec(),
+                mode: 0o644,
+                create_parents: false,
+                follow_symlinks: false,
+            },
+        )
+        .expect("write b");
+        match (write_a, write_b) {
+            (FsResult::Write { bytes_written: 1 }, FsResult::Write { bytes_written: 2 }) => {}
+            other => panic!("expected 1-byte / 2-byte writes, got {other:?}"),
+        }
+    }
+}

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -275,6 +275,37 @@ pub fn dev_build(
     profile: Option<&str>,
     mode: BuildMode,
 ) -> Result<DevBuildResult> {
+    // Plan 68: `MVM_BUILD_STUB_OUTDIR` lets the live test suite
+    // skip the Nix build entirely and treat the env-var's value as
+    // the build output directory. The directory must contain
+    // `vmlinux` + `rootfs.ext4`. Same env-var-escape-hatch shape
+    // `MVM_DIRECT_BOOT` uses for `mvmctl up`. Logged loudly so a
+    // production misconfiguration can't go silent.
+    if let Ok(stub) = std::env::var("MVM_BUILD_STUB_OUTDIR")
+        && !stub.trim().is_empty()
+    {
+        env.log_warn(&format!(
+            "MVM_BUILD_STUB_OUTDIR={stub} set; skipping nix build (test path)."
+        ));
+        let _ = (flake_ref, profile, mode);
+        let stub_path = std::path::PathBuf::from(stub.trim());
+        let revision_hash = stub_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(String::from)
+            .unwrap_or_else(|| "stub".to_string());
+        return Ok(DevBuildResult {
+            build_dir: stub_path.display().to_string(),
+            vmlinux_path: stub_path.join("vmlinux").display().to_string(),
+            rootfs_path: stub_path.join("rootfs.ext4").display().to_string(),
+            initrd_path: None,
+            revision_hash,
+            cached: false,
+            runner_dir: None,
+            artifact_sizes: mvm_core::pool::ArtifactSizes::default(),
+        });
+    }
+
     // W7.x.2 dispatch: if the `env` channel has `nix` on PATH, run
     // the build there (host on Linux+host-Nix, Apple Container dev
     // VM on macOS 26+, etc.). Otherwise spawn a microsandbox builder
@@ -850,6 +881,17 @@ pub fn ensure_guest_agent_if_needed(
     env: &dyn ShellEnvironment,
     build_result: &DevBuildResult,
 ) -> Result<()> {
+    // Plan 68: same stub-outdir escape-hatch as `dev_build`. When the
+    // build itself was a stub, the rootfs is a placeholder file, not
+    // an ext4 image — attempting to `sudo mount` it would prompt for
+    // a password and hang the test. Skip injection in that mode.
+    if std::env::var("MVM_BUILD_STUB_OUTDIR")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
+    {
+        env.log_warn("MVM_BUILD_STUB_OUTDIR set; skipping guest-agent injection (test path).");
+        return Ok(());
+    }
     let mvm_src = match detect_mvm_src() {
         Some(p) => p,
         None => {

--- a/crates/mvm-cli/src/commands/env/uninstall.rs
+++ b/crates/mvm-cli/src/commands/env/uninstall.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 use clap::Args as ClapArgs;
+use std::path::PathBuf;
 
 use crate::ui;
 
@@ -9,6 +10,28 @@ use mvm_backend::microvm;
 use mvm_core::user_config::MvmConfig;
 
 use super::Cli;
+
+/// Optionally rewrite an absolute system path under a sandbox prefix.
+/// Plan 70: when `MVM_UNINSTALL_PATH_PREFIX` is set, the verb's
+/// `/var/lib/mvm` and `/usr/local/bin/mvmctl` targets relocate under
+/// the prefix and the sudo invocation is skipped (plain
+/// `std::fs::remove_*`) because the rewritten paths live in
+/// test-owned territory. Logs a `ui::warn` on bypass so the
+/// override is visible.
+///
+/// Returns `(rewritten_path, use_sudo)`. `use_sudo == false` means
+/// the caller should bypass `sudo` because either (a) the override
+/// is set, or (b) future caller logic may want to drop sudo for
+/// some other reason — currently only (a) is wired.
+fn sandbox_path(p: &str) -> (PathBuf, bool) {
+    match std::env::var("MVM_UNINSTALL_PATH_PREFIX") {
+        Ok(prefix) if !prefix.trim().is_empty() => {
+            let stripped = p.strip_prefix('/').unwrap_or(p);
+            (PathBuf::from(prefix.trim()).join(stripped), false)
+        }
+        _ => (PathBuf::from(p), true),
+    }
+}
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -55,6 +78,20 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         }
     }
 
+    // Plan 70: when MVM_UNINSTALL_PATH_PREFIX is set the system
+    // paths below get rewritten under that prefix and sudo is
+    // skipped. Surface the bypass loudly so a misconfigured
+    // production caller can't miss it.
+    let prefix_set = std::env::var("MVM_UNINSTALL_PATH_PREFIX")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false);
+    if prefix_set {
+        ui::warn(
+            "MVM_UNINSTALL_PATH_PREFIX set; rewriting system paths under \
+             the prefix and skipping sudo (test path).",
+        );
+    }
+
     // Stop running microVMs first (best-effort). Plan-60 / ADR-013
     // dropped Lima; there is no Lima VM to destroy.
     if let Err(e) = microvm::stop() {
@@ -62,16 +99,21 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     }
 
     // Remove /var/lib/mvm/.
-    let state_dir = std::path::Path::new("/var/lib/mvm");
+    let (state_dir, use_sudo) = sandbox_path("/var/lib/mvm");
     if state_dir.exists() {
-        ui::info("Removing /var/lib/mvm/...");
-        let status = std::process::Command::new("sudo")
-            .args(["rm", "-rf", "/var/lib/mvm"])
-            .status();
-        match status {
-            Ok(s) if s.success() => {}
-            Ok(s) => tracing::warn!("sudo rm /var/lib/mvm exited with status {s}"),
-            Err(e) => tracing::warn!("failed to remove /var/lib/mvm: {e}"),
+        ui::info(&format!("Removing {}...", state_dir.display()));
+        if use_sudo {
+            let status = std::process::Command::new("sudo")
+                .args(["rm", "-rf"])
+                .arg(&state_dir)
+                .status();
+            match status {
+                Ok(s) if s.success() => {}
+                Ok(s) => tracing::warn!("sudo rm {} exited with status {s}", state_dir.display()),
+                Err(e) => tracing::warn!("failed to remove {}: {e}", state_dir.display()),
+            }
+        } else if let Err(e) = std::fs::remove_dir_all(&state_dir) {
+            tracing::warn!("failed to remove {}: {e}", state_dir.display());
         }
     }
 
@@ -88,16 +130,21 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         }
 
         // Remove /usr/local/bin/mvmctl.
-        let bin = std::path::Path::new("/usr/local/bin/mvmctl");
+        let (bin, use_sudo) = sandbox_path("/usr/local/bin/mvmctl");
         if bin.exists() {
-            ui::info("Removing /usr/local/bin/mvmctl...");
-            let status = std::process::Command::new("sudo")
-                .args(["rm", "-f", "/usr/local/bin/mvmctl"])
-                .status();
-            match status {
-                Ok(s) if s.success() => {}
-                Ok(s) => tracing::warn!("sudo rm mvmctl exited with status {s}"),
-                Err(e) => tracing::warn!("failed to remove /usr/local/bin/mvmctl: {e}"),
+            ui::info(&format!("Removing {}...", bin.display()));
+            if use_sudo {
+                let status = std::process::Command::new("sudo")
+                    .args(["rm", "-f"])
+                    .arg(&bin)
+                    .status();
+                match status {
+                    Ok(s) if s.success() => {}
+                    Ok(s) => tracing::warn!("sudo rm {} exited with status {s}", bin.display()),
+                    Err(e) => tracing::warn!("failed to remove {}: {e}", bin.display()),
+                }
+            } else if let Err(e) = std::fs::remove_file(&bin) {
+                tracing::warn!("failed to remove {}: {e}", bin.display());
             }
         }
     }

--- a/crates/mvm-cli/src/commands/vm/fs.rs
+++ b/crates/mvm-cli/src/commands/vm/fs.rs
@@ -165,6 +165,16 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
 
 fn instance_dir_for(name: &str) -> Result<String> {
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
+    // Plan 66 W3: if a mock VM is registered at
+    // `<mvm_data_dir>/mock-vms/<name>/runtime/v.sock`, route to it
+    // directly. The check is filesystem-based — production code
+    // never reaches the mock-vms path because `MockBackend` only
+    // populates it under `--hypervisor mock`. Falls through to the
+    // Lima-era resolver when no mock is in play.
+    let mock_dir = mvm_backend::MockBackend::vm_dir(name);
+    if mock_dir.join("runtime").join("v.sock").exists() {
+        return Ok(mock_dir.to_string_lossy().into_owned());
+    }
     microvm::resolve_running_vm_dir(name)
 }
 

--- a/crates/mvm-cli/src/commands/vm/pause.rs
+++ b/crates/mvm-cli/src/commands/vm/pause.rs
@@ -18,7 +18,9 @@ use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
 
-use mvm::vm::instance_snapshot::{FirecrackerIO, pause_and_seal, verify_and_resume};
+use mvm::vm::instance_snapshot::{
+    CannedIO, FirecrackerIO, SnapshotIO, pause_and_seal, verify_and_resume,
+};
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
 
@@ -30,6 +32,14 @@ pub(in crate::commands) struct PauseArgs {
     /// Name of the VM to pause
     #[arg(value_parser = clap_vm_name)]
     pub name: String,
+    /// Hypervisor to drive the snapshot through. Defaults to
+    /// `firecracker`. `--hypervisor mock` swaps the FirecrackerIO
+    /// snapshot transport for `CannedIO` (writes deterministic
+    /// stub bytes to vmstate.bin + mem.bin), letting plan 65's
+    /// live tests exercise `WorkloadSleep` without a real
+    /// Firecracker socket.
+    #[arg(long, default_value = "firecracker")]
+    pub hypervisor: String,
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -37,17 +47,48 @@ pub(in crate::commands) struct ResumeArgs {
     /// Name of the VM to resume
     #[arg(value_parser = clap_vm_name)]
     pub name: String,
+    /// Hypervisor to drive the restore through. Defaults to
+    /// `firecracker`. See `pause --help` for the `mock` variant.
+    #[arg(long, default_value = "firecracker")]
+    pub hypervisor: String,
+}
+
+/// Pick the `SnapshotIO` impl matching the hypervisor selector.
+/// Plan 65 W2: `mock` swaps in `CannedIO` for hermetic
+/// `WorkloadSleep` / `WorkloadWake` audit-emit coverage; every
+/// other selector uses `FirecrackerIO` against the running VM's
+/// UDS socket.
+fn snapshot_io_for(hypervisor: &str, vm_name: &str) -> Result<Box<dyn SnapshotIO>> {
+    if hypervisor == "mock" {
+        // The mock VM's per-VM directory lives at
+        // `<mvm_data_dir>/mock-vms/<name>/` and is created by
+        // `MockBackend::start_with_mode`. Nothing to validate here
+        // beyond its existence — `pause_and_seal` writes the
+        // snapshot files into a sibling `snapshot/` directory.
+        let dir = mvm_backend::MockBackend::vm_dir(vm_name);
+        if !dir.exists() {
+            bail!(
+                "mock VM {vm_name:?} is not running (no directory at {})",
+                dir.display()
+            );
+        }
+        return Ok(Box::new(CannedIO {
+            vmstate_bytes: b"mock-vmstate".to_vec(),
+            mem_bytes: b"mock-mem".to_vec(),
+        }));
+    }
+    let vm_dir = mvm_backend::microvm::resolve_running_vm_dir(vm_name)
+        .with_context(|| format!("VM {vm_name:?} is not running"))?;
+    let socket = firecracker_socket(&vm_dir);
+    Ok(Box::new(FirecrackerIO::new(socket)))
 }
 
 pub(in crate::commands) fn run_pause(_cli: &Cli, args: PauseArgs, _cfg: &MvmConfig) -> Result<()> {
     validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
-    let vm_dir = mvm_backend::microvm::resolve_running_vm_dir(&args.name)
-        .with_context(|| format!("VM {:?} is not running", args.name))?;
-    let socket = firecracker_socket(&vm_dir);
-    let io = FirecrackerIO::new(socket);
+    let io = snapshot_io_for(&args.hypervisor, &args.name)?;
 
     let sidecar =
-        pause_and_seal(&args.name, &io).with_context(|| format!("pausing VM {:?}", args.name))?;
+        pause_and_seal(&args.name, &*io).with_context(|| format!("pausing VM {:?}", args.name))?;
 
     let registry_path = mvm::vm::name_registry::registry_path();
     if let Ok(mut registry) = mvm::vm::name_registry::VmNameRegistry::load(&registry_path) {
@@ -58,7 +99,7 @@ pub(in crate::commands) fn run_pause(_cli: &Cli, args: PauseArgs, _cfg: &MvmConf
         "{}: paused (epoch {}, vmstate {} B, mem {} B)",
         args.name, sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
-    mvm_core::audit_emit!(WorkloadSleep, vm: args.name, "epoch={} vmstate={} mem={}" ,
+    mvm_core::audit_emit!(WorkloadSleep, vm: &args.name, "epoch={} vmstate={} mem={}" ,
         sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
     Ok(())
@@ -76,19 +117,13 @@ pub(in crate::commands) fn run_resume(
     // requires the user to have already started a fresh VM
     // shell that's waiting for the snapshot load (Firecracker's
     // restore-into-empty-VMM workflow). The substrate is
-    // ready; the launcher integration is a follow-up.
-    let vm_dir = mvm_backend::microvm::resolve_running_vm_dir(&args.name).with_context(|| {
-        format!(
-            "VM {:?} has no running Firecracker shell; resume currently \
-                 requires a fresh `mvmctl up --resume-from-snapshot` (follow-up). \
-                 Substrate verifies, the launcher integration is pending.",
-            args.name
-        )
-    })?;
-    let socket = firecracker_socket(&vm_dir);
-    let io = FirecrackerIO::new(socket);
+    // ready; the launcher integration is a follow-up. Plan 65
+    // W2: `--hypervisor mock` swaps in `CannedIO` so the
+    // verify-resume path can land its `WorkloadWake` audit emit
+    // without a live Firecracker socket.
+    let io = snapshot_io_for(&args.hypervisor, &args.name)?;
 
-    let sidecar = verify_and_resume(&args.name, &io)
+    let sidecar = verify_and_resume(&args.name, &*io)
         .with_context(|| format!("resuming VM {:?}", args.name))?;
 
     let registry_path = mvm::vm::name_registry::registry_path();
@@ -100,7 +135,7 @@ pub(in crate::commands) fn run_resume(
         "{}: resumed (epoch {}, vmstate {} B, mem {} B)",
         args.name, sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
-    mvm_core::audit_emit!(WorkloadWake, vm: args.name, "epoch={} vmstate={} mem={}" ,
+    mvm_core::audit_emit!(WorkloadWake, vm: &args.name, "epoch={} vmstate={} mem={}" ,
         sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
     Ok(())

--- a/crates/mvm-cli/src/commands/vm/proc.rs
+++ b/crates/mvm-cli/src/commands/vm/proc.rs
@@ -126,6 +126,16 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
 
 fn instance_dir_for(name: &str) -> Result<String> {
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
+    // Plan 66 W3: if a mock VM is registered at
+    // `<mvm_data_dir>/mock-vms/<name>/runtime/v.sock`, route to it
+    // directly. The check is filesystem-based — production code
+    // never reaches the mock-vms path because `MockBackend` only
+    // populates it under `--hypervisor mock`. Falls through to the
+    // Lima-era resolver when no mock is in play.
+    let mock_dir = mvm_backend::MockBackend::vm_dir(name);
+    if mock_dir.join("runtime").join("v.sock").exists() {
+        return Ok(mock_dir.to_string_lossy().into_owned());
+    }
     microvm::resolve_running_vm_dir(name)
 }
 

--- a/crates/mvm-cli/src/update.rs
+++ b/crates/mvm-cli/src/update.rs
@@ -41,10 +41,42 @@ fn detect_target() -> Result<&'static str> {
     );
 }
 
+/// Base URL for the GitHub releases query.
+///
+/// Defaults to `https://api.github.com`. `MVM_UPDATE_API_URL` overrides
+/// for hermetic tests (plan 69) — the env-var supplies the bare host
+/// (e.g. `http://127.0.0.1:8080`) and the existing path suffix
+/// `/repos/<repo>/releases/latest` is appended. The override path
+/// emits a warning so the bypass is visible in stderr.
+fn github_api_base() -> String {
+    if let Ok(base) = std::env::var("MVM_UPDATE_API_URL")
+        && !base.trim().is_empty()
+    {
+        eprintln!("[mvm] MVM_UPDATE_API_URL set; using {base} (test path).");
+        return base.trim().trim_end_matches('/').to_string();
+    }
+    String::from("https://api.github.com")
+}
+
+/// Base URL for GitHub release-asset downloads.
+///
+/// Defaults to `https://github.com`. `MVM_UPDATE_DOWNLOAD_URL` overrides
+/// for hermetic tests — same shape as `MVM_UPDATE_API_URL`.
+fn github_download_base() -> String {
+    if let Ok(base) = std::env::var("MVM_UPDATE_DOWNLOAD_URL")
+        && !base.trim().is_empty()
+    {
+        eprintln!("[mvm] MVM_UPDATE_DOWNLOAD_URL set; using {base} (test path).");
+        return base.trim().trim_end_matches('/').to_string();
+    }
+    String::from("https://github.com")
+}
+
 /// Query the GitHub releases API for the latest release tag name.
 fn fetch_latest_version() -> Result<String> {
     let url = format!(
-        "https://api.github.com/repos/{}/releases/latest",
+        "{}/repos/{}/releases/latest",
+        github_api_base(),
         GITHUB_REPO
     );
 
@@ -90,8 +122,10 @@ fn parse_checksum_line(line: &str) -> Result<[u8; 32]> {
 /// and confirms it matches the digest of the file at `archive_path`.
 fn verify_checksum(version: &str, archive_name: &str, archive_path: &Path) -> Result<()> {
     let checksum_url = format!(
-        "https://github.com/{}/releases/download/{}/checksums-sha256.txt",
-        GITHUB_REPO, version
+        "{}/{}/releases/download/{}/checksums-sha256.txt",
+        github_download_base(),
+        GITHUB_REPO,
+        version
     );
 
     let checksum_text = http::fetch_text(&checksum_url)
@@ -140,8 +174,11 @@ fn hex_encode(bytes: &[u8]) -> String {
 fn download_release(version: &str, target: &str, tmp_dir: &Path) -> Result<()> {
     let archive_name = format!("mvmctl-{}.tar.gz", target);
     let download_url = format!(
-        "https://github.com/{}/releases/download/{}/{}",
-        GITHUB_REPO, version, archive_name
+        "{}/{}/releases/download/{}/{}",
+        github_download_base(),
+        GITHUB_REPO,
+        version,
+        archive_name
     );
     let dest = tmp_dir.join(&archive_name);
 
@@ -428,8 +465,11 @@ fn verify_signature(version: &str, archive_name: &str, archive_path: &Path) -> R
 
     let bundle_name = format!("{}.bundle", archive_name);
     let bundle_url = format!(
-        "https://github.com/{}/releases/download/{}/{}",
-        GITHUB_REPO, version, bundle_name
+        "{}/{}/releases/download/{}/{}",
+        github_download_base(),
+        GITHUB_REPO,
+        version,
+        bundle_name
     );
     let bundle_path = archive_path
         .parent()

--- a/crates/mvm/src/vm/instance_snapshot.rs
+++ b/crates/mvm/src/vm/instance_snapshot.rs
@@ -117,7 +117,7 @@ pub trait SnapshotIO {
 /// 3. Tighten file modes to 0600.
 /// 4. Bump the per-instance epoch counter.
 /// 5. Seal the HMAC envelope with the new epoch.
-pub fn pause_and_seal<IO: SnapshotIO>(vm_name: &str, io: &IO) -> Result<IntegritySidecar> {
+pub fn pause_and_seal<IO: SnapshotIO + ?Sized>(vm_name: &str, io: &IO) -> Result<IntegritySidecar> {
     let dir = prepare_instance_snapshot_dir(vm_name)?;
     io.create_snapshot(&dir)
         .with_context(|| format!("Firecracker create_snapshot({})", dir.display()))?;
@@ -159,7 +159,10 @@ pub fn pause_and_seal<IO: SnapshotIO>(vm_name: &str, io: &IO) -> Result<Integrit
 ///
 /// Returns the verified sidecar so the caller can audit it before
 /// resuming Firecracker.
-pub fn verify_and_resume<IO: SnapshotIO>(vm_name: &str, io: &IO) -> Result<IntegritySidecar> {
+pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
+    vm_name: &str,
+    io: &IO,
+) -> Result<IntegritySidecar> {
     let dir = snapshot_dir(vm_name);
     if !dir.exists() {
         bail!(

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -75,6 +75,11 @@
 //!   entry (the `ATTEST` leaves are all ReadOnly)
 //! - `mvmctl session ls` / `volume ls <vm>` → **no** audit entry
 //!   (SESSION ls and VOLUME ls leaves are both ReadOnly)
+//! - `mvmctl volume mount <vm> ...` → `VmVolumeAdd` (Plan 67:
+//!   the verb operates purely on the host-side
+//!   `~/.mvm/instances/<vm>/volume_mounts.json` registry — no
+//!   virtio-fs daemon attach, no backend dispatch)
+//! - `mvmctl volume unmount <vm> <guest>` → `VmVolumeRemove`
 //! - `mvmctl ls` / `metrics` / `catalog list` → **no** audit entry
 //!   (top-level ReadOnly verbs — three more rows from
 //!   `AUDIT_POSTURE` pinned against a future regression that
@@ -1333,6 +1338,105 @@ fn volume_ls_does_not_emit_audit_entry() {
         log.is_empty(),
         "read-only `volume ls` must not write to the LocalAudit \
          stream. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn volume_mount_emits_vm_volume_add_audit_entry() {
+    // Plan 67: `volume mount` operates purely on the host-side
+    // `~/.mvm/instances/<vm>/volume_mounts.json` registry — no
+    // virtio-fs daemon attach, no Firecracker socket. The audit
+    // emit fires after the registry write. Hermetic out of the box.
+    let sandbox = AuditSandbox::new();
+    let host_share = sandbox.home_path().join("share");
+    std::fs::create_dir_all(&host_share).expect("mkdir host share");
+
+    let output = sandbox
+        .mvmctl()
+        .args([
+            "volume",
+            "mount",
+            "vol-test-vm",
+            "--volume",
+            "mydata",
+            "--host",
+            host_share.to_str().expect("utf-8 path"),
+            "--guest",
+            "/mnt/data",
+        ])
+        .output()
+        .expect("spawn mvmctl volume mount");
+    assert!(
+        output.status.success(),
+        "mvmctl volume mount failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_volume_add");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_volume_add entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"vol-test-vm\""),
+        "vm_volume_add must carry vm_name=vol-test-vm. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("guest=/mnt/data"),
+        "vm_volume_add detail must record guest=/mnt/data. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn volume_unmount_emits_vm_volume_remove_audit_entry() {
+    // Plan 67: mount-then-unmount round-trip. Both emits land in
+    // the LocalAudit stream; this test pins the remove half.
+    let sandbox = AuditSandbox::new();
+    let host_share = sandbox.home_path().join("share");
+    std::fs::create_dir_all(&host_share).expect("mkdir host share");
+
+    let mount = sandbox
+        .mvmctl()
+        .args([
+            "volume",
+            "mount",
+            "vol-rm-vm",
+            "--volume",
+            "mydata",
+            "--host",
+            host_share.to_str().expect("utf-8 path"),
+            "--guest",
+            "/mnt/data",
+        ])
+        .output()
+        .expect("spawn mvmctl volume mount");
+    assert!(
+        mount.status.success(),
+        "mvmctl volume mount failed: stderr={}",
+        String::from_utf8_lossy(&mount.stderr)
+    );
+
+    let unmount = sandbox
+        .mvmctl()
+        .args(["volume", "unmount", "vol-rm-vm", "/mnt/data"])
+        .output()
+        .expect("spawn mvmctl volume unmount");
+    assert!(
+        unmount.status.success(),
+        "mvmctl volume unmount failed: stderr={}",
+        String::from_utf8_lossy(&unmount.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_volume_remove");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_volume_remove entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"vol-rm-vm\""),
+        "vm_volume_remove must carry vm_name=vol-rm-vm. Full log:\n{log}"
     );
 }
 

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -92,6 +92,12 @@
 //!   `update::update` exits early with "already up to date" and
 //!   the outer wrapper emits `UpdateInstall`. No real network, no
 //!   binary swap.)
+//! - `mvmctl uninstall --yes --all` (with `MVM_UNINSTALL_PATH_PREFIX`
+//!   pointing at a sandbox sub-dir) → `Uninstall` (Plan 70: the
+//!   override rewrites `/var/lib/mvm` and `/usr/local/bin/mvmctl`
+//!   under the prefix and skips sudo, so the positive path is
+//!   exercised end-to-end without sudo prompts or destruction of
+//!   a developer's real install)
 //! - `mvmctl uninstall --yes --dry-run` → **no** audit entry
 //!   (the positive `Uninstall` path is real-system-destructive
 //!   and not safely-hermetic, but the dry-run path is read-only
@@ -1341,6 +1347,54 @@ fn update_check_does_not_emit_audit_entry() {
         hits, 0,
         "read-only `update --check` must not emit; got {hits}. \
          Full log:\n{log}"
+    );
+}
+
+#[test]
+fn uninstall_yes_all_emits_uninstall_audit_entry_via_prefix_override() {
+    // Plan 70: the positive `Uninstall` path mutates real system
+    // paths (`/var/lib/mvm`, `/usr/local/bin/mvmctl`) via sudo —
+    // not safely-hermetic on a developer's machine. The
+    // `MVM_UNINSTALL_PATH_PREFIX` env-var rewrites the targets
+    // under a sandbox sub-dir and skips sudo. The audit emit fires
+    // unconditionally at the end of the verb, so the test pins the
+    // emit + the on-disk side-effect (the rewritten paths are
+    // gone).
+    let sandbox = AuditSandbox::new();
+    let prefix = sandbox.home_path().join("system-root");
+    let stub_state_dir = prefix.join("var/lib/mvm");
+    let stub_bin = prefix.join("usr/local/bin/mvmctl");
+    std::fs::create_dir_all(&stub_state_dir).expect("mkdir state stub");
+    std::fs::create_dir_all(stub_bin.parent().unwrap()).expect("mkdir bin dir");
+    std::fs::write(&stub_bin, b"#!/bin/sh\nexit 0\n").expect("write stub binary");
+
+    let output = sandbox
+        .mvmctl()
+        .env("MVM_UNINSTALL_PATH_PREFIX", &prefix)
+        .args(["uninstall", "--yes", "--all"])
+        .output()
+        .expect("spawn mvmctl uninstall");
+    assert!(
+        output.status.success(),
+        "mvmctl uninstall failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "uninstall");
+    assert!(
+        hits >= 1,
+        "expected ≥1 uninstall entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        !stub_state_dir.exists(),
+        "stub state dir at {} must be removed",
+        stub_state_dir.display()
+    );
+    assert!(
+        !stub_bin.exists(),
+        "stub binary at {} must be removed",
+        stub_bin.display()
     );
 }
 

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -50,6 +50,15 @@
 //! - `mvmctl set-ttl <vm> <duration>` (after `up --hypervisor mock`)
 //!   → `VmTtlSet` (chains off the up-via-mock fixture; the verb
 //!   operates on the persistent name registry that `up` populates)
+//! - `mvmctl pause <vm> --hypervisor mock` (after `up`) →
+//!   `WorkloadSleep` (Plan 65: pause routes through the SnapshotIO
+//!   trait; `--hypervisor mock` swaps in `CannedIO` so the seal
+//!   step writes deterministic 12-byte vmstate + 8-byte mem stubs
+//!   instead of talking to a real Firecracker UDS)
+//! - `mvmctl resume <vm> --hypervisor mock` (after `pause`) →
+//!   `WorkloadWake` (mirrors; verify-and-resume against the sealed
+//!   sidecar succeeds because the seal was written under
+//!   deterministic-stubs round-trip)
 //! - `mvmctl down` (no args, empty sandbox) → `VmStop`
 //!   (`stop_all` is tolerant of an empty VM registry and emits
 //!   with `detail=stop_all_ok`)
@@ -900,6 +909,86 @@ fn set_ttl_clear_emits_vm_ttl_set_with_cleared_detail() {
     assert!(
         log.contains("expires_at=cleared"),
         "set-ttl --clear must record expires_at=cleared. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn pause_emits_workload_sleep_audit_entry() {
+    // Plan 65 W3: `mvmctl pause --hypervisor mock` exercises the
+    // snapshot-and-seal path against `CannedIO` (deterministic
+    // 12-byte vmstate + 8-byte mem stubs). Pre-Plan-65 the verb
+    // would have bailed on `resolve_running_vm_dir` because the
+    // mock VM has no Lima-shaped vm_dir; the `--hypervisor mock`
+    // selector routes through `MockBackend::vm_dir(name)` instead.
+    let sandbox = AuditSandbox::new();
+    bring_up_mock_vm(&sandbox, "pause-vm");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["pause", "pause-vm", "--hypervisor", "mock"])
+        .output()
+        .expect("spawn mvmctl pause");
+    assert!(
+        output.status.success(),
+        "mvmctl pause failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "workload_sleep");
+    assert!(
+        hits >= 1,
+        "expected ≥1 workload_sleep entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"pause-vm\""),
+        "workload_sleep must carry vm_name=pause-vm. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("epoch="),
+        "workload_sleep detail must record the epoch. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn resume_emits_workload_wake_audit_entry() {
+    // Plan 65 W3: pause-then-resume against the mock backend.
+    // The seal-and-verify round-trip works because `CannedIO`
+    // writes its stubs to disk and `verify_and_resume` reads
+    // them back through the same HMAC-sealed sidecar.
+    let sandbox = AuditSandbox::new();
+    bring_up_mock_vm(&sandbox, "resume-vm");
+
+    let pause = sandbox
+        .mvmctl()
+        .args(["pause", "resume-vm", "--hypervisor", "mock"])
+        .output()
+        .expect("spawn mvmctl pause");
+    assert!(
+        pause.status.success(),
+        "mvmctl pause failed: stderr={}",
+        String::from_utf8_lossy(&pause.stderr)
+    );
+    let resume = sandbox
+        .mvmctl()
+        .args(["resume", "resume-vm", "--hypervisor", "mock"])
+        .output()
+        .expect("spawn mvmctl resume");
+    assert!(
+        resume.status.success(),
+        "mvmctl resume failed: stderr={}",
+        String::from_utf8_lossy(&resume.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "workload_wake");
+    assert!(
+        hits >= 1,
+        "expected ≥1 workload_wake entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"resume-vm\""),
+        "workload_wake must carry vm_name=resume-vm. Full log:\n{log}"
     );
 }
 

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -1801,3 +1801,67 @@ fn secret_rm_emits_delete_action_in_secret_audit_log() {
         "expected an 'action':'delete' entry in secrets audit log. Full log:\n{log}"
     );
 }
+
+#[test]
+fn build_emits_template_build_audit_entry_against_stub_outdir() {
+    // Plan 68: `mvmctl build --flake <stub-flake> --profile minimal`
+    // reaches `mvm_build::dev_build::dev_build`, which normally
+    // shells out to `nix build`. With `MVM_BUILD_STUB_OUTDIR` set,
+    // dev_build returns a synthetic `DevBuildResult` pointing at
+    // the stub directory and skips both the Nix invocation and the
+    // guest-agent injection step. The outer build_flake wrapper
+    // still calls `audit_build_ok("flake", &resolved, "", &revision)`,
+    // which emits one `template_build` record. Hermetic — no Nix,
+    // no Lima, no Apple Container, no sudo.
+    let sandbox = AuditSandbox::new();
+
+    // Stub build output: a directory whose basename becomes the
+    // revision hash (per dev_build's stub branch). `vmlinux` and
+    // `rootfs.ext4` are placeholders so any downstream caller that
+    // statted them sees real files.
+    let stub_out = sandbox.home_path().join("stub-out");
+    std::fs::create_dir_all(&stub_out).expect("mkdir stub_out");
+    std::fs::write(stub_out.join("vmlinux"), b"fake-kernel").expect("write stub kernel");
+    std::fs::write(stub_out.join("rootfs.ext4"), b"fake-rootfs").expect("write stub rootfs");
+
+    // Stub flake source. `validate_flake_ref` accepts a local path
+    // containing `flake.nix`; the stub-outdir branch never reads
+    // it.
+    let flake_dir = sandbox.home_path().join("flake");
+    std::fs::create_dir_all(&flake_dir).expect("mkdir flake_dir");
+    std::fs::write(flake_dir.join("flake.nix"), b"# stub\n").expect("write stub flake");
+
+    let output = sandbox
+        .mvmctl()
+        .env("MVM_BUILD_STUB_OUTDIR", &stub_out)
+        .args([
+            "build",
+            "--flake",
+            flake_dir.to_str().expect("utf-8 flake path"),
+            "--profile",
+            "minimal",
+        ])
+        .output()
+        .expect("spawn mvmctl build");
+    assert!(
+        output.status.success(),
+        "mvmctl build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "template_build");
+    assert!(
+        hits >= 1,
+        "expected ≥1 template_build entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("mode=flake"),
+        "expected detail to record mode=flake. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("artifact=stub-out"),
+        "expected detail to record artifact=stub-out (the stub-outdir basename). Full log:\n{log}"
+    );
+}

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -84,6 +84,14 @@
 //!   (top-level ReadOnly verbs — three more rows from
 //!   `AUDIT_POSTURE` pinned against a future regression that
 //!   adds an emit to a read-only path)
+//! - `mvmctl update` (against an `httpmock` server returning the
+//!   current version) → `UpdateInstall` (Plan 69: the
+//!   `MVM_UPDATE_API_URL` env-var redirects the
+//!   `https://api.github.com/.../releases/latest` query to a local
+//!   mock that returns the current binary's own version.
+//!   `update::update` exits early with "already up to date" and
+//!   the outer wrapper emits `UpdateInstall`. No real network, no
+//!   binary swap.)
 //! - `mvmctl uninstall --yes --dry-run` → **no** audit entry
 //!   (the positive `Uninstall` path is real-system-destructive
 //!   and not safely-hermetic, but the dry-run path is read-only
@@ -1255,6 +1263,84 @@ fn catalog_list_does_not_emit_audit_entry() {
         log.is_empty(),
         "read-only `mvmctl catalog list` must not write to the \
          LocalAudit stream. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn update_emits_update_install_audit_entry_against_mocked_github() {
+    // Plan 69: `mvmctl update` reaches `api.github.com/releases/latest`
+    // by default. The `MVM_UPDATE_API_URL` env-var redirects the
+    // base URL to a local `httpmock` server, which returns the
+    // current binary's own version. `update::update` then exits
+    // early on the "already up to date" branch — Ok(()) without
+    // swapping the binary — and the outer wrapper at
+    // `commands/env/update.rs` emits `UpdateInstall`. No real
+    // network, no binary swap, no install dance.
+    let server = httpmock::MockServer::start();
+    let current_version = env!("CARGO_PKG_VERSION");
+    let _api_mock = server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path_contains("/releases/latest");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(format!(r#"{{"tag_name":"v{current_version}"}}"#));
+    });
+
+    let sandbox = AuditSandbox::new();
+    let output = sandbox
+        .mvmctl()
+        .env("MVM_UPDATE_API_URL", server.base_url())
+        .args(["update"])
+        .output()
+        .expect("spawn mvmctl update");
+    assert!(
+        output.status.success(),
+        "mvmctl update failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "update_install");
+    assert!(
+        hits >= 1,
+        "expected ≥1 update_install entry, got {hits}. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn update_check_does_not_emit_audit_entry() {
+    // Negative: `update --check` short-circuits before the install
+    // path AND before the outer wrapper's audit-emit branch
+    // (`!args.check` guard at `commands/env/update.rs`). Read-only;
+    // pins that against a future regression that emits on check.
+    let server = httpmock::MockServer::start();
+    let _api_mock = server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path_contains("/releases/latest");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(r#"{"tag_name":"v0.999.0"}"#);
+    });
+
+    let sandbox = AuditSandbox::new();
+    let output = sandbox
+        .mvmctl()
+        .env("MVM_UPDATE_API_URL", server.base_url())
+        .args(["update", "--check"])
+        .output()
+        .expect("spawn mvmctl update --check");
+    assert!(
+        output.status.success(),
+        "mvmctl update --check failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "update_install");
+    assert_eq!(
+        hits, 0,
+        "read-only `update --check` must not emit; got {hits}. \
+         Full log:\n{log}"
     );
 }
 

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -845,6 +845,36 @@ fn bring_up_mock_vm(sandbox: &AuditSandbox, name: &str) {
     );
 }
 
+/// Per-test handle for a mock VM whose host-side vsock surface lives
+/// in *this* (test) process. Pair with `mvmctl fs *` / `mvmctl proc *`
+/// subprocesses — they discover the listener via the
+/// filesystem-based mock detection in `instance_dir_for`.
+///
+/// Plan 66 W4. The `mvmctl up --hypervisor mock` subprocess pattern
+/// used by `bring_up_mock_vm` doesn't work here because the
+/// MockGuestAgent the subprocess spawns dies with the subprocess —
+/// follow-up commands would find a stale socket and fail to connect.
+/// Hosting the agent in the test process keeps it alive across every
+/// subprocess invocation for the duration of the test.
+struct MockVmAgentFixture {
+    _agent: mvm_backend::mock_guest_agent::MockGuestAgent,
+}
+
+/// Create the mock-vms VM directory under the sandbox's HOME and
+/// spawn a [`MockGuestAgent`](mvm_backend::mock_guest_agent::MockGuestAgent)
+/// listening at `<vm_dir>/runtime/v.sock`. Returns when the listener
+/// is ready to accept connections.
+fn start_mock_vm_agent(sandbox: &AuditSandbox, name: &str) -> MockVmAgentFixture {
+    // mvm_data_dir() resolves to `<HOME>/.mvm` by default. The
+    // subprocess sees HOME=sandbox.home_path() and so will compute
+    // the same path; we compute it here from the same root.
+    let vm_dir = sandbox.home_path().join(".mvm").join("mock-vms").join(name);
+    std::fs::create_dir_all(&vm_dir).expect("mkdir mock vm_dir");
+    let agent = mvm_backend::mock_guest_agent::MockGuestAgent::start(&vm_dir)
+        .expect("start mock guest agent");
+    MockVmAgentFixture { _agent: agent }
+}
+
 #[test]
 fn up_with_mock_backend_emits_vm_start_audit_entry() {
     // End-to-end test of `mvmctl up` against the in-memory
@@ -1863,5 +1893,295 @@ fn build_emits_template_build_audit_entry_against_stub_outdir() {
     assert!(
         log.contains("artifact=stub-out"),
         "expected detail to record artifact=stub-out (the stub-outdir basename). Full log:\n{log}"
+    );
+}
+
+// ============================================================================
+// Plan 66 W4 — `mvmctl fs *` and `mvmctl proc *` live tests.
+//
+// Each test stands up a `MockGuestAgent` in the test process, then
+// drives the matching CLI subcommand as a subprocess. The CLI's
+// `instance_dir_for` helper detects the mock-vms socket and routes
+// the vsock request to the in-process agent instead of the
+// Lima-era `microvm::resolve_running_vm_dir` shell-out.
+// ============================================================================
+
+#[test]
+fn fs_write_emits_vm_fs_mutate_audit_entry() {
+    let sandbox = AuditSandbox::new();
+    let _fixture = start_mock_vm_agent(&sandbox, "t-fsw");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["fs", "write", "t-fsw", "/tmp/hello", "--content", "hi"])
+        .output()
+        .expect("spawn mvmctl fs write");
+    assert!(
+        output.status.success(),
+        "mvmctl fs write failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_fs_mutate");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_fs_mutate entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("op=write path=/tmp/hello bytes=2"),
+        "expected op=write detail with bytes=2. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn fs_mkdir_emits_vm_fs_mutate_audit_entry() {
+    let sandbox = AuditSandbox::new();
+    let _fixture = start_mock_vm_agent(&sandbox, "t-fsmk");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["fs", "mkdir", "t-fsmk", "/tmp/newdir"])
+        .output()
+        .expect("spawn mvmctl fs mkdir");
+    assert!(
+        output.status.success(),
+        "mvmctl fs mkdir failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_fs_mutate");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_fs_mutate entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("op=mkdir path=/tmp/newdir"),
+        "expected op=mkdir detail. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn fs_rm_emits_vm_fs_mutate_audit_entry() {
+    let sandbox = AuditSandbox::new();
+    let _fixture = start_mock_vm_agent(&sandbox, "t-fsrm");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["fs", "rm", "t-fsrm", "/tmp/stale"])
+        .output()
+        .expect("spawn mvmctl fs rm");
+    assert!(
+        output.status.success(),
+        "mvmctl fs rm failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_fs_mutate");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_fs_mutate entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("op=rm path=/tmp/stale"),
+        "expected op=rm detail. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn fs_mv_emits_vm_fs_mutate_audit_entry() {
+    let sandbox = AuditSandbox::new();
+    let _fixture = start_mock_vm_agent(&sandbox, "t-fsmv");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["fs", "mv", "t-fsmv", "/tmp/src", "/tmp/dst"])
+        .output()
+        .expect("spawn mvmctl fs mv");
+    assert!(
+        output.status.success(),
+        "mvmctl fs mv failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_fs_mutate");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_fs_mutate entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("op=mv from=/tmp/src to=/tmp/dst"),
+        "expected op=mv detail. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn fs_ls_does_not_emit_audit_entry() {
+    // Read-only: `fs ls` doesn't mutate, so no LocalAudit emit.
+    let sandbox = AuditSandbox::new();
+    let _fixture = start_mock_vm_agent(&sandbox, "t-fsls");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["fs", "ls", "t-fsls", "/tmp"])
+        .output()
+        .expect("spawn mvmctl fs ls");
+    assert!(
+        output.status.success(),
+        "mvmctl fs ls failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    assert!(
+        log.is_empty(),
+        "read-only `mvmctl fs ls` must not write to LocalAudit. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn proc_start_emits_vm_proc_start_audit_entry() {
+    let sandbox = AuditSandbox::new();
+    let _fixture = start_mock_vm_agent(&sandbox, "t-ps");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["proc", "start", "t-ps", "--", "/bin/true"])
+        .output()
+        .expect("spawn mvmctl proc start");
+    assert!(
+        output.status.success(),
+        "mvmctl proc start failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_proc_start");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_proc_start entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("argv0=/bin/true"),
+        "expected argv0=/bin/true detail. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn proc_signal_emits_vm_proc_signal_audit_entry() {
+    let sandbox = AuditSandbox::new();
+    let _fixture = start_mock_vm_agent(&sandbox, "t-psg");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["proc", "signal", "t-psg", "proc-fake-token", "15"])
+        .output()
+        .expect("spawn mvmctl proc signal");
+    assert!(
+        output.status.success(),
+        "mvmctl proc signal failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_proc_signal");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_proc_signal entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("token=proc-fake-token signum=15"),
+        "expected token+signum detail. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn proc_kill_emits_kill_audit_entry() {
+    let sandbox = AuditSandbox::new();
+    let _fixture = start_mock_vm_agent(&sandbox, "t-pk");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["proc", "kill", "t-pk", "proc-fake-token"])
+        .output()
+        .expect("spawn mvmctl proc kill");
+    assert!(
+        output.status.success(),
+        "mvmctl proc kill failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "kill");
+    assert!(
+        hits >= 1,
+        "expected ≥1 kill entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("scope=guest_proc token=proc-fake-token"),
+        "expected scope=guest_proc detail. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn proc_stdin_emits_vm_proc_stdin_audit_entry() {
+    let sandbox = AuditSandbox::new();
+    let _fixture = start_mock_vm_agent(&sandbox, "t-pst");
+
+    let output = sandbox
+        .mvmctl()
+        .args([
+            "proc",
+            "stdin",
+            "t-pst",
+            "proc-fake-token",
+            "--content",
+            "hello",
+        ])
+        .output()
+        .expect("spawn mvmctl proc stdin");
+    assert!(
+        output.status.success(),
+        "mvmctl proc stdin failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "vm_proc_stdin");
+    assert!(
+        hits >= 1,
+        "expected ≥1 vm_proc_stdin entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("token=proc-fake-token bytes=5"),
+        "expected token+bytes=5 detail. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn proc_ls_does_not_emit_audit_entry() {
+    // Read-only: `proc ls` doesn't mutate, so no LocalAudit emit.
+    let sandbox = AuditSandbox::new();
+    let _fixture = start_mock_vm_agent(&sandbox, "t-pls");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["proc", "ls", "t-pls"])
+        .output()
+        .expect("spawn mvmctl proc ls");
+    assert!(
+        output.status.success(),
+        "mvmctl proc ls failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    assert!(
+        log.is_empty(),
+        "read-only `mvmctl proc ls` must not write to LocalAudit. Full log:\n{log}"
     );
 }


### PR DESCRIPTION
## Summary

- Closes the audit-emit coverage gap for \`mvmctl fs *\` and \`mvmctl proc *\` — the last unbroken rows in the AUDIT_POSTURE Emits matrix.
- **W3 routing:** \`instance_dir_for\` in \`fs.rs\` / \`proc.rs\` checks \`<mvm_data_dir>/mock-vms/<name>/runtime/v.sock\` before falling back to \`microvm::resolve_running_vm_dir\`. Production code never reaches the mock-vms path; \`MockBackend\` only populates it under \`--hypervisor mock\`.
- **W4 tests:** 10 new live tests cover every fs/proc Emits row plus the two read-only no-emit invariants.
- Live audit suite: **48 → 58** tests. Plan 66 closes; audit-emit campaign batch 3 wraps.

## Stacked on

Stacks on **#122** (W1+W2). Re-target to \`main\` once the stack lands.

## Verb coverage

| Verb | Audit kind |
|---|---|
| \`fs write\` | \`VmFsMutate\` (op=write) |
| \`fs mkdir\` | \`VmFsMutate\` (op=mkdir) |
| \`fs rm\` | \`VmFsMutate\` (op=rm) |
| \`fs mv\` | \`VmFsMutate\` (op=mv) |
| \`fs ls\` | (no emit — pinned) |
| \`proc start\` | \`VmProcStart\` |
| \`proc signal\` | \`VmProcSignal\` |
| \`proc kill\` | \`Kill\` (scope=guest_proc) |
| \`proc stdin\` | \`VmProcStdin\` |
| \`proc ls\` | (no emit — pinned) |

## Why host the agent in the test process

Tests host the \`MockGuestAgent\` in the test process rather than via \`bring_up_mock_vm\`'s \`mvmctl up\` subprocess. The subprocess pattern's agent dies with the subprocess — follow-up \`mvmctl fs *\` calls would hit a stale socket file. Hosting the agent in the test process keeps it alive across every subprocess invocation.

## SUN_LEN note

VM names are kept short (≤6 chars: \`t-fsw\`, \`t-ps\`, etc.) so the mock-vms socket path fits inside macOS's \`sun_path\` ceiling (~104 bytes) when the sandbox tempdir is under \`/var/folders/\`.

## Test plan

- [x] 10 new tests pass (\`cargo test --test audit_emissions_live -- fs_ proc_\`)
- [x] Full live audit suite passes (58/58)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` (clean)
- [x] \`cargo test --workspace --no-fail-fast\` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)