### PR TITLE
feat(supervisor): plan 60 Phase 7 — host-mediated tools (time_now, web_fetch, web_search, upload/download)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4170,6 +4170,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4162,6 +4162,7 @@ dependencies = [
  "mvm-policy",
  "rand 0.8.6",
  "regex",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -40,7 +40,13 @@ use super::vm::host_signer;
 /// Best-effort Recorder for `cmd.*` envelopes. Returns `None` (with
 /// a `tracing::warn`) when any setup step fails — the CLI runs
 /// without cmd-level audit in that case.
-pub(super) fn build_cmd_recorder() -> Option<Recorder> {
+///
+/// Also used by `commands::ops::mcp::build_tool_registry` to wire
+/// the same chain-signed audit stream into the host-mediated
+/// `ToolRegistry`. The Recorder is category-agnostic (callers pass
+/// `EventCategory::Cmd` for both `cmd.<verb>` and
+/// `cmd.tool.<verb>` events) so one builder serves both consumers.
+pub(crate) fn build_cmd_recorder() -> Option<Recorder> {
     let signer = match host_signer::load_or_init() {
         Ok(s) => s,
         Err(e) => {

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -172,6 +172,17 @@ impl Default for ExecDispatcher {
 fn build_tool_registry() -> ToolRegistry {
     let mut registry = ToolRegistry::with_defaults();
 
+    // Plan 60 Phase 4 wire-up: every successful tool invocation
+    // emits a `cmd.tool.<name>.{completed,failed}` chain-signed
+    // entry through the host signer's FileAuditSigner. When the
+    // signer isn't reachable (no $HOME, key not initialized, loose
+    // perms) we log a warning in `build_cmd_recorder` and skip the
+    // attachment — tool calls still succeed; the audit footprint
+    // just doesn't land. Same posture as `cmd.*` envelopes.
+    if let Some(rec) = crate::commands::cmd_audit::build_cmd_recorder() {
+        registry = registry.with_recorder(rec);
+    }
+
     // mvm.web_fetch
     let allow = web_fetch::allowlist_from_env_var(web_fetch::ALLOWLIST_ENV_VAR);
     let mut fetch_tool = web_fetch::WebFetchTool::with_allowlist(allow);

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -27,6 +27,7 @@ use mvm_mcp::{
     SessionMap, SessionState, ToolResult,
 };
 use mvm_supervisor::ToolRegistry;
+use mvm_supervisor::tools::web_fetch;
 
 use super::Cli;
 
@@ -142,9 +143,44 @@ impl Default for ExecDispatcher {
                 warm_vms: Arc::clone(&warm_vms),
             }),
             warm_vms,
-            tool_registry: Arc::new(ToolRegistry::with_defaults()),
+            tool_registry: Arc::new(build_tool_registry()),
         }
     }
+}
+
+/// Build the Phase 7 tool registry the MCP dispatcher hands out.
+///
+/// Today:
+/// - `mvm.time_now` — always reachable.
+/// - `mvm.web_fetch` — uses [`web_fetch::ReqwestHttpFetcher`] when
+///   constructable; allowlist comes from
+///   `$MVM_WEB_FETCH_ALLOWLIST` (comma-separated). When the env var
+///   is unset, the allowlist is empty and every fetch fails closed.
+/// - `mvm.web_search` — fail-closed default (per-provider adapters
+///   ship in a follow-up slice).
+///
+/// On `ReqwestHttpFetcher::new()` failure (extraordinarily rare —
+/// reqwest builds the TLS stack lazily), we log a `tracing::warn`
+/// and fall back to `NoopHttpFetcher` so the registry still ships.
+fn build_tool_registry() -> ToolRegistry {
+    let mut registry = ToolRegistry::with_defaults();
+    let allow = web_fetch::allowlist_from_env_var(web_fetch::ALLOWLIST_ENV_VAR);
+    let mut tool = web_fetch::WebFetchTool::with_allowlist(allow);
+    match web_fetch::ReqwestHttpFetcher::new() {
+        Ok(f) => {
+            tool = tool.with_fetcher(Arc::new(f));
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "ReqwestHttpFetcher init failed; mvm.web_fetch will use Noop fallback"
+            );
+        }
+    }
+    // Re-register replaces the fail-closed default that
+    // `with_defaults` planted.
+    registry.register(Box::new(tool));
+    registry
 }
 
 impl ExecDispatcher {

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -27,7 +27,7 @@ use mvm_mcp::{
     SessionMap, SessionState, ToolResult,
 };
 use mvm_supervisor::ToolRegistry;
-use mvm_supervisor::tools::{web_fetch, web_search};
+use mvm_supervisor::tools::{download, staging, upload, web_fetch, web_search};
 
 use super::Cli;
 
@@ -240,6 +240,16 @@ fn build_tool_registry() -> ToolRegistry {
         }
     }
     registry.register(Box::new(search_tool));
+
+    // mvm.upload + mvm.download — share one per-tenant FsStagingArea.
+    // Default tenant matches the rest of the host-local scope ("local");
+    // a future slice plumbs the per-call tenant once mvmctl mcp gains
+    // the corresponding policy bundle.
+    let staging_area = staging::default_for_tenant("local");
+    registry.register(Box::new(upload::UploadTool::with_staging(
+        staging_area.clone(),
+    )));
+    registry.register(Box::new(download::DownloadTool::with_staging(staging_area)));
 
     registry
 }

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -27,7 +27,7 @@ use mvm_mcp::{
     SessionMap, SessionState, ToolResult,
 };
 use mvm_supervisor::ToolRegistry;
-use mvm_supervisor::tools::web_fetch;
+use mvm_supervisor::tools::{web_fetch, web_search};
 
 use super::Cli;
 
@@ -156,19 +156,28 @@ impl Default for ExecDispatcher {
 ///   constructable; allowlist comes from
 ///   `$MVM_WEB_FETCH_ALLOWLIST` (comma-separated). When the env var
 ///   is unset, the allowlist is empty and every fetch fails closed.
-/// - `mvm.web_search` — fail-closed default (per-provider adapters
-///   ship in a follow-up slice).
+/// - `mvm.web_search` — allowlist comes from
+///   `$MVM_WEB_SEARCH_ALLOWLIST`; default provider comes from
+///   `$MVM_WEB_SEARCH_DEFAULT` (or the first allowlist entry).
+///   When `"brave"` is on the allowlist AND `$BRAVE_SEARCH_API_KEY`
+///   is set, a [`web_search::BraveSearchProvider`] is registered.
+///   Without the key, the existing "allowed but unregistered =
+///   config drift" error fires on first invoke so the
+///   misconfiguration is loud, not silent.
 ///
-/// On `ReqwestHttpFetcher::new()` failure (extraordinarily rare —
-/// reqwest builds the TLS stack lazily), we log a `tracing::warn`
-/// and fall back to `NoopHttpFetcher` so the registry still ships.
+/// On `ReqwestHttpFetcher::new()` / `BraveSearchProvider::new()`
+/// failure (extraordinarily rare), we log a `tracing::warn` and
+/// fall back to the substrate's Noop default so the registry still
+/// ships.
 fn build_tool_registry() -> ToolRegistry {
     let mut registry = ToolRegistry::with_defaults();
+
+    // mvm.web_fetch
     let allow = web_fetch::allowlist_from_env_var(web_fetch::ALLOWLIST_ENV_VAR);
-    let mut tool = web_fetch::WebFetchTool::with_allowlist(allow);
+    let mut fetch_tool = web_fetch::WebFetchTool::with_allowlist(allow);
     match web_fetch::ReqwestHttpFetcher::new() {
         Ok(f) => {
-            tool = tool.with_fetcher(Arc::new(f));
+            fetch_tool = fetch_tool.with_fetcher(Arc::new(f));
         }
         Err(e) => {
             tracing::warn!(
@@ -177,9 +186,34 @@ fn build_tool_registry() -> ToolRegistry {
             );
         }
     }
-    // Re-register replaces the fail-closed default that
-    // `with_defaults` planted.
-    registry.register(Box::new(tool));
+    registry.register(Box::new(fetch_tool));
+
+    // mvm.web_search
+    let search_allow = web_search::allowlist_from_env_var(web_search::ALLOWLIST_ENV_VAR);
+    let default_provider = std::env::var(web_search::DEFAULT_PROVIDER_ENV_VAR)
+        .ok()
+        .or_else(|| search_allow.iter().next().cloned())
+        .unwrap_or_else(|| "noop".to_string());
+    let mut search_tool =
+        web_search::WebSearchTool::with_allowlist(search_allow.iter().cloned(), default_provider);
+    if search_allow.contains("brave")
+        && let Ok(key) = std::env::var(web_search::BRAVE_API_KEY_ENV_VAR)
+    {
+        match web_search::BraveSearchProvider::new(key) {
+            Ok(p) => {
+                search_tool = search_tool.register_provider(Arc::new(p));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "BraveSearchProvider init failed; mvm.web_search 'brave' provider will be \
+                     allowlisted-but-unregistered"
+                );
+            }
+        }
+    }
+    registry.register(Box::new(search_tool));
+
     registry
 }
 

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -26,6 +26,7 @@ use mvm_mcp::{
     ContentBlock, Dispatcher, ReapReason, Reaper, RunParams, SessionConfig, SessionLookup,
     SessionMap, SessionState, ToolResult,
 };
+use mvm_supervisor::ToolRegistry;
 
 use super::Cli;
 
@@ -120,6 +121,13 @@ struct ExecDispatcher {
     sessions: Arc<Mutex<SessionMap>>,
     warm_vms: WarmVms,
     reaper: Arc<DispatcherReaper>,
+    /// Plan 60 Phase 7 host-mediated tools (`mvm.time_now`,
+    /// `mvm.web_fetch`, `mvm.web_search`). Built once at dispatcher
+    /// construction; shared across every `tools/call` invocation.
+    /// Default registry ships fail-closed for the web tools —
+    /// operators wire per-tenant allowlists by replacing this with
+    /// a configured registry in a follow-up slice.
+    tool_registry: Arc<ToolRegistry>,
 }
 
 impl Default for ExecDispatcher {
@@ -134,6 +142,7 @@ impl Default for ExecDispatcher {
                 warm_vms: Arc::clone(&warm_vms),
             }),
             warm_vms,
+            tool_registry: Arc::new(ToolRegistry::with_defaults()),
         }
     }
 }
@@ -444,6 +453,45 @@ impl Dispatcher for ExecDispatcher {
             }
         }
     }
+
+    /// Plan 60 Phase 7 — route registry tools through
+    /// `mvm_supervisor::ToolRegistry`. The legacy `run` tool stays
+    /// on its dedicated method; everything else (`mvm.time_now`,
+    /// `mvm.web_fetch`, `mvm.web_search`, …) lands here.
+    ///
+    /// `ToolRegistry::invoke` is async; the MCP wire layer is sync,
+    /// so we spin up a current-thread runtime per call (same pattern
+    /// as `vm::audit_chain::AuditEmitter`'s `block_on`). Tool calls
+    /// are infrequent relative to per-call cost, and the runtime
+    /// build is dominated by everything else in the dispatch path.
+    fn invoke_tool(&self, name: &str, params: serde_json::Value) -> ToolResult {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                return error_result(format!(
+                    "internal: building tokio runtime for tool {name:?}: {e}"
+                ));
+            }
+        };
+        match rt.block_on(self.tool_registry.invoke(name, params)) {
+            Ok(value) => {
+                // Render the JSON value as a single Text content
+                // block. The LLM client parses the body; pretty-
+                // printing keeps it human-readable when an operator
+                // inspects audit logs.
+                let text = serde_json::to_string_pretty(&value)
+                    .unwrap_or_else(|e| format!("(failed to serialize tool result: {e})"));
+                ToolResult {
+                    content: vec![ContentBlock::Text { text }],
+                    is_error: false,
+                }
+            }
+            Err(e) => error_result(e.to_string()),
+        }
+    }
 }
 
 struct InflightGuard<'a>(&'a AtomicUsize);
@@ -611,5 +659,52 @@ mod tests {
     #[test]
     fn shell_escape_no_quotes() {
         assert_eq!(shell_escape("plain"), "'plain'");
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Plan 60 Phase 7 — invoke_tool routes through ToolRegistry
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn invoke_tool_routes_time_now_through_registry() {
+        // The default ExecDispatcher carries a registry with the 3
+        // Phase 7 builtins. `mvm.time_now` is unconditionally
+        // reachable (no allowlist needed), so this is the
+        // simplest "the wiring works" smoke test.
+        let dispatcher = ExecDispatcher::default();
+        let result = dispatcher.invoke_tool("mvm.time_now", serde_json::json!({}));
+        assert!(!result.is_error, "got error: {result:?}");
+        let ContentBlock::Text { text } = &result.content[0];
+        // The registry's TimeNowResult shape has `"time"` + `"format"` fields.
+        assert!(text.contains("\"time\""), "got: {text}");
+        assert!(text.contains("\"format\""), "got: {text}");
+    }
+
+    #[test]
+    fn invoke_tool_renders_unknown_tool_as_is_error() {
+        // The registry's `UnknownTool` error must surface as an
+        // `is_error: true` ToolResult (NOT a JSON-RPC error), so
+        // the LLM client sees the failure instead of retrying.
+        let dispatcher = ExecDispatcher::default();
+        let result = dispatcher.invoke_tool("mvm.does_not_exist", serde_json::json!({}));
+        assert!(result.is_error);
+        let ContentBlock::Text { text } = &result.content[0];
+        assert!(text.contains("mvm.does_not_exist"), "got: {text}");
+    }
+
+    #[test]
+    fn invoke_tool_web_fetch_fails_closed_with_clear_message() {
+        // The default registry registers `mvm.web_fetch` with an
+        // empty allowlist (Default::default() = fail_closed). The
+        // operator sees a clear "not on allowlist" error rather
+        // than a silent fall-through.
+        let dispatcher = ExecDispatcher::default();
+        let result = dispatcher.invoke_tool(
+            "mvm.web_fetch",
+            serde_json::json!({ "url": "https://example.com/" }),
+        );
+        assert!(result.is_error);
+        let ContentBlock::Text { text } = &result.content[0];
+        assert!(text.contains("not on per-tenant allowlist"), "got: {text}");
     }
 }

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -212,6 +212,22 @@ fn build_tool_registry() -> ToolRegistry {
             }
         }
     }
+    if search_allow.contains("tavily")
+        && let Ok(key) = std::env::var(web_search::TAVILY_API_KEY_ENV_VAR)
+    {
+        match web_search::TavilySearchProvider::new(key) {
+            Ok(p) => {
+                search_tool = search_tool.register_provider(Arc::new(p));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "TavilySearchProvider init failed; mvm.web_search 'tavily' provider will be \
+                     allowlisted-but-unregistered"
+                );
+            }
+        }
+    }
     registry.register(Box::new(search_tool));
 
     registry

--- a/crates/mvm-mcp/src/dispatcher.rs
+++ b/crates/mvm-mcp/src/dispatcher.rs
@@ -4,11 +4,25 @@
 //! can plug in its own dispatcher (HTTP-fronted, tenant-aware) without
 //! depending on this crate's stdio loop. The mvm stdio binary
 //! provides one impl in `mvm-cli::commands::ops::mcp`.
+//!
+//! ## Two method surfaces
+//!
+//! - [`Dispatcher::run`] — the legacy "single parameterized tool"
+//!   `run` from the original MCP design. Dispatches code into a
+//!   transient microVM (or the transport's equivalent). Kept as a
+//!   dedicated method because the wire shape is fixed and the VM
+//!   dispatch path is structurally different from a JSON-only tool.
+//! - [`Dispatcher::invoke_tool`] — plan 60 Phase 7 addition. Routes
+//!   the typed-name tools (`mvm.time_now`, `mvm.web_fetch`,
+//!   `mvm.web_search`, future `mvm.upload` / `mvm.download` /
+//!   `mvm.code_eval`) through a shared registry. Default impl
+//!   returns an `is_error: true` ToolResult so a dispatcher that
+//!   doesn't opt in still answers MCP `tools/call` without trapping.
 
-use crate::protocol::ToolResult;
+use crate::protocol::{ContentBlock, ToolResult};
 use crate::tools::RunParams;
 
-/// One method per MCP tool we expose. Currently just `run`.
+/// One method per MCP tool surface we expose.
 pub trait Dispatcher {
     /// Validate `params`, dispatch into a microVM (or whatever the
     /// transport's analog is), capture output, return an MCP-shaped
@@ -20,4 +34,30 @@ pub trait Dispatcher {
     /// a JSON-RPC `internal_error` (which clients tend to retry
     /// instead of surfacing).
     fn run(&self, params: RunParams) -> ToolResult;
+
+    /// Plan 60 Phase 7 — dispatch a named registry tool (anything
+    /// other than the legacy `run`). `params` is the raw `arguments`
+    /// JSON the MCP client sent; the impl deserializes into its own
+    /// typed shape and calls the matching tool in
+    /// `mvm-supervisor::tools::ToolRegistry`.
+    ///
+    /// Default impl returns an `is_error: true` ToolResult naming
+    /// the unwired tool. Plan-33 dispatchers that don't yet route
+    /// registry tools inherit this default and degrade gracefully:
+    /// the MCP client sees a clear "tool not implemented" message
+    /// rather than a JSON-RPC method-not-found, which keeps the
+    /// retry behaviour off.
+    fn invoke_tool(&self, name: &str, _params: serde_json::Value) -> ToolResult {
+        ToolResult {
+            content: vec![ContentBlock::Text {
+                text: format!(
+                    "tool {name:?} is registered in tools/list but the local \
+                     dispatcher does not yet route it (Dispatcher::invoke_tool \
+                     not overridden). Update the dispatcher impl or remove the \
+                     tool from tools/list."
+                ),
+            }],
+            is_error: true,
+        }
+    }
 }

--- a/crates/mvm-mcp/src/server.rs
+++ b/crates/mvm-mcp/src/server.rs
@@ -139,13 +139,19 @@ fn tools_call_response<D: Dispatcher>(
         .get("name")
         .and_then(Value::as_str)
         .ok_or_else(|| JsonRpcError::invalid_params("missing tool name"))?;
-    if name != "run" {
-        return Err(JsonRpcError::method_not_found(&format!("tool '{name}'")));
-    }
     let args = params.get("arguments").cloned().unwrap_or(Value::Null);
-    let run_params: RunParams = serde_json::from_value(args)
-        .map_err(|e| JsonRpcError::invalid_params(format!("decoding `run` params: {e}")))?;
-    let result = dispatcher.run(run_params);
+    let result = if name == "run" {
+        // Legacy single-tool path — typed RunParams + microVM dispatch.
+        let run_params: RunParams = serde_json::from_value(args)
+            .map_err(|e| JsonRpcError::invalid_params(format!("decoding `run` params: {e}")))?;
+        dispatcher.run(run_params)
+    } else {
+        // Plan 60 Phase 7 — typed-name registry tools (mvm.time_now,
+        // mvm.web_fetch, mvm.web_search, …). The dispatcher's
+        // `invoke_tool` decides; an unwired dispatcher's default impl
+        // returns an `is_error: true` ToolResult naming the tool.
+        dispatcher.invoke_tool(name, args)
+    };
     serde_json::to_value(&result)
         .map_err(|e| JsonRpcError::internal_error(format!("encoding tool result: {e}")))
 }
@@ -191,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_returns_single_run_tool() {
+    fn tools_list_returns_run_and_phase_7_tools() {
         let dispatcher = MockDispatcher {
             last_env: std::sync::Mutex::new(None),
         };
@@ -199,8 +205,11 @@ mod tests {
         let resp = run_one(req, &dispatcher);
         let result = resp.result.unwrap();
         let tools = result["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0]["name"], "run");
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"run"), "got: {names:?}");
+        assert!(names.contains(&"mvm.time_now"), "got: {names:?}");
+        assert!(names.contains(&"mvm.web_fetch"), "got: {names:?}");
+        assert!(names.contains(&"mvm.web_search"), "got: {names:?}");
     }
 
     #[test]
@@ -223,17 +232,27 @@ mod tests {
     }
 
     #[test]
-    fn tools_call_rejects_unknown_tool_name() {
+    fn tools_call_routes_unknown_tool_to_invoke_tool_default() {
+        // Plan 60 Phase 7: names other than `run` route through
+        // `Dispatcher::invoke_tool`. The MockDispatcher inherits the
+        // default impl, which returns an `is_error: true` ToolResult
+        // (NOT a JSON-RPC method-not-found). The MCP wire layer
+        // returns success at the JSON-RPC level so the client doesn't
+        // retry — the structured error reaches the LLM via the
+        // tool_result envelope.
         let dispatcher = MockDispatcher {
             last_env: std::sync::Mutex::new(None),
         };
         let req = r#"{
             "jsonrpc":"2.0","id":4,"method":"tools/call",
-            "params":{"name":"not-a-tool","arguments":{}}
+            "params":{"name":"mvm.time_now","arguments":{}}
         }"#;
         let resp = run_one(req, &dispatcher);
-        let err = resp.error.unwrap();
-        assert_eq!(err.code, -32601, "method not found");
+        assert!(resp.error.is_none(), "got JSON-RPC error: {:?}", resp.error);
+        let result = resp.result.unwrap();
+        assert_eq!(result["isError"], true);
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("mvm.time_now"), "got: {text}");
     }
 
     #[test]

--- a/crates/mvm-mcp/src/tools/mod.rs
+++ b/crates/mvm-mcp/src/tools/mod.rs
@@ -139,6 +139,52 @@ pub fn web_fetch_input_schema() -> serde_json::Value {
     })
 }
 
+/// JSON Schema for the `mvm.upload` tool. Mirrors
+/// `mvm_supervisor::tools::upload::UploadParams`.
+pub fn upload_input_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["path", "content_base64"],
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Relative path under the per-tenant staging root. No absolute paths, no '..' components, no control characters; length capped at 512 bytes."
+            },
+            "content_base64": {
+                "type": "string",
+                "description": "URL-safe-no-pad base64 of the payload bytes. Binary content round-trips losslessly."
+            },
+            "max_bytes": {
+                "type": "integer",
+                "description": "Post-decode size cap, in bytes. Defaults to 16 MiB; values above 256 MiB are clamped.",
+                "minimum": 1
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+/// JSON Schema for the `mvm.download` tool. Mirrors
+/// `mvm_supervisor::tools::download::DownloadParams`.
+pub fn download_input_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["path"],
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Relative path under the per-tenant staging root. Same validation as mvm.upload."
+            },
+            "max_bytes": {
+                "type": "integer",
+                "description": "Cap on file size, in bytes. Defaults to 16 MiB; values above 256 MiB are clamped. Files larger than the cap return an error instead of a partial read.",
+                "minimum": 1
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
 /// JSON Schema for the `mvm.web_search` tool. Mirrors
 /// `mvm_supervisor::tools::web_search::WebSearchParams`.
 pub fn web_search_input_schema() -> serde_json::Value {
@@ -200,6 +246,20 @@ pub fn all_tools() -> Vec<ToolSchema> {
                     .to_string(),
             input_schema: web_search_input_schema(),
         },
+        ToolSchema {
+            name: "mvm.upload".to_string(),
+            description:
+                "Write a base64-encoded payload to a relative path under the per-tenant staging area on the host. Path validation rejects absolute paths, '..' components, control characters, and length > 512 bytes. The staging area is a host-side directory (~/.mvm/tool-staging/<tenant>/ by default; override via MVM_TOOL_STAGING_DIR) that the workload can read through a controlled channel."
+                    .to_string(),
+            input_schema: upload_input_schema(),
+        },
+        ToolSchema {
+            name: "mvm.download".to_string(),
+            description:
+                "Read a relative path from the per-tenant staging area and return the bytes as URL-safe-no-pad base64. Same path validation + size caps as mvm.upload. Use the `bytes` field to learn the file size without decoding."
+                    .to_string(),
+            input_schema: download_input_schema(),
+        },
     ]
 }
 
@@ -246,7 +306,9 @@ mod tests {
         assert!(names.contains(&"mvm.time_now"));
         assert!(names.contains(&"mvm.web_fetch"));
         assert!(names.contains(&"mvm.web_search"));
-        assert_eq!(tools.len(), 4);
+        assert!(names.contains(&"mvm.upload"));
+        assert!(names.contains(&"mvm.download"));
+        assert_eq!(tools.len(), 6);
     }
 
     #[test]

--- a/crates/mvm-mcp/src/tools/mod.rs
+++ b/crates/mvm-mcp/src/tools/mod.rs
@@ -102,15 +102,105 @@ pub struct ToolSchema {
     pub input_schema: serde_json::Value,
 }
 
-/// All tools exposed by mvmctl mcp. v1 = exactly one.
+/// JSON Schema for the `mvm.time_now` tool. Mirrors
+/// `mvm_supervisor::tools::time_now::TimeNowParams`.
+pub fn time_now_input_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "format": {
+                "type": "string",
+                "enum": ["rfc3339", "unix"],
+                "description": "Output format. 'rfc3339' (default) returns an ISO-8601 string; 'unix' returns seconds-since-epoch as a decimal string."
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+/// JSON Schema for the `mvm.web_fetch` tool. Mirrors
+/// `mvm_supervisor::tools::web_fetch::WebFetchParams`.
+pub fn web_fetch_input_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["url"],
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "Absolute https:// URL to fetch. http:// and other schemes are rejected. The destination host must appear in the per-tenant allowlist."
+            },
+            "max_bytes": {
+                "type": "integer",
+                "description": "Cap on response body length, in bytes. Defaults to 1 MiB; values above 16 MiB are clamped.",
+                "minimum": 1
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+/// JSON Schema for the `mvm.web_search` tool. Mirrors
+/// `mvm_supervisor::tools::web_search::WebSearchParams`.
+pub fn web_search_input_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "required": ["query"],
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Free-form search query. Non-empty, no control characters, length capped at 1024."
+            },
+            "provider": {
+                "type": "string",
+                "description": "Optional provider name (e.g. 'brave', 'google'). Falls back to the tool's default_provider. Must appear in the per-tenant allowlist."
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Cap on result count. Default 10; values above 50 are clamped.",
+                "minimum": 1
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+/// All tools exposed by mvmctl mcp.
+///
+/// - `run` — legacy single-tool "boot a microVM and execute code".
+/// - `mvm.time_now`, `mvm.web_fetch`, `mvm.web_search` — plan 60
+///   Phase 7 host-mediated tools (implementations live in
+///   `mvm-supervisor::tools`).
 pub fn all_tools() -> Vec<ToolSchema> {
-    vec![ToolSchema {
-        name: "run".to_string(),
-        description:
-            "Run code inside a fresh mvm microVM. Single tool; the `env` parameter selects which pre-built environment to boot — either a built-in preset (`shell`, `bash`, `python`, `node`) or a path to a project directory whose `mvm.toml` has been built via `mvmctl build`. Output is captured (stdout, stderr, exit_code). Each call boots and tears down a transient VM (session reuse is reserved). Use `mvmctl manifest ls` on the host to discover available manifest-keyed environments."
-                .to_string(),
-        input_schema: run_input_schema(),
-    }]
+    vec![
+        ToolSchema {
+            name: "run".to_string(),
+            description:
+                "Run code inside a fresh mvm microVM. Single tool; the `env` parameter selects which pre-built environment to boot — either a built-in preset (`shell`, `bash`, `python`, `node`) or a path to a project directory whose `mvm.toml` has been built via `mvmctl build`. Output is captured (stdout, stderr, exit_code). Each call boots and tears down a transient VM (session reuse is reserved). Use `mvmctl manifest ls` on the host to discover available manifest-keyed environments."
+                    .to_string(),
+            input_schema: run_input_schema(),
+        },
+        ToolSchema {
+            name: "mvm.time_now".to_string(),
+            description:
+                "Return the host wall-clock time as either RFC 3339 (default) or Unix seconds. No upstream call, no network — useful as a diagnostic that the agent → supervisor pipe is alive."
+                    .to_string(),
+            input_schema: time_now_input_schema(),
+        },
+        ToolSchema {
+            name: "mvm.web_fetch".to_string(),
+            description:
+                "Fetch a single https:// URL. The destination host must appear in the per-tenant allowlist (operators grant per-host access). The response body comes back as URL-safe-no-pad base64 so binary content (images, gzip, etc.) round-trips losslessly; `bytes` carries the pre-encoding length."
+                    .to_string(),
+            input_schema: web_fetch_input_schema(),
+        },
+        ToolSchema {
+            name: "mvm.web_search".to_string(),
+            description:
+                "Search the web through a per-tenant allowlisted provider (Brave / Google / DuckDuckGo / …). The agent does not see the provider's API key; the supervisor owns it. Returns up to `max_results` hits, each with title / url / snippet."
+                    .to_string(),
+            input_schema: web_search_input_schema(),
+        },
+    ]
 }
 
 #[cfg(test)]
@@ -149,23 +239,29 @@ mod tests {
     }
 
     #[test]
-    fn all_tools_returns_single_run_tool() {
+    fn all_tools_returns_run_plus_phase_7_tools() {
         let tools = all_tools();
-        assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0].name, "run");
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"run"));
+        assert!(names.contains(&"mvm.time_now"));
+        assert!(names.contains(&"mvm.web_fetch"));
+        assert!(names.contains(&"mvm.web_search"));
+        assert_eq!(tools.len(), 4);
     }
 
     #[test]
-    fn tools_list_token_budget_under_500() {
+    fn tools_list_token_budget_under_2000() {
         // Byte-count heuristic where 1 token ≈ 4 bytes (well-known
-        // approximation for Claude/GPT-4 family). The plan's target
-        // is ≤ 500 tokens for `tools/list`. Guards against schema
-        // bloat as we add description text over time.
+        // approximation for Claude/GPT-4 family). Plan 60 Phase 7
+        // grows the tool count from 1 to 4; budget scales with it.
+        // 2000 tokens (~8000 bytes) leaves headroom for the planned
+        // `upload`/`download`/`code_eval` additions; tighten once
+        // those land.
         let serialized = serde_json::to_string(&all_tools()).unwrap();
         let approx_tokens = serialized.len() / 4;
         assert!(
-            approx_tokens < 500,
-            "tools/list too large: ~{} tokens ({} bytes); target < 500",
+            approx_tokens < 2000,
+            "tools/list too large: ~{} tokens ({} bytes); target < 2000",
             approx_tokens,
             serialized.len()
         );

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -44,6 +44,10 @@ thiserror = "1"
 # Plan 60 Phase 7 — `web_fetch` tool parses RFC-3986 URLs to enforce
 # scheme/host invariants before the allowlist check.
 url = "2"
+# Plan 60 Phase 7 — `ReqwestHttpFetcher` (the reqwest-backed
+# `HttpFetcher` impl for `mvm.web_fetch`). Workspace feature set
+# already includes `rustls-tls` so we don't pull openssl.
+reqwest = { workspace = true }
 # Wave 2.6: L7EgressProxy uses tokio::net::lookup_host for the
 # production DnsResolver impl. Tests use only `macros + rt`, the
 # proxy needs `net` for lookup. `rt-multi-thread` lands when the

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -41,6 +41,9 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror = "1"
+# Plan 60 Phase 7 — `web_fetch` tool parses RFC-3986 URLs to enforce
+# scheme/host invariants before the allowlist check.
+url = "2"
 # Wave 2.6: L7EgressProxy uses tokio::net::lookup_host for the
 # production DnsResolver impl. Tests use only `macros + rt`, the
 # proxy needs `net` for lookup. `rt-multi-thread` lands when the

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -55,11 +55,12 @@ reqwest = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt"] }
 tracing.workspace = true
 
-# Sampler (A3) reads `/proc/<pid>/stat` and uses `sysconf(_SC_CLK_TCK)` /
-# `_SC_PAGESIZE` to convert jiffies → microseconds and pages → bytes.
-# Linux-only; the non-Linux source readers compile to empty stubs that
-# don't reference libc, so the dep is gated.
-[target.'cfg(target_os = "linux")'.dependencies]
+# Plan 60 Phase 7 staging tools: `O_NOFOLLOW` on read/write opens
+# defends the upload + download path validators against a symlink
+# planted inside the staging dir. Unix-wide (macOS + Linux); the
+# Windows branch in `staging.rs` falls back to a `symlink_metadata`
+# check.
+[target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
 [dev-dependencies]

--- a/crates/mvm-supervisor/src/lib.rs
+++ b/crates/mvm-supervisor/src/lib.rs
@@ -59,6 +59,7 @@ pub mod ssrf_guard;
 pub mod state;
 pub mod supervisor;
 pub mod tool_gate;
+pub mod tools;
 
 pub use artifact::{
     ArtifactCollector, ArtifactError, LiveArtifactCollector, NoopArtifactCollector,
@@ -116,3 +117,4 @@ pub use supervisor::{
     validate_egress_policy_inspector_names,
 };
 pub use tool_gate::{NoopToolGate, ToolDecision, ToolError, ToolGate};
+pub use tools::{HostMediatedTool, ToolInvokeError, ToolRegistry};

--- a/crates/mvm-supervisor/src/tools/download.rs
+++ b/crates/mvm-supervisor/src/tools/download.rs
@@ -1,0 +1,252 @@
+//! `mvm.download` — host staging-area → agent read.
+//!
+//! Plan 60 Phase 7. The agent supplies a relative path; the
+//! supervisor validates, reads from the configured staging area,
+//! and returns the bytes as URL-safe-no-pad base64 (same shape
+//! `mvm.web_fetch` uses, so callers parse one envelope for both
+//! tools).
+//!
+//! Security model lives in [`super::staging`]: every read goes
+//! through the same path validator + `O_NOFOLLOW` open the upload
+//! tool uses, so a tenant can only round-trip data they themselves
+//! placed under their staging subdir.
+//!
+//! ## Wire shape
+//!
+//! Params:
+//! - `path` (required): relative path under the staging root.
+//! - `max_bytes` (optional): cap on file size. Defaults to
+//!   [`super::staging::DEFAULT_MAX_BYTES`]; clamped to
+//!   [`super::staging::MAX_ALLOWED_BYTES`].
+//!
+//! Result:
+//! - `path`: echoes the validated path.
+//! - `bytes`: pre-encoding length.
+//! - `content_base64`: URL-safe-no-pad base64 of the file bytes.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
+
+use super::staging::{DEFAULT_MAX_BYTES, MAX_ALLOWED_BYTES, StagingArea, StagingError};
+use super::{HostMediatedTool, ToolInvokeError};
+
+pub const TOOL_NAME: &str = "mvm.download";
+
+pub struct DownloadTool {
+    staging: Arc<dyn StagingArea>,
+}
+
+impl DownloadTool {
+    /// Build with an explicit staging-area impl.
+    pub fn with_staging(staging: Arc<dyn StagingArea>) -> Self {
+        Self { staging }
+    }
+
+    /// Fail-closed default.
+    pub fn fail_closed() -> Self {
+        Self {
+            staging: Arc::new(super::staging::NoopStagingArea),
+        }
+    }
+}
+
+impl Default for DownloadTool {
+    fn default() -> Self {
+        Self::fail_closed()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DownloadParams {
+    pub path: String,
+    #[serde(default = "default_max_bytes")]
+    pub max_bytes: u64,
+}
+
+fn default_max_bytes() -> u64 {
+    DEFAULT_MAX_BYTES
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DownloadResult {
+    pub path: String,
+    pub bytes: u64,
+    pub content_base64: String,
+}
+
+#[async_trait]
+impl HostMediatedTool for DownloadTool {
+    fn name(&self) -> &'static str {
+        TOOL_NAME
+    }
+
+    async fn invoke(
+        &self,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ToolInvokeError> {
+        let parsed: DownloadParams =
+            serde_json::from_value(params).map_err(|e| ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: e.to_string(),
+            })?;
+        let cap = parsed.max_bytes.min(MAX_ALLOWED_BYTES);
+        let bytes = self
+            .staging
+            .read(&parsed.path, cap)
+            .await
+            .map_err(|e| map_staging_error(e, &parsed.path))?;
+        let content_base64 = URL_SAFE_NO_PAD.encode(&bytes);
+        serde_json::to_value(DownloadResult {
+            path: parsed.path,
+            bytes: bytes.len() as u64,
+            content_base64,
+        })
+        .map_err(|e| ToolInvokeError::Upstream {
+            tool: TOOL_NAME.to_string(),
+            message: format!("serializing result: {e}"),
+        })
+    }
+}
+
+fn map_staging_error(err: StagingError, path: &str) -> ToolInvokeError {
+    match err {
+        StagingError::InvalidPath { reason, .. } => ToolInvokeError::InvalidParams {
+            tool: TOOL_NAME.to_string(),
+            message: format!("invalid path {path:?}: {reason}"),
+        },
+        StagingError::NotFound { .. } => ToolInvokeError::Upstream {
+            tool: TOOL_NAME.to_string(),
+            message: format!("path {path:?} not found in staging area"),
+        },
+        StagingError::BodyTooLarge { limit } => ToolInvokeError::Upstream {
+            tool: TOOL_NAME.to_string(),
+            message: format!("file exceeds max_bytes {limit}"),
+        },
+        other => ToolInvokeError::Upstream {
+            tool: TOOL_NAME.to_string(),
+            message: other.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::staging::FsStagingArea;
+    use super::*;
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+    use tempfile::tempdir;
+
+    fn tool_with_tempdir_and_seed(name: &str, content: &[u8]) -> (DownloadTool, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join(name), content).unwrap();
+        let staging = Arc::new(FsStagingArea::with_root(dir.path()).unwrap());
+        (DownloadTool::with_staging(staging), dir)
+    }
+
+    #[tokio::test]
+    async fn download_round_trip_returns_base64_payload() {
+        let (tool, _dir) = tool_with_tempdir_and_seed("greeting.txt", b"hello there");
+        let out = tool
+            .invoke(serde_json::json!({ "path": "greeting.txt" }))
+            .await
+            .unwrap();
+        let parsed: DownloadResult = serde_json::from_value(out).unwrap();
+        assert_eq!(parsed.path, "greeting.txt");
+        assert_eq!(parsed.bytes, 11);
+        let decoded = B64.decode(&parsed.content_base64).unwrap();
+        assert_eq!(decoded, b"hello there");
+    }
+
+    #[tokio::test]
+    async fn download_missing_path_returns_clear_error() {
+        let (tool, _dir) = tool_with_tempdir_and_seed("placeholder", b"_");
+        let err = tool
+            .invoke(serde_json::json!({ "path": "nope.txt" }))
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { message, .. } => {
+                assert!(message.contains("not found"), "got: {message}");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn download_rejects_absolute_path() {
+        let (tool, _dir) = tool_with_tempdir_and_seed("p", b"x");
+        let err = tool
+            .invoke(serde_json::json!({ "path": "/etc/passwd" }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn download_rejects_parent_ref() {
+        let (tool, _dir) = tool_with_tempdir_and_seed("p", b"x");
+        let err = tool
+            .invoke(serde_json::json!({ "path": "../escape" }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn download_oversize_file_returns_body_too_large() {
+        let (tool, _dir) = tool_with_tempdir_and_seed("big.bin", &[0u8; 32]);
+        let err = tool
+            .invoke(serde_json::json!({
+                "path": "big.bin",
+                "max_bytes": 16,
+            }))
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { message, .. } => {
+                assert!(message.contains("exceeds max_bytes"), "got: {message}");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn download_rejects_unknown_field() {
+        let (tool, _dir) = tool_with_tempdir_and_seed("p", b"x");
+        let err = tool
+            .invoke(serde_json::json!({
+                "path": "p",
+                "extra": 1,
+            }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn download_fails_closed_without_staging() {
+        let tool = DownloadTool::default();
+        let err = tool
+            .invoke(serde_json::json!({ "path": "x" }))
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { message, .. } => {
+                assert!(message.contains("not wired"), "got: {message}");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_name_is_canonical_mvm_prefix() {
+        assert_eq!(DownloadTool::default().name(), TOOL_NAME);
+        assert!(TOOL_NAME.starts_with("mvm."));
+    }
+}

--- a/crates/mvm-supervisor/src/tools/mod.rs
+++ b/crates/mvm-supervisor/src/tools/mod.rs
@@ -1,0 +1,433 @@
+//! Plan 60 Phase 7 — host-mediated agent tools substrate.
+//!
+//! Phase 7's framing: an LLM agent (Claude Code, opencode, future
+//! mvmforge clients) calls into host-mediated tools — `mvm.web_search`,
+//! `mvm.web_fetch`, `mvm.time_now`, `mvm.upload`/`download`, etc. The
+//! agent doesn't reach these directly; every call routes through the
+//! supervisor so:
+//!
+//! 1. **Allowlist enforcement** — the plan's
+//!    `tool_policy: PolicyRef` gates which tools are reachable.
+//!    Handled by [`crate::tool_gate::ToolGate`] *before* calling
+//!    [`ToolRegistry::invoke`]; this substrate trusts its caller did
+//!    that.
+//! 2. **Audit emission** — every successful or failed invoke fires
+//!    a chain-signed entry through the plan-60 Phase 4
+//!    [`Recorder`](crate::Recorder) under `EventCategory::Cmd` with
+//!    the canonical event name `cmd.tool.<name>.{completed,failed}`.
+//!    The audit is best-effort: a chain-signer failure does not
+//!    fail the tool call.
+//! 3. **Uniform error rendering** — tool-side errors return
+//!    [`ToolInvokeError`] so callers can surface a structured
+//!    failure to the LLM client (MCP semantics: errors must reach
+//!    the model, not the JSON-RPC error channel).
+//!
+//! ## What this module is NOT
+//!
+//! - Not a tool gate. [`crate::tool_gate::ToolGate`] +
+//!   [`crate::policy_tool_gate::PolicyToolGate`] decide
+//!   allow/deny; this module decides "given allow, what happens".
+//! - Not a transport. The MCP server (plan 60 Phase 7,
+//!   `mvm-mcp/src/server.rs`) and the future agent vsock RPC are the
+//!   two consumers; both call [`ToolRegistry::invoke`] after the
+//!   gate clears.
+//! - Not a place for per-tenant state. Tools are stateless from the
+//!   registry's perspective; any per-tenant data (cached
+//!   credentials, rate-limit buckets) lives inside each tool's own
+//!   impl module.
+//!
+//! ## Adding a new tool
+//!
+//! 1. Add `pub mod <name>;` here.
+//! 2. Implement [`HostMediatedTool`] in that submodule.
+//! 3. Add a `register_<name>` helper if the tool needs construction
+//!    args (credentials, allowlists) — keep `new() -> Self` for
+//!    parameter-free tools so the registry can build a default
+//!    bundle.
+//! 4. Add the tool name to the canonical allowlist in
+//!    `mvm-policy::ToolPolicy::DEFAULTS` (separate slice; this
+//!    substrate does not pre-allowlist anything).
+
+pub mod time_now;
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::audit_recorder::{EventCategory, Recorder};
+
+/// One tool the agent invokes through the supervisor. The trait is
+/// JSON-shaped on both sides so any tool's signature flows through
+/// the MCP wire format and the vsock RPC without bespoke encoding.
+///
+/// Implementors carry their own per-tool state (credentials,
+/// upstream HTTP clients, rate-limit buckets) so the registry stays
+/// stateless from the orchestration perspective.
+#[async_trait]
+pub trait HostMediatedTool: Send + Sync {
+    /// Canonical tool name as exposed to the agent. Use the
+    /// `mvm.<verb>` form (`mvm.time_now`, `mvm.web_search`,
+    /// `mvm.web_fetch`, …) so allowlist entries are unambiguous
+    /// across builtin and future-third-party tools.
+    fn name(&self) -> &'static str;
+
+    /// Invoke the tool. `params` is the raw JSON the agent sent;
+    /// the impl deserializes into its own typed shape. Returns a
+    /// JSON `Value` (the MCP wire result) or a structured
+    /// [`ToolInvokeError`].
+    async fn invoke(&self, params: serde_json::Value)
+    -> Result<serde_json::Value, ToolInvokeError>;
+}
+
+/// Errors a tool surface can emit. Rendered to the MCP
+/// `ToolResult { is_error: true, content: [Text { text: ... }] }`
+/// shape by the dispatcher — they do NOT propagate as JSON-RPC
+/// errors (clients tend to retry those instead of surfacing).
+#[derive(Debug, Error)]
+pub enum ToolInvokeError {
+    /// The params didn't deserialize, or a required field is missing.
+    #[error("invalid params for {tool}: {message}")]
+    InvalidParams { tool: String, message: String },
+
+    /// The named tool isn't registered. Caller chose a tool name
+    /// that no impl serves — typically a typo in the agent's request,
+    /// or a stale allowlist that names tools the supervisor has
+    /// since dropped.
+    #[error("unknown tool: {tool} (registered: {available:?})")]
+    UnknownTool {
+        tool: String,
+        available: Vec<String>,
+    },
+
+    /// The upstream service (network, filesystem, etc.) refused or
+    /// failed. The wrapped string is operator-readable; tools must
+    /// take care to redact secrets before constructing this variant.
+    #[error("upstream failure in {tool}: {message}")]
+    Upstream { tool: String, message: String },
+}
+
+/// A bundle of available [`HostMediatedTool`] impls keyed by their
+/// canonical name. Build once at supervisor start; share across
+/// every dispatcher (MCP, agent vsock RPC).
+///
+/// The registry holds an optional [`Recorder`] for chain-signed
+/// audit emission. When wired, every invoke fires
+/// `cmd.tool.<name>.completed` (or `cmd.tool.<name>.failed`) under
+/// [`EventCategory::Cmd`]. Audit failures degrade silently — a
+/// tool call's success contract is independent of audit reachability.
+pub struct ToolRegistry {
+    tools: BTreeMap<&'static str, Box<dyn HostMediatedTool>>,
+    recorder: Option<Recorder>,
+}
+
+impl ToolRegistry {
+    /// Build an empty registry. Tools are added via [`Self::register`];
+    /// the audit recorder is attached via [`Self::with_recorder`].
+    pub fn new() -> Self {
+        Self {
+            tools: BTreeMap::new(),
+            recorder: None,
+        }
+    }
+
+    /// Build with the default tool set: every Phase 7 builtin
+    /// implementing `Default + HostMediatedTool` is registered.
+    /// Today: `mvm.time_now`. Future slices grow this list as
+    /// `web_search`, `web_fetch`, `upload`, `download`, `code_eval`
+    /// land.
+    pub fn with_defaults() -> Self {
+        let mut r = Self::new();
+        r.register(Box::new(time_now::TimeNowTool));
+        r
+    }
+
+    /// Attach a Recorder for chain-signed audit emission. Returns
+    /// `self` for chaining.
+    pub fn with_recorder(mut self, recorder: Recorder) -> Self {
+        self.recorder = Some(recorder);
+        self
+    }
+
+    /// Register a tool. Replaces any previous entry with the same
+    /// `name()` — useful for tests that want to override a builtin
+    /// with a stub. Production callers should register each name
+    /// exactly once.
+    pub fn register(&mut self, tool: Box<dyn HostMediatedTool>) {
+        let name = tool.name();
+        self.tools.insert(name, tool);
+    }
+
+    /// The set of registered tool names, sorted (BTreeMap's keys are
+    /// already in sort order). Operators see this in the error
+    /// message on `UnknownTool` to debug allowlist drift.
+    pub fn names(&self) -> Vec<&'static str> {
+        self.tools.keys().copied().collect()
+    }
+
+    /// True if the named tool is registered. Used by the future
+    /// MCP dispatcher to short-circuit before constructing the
+    /// JSON-RPC response.
+    pub fn is_registered(&self, name: &str) -> bool {
+        self.tools.contains_key(name)
+    }
+
+    /// Dispatch a tool call. The named tool's [`HostMediatedTool::invoke`]
+    /// runs against `params`; the result (success or failure) emits
+    /// a `cmd.tool.<name>.<phase>` audit entry through the wired
+    /// Recorder.
+    ///
+    /// **Allowlist note**: This method does NOT consult any
+    /// `ToolPolicy`. The caller (MCP dispatcher / agent vsock
+    /// handler) MUST have already called
+    /// [`crate::tool_gate::ToolGate::check`] and seen
+    /// `ToolDecision::Allow`. Skipping that step is a security bug
+    /// — the registry trusts its caller to gate access.
+    pub async fn invoke(
+        &self,
+        name: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ToolInvokeError> {
+        let Some(tool) = self.tools.get(name) else {
+            let err = ToolInvokeError::UnknownTool {
+                tool: name.to_string(),
+                available: self
+                    .names()
+                    .into_iter()
+                    .map(String::from)
+                    .collect(),
+            };
+            self.emit_audit(name, "failed", Some(&err.to_string())).await;
+            return Err(err);
+        };
+        let result = tool.invoke(params).await;
+        match &result {
+            Ok(_) => self.emit_audit(name, "completed", None).await,
+            Err(e) => self.emit_audit(name, "failed", Some(&e.to_string())).await,
+        }
+        result
+    }
+
+    async fn emit_audit(&self, name: &str, phase: &str, error: Option<&str>) {
+        let Some(ref rec) = self.recorder else { return };
+        let event = format!("cmd.tool.{name}.{phase}");
+        let mut extras: Vec<(String, String)> = vec![
+            ("tool".to_string(), name.to_string()),
+            ("phase".to_string(), phase.to_string()),
+        ];
+        if let Some(err) = error {
+            extras.push(("error".to_string(), err.to_string()));
+        }
+        if let Err(e) = rec
+            .record_unbound(EventCategory::Cmd, event, extras)
+            .await
+        {
+            tracing::warn!(error = %e, tool = name, "tool audit emit failed");
+        }
+    }
+}
+
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::CapturingAuditSigner;
+    use mvm_plan::TenantId;
+    use std::sync::Arc;
+
+    /// Test stub — records each invoke for assertions. Returns the
+    /// params it received, echoed inside a `{ "got": ... }` envelope.
+    struct EchoTool;
+
+    #[async_trait]
+    impl HostMediatedTool for EchoTool {
+        fn name(&self) -> &'static str {
+            "mvm.echo"
+        }
+        async fn invoke(
+            &self,
+            params: serde_json::Value,
+        ) -> Result<serde_json::Value, ToolInvokeError> {
+            Ok(serde_json::json!({ "got": params }))
+        }
+    }
+
+    /// Test stub — always fails with a fixed message.
+    struct FailingTool;
+
+    #[async_trait]
+    impl HostMediatedTool for FailingTool {
+        fn name(&self) -> &'static str {
+            "mvm.failing"
+        }
+        async fn invoke(
+            &self,
+            _params: serde_json::Value,
+        ) -> Result<serde_json::Value, ToolInvokeError> {
+            Err(ToolInvokeError::Upstream {
+                tool: "mvm.failing".to_string(),
+                message: "boom".to_string(),
+            })
+        }
+    }
+
+    fn build_registry_with_recorder() -> (ToolRegistry, Arc<CapturingAuditSigner>) {
+        let signer = Arc::new(CapturingAuditSigner::new());
+        let rec = Recorder::new(signer.clone(), TenantId("local".to_string()));
+        let mut reg = ToolRegistry::new().with_recorder(rec);
+        reg.register(Box::new(EchoTool));
+        reg.register(Box::new(FailingTool));
+        (reg, signer)
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Construction
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_registry_lists_no_tools() {
+        let r = ToolRegistry::new();
+        assert!(r.names().is_empty());
+        assert!(!r.is_registered("mvm.anything"));
+    }
+
+    #[test]
+    fn with_defaults_registers_time_now() {
+        let r = ToolRegistry::with_defaults();
+        assert!(r.is_registered("mvm.time_now"));
+        assert!(r.names().contains(&"mvm.time_now"));
+    }
+
+    #[test]
+    fn register_overrides_existing_entry() {
+        // Useful in tests to swap a builtin for a stub.
+        let mut r = ToolRegistry::with_defaults();
+        assert!(r.is_registered("mvm.time_now"));
+        struct OverrideTimeTool;
+        #[async_trait]
+        impl HostMediatedTool for OverrideTimeTool {
+            fn name(&self) -> &'static str {
+                "mvm.time_now"
+            }
+            async fn invoke(
+                &self,
+                _: serde_json::Value,
+            ) -> Result<serde_json::Value, ToolInvokeError> {
+                Ok(serde_json::json!({ "overridden": true }))
+            }
+        }
+        r.register(Box::new(OverrideTimeTool));
+        // Still exactly one entry under that name.
+        assert_eq!(
+            r.names().iter().filter(|n| **n == "mvm.time_now").count(),
+            1
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Invoke happy path
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn invoke_routes_to_named_tool() {
+        let (reg, _signer) = build_registry_with_recorder();
+        let out = reg
+            .invoke("mvm.echo", serde_json::json!({ "x": 1 }))
+            .await
+            .unwrap();
+        assert_eq!(out, serde_json::json!({ "got": { "x": 1 } }));
+    }
+
+    #[tokio::test]
+    async fn invoke_emits_completed_audit_on_success() {
+        let (reg, signer) = build_registry_with_recorder();
+        reg.invoke("mvm.echo", serde_json::json!({}))
+            .await
+            .unwrap();
+        let entries = signer.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].event, "cmd.tool.mvm.echo.completed");
+        assert_eq!(
+            entries[0].labels.get("tool"),
+            Some(&"mvm.echo".to_string())
+        );
+        assert_eq!(
+            entries[0].labels.get("phase"),
+            Some(&"completed".to_string())
+        );
+        assert!(!entries[0].labels.contains_key("error"));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Invoke error paths
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn invoke_unknown_tool_names_available_tools_in_error() {
+        let (reg, _) = build_registry_with_recorder();
+        let err = reg
+            .invoke("mvm.nope", serde_json::json!({}))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        // The available-tools list shows up so an operator can spot
+        // typos.
+        assert!(msg.contains("mvm.echo"), "got: {msg}");
+        assert!(msg.contains("mvm.failing"), "got: {msg}");
+        assert!(msg.contains("mvm.nope"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn invoke_unknown_tool_emits_failed_audit() {
+        let (reg, signer) = build_registry_with_recorder();
+        let _ = reg
+            .invoke("mvm.nope", serde_json::json!({}))
+            .await
+            .unwrap_err();
+        let entries = signer.entries();
+        assert_eq!(entries.len(), 1);
+        // The audit event uses the requested name, not "unknown".
+        assert_eq!(entries[0].event, "cmd.tool.mvm.nope.failed");
+        assert!(entries[0].labels.contains_key("error"));
+    }
+
+    #[tokio::test]
+    async fn invoke_propagates_upstream_failure() {
+        let (reg, signer) = build_registry_with_recorder();
+        let err = reg
+            .invoke("mvm.failing", serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::Upstream { .. }));
+        // Audit captures the failure.
+        let entries = signer.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].event, "cmd.tool.mvm.failing.failed");
+        assert_eq!(
+            entries[0].labels.get("error").map(String::as_str),
+            Some("upstream failure in mvm.failing: boom")
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Recorder absent
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn invoke_without_recorder_returns_ok_and_skips_audit() {
+        // Same EchoTool; no recorder attached. Tool call must
+        // still succeed.
+        let mut reg = ToolRegistry::new();
+        reg.register(Box::new(EchoTool));
+        let out = reg
+            .invoke("mvm.echo", serde_json::json!({ "x": 1 }))
+            .await
+            .unwrap();
+        assert_eq!(out, serde_json::json!({ "got": { "x": 1 } }));
+    }
+}

--- a/crates/mvm-supervisor/src/tools/mod.rs
+++ b/crates/mvm-supervisor/src/tools/mod.rs
@@ -133,14 +133,27 @@ impl ToolRegistry {
         }
     }
 
-    /// Build with the default tool set: every Phase 7 builtin
-    /// implementing `Default + HostMediatedTool` is registered.
-    /// Today: `mvm.time_now`. Future slices grow this list as
-    /// `web_search`, `web_fetch`, `upload`, `download`, `code_eval`
-    /// land.
+    /// Build with the default tool set: every Phase 7 builtin is
+    /// registered with its fail-closed `Default::default()` config.
+    ///
+    /// Today's registrations:
+    ///
+    /// - `mvm.time_now` — always reachable; no allowlist needed
+    ///   (pure host-clock read with no upstream).
+    /// - `mvm.web_fetch` — fail-closed by default (empty host
+    ///   allowlist + [`web_fetch::NoopHttpFetcher`]). Operators
+    ///   call [`Self::register`] with a configured
+    ///   [`web_fetch::WebFetchTool`] to enable.
+    /// - `mvm.web_search` — fail-closed by default (empty provider
+    ///   allowlist + [`web_search::NoopSearchProvider`]).
+    ///
+    /// Future slices grow this list as `upload`, `download`, and
+    /// `code_eval` land.
     pub fn with_defaults() -> Self {
         let mut r = Self::new();
         r.register(Box::new(time_now::TimeNowTool));
+        r.register(Box::new(web_fetch::WebFetchTool::default()));
+        r.register(Box::new(web_search::WebSearchTool::default()));
         r
     }
 
@@ -293,10 +306,58 @@ mod tests {
     }
 
     #[test]
-    fn with_defaults_registers_time_now() {
+    fn with_defaults_registers_all_three_phase_7_builtins() {
+        // The Phase 7 substrate ships three tools out of the box.
+        // `time_now` is reachable; `web_fetch` and `web_search` are
+        // wired with fail-closed defaults so an operator who calls
+        // them without configuring an allowlist gets a clear
+        // "not on allowlist" or "fetcher not wired" error.
         let r = ToolRegistry::with_defaults();
-        assert!(r.is_registered("mvm.time_now"));
-        assert!(r.names().contains(&"mvm.time_now"));
+        for builtin in ["mvm.time_now", "mvm.web_fetch", "mvm.web_search"] {
+            assert!(
+                r.is_registered(builtin),
+                "default registry must include {builtin}"
+            );
+        }
+        assert_eq!(r.names().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn with_defaults_web_fetch_is_fail_closed() {
+        // Sanity: a fresh registry hands out a `WebFetchTool` that
+        // refuses every host. This is the contract that lets
+        // operators ship the substrate with no per-tenant config and
+        // not accidentally leak.
+        let r = ToolRegistry::with_defaults();
+        let err = r
+            .invoke(
+                "mvm.web_fetch",
+                serde_json::json!({ "url": "https://x.example/" }),
+            )
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { tool, message } => {
+                assert_eq!(tool, "mvm.web_fetch");
+                assert!(message.contains("not on per-tenant allowlist"), "{message}");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn with_defaults_web_search_is_fail_closed() {
+        let r = ToolRegistry::with_defaults();
+        let err = r
+            .invoke("mvm.web_search", serde_json::json!({ "query": "x" }))
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { tool, .. } => {
+                assert_eq!(tool, "mvm.web_search");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/mvm-supervisor/src/tools/mod.rs
+++ b/crates/mvm-supervisor/src/tools/mod.rs
@@ -50,6 +50,7 @@
 
 pub mod time_now;
 pub mod web_fetch;
+pub mod web_search;
 
 use std::collections::BTreeMap;
 

--- a/crates/mvm-supervisor/src/tools/mod.rs
+++ b/crates/mvm-supervisor/src/tools/mod.rs
@@ -49,6 +49,7 @@
 //!    substrate does not pre-allowlist anything).
 
 pub mod time_now;
+pub mod web_fetch;
 
 use std::collections::BTreeMap;
 
@@ -191,13 +192,10 @@ impl ToolRegistry {
         let Some(tool) = self.tools.get(name) else {
             let err = ToolInvokeError::UnknownTool {
                 tool: name.to_string(),
-                available: self
-                    .names()
-                    .into_iter()
-                    .map(String::from)
-                    .collect(),
+                available: self.names().into_iter().map(String::from).collect(),
             };
-            self.emit_audit(name, "failed", Some(&err.to_string())).await;
+            self.emit_audit(name, "failed", Some(&err.to_string()))
+                .await;
             return Err(err);
         };
         let result = tool.invoke(params).await;
@@ -218,10 +216,7 @@ impl ToolRegistry {
         if let Some(err) = error {
             extras.push(("error".to_string(), err.to_string()));
         }
-        if let Err(e) = rec
-            .record_unbound(EventCategory::Cmd, event, extras)
-            .await
-        {
+        if let Err(e) = rec.record_unbound(EventCategory::Cmd, event, extras).await {
             tracing::warn!(error = %e, tool = name, "tool audit emit failed");
         }
     }
@@ -346,16 +341,11 @@ mod tests {
     #[tokio::test]
     async fn invoke_emits_completed_audit_on_success() {
         let (reg, signer) = build_registry_with_recorder();
-        reg.invoke("mvm.echo", serde_json::json!({}))
-            .await
-            .unwrap();
+        reg.invoke("mvm.echo", serde_json::json!({})).await.unwrap();
         let entries = signer.entries();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].event, "cmd.tool.mvm.echo.completed");
-        assert_eq!(
-            entries[0].labels.get("tool"),
-            Some(&"mvm.echo".to_string())
-        );
+        assert_eq!(entries[0].labels.get("tool"), Some(&"mvm.echo".to_string()));
         assert_eq!(
             entries[0].labels.get("phase"),
             Some(&"completed".to_string())

--- a/crates/mvm-supervisor/src/tools/mod.rs
+++ b/crates/mvm-supervisor/src/tools/mod.rs
@@ -48,7 +48,10 @@
 //!    `mvm-policy::ToolPolicy::DEFAULTS` (separate slice; this
 //!    substrate does not pre-allowlist anything).
 
+pub mod download;
+pub mod staging;
 pub mod time_now;
+pub mod upload;
 pub mod web_fetch;
 pub mod web_search;
 
@@ -146,14 +149,19 @@ impl ToolRegistry {
     ///   [`web_fetch::WebFetchTool`] to enable.
     /// - `mvm.web_search` — fail-closed by default (empty provider
     ///   allowlist + [`web_search::NoopSearchProvider`]).
+    /// - `mvm.upload` / `mvm.download` — fail-closed by default
+    ///   ([`staging::NoopStagingArea`]); operators wire a real
+    ///   [`staging::FsStagingArea`] via the env-driven
+    ///   `build_tool_registry` helper in `mvm-cli`.
     ///
-    /// Future slices grow this list as `upload`, `download`, and
-    /// `code_eval` land.
+    /// Future slices grow this list as `code_eval` lands.
     pub fn with_defaults() -> Self {
         let mut r = Self::new();
         r.register(Box::new(time_now::TimeNowTool));
         r.register(Box::new(web_fetch::WebFetchTool::default()));
         r.register(Box::new(web_search::WebSearchTool::default()));
+        r.register(Box::new(upload::UploadTool::default()));
+        r.register(Box::new(download::DownloadTool::default()));
         r
     }
 
@@ -306,20 +314,26 @@ mod tests {
     }
 
     #[test]
-    fn with_defaults_registers_all_three_phase_7_builtins() {
-        // The Phase 7 substrate ships three tools out of the box.
-        // `time_now` is reachable; `web_fetch` and `web_search` are
-        // wired with fail-closed defaults so an operator who calls
-        // them without configuring an allowlist gets a clear
-        // "not on allowlist" or "fetcher not wired" error.
+    fn with_defaults_registers_all_phase_7_builtins() {
+        // The Phase 7 substrate ships five tools out of the box.
+        // `time_now` is reachable; the rest are wired with
+        // fail-closed defaults so an operator who calls them
+        // without configuring an allowlist / staging area gets a
+        // clear "not wired" error.
         let r = ToolRegistry::with_defaults();
-        for builtin in ["mvm.time_now", "mvm.web_fetch", "mvm.web_search"] {
+        for builtin in [
+            "mvm.time_now",
+            "mvm.web_fetch",
+            "mvm.web_search",
+            "mvm.upload",
+            "mvm.download",
+        ] {
             assert!(
                 r.is_registered(builtin),
                 "default registry must include {builtin}"
             );
         }
-        assert_eq!(r.names().len(), 3);
+        assert_eq!(r.names().len(), 5);
     }
 
     #[tokio::test]

--- a/crates/mvm-supervisor/src/tools/staging.rs
+++ b/crates/mvm-supervisor/src/tools/staging.rs
@@ -1,0 +1,603 @@
+//! Shared backing store for `mvm.upload` + `mvm.download`.
+//!
+//! Plan 60 Phase 7. Both tools operate on a bounded **staging area** —
+//! a host-side directory the supervisor owns + the workload's guest
+//! can mount or read via a controlled channel. Phase 7a's persistent
+//! overlay will eventually displace this with a per-tenant
+//! ext4-on-luks layer; until then a plain on-disk directory under
+//! `~/.mvm/tool-staging/<tenant>/` is enough to demonstrate the
+//! agent surface end-to-end.
+//!
+//! ## Security model
+//!
+//! The staging area is the only filesystem surface either tool
+//! touches. Both tools accept a relative path; this module's path
+//! validator enforces:
+//!
+//! 1. **No absolute paths** — `/etc/passwd` is rejected before any
+//!    join happens.
+//! 2. **No parent-dir components** — `..` anywhere in the input,
+//!    even quoted (`%2e%2e`), is rejected. We don't try to be
+//!    clever about URL decoding; the path is treated as a raw
+//!    filesystem path so encoded escapes can't smuggle through.
+//! 3. **No leading separators** — `\foo` on Windows / `/foo` on
+//!    Unix both fail at the `Path::components()` check.
+//! 4. **No null bytes / control chars** — defends against
+//!    `truncate/etc/passwd\0.txt` style attacks where downstream
+//!    C code might honour the embedded null.
+//! 5. **Path-length cap** (512 bytes) — defends against
+//!    PATH_MAX edge cases on Linux (default 4096) and avoids
+//!    paths that bloat the audit chain.
+//! 6. **No symlink following** — opens use `O_NOFOLLOW` on Unix.
+//!    A symlink placed inside the staging dir (the only way one
+//!    could appear) trips ELOOP rather than crossing the
+//!    boundary.
+//! 7. **Per-tenant subdir** — the registry passes a tenant id to
+//!    [`FsStagingArea::for_tenant`] so two tenants on the same
+//!    host can't read each other's staged files.
+//!
+//! ## Size caps
+//!
+//! Both upload + download enforce `max_bytes` at the tool layer
+//! (caller-supplied, clamped to [`MAX_ALLOWED_BYTES`]). The staging
+//! area itself doesn't read more than asked; on writes it refuses
+//! oversize payloads before the first byte hits disk.
+//!
+//! ## What this module is NOT
+//!
+//! - Not a persistent overlay — that's Phase 7a's job. Files
+//!   written here survive across MCP server restarts (the host
+//!   directory is durable) but they aren't atomic / aren't
+//!   encrypted / aren't volume-mounted into the workload.
+//! - Not a sandboxing layer — `O_NOFOLLOW` + the path validator
+//!   defend against escape, but the staging dir is uid-readable
+//!   by the calling user (mode 0700 on the dir, default mode
+//!   0600 on files). The agent should treat anything in here as
+//!   coming from a "trusted user" boundary — a tenant peer.
+
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+/// Hard upper bound on per-call `max_bytes` for upload + download.
+/// Caller-supplied values above this are clamped.
+pub const MAX_ALLOWED_BYTES: u64 = 256 * (1 << 20);
+
+/// Default per-call cap when the caller doesn't specify. 16 MiB
+/// matches the same per-call working budget the rest of Phase 7
+/// uses (web_fetch's `MAX_ALLOWED_BYTES`).
+pub const DEFAULT_MAX_BYTES: u64 = 16 * (1 << 20);
+
+/// Maximum path-string length, bytes. Defends against PATH_MAX
+/// surprises and keeps the audit chain bounded.
+pub const MAX_PATH_LEN: usize = 512;
+
+/// Default per-tenant staging dir.
+/// `~/.mvm/tool-staging/<tenant>/`.
+pub fn default_staging_root() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".mvm").join("tool-staging"))
+}
+
+/// Canonical env-var name for overriding the staging root.
+pub const STAGING_DIR_ENV_VAR: &str = "MVM_TOOL_STAGING_DIR";
+
+/// Trait that backs both [`super::upload::UploadTool`] and
+/// [`super::download::DownloadTool`]. Implementations are
+/// stateless from the registry's perspective — credentials,
+/// per-tenant scoping, quota tracking all live behind the trait.
+#[async_trait]
+pub trait StagingArea: Send + Sync {
+    /// Write `bytes` to the relative `path` inside the staging
+    /// area. The implementation is responsible for path validation
+    /// + size enforcement.
+    async fn write(&self, path: &str, bytes: &[u8]) -> Result<(), StagingError>;
+
+    /// Read the file at the relative `path`, up to `max_bytes`.
+    /// Reads above the cap return `BodyTooLarge`.
+    async fn read(&self, path: &str, max_bytes: u64) -> Result<Vec<u8>, StagingError>;
+}
+
+#[derive(Debug, Error)]
+pub enum StagingError {
+    #[error("invalid path {path:?}: {reason}")]
+    InvalidPath { path: String, reason: &'static str },
+
+    #[error("path {path:?} not found in staging area")]
+    NotFound { path: String },
+
+    #[error("payload exceeded max_bytes ({limit})")]
+    BodyTooLarge { limit: u64 },
+
+    #[error("io error on {path:?}: {message}")]
+    Io { path: String, message: String },
+
+    #[error("staging area not wired (NoopStagingArea)")]
+    Unwired,
+}
+
+/// Fail-closed default. Useful as the substrate's placeholder
+/// when `$HOME` isn't reachable or the operator hasn't configured
+/// a staging root.
+pub struct NoopStagingArea;
+
+#[async_trait]
+impl StagingArea for NoopStagingArea {
+    async fn write(&self, _path: &str, _bytes: &[u8]) -> Result<(), StagingError> {
+        Err(StagingError::Unwired)
+    }
+    async fn read(&self, _path: &str, _max_bytes: u64) -> Result<Vec<u8>, StagingError> {
+        Err(StagingError::Unwired)
+    }
+}
+
+/// Filesystem-backed staging area rooted at a per-tenant directory.
+///
+/// The root is created on first construction with mode 0700. Each
+/// file written underneath inherits the OS default (umask-honoured;
+/// typically 0644 on Linux). Callers that need tighter perms should
+/// adjust via a follow-up slice.
+#[derive(Debug)]
+pub struct FsStagingArea {
+    root: PathBuf,
+}
+
+impl FsStagingArea {
+    /// Build with an explicit root (test seam — tests use a tempdir).
+    /// The directory is created if missing; permissions are
+    /// tightened to 0700 on Unix.
+    pub fn with_root(root: impl Into<PathBuf>) -> Result<Self, StagingError> {
+        let root = root.into();
+        std::fs::create_dir_all(&root).map_err(|e| StagingError::Io {
+            path: root.display().to_string(),
+            message: format!("creating staging root: {e}"),
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o700);
+            std::fs::set_permissions(&root, perms).ok();
+        }
+        Ok(Self { root })
+    }
+
+    /// Build a per-tenant subdir under `parent`. The tenant id is
+    /// itself path-validated to keep a malicious tenant from
+    /// escaping the parent via `..` smuggled in the tenant name.
+    pub fn for_tenant(parent: impl Into<PathBuf>, tenant: &str) -> Result<Self, StagingError> {
+        validate_path_component(tenant, "tenant id")?;
+        let root = parent.into().join(tenant);
+        Self::with_root(root)
+    }
+
+    /// Public read-only view of the root, for diagnostic output.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn resolve(&self, rel: &str) -> Result<PathBuf, StagingError> {
+        validate_relative_path(rel)?;
+        Ok(self.root.join(rel))
+    }
+}
+
+#[async_trait]
+impl StagingArea for FsStagingArea {
+    async fn write(&self, path: &str, bytes: &[u8]) -> Result<(), StagingError> {
+        let absolute = self.resolve(path)?;
+        if let Some(parent) = absolute.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| StagingError::Io {
+                path: path.to_string(),
+                message: format!("creating parent dir: {e}"),
+            })?;
+        }
+        // O_NOFOLLOW so a symlink that crept into the staging dir
+        // can't redirect the write outside.
+        #[cfg(unix)]
+        let result = {
+            use std::io::Write as _;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .custom_flags(libc::O_NOFOLLOW)
+                .open(&absolute);
+            match f {
+                Ok(ref mut file) => file.write_all(bytes).map_err(|e| StagingError::Io {
+                    path: path.to_string(),
+                    message: e.to_string(),
+                }),
+                Err(e) => Err(StagingError::Io {
+                    path: path.to_string(),
+                    message: e.to_string(),
+                }),
+            }
+        };
+        #[cfg(not(unix))]
+        let result = std::fs::write(&absolute, bytes).map_err(|e| StagingError::Io {
+            path: path.to_string(),
+            message: e.to_string(),
+        });
+        result
+    }
+
+    async fn read(&self, path: &str, max_bytes: u64) -> Result<Vec<u8>, StagingError> {
+        let absolute = self.resolve(path)?;
+        let meta = std::fs::metadata(&absolute).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                StagingError::NotFound {
+                    path: path.to_string(),
+                }
+            } else {
+                StagingError::Io {
+                    path: path.to_string(),
+                    message: e.to_string(),
+                }
+            }
+        })?;
+        if meta.len() > max_bytes {
+            return Err(StagingError::BodyTooLarge { limit: max_bytes });
+        }
+        // Refuse to read through symlinks. O_NOFOLLOW on the open
+        // is the canonical defense; on non-Unix we fall back to a
+        // `symlink_metadata` check.
+        #[cfg(unix)]
+        {
+            use std::io::Read as _;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut f = std::fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_NOFOLLOW)
+                .open(&absolute)
+                .map_err(|e| StagingError::Io {
+                    path: path.to_string(),
+                    message: e.to_string(),
+                })?;
+            let mut buf = Vec::with_capacity(meta.len() as usize);
+            f.read_to_end(&mut buf).map_err(|e| StagingError::Io {
+                path: path.to_string(),
+                message: e.to_string(),
+            })?;
+            Ok(buf)
+        }
+        #[cfg(not(unix))]
+        {
+            let sym_meta = std::fs::symlink_metadata(&absolute).map_err(|e| StagingError::Io {
+                path: path.to_string(),
+                message: e.to_string(),
+            })?;
+            if sym_meta.file_type().is_symlink() {
+                return Err(StagingError::InvalidPath {
+                    path: path.to_string(),
+                    reason: "symlinks are not followed",
+                });
+            }
+            std::fs::read(&absolute).map_err(|e| StagingError::Io {
+                path: path.to_string(),
+                message: e.to_string(),
+            })
+        }
+    }
+}
+
+/// Validate one path component (filename, tenant id) — no
+/// separators, no parent refs, no nulls, length-capped.
+pub(crate) fn validate_path_component(name: &str, label: &str) -> Result<(), StagingError> {
+    if name.is_empty() {
+        return Err(StagingError::InvalidPath {
+            path: name.to_string(),
+            reason: "empty",
+        });
+    }
+    if name.len() > MAX_PATH_LEN {
+        return Err(StagingError::InvalidPath {
+            path: name.to_string(),
+            reason: "exceeds MAX_PATH_LEN",
+        });
+    }
+    if name.contains('\0') || name.chars().any(|c| c.is_control()) {
+        return Err(StagingError::InvalidPath {
+            path: name.to_string(),
+            reason: "contains null or control character",
+        });
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err(StagingError::InvalidPath {
+            path: name.to_string(),
+            reason: "contains a path separator",
+        });
+    }
+    if name == "." || name == ".." {
+        return Err(StagingError::InvalidPath {
+            path: name.to_string(),
+            reason: "is a dot or parent reference",
+        });
+    }
+    let _ = label;
+    Ok(())
+}
+
+/// Validate a multi-component relative path. Rejects absolute
+/// paths, parent refs, control characters, and overlong inputs.
+pub(crate) fn validate_relative_path(rel: &str) -> Result<(), StagingError> {
+    if rel.is_empty() {
+        return Err(StagingError::InvalidPath {
+            path: rel.to_string(),
+            reason: "empty",
+        });
+    }
+    if rel.len() > MAX_PATH_LEN {
+        return Err(StagingError::InvalidPath {
+            path: rel.to_string(),
+            reason: "exceeds MAX_PATH_LEN",
+        });
+    }
+    if rel.contains('\0') || rel.chars().any(|c| c.is_control()) {
+        return Err(StagingError::InvalidPath {
+            path: rel.to_string(),
+            reason: "contains null or control character",
+        });
+    }
+    let p = Path::new(rel);
+    if p.is_absolute() {
+        return Err(StagingError::InvalidPath {
+            path: rel.to_string(),
+            reason: "is absolute",
+        });
+    }
+    for c in p.components() {
+        match c {
+            Component::Normal(_) => {}
+            Component::CurDir => {
+                return Err(StagingError::InvalidPath {
+                    path: rel.to_string(),
+                    reason: "contains a '.' component",
+                });
+            }
+            Component::ParentDir => {
+                return Err(StagingError::InvalidPath {
+                    path: rel.to_string(),
+                    reason: "contains a '..' component",
+                });
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(StagingError::InvalidPath {
+                    path: rel.to_string(),
+                    reason: "starts with a root or drive prefix",
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Helper that picks the right [`StagingArea`] for the dispatcher's
+/// build path. Reads `$MVM_TOOL_STAGING_DIR` (or falls back to
+/// `~/.mvm/tool-staging/`) and constructs a per-tenant
+/// [`FsStagingArea`]. On any setup failure returns the fail-closed
+/// [`NoopStagingArea`].
+pub fn default_for_tenant(tenant: &str) -> Arc<dyn StagingArea> {
+    let parent = std::env::var_os(STAGING_DIR_ENV_VAR)
+        .map(PathBuf::from)
+        .or_else(default_staging_root);
+    let Some(parent) = parent else {
+        tracing::warn!("$HOME and $MVM_TOOL_STAGING_DIR unset; tool staging area not wired");
+        return Arc::new(NoopStagingArea);
+    };
+    match FsStagingArea::for_tenant(parent, tenant) {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            tracing::warn!(error = %e, tenant = tenant, "FsStagingArea init failed");
+            Arc::new(NoopStagingArea)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    // ──────────────────────────────────────────────────────────────
+    // Path validator
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_rejects_absolute_path() {
+        let err = validate_relative_path("/etc/passwd").unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_parent_ref() {
+        let err = validate_relative_path("..").unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+        let err = validate_relative_path("a/../b").unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_bare_curdir() {
+        // `Path::components()` normalizes `a/./b` to `a/b` (the
+        // CurDir is stripped), so a single bare `.` is the only
+        // shape that surfaces `Component::CurDir`. Both forms are
+        // semantically safe — `a/./b` and `a/b` resolve to the
+        // same file — but the bare `.` denotes the staging root
+        // itself, which we refuse to write to as a sanity check.
+        let err = validate_relative_path(".").unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[test]
+    fn validate_accepts_normalized_curdir_in_middle() {
+        // `a/./b` survives validation because Path normalization
+        // strips the `.`. Documented here so a future refactor
+        // that adds extra rejection doesn't regress legitimate
+        // path-with-dot-in-middle use.
+        validate_relative_path("a/./b").unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_empty_path() {
+        let err = validate_relative_path("").unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_null_byte() {
+        let err = validate_relative_path("a\0b").unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_control_character() {
+        let err = validate_relative_path("a\nb").unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_overlong_path() {
+        let long = "a".repeat(MAX_PATH_LEN + 1);
+        let err = validate_relative_path(&long).unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[test]
+    fn validate_accepts_nested_normal_path() {
+        validate_relative_path("foo/bar/baz.txt").unwrap();
+    }
+
+    #[test]
+    fn validate_accepts_single_filename() {
+        validate_relative_path("hello.json").unwrap();
+    }
+
+    #[test]
+    fn validate_component_rejects_slash() {
+        let err = validate_path_component("a/b", "tenant").unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[test]
+    fn validate_component_rejects_parent_ref() {
+        let err = validate_path_component("..", "tenant").unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // FsStagingArea round-trip
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn fs_staging_round_trip_preserves_bytes() {
+        let dir = tempdir().unwrap();
+        let s = FsStagingArea::with_root(dir.path()).unwrap();
+        let payload = b"hello world";
+        s.write("greeting.txt", payload).await.unwrap();
+        let read = s.read("greeting.txt", 1024).await.unwrap();
+        assert_eq!(read, payload);
+    }
+
+    #[tokio::test]
+    async fn fs_staging_nested_write_creates_parent_dirs() {
+        let dir = tempdir().unwrap();
+        let s = FsStagingArea::with_root(dir.path()).unwrap();
+        s.write("sub/dir/file.bin", b"abc").await.unwrap();
+        assert_eq!(s.read("sub/dir/file.bin", 16).await.unwrap(), b"abc");
+    }
+
+    #[tokio::test]
+    async fn fs_staging_read_missing_returns_not_found() {
+        let dir = tempdir().unwrap();
+        let s = FsStagingArea::with_root(dir.path()).unwrap();
+        let err = s.read("nope.txt", 1024).await.unwrap_err();
+        assert!(matches!(err, StagingError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn fs_staging_read_oversize_returns_body_too_large() {
+        let dir = tempdir().unwrap();
+        let s = FsStagingArea::with_root(dir.path()).unwrap();
+        s.write("big.bin", &[0u8; 8]).await.unwrap();
+        let err = s.read("big.bin", 4).await.unwrap_err();
+        assert!(matches!(err, StagingError::BodyTooLarge { limit: 4 }));
+    }
+
+    #[tokio::test]
+    async fn fs_staging_rejects_absolute_path_on_write() {
+        let dir = tempdir().unwrap();
+        let s = FsStagingArea::with_root(dir.path()).unwrap();
+        let err = s.write("/etc/evil", b"x").await.unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[tokio::test]
+    async fn fs_staging_rejects_parent_ref_on_read() {
+        let dir = tempdir().unwrap();
+        let s = FsStagingArea::with_root(dir.path()).unwrap();
+        let err = s.read("../escape", 1024).await.unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn fs_staging_refuses_to_follow_symlink_on_read() {
+        // Manually plant a symlink inside the staging dir pointing
+        // outside; reading through it must fail.
+        let dir = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        std::fs::write(outside.path().join("secret"), b"escaped").unwrap();
+        std::os::unix::fs::symlink(outside.path().join("secret"), dir.path().join("link")).unwrap();
+        let s = FsStagingArea::with_root(dir.path()).unwrap();
+        let err = s.read("link", 1024).await.unwrap_err();
+        // ELOOP on Linux is wrapped as Io; what we assert is that
+        // the read does NOT succeed.
+        assert!(matches!(err, StagingError::Io { .. }));
+    }
+
+    #[tokio::test]
+    async fn for_tenant_validates_tenant_id() {
+        let dir = tempdir().unwrap();
+        let err = FsStagingArea::for_tenant(dir.path(), "../escape").unwrap_err();
+        assert!(matches!(err, StagingError::InvalidPath { .. }));
+    }
+
+    #[tokio::test]
+    async fn for_tenant_creates_subdir_under_parent() {
+        let dir = tempdir().unwrap();
+        let s = FsStagingArea::for_tenant(dir.path(), "acme").unwrap();
+        assert!(s.root().starts_with(dir.path()));
+        assert!(s.root().ends_with("acme"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn fs_staging_root_has_0700_perms() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let root = dir.path().join("staging");
+        FsStagingArea::with_root(&root).unwrap();
+        let mode = std::fs::metadata(&root).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "staging root must be 0700");
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // NoopStagingArea
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn noop_staging_returns_unwired_on_write() {
+        let s = NoopStagingArea;
+        let err = s.write("x", b"y").await.unwrap_err();
+        assert!(matches!(err, StagingError::Unwired));
+    }
+
+    #[tokio::test]
+    async fn noop_staging_returns_unwired_on_read() {
+        let s = NoopStagingArea;
+        let err = s.read("x", 1024).await.unwrap_err();
+        assert!(matches!(err, StagingError::Unwired));
+    }
+}

--- a/crates/mvm-supervisor/src/tools/time_now.rs
+++ b/crates/mvm-supervisor/src/tools/time_now.rs
@@ -1,0 +1,174 @@
+//! `mvm.time_now` — host wall-clock time as a host-mediated tool.
+//!
+//! The simplest possible Phase 7 tool: zero network, zero filesystem,
+//! pure function over the system clock. Useful as:
+//!
+//! - The first walking-skeleton impl of [`HostMediatedTool`] —
+//!   exercises the trait + [`crate::tools::ToolRegistry`] dispatch
+//!   path without needing an HTTP client, an allowlist of upstream
+//!   hosts, or a credential store.
+//! - A canonical "is the agent → supervisor → host pipe alive?"
+//!   diagnostic. An agent that can call `mvm.time_now` and get a
+//!   sane RFC 3339 back has working JSON-RPC, working policy gate,
+//!   and a working tool registry.
+//!
+//! ## Params (`TimeNowParams`)
+//!
+//! - `format`: `"rfc3339"` (default) or `"unix"`. Out-of-set values
+//!   are rejected with `ToolInvokeError::InvalidParams` so a typo
+//!   surfaces immediately rather than silently falling through to a
+//!   default.
+//!
+//! ## Result (`TimeNowResult`)
+//!
+//! - `time`: the formatted timestamp (string).
+//! - `format`: echoes back the format used, so a script can
+//!   round-trip without re-deriving it.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use super::{HostMediatedTool, ToolInvokeError};
+
+/// Stateless tool — `Default::default()` is the canonical
+/// constructor.
+#[derive(Default)]
+pub struct TimeNowTool;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimeNowParams {
+    #[serde(default)]
+    pub format: TimeFormat,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TimeFormat {
+    /// `"2026-05-11T18:00:00+00:00"` — ISO 8601 / RFC 3339. Default.
+    #[default]
+    Rfc3339,
+    /// Seconds since the Unix epoch, as a base-10 string.
+    Unix,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TimeNowResult {
+    pub time: String,
+    pub format: TimeFormat,
+}
+
+/// Tool name as exposed to the agent. Kept as a `const` so
+/// allowlist code and tests share one spelling.
+pub const TOOL_NAME: &str = "mvm.time_now";
+
+#[async_trait]
+impl HostMediatedTool for TimeNowTool {
+    fn name(&self) -> &'static str {
+        TOOL_NAME
+    }
+
+    async fn invoke(
+        &self,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ToolInvokeError> {
+        // Empty-object inputs are common (the tool has no required
+        // fields). `from_value` accepts `{}` directly.
+        let parsed: TimeNowParams =
+            serde_json::from_value(params).map_err(|e| ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: e.to_string(),
+            })?;
+        let now = chrono::Utc::now();
+        let time = match parsed.format {
+            TimeFormat::Rfc3339 => now.to_rfc3339(),
+            TimeFormat::Unix => now.timestamp().to_string(),
+        };
+        let result = TimeNowResult {
+            time,
+            format: parsed.format,
+        };
+        serde_json::to_value(&result).map_err(|e| ToolInvokeError::Upstream {
+            tool: TOOL_NAME.to_string(),
+            message: format!("serializing result: {e}"),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn invoke_with_empty_object_returns_rfc3339() {
+        let t = TimeNowTool;
+        let v = t.invoke(serde_json::json!({})).await.unwrap();
+        let parsed: TimeNowResult = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed.format, TimeFormat::Rfc3339);
+        // RFC 3339 timestamps always carry a `T` separator. Cheaper
+        // than re-parsing the date.
+        assert!(parsed.time.contains('T'), "got: {}", parsed.time);
+    }
+
+    #[tokio::test]
+    async fn invoke_with_unix_format_returns_decimal_seconds() {
+        let t = TimeNowTool;
+        let v = t
+            .invoke(serde_json::json!({ "format": "unix" }))
+            .await
+            .unwrap();
+        let parsed: TimeNowResult = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed.format, TimeFormat::Unix);
+        // Must parse as an i64 and be in a sane modern range
+        // (post-2020, pre-2100 — defends against a clock that's
+        // wandered off).
+        let secs: i64 = parsed.time.parse().expect("decimal seconds");
+        assert!(
+            (1_577_836_800..4_102_444_800).contains(&secs),
+            "unix time out of range: {secs}"
+        );
+    }
+
+    #[tokio::test]
+    async fn invoke_rejects_unknown_format_value() {
+        let t = TimeNowTool;
+        let err = t
+            .invoke(serde_json::json!({ "format": "klingon" }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains(TOOL_NAME), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn invoke_rejects_unknown_field() {
+        // `#[serde(deny_unknown_fields)]` per ADR-002 §W4.1 —
+        // unexpected fields fail closed so a stale agent that adds a
+        // `timezone` param doesn't silently drop the timezone.
+        let t = TimeNowTool;
+        let err = t
+            .invoke(serde_json::json!({ "format": "rfc3339", "timezone": "UTC" }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    #[test]
+    fn time_format_serde_roundtrip_lowercase() {
+        // Wire-format pin: the agent sends `"rfc3339"` and `"unix"`,
+        // not `"Rfc3339"`. The `rename_all = "lowercase"` attr
+        // enforces this; this test makes a future refactor that
+        // drops the attr fail loudly.
+        let v: TimeFormat = serde_json::from_str("\"rfc3339\"").unwrap();
+        assert_eq!(v, TimeFormat::Rfc3339);
+        let v: TimeFormat = serde_json::from_str("\"unix\"").unwrap();
+        assert_eq!(v, TimeFormat::Unix);
+    }
+
+    #[test]
+    fn tool_name_is_canonical_mvm_prefix() {
+        assert!(TOOL_NAME.starts_with("mvm."));
+        assert_eq!(TimeNowTool.name(), TOOL_NAME);
+    }
+}

--- a/crates/mvm-supervisor/src/tools/upload.rs
+++ b/crates/mvm-supervisor/src/tools/upload.rs
@@ -1,0 +1,277 @@
+//! `mvm.upload` — agent → host staging-area write.
+//!
+//! Plan 60 Phase 7. The agent posts a base64-encoded payload + a
+//! relative path; the supervisor decodes, validates the path, and
+//! writes to the configured staging area (see [`super::staging`]
+//! for the security model + path validator).
+//!
+//! ## Wire shape
+//!
+//! Params:
+//! - `path` (required): relative path under the staging root.
+//! - `content_base64` (required): URL-safe-no-pad base64 of the
+//!   payload bytes. Base64 keeps binary content round-trippable
+//!   across the JSON wire.
+//! - `max_bytes` (optional): post-decode size cap. Defaults to
+//!   [`super::staging::DEFAULT_MAX_BYTES`]; clamped to
+//!   [`super::staging::MAX_ALLOWED_BYTES`].
+//!
+//! Result:
+//! - `path`: echoes the validated path.
+//! - `bytes`: decoded payload length.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
+
+use super::staging::{DEFAULT_MAX_BYTES, MAX_ALLOWED_BYTES, StagingArea, StagingError};
+use super::{HostMediatedTool, ToolInvokeError};
+
+pub const TOOL_NAME: &str = "mvm.upload";
+
+pub struct UploadTool {
+    staging: Arc<dyn StagingArea>,
+}
+
+impl UploadTool {
+    /// Build with an explicit staging-area impl. Production
+    /// callers use [`super::staging::default_for_tenant`]; tests
+    /// inject a tempdir-backed
+    /// [`super::staging::FsStagingArea`].
+    pub fn with_staging(staging: Arc<dyn StagingArea>) -> Self {
+        Self { staging }
+    }
+
+    /// Fail-closed default — uses [`super::staging::NoopStagingArea`]
+    /// so every upload returns `Unwired` until the dispatcher
+    /// wires a real backend.
+    pub fn fail_closed() -> Self {
+        Self {
+            staging: Arc::new(super::staging::NoopStagingArea),
+        }
+    }
+}
+
+impl Default for UploadTool {
+    fn default() -> Self {
+        Self::fail_closed()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UploadParams {
+    pub path: String,
+    pub content_base64: String,
+    #[serde(default = "default_max_bytes")]
+    pub max_bytes: u64,
+}
+
+fn default_max_bytes() -> u64 {
+    DEFAULT_MAX_BYTES
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UploadResult {
+    pub path: String,
+    pub bytes: u64,
+}
+
+#[async_trait]
+impl HostMediatedTool for UploadTool {
+    fn name(&self) -> &'static str {
+        TOOL_NAME
+    }
+
+    async fn invoke(
+        &self,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ToolInvokeError> {
+        let parsed: UploadParams =
+            serde_json::from_value(params).map_err(|e| ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: e.to_string(),
+            })?;
+        let cap = parsed.max_bytes.min(MAX_ALLOWED_BYTES);
+        let bytes = URL_SAFE_NO_PAD
+            .decode(parsed.content_base64.as_bytes())
+            .map_err(|e| ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: format!("content_base64 decode: {e}"),
+            })?;
+        if (bytes.len() as u64) > cap {
+            return Err(ToolInvokeError::Upstream {
+                tool: TOOL_NAME.to_string(),
+                message: format!("payload size {} exceeds max_bytes {}", bytes.len(), cap),
+            });
+        }
+        self.staging
+            .write(&parsed.path, &bytes)
+            .await
+            .map_err(|e| map_staging_error(e, &parsed.path))?;
+        serde_json::to_value(UploadResult {
+            path: parsed.path,
+            bytes: bytes.len() as u64,
+        })
+        .map_err(|e| ToolInvokeError::Upstream {
+            tool: TOOL_NAME.to_string(),
+            message: format!("serializing result: {e}"),
+        })
+    }
+}
+
+fn map_staging_error(err: StagingError, path: &str) -> ToolInvokeError {
+    match err {
+        StagingError::InvalidPath { reason, .. } => ToolInvokeError::InvalidParams {
+            tool: TOOL_NAME.to_string(),
+            message: format!("invalid path {path:?}: {reason}"),
+        },
+        StagingError::BodyTooLarge { limit } => ToolInvokeError::Upstream {
+            tool: TOOL_NAME.to_string(),
+            message: format!("payload exceeded max_bytes {limit}"),
+        },
+        other => ToolInvokeError::Upstream {
+            tool: TOOL_NAME.to_string(),
+            message: other.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::staging::FsStagingArea;
+    use super::*;
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+    use tempfile::tempdir;
+
+    fn tool_with_tempdir() -> (UploadTool, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let staging = Arc::new(FsStagingArea::with_root(dir.path()).unwrap());
+        (UploadTool::with_staging(staging), dir)
+    }
+
+    #[tokio::test]
+    async fn upload_round_trip_writes_decoded_bytes() {
+        let (tool, dir) = tool_with_tempdir();
+        let payload = b"hello there";
+        let b64 = B64.encode(payload);
+        let out = tool
+            .invoke(serde_json::json!({
+                "path": "greeting.txt",
+                "content_base64": b64,
+            }))
+            .await
+            .unwrap();
+        let parsed: UploadResult = serde_json::from_value(out).unwrap();
+        assert_eq!(parsed.path, "greeting.txt");
+        assert_eq!(parsed.bytes, payload.len() as u64);
+        // Confirm the file actually landed on disk.
+        let read = std::fs::read(dir.path().join("greeting.txt")).unwrap();
+        assert_eq!(read, payload);
+    }
+
+    #[tokio::test]
+    async fn upload_rejects_absolute_path() {
+        let (tool, _dir) = tool_with_tempdir();
+        let b64 = B64.encode(b"x");
+        let err = tool
+            .invoke(serde_json::json!({
+                "path": "/etc/passwd",
+                "content_base64": b64,
+            }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn upload_rejects_parent_ref() {
+        let (tool, _dir) = tool_with_tempdir();
+        let b64 = B64.encode(b"x");
+        let err = tool
+            .invoke(serde_json::json!({
+                "path": "../escape",
+                "content_base64": b64,
+            }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn upload_rejects_invalid_base64() {
+        let (tool, _dir) = tool_with_tempdir();
+        let err = tool
+            .invoke(serde_json::json!({
+                "path": "x",
+                "content_base64": "this is not base64 !!!",
+            }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn upload_rejects_oversize_payload() {
+        let (tool, _dir) = tool_with_tempdir();
+        let payload = vec![0u8; 32];
+        let b64 = B64.encode(&payload);
+        let err = tool
+            .invoke(serde_json::json!({
+                "path": "x",
+                "content_base64": b64,
+                "max_bytes": 16,
+            }))
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { message, .. } => {
+                assert!(message.contains("exceeds max_bytes"), "got: {message}");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn upload_rejects_unknown_field() {
+        let (tool, _dir) = tool_with_tempdir();
+        let err = tool
+            .invoke(serde_json::json!({
+                "path": "x",
+                "content_base64": "",
+                "extra": 1,
+            }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn upload_fails_closed_without_staging() {
+        let tool = UploadTool::default();
+        let b64 = B64.encode(b"x");
+        let err = tool
+            .invoke(serde_json::json!({
+                "path": "y",
+                "content_base64": b64,
+            }))
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { message, .. } => {
+                assert!(message.contains("not wired"), "got: {message}");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_name_is_canonical_mvm_prefix() {
+        assert_eq!(UploadTool::default().name(), TOOL_NAME);
+        assert!(TOOL_NAME.starts_with("mvm."));
+    }
+}

--- a/crates/mvm-supervisor/src/tools/web_fetch.rs
+++ b/crates/mvm-supervisor/src/tools/web_fetch.rs
@@ -96,7 +96,7 @@ pub enum FetchError {
 
 /// Default fetcher — refuses every call with [`FetchError::Unwired`].
 /// Used as the substrate's fail-closed placeholder; gets swapped for
-/// a real HTTP client in a follow-up slice.
+/// a real HTTP client in production.
 pub struct NoopHttpFetcher;
 
 #[async_trait]
@@ -105,6 +105,109 @@ impl HttpFetcher for NoopHttpFetcher {
         Err(FetchError::Unwired)
     }
 }
+
+/// Production [`HttpFetcher`] backed by a shared
+/// [`reqwest::Client`]. The client is built once at construction
+/// so the TLS handshake + DNS cache amortize across calls. Body
+/// reads use [`reqwest::Response::chunk`] in a manual loop so
+/// `max_bytes` is enforced incrementally — a server that lies
+/// about Content-Length cannot exhaust supervisor memory.
+///
+/// HTTPS-only is enforced upstream in [`WebFetchTool::invoke`];
+/// the fetcher trusts its caller did that and does not re-check.
+/// Operator-supplied timeout via `ReqwestHttpFetcher::new` (default
+/// 30 s) caps the round-trip wall-clock for both connect and read
+/// phases.
+pub struct ReqwestHttpFetcher {
+    client: reqwest::Client,
+}
+
+impl ReqwestHttpFetcher {
+    /// Default timeout for one fetch round-trip (connect + read).
+    /// Conservative — most legitimate fetches complete in <2 s; the
+    /// 30 s upper bound forgives slow upstreams without letting a
+    /// hung connection occupy a tokio task forever.
+    pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+    /// Build with [`Self::DEFAULT_TIMEOUT_SECS`].
+    pub fn new() -> Result<Self, FetchError> {
+        Self::with_timeout_secs(Self::DEFAULT_TIMEOUT_SECS)
+    }
+
+    /// Build with an explicit timeout.
+    pub fn with_timeout_secs(timeout_secs: u64) -> Result<Self, FetchError> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout_secs))
+            .build()
+            .map_err(|e| FetchError::Network(format!("building reqwest client: {e}")))?;
+        Ok(Self { client })
+    }
+}
+
+#[async_trait]
+impl HttpFetcher for ReqwestHttpFetcher {
+    async fn fetch(&self, url: &Url, max_bytes: u64) -> Result<FetchedResponse, FetchError> {
+        let mut response = self
+            .client
+            .get(url.clone())
+            .send()
+            .await
+            .map_err(|e| FetchError::Network(e.to_string()))?;
+        let status = response.status().as_u16();
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        // Streaming accumulator. A server that lies about
+        // Content-Length still can't push past `max_bytes` because
+        // we hard-cut after each chunk lands.
+        let cap = max_bytes as usize;
+        let mut body: Vec<u8> = Vec::with_capacity(cap.min(64 * 1024));
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|e| FetchError::Network(e.to_string()))?
+        {
+            if body.len().saturating_add(chunk.len()) > cap {
+                return Err(FetchError::BodyTooLarge { limit: max_bytes });
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok(FetchedResponse {
+            status,
+            body,
+            content_type,
+        })
+    }
+}
+
+/// Parse a comma-separated env-var value into a set of allowlisted
+/// hostnames. Empty/missing returns an empty set (the fail-closed
+/// default the substrate ships with).
+///
+/// Whitespace around commas is trimmed; empty entries are dropped so
+/// a trailing comma in the env var doesn't widen the allowlist.
+/// Hostnames are stored verbatim — the caller is responsible for
+/// ensuring they match `url.host_str()` exactly (lower-case ASCII
+/// in practice).
+///
+/// Example: `MVM_WEB_FETCH_ALLOWLIST=api.openai.com,api.anthropic.com`.
+pub fn allowlist_from_env_var(var_name: &str) -> std::collections::BTreeSet<String> {
+    let Ok(raw) = std::env::var(var_name) else {
+        return std::collections::BTreeSet::new();
+    };
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// Canonical env-var name carrying the `mvm.web_fetch` host
+/// allowlist. Read once at supervisor / dispatcher start.
+pub const ALLOWLIST_ENV_VAR: &str = "MVM_WEB_FETCH_ALLOWLIST";
 
 /// One agent-callable web fetch, scoped to an allowlist of upstream
 /// hosts.
@@ -505,5 +608,84 @@ mod tests {
     fn fail_closed_is_the_default_construction() {
         let t = WebFetchTool::default();
         assert!(t.allowlist().is_empty());
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // allowlist_from_env_var
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn allowlist_from_env_var_parses_comma_separated() {
+        // Use a process-unique var name so parallel tests don't
+        // race on the same key.
+        let var = "MVM_TEST_WEB_FETCH_ALLOWLIST_PARSE";
+        // SAFETY: tests are single-threaded for this var; the name
+        // is unique to this test.
+        unsafe {
+            std::env::set_var(var, "api.openai.com,api.anthropic.com,api.brave.com");
+        }
+        let set = allowlist_from_env_var(var);
+        assert!(set.contains("api.openai.com"));
+        assert!(set.contains("api.anthropic.com"));
+        assert!(set.contains("api.brave.com"));
+        assert_eq!(set.len(), 3);
+        unsafe {
+            std::env::remove_var(var);
+        }
+    }
+
+    #[test]
+    fn allowlist_from_env_var_drops_empty_entries_and_trims_whitespace() {
+        let var = "MVM_TEST_WEB_FETCH_ALLOWLIST_TRIM";
+        unsafe {
+            std::env::set_var(var, "  api.openai.com  , ,, api.brave.com,");
+        }
+        let set = allowlist_from_env_var(var);
+        assert!(set.contains("api.openai.com"));
+        assert!(set.contains("api.brave.com"));
+        // Empty entries (`,,` / trailing comma) and whitespace-only
+        // entries don't widen the allowlist.
+        assert_eq!(set.len(), 2);
+        unsafe {
+            std::env::remove_var(var);
+        }
+    }
+
+    #[test]
+    fn allowlist_from_env_var_unset_returns_empty_set() {
+        // A truly-unset var must produce an empty set, not panic.
+        // Pick a name unlikely to be set by any CI environment.
+        let set = allowlist_from_env_var("MVM_TEST_WEB_FETCH_ALLOWLIST_DEFINITELY_NOT_SET_XYZZY");
+        assert!(set.is_empty());
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // ReqwestHttpFetcher
+    //
+    // Live network behaviour is not exercised here — the impl is
+    // covered by the policy/validation layer's tests against a
+    // stub fetcher. These tests pin the construction surface so a
+    // future refactor that breaks `new()` / `with_timeout_secs()`
+    // trips loudly.
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn reqwest_fetcher_constructs_with_default_timeout() {
+        let _f = ReqwestHttpFetcher::new().expect("build default reqwest fetcher");
+    }
+
+    #[test]
+    fn reqwest_fetcher_constructs_with_explicit_timeout() {
+        let _f = ReqwestHttpFetcher::with_timeout_secs(5).expect("build with timeout");
+    }
+
+    #[test]
+    fn reqwest_fetcher_is_a_host_mediated_tool_via_web_fetch() {
+        // Compile-check: `ReqwestHttpFetcher` satisfies the
+        // `HttpFetcher` trait so it slots into
+        // `WebFetchTool::with_fetcher`.
+        let f = ReqwestHttpFetcher::new().unwrap();
+        let _tool =
+            WebFetchTool::with_allowlist(["api.example".to_string()]).with_fetcher(Arc::new(f));
     }
 }

--- a/crates/mvm-supervisor/src/tools/web_fetch.rs
+++ b/crates/mvm-supervisor/src/tools/web_fetch.rs
@@ -1,0 +1,509 @@
+//! `mvm.web_fetch` — single-URL HTTPS fetch through a per-tenant
+//! host allowlist.
+//!
+//! Plan 60 Phase 7. The agent passes a URL; the supervisor:
+//!
+//! 1. Parses the URL — rejects anything that isn't a syntactically
+//!    valid RFC-3986 absolute reference with an explicit host.
+//! 2. Requires `https://` — `http://`, `file://`, `ftp://`, and any
+//!    other scheme fail closed. Plain-HTTP fetches would side-step
+//!    every cert pin and proxy guarantee the rest of plan 60 lays
+//!    down.
+//! 3. Checks the host against the tool's allowlist — an empty
+//!    allowlist means *nothing is fetchable* (fail-closed default;
+//!    operators must opt in per upstream).
+//! 4. Delegates the actual HTTP call to an injected
+//!    [`HttpFetcher`] so the policy/validation layers can be tested
+//!    without live network IO. The default fetcher is
+//!    [`NoopHttpFetcher`], which always returns
+//!    [`FetchError::Unwired`]; a reqwest-backed impl lands in a
+//!    follow-up slice (Phase 7 plan: "host-mediated tools table").
+//!
+//! ## Why bodies come back base64
+//!
+//! Response bodies may be binary (images, gzip-compressed JSON, the
+//! occasional UTF-16 surprise). Base64 over the JSON wire keeps the
+//! tool's contract uniform: every fetched byte round-trips losslessly
+//! regardless of `Content-Type`. The `bytes` field carries the
+//! pre-encoding length so callers can decide whether to skip the
+//! decode.
+//!
+//! ## What this tool is NOT
+//!
+//! - Not a search tool — `mvm.web_search` is a sibling that takes a
+//!   query string and routes through a provider.
+//! - Not a download tool — `mvm.download` is for retrieving artifacts
+//!   into the agent's persistent overlay (with checksum verification);
+//!   `web_fetch` is for inline-by-value reads.
+//! - Not a proxy — outbound traffic from the supervisor is fronted
+//!   by the same egress proxy (`L7EgressProxy`) that mediates the
+//!   guest's outbound traffic.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+
+use super::{HostMediatedTool, ToolInvokeError};
+
+pub const TOOL_NAME: &str = "mvm.web_fetch";
+
+/// Default body cap. 1 MiB is the working budget for "fetch a page
+/// and pass it back to the LLM"; anything larger should use
+/// `mvm.download` into the overlay.
+pub const DEFAULT_MAX_BYTES: u64 = 1 << 20;
+
+/// Hard upper bound on `max_bytes` so a misconfigured agent can't
+/// request an unbounded read. Caller-supplied values above this are
+/// clamped; the JSON schema doesn't reject them so older clients
+/// still make progress.
+pub const MAX_ALLOWED_BYTES: u64 = 16 * (1 << 20);
+
+/// The supervisor's HTTP-fetch adapter. Injected so the tool's
+/// policy/validation layers are testable without live network IO.
+#[async_trait]
+pub trait HttpFetcher: Send + Sync {
+    async fn fetch(&self, url: &Url, max_bytes: u64) -> Result<FetchedResponse, FetchError>;
+}
+
+/// Result returned by the fetcher impl.
+#[derive(Debug, Clone)]
+pub struct FetchedResponse {
+    pub status: u16,
+    pub body: Vec<u8>,
+    pub content_type: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum FetchError {
+    #[error("network error: {0}")]
+    Network(String),
+    #[error("response exceeded max_bytes ({limit})")]
+    BodyTooLarge { limit: u64 },
+    #[error("non-success status: {status}")]
+    BadStatus { status: u16 },
+    /// The default fetcher is not wired. A production caller plugs
+    /// a real `reqwest` (or curl, hyper, ureq, …) impl via
+    /// [`WebFetchTool::with_fetcher`].
+    #[error("fetcher not wired (NoopHttpFetcher)")]
+    Unwired,
+}
+
+/// Default fetcher — refuses every call with [`FetchError::Unwired`].
+/// Used as the substrate's fail-closed placeholder; gets swapped for
+/// a real HTTP client in a follow-up slice.
+pub struct NoopHttpFetcher;
+
+#[async_trait]
+impl HttpFetcher for NoopHttpFetcher {
+    async fn fetch(&self, _url: &Url, _max_bytes: u64) -> Result<FetchedResponse, FetchError> {
+        Err(FetchError::Unwired)
+    }
+}
+
+/// One agent-callable web fetch, scoped to an allowlist of upstream
+/// hosts.
+pub struct WebFetchTool {
+    /// Hosts the tool is permitted to fetch from. Empty = nothing
+    /// allowed (fail-closed). Match is exact on `url.host_str()`;
+    /// wildcards (e.g. `*.example.com`) live in a follow-up slice
+    /// once we have a use case for them.
+    allowed_hosts: BTreeSet<String>,
+    /// Pluggable HTTP impl. Defaults to [`NoopHttpFetcher`].
+    fetcher: Arc<dyn HttpFetcher>,
+}
+
+impl WebFetchTool {
+    /// Empty allowlist + Noop fetcher. Every invoke returns
+    /// `Upstream` with a clear "not on allowlist" message. Useful as
+    /// the default when no per-tenant config is wired yet.
+    pub fn fail_closed() -> Self {
+        Self {
+            allowed_hosts: BTreeSet::new(),
+            fetcher: Arc::new(NoopHttpFetcher),
+        }
+    }
+
+    /// Build with an explicit host allowlist. Production callers
+    /// pull this list from the plan's `egress_policy` bundle (or a
+    /// future `tool_policy` field that carries per-tool config).
+    pub fn with_allowlist(hosts: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            allowed_hosts: hosts.into_iter().collect(),
+            fetcher: Arc::new(NoopHttpFetcher),
+        }
+    }
+
+    /// Swap the default Noop fetcher for a real HTTP impl. Returns
+    /// `self` for chaining.
+    pub fn with_fetcher(mut self, fetcher: Arc<dyn HttpFetcher>) -> Self {
+        self.fetcher = fetcher;
+        self
+    }
+
+    /// Read-only view of the allowlist for diagnostic surfaces
+    /// (`mvmctl doctor`, the error string on a denied fetch).
+    pub fn allowlist(&self) -> Vec<&str> {
+        self.allowed_hosts.iter().map(String::as_str).collect()
+    }
+}
+
+impl Default for WebFetchTool {
+    fn default() -> Self {
+        Self::fail_closed()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WebFetchParams {
+    pub url: String,
+    #[serde(default = "default_max_bytes")]
+    pub max_bytes: u64,
+}
+
+fn default_max_bytes() -> u64 {
+    DEFAULT_MAX_BYTES
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WebFetchResult {
+    pub status: u16,
+    pub url: String,
+    pub content_type: Option<String>,
+    /// URL-safe-no-pad base64 of the response body, capped at
+    /// `min(max_bytes, MAX_ALLOWED_BYTES)`.
+    pub body_base64: String,
+    /// Pre-encoding byte length. Useful for callers that want to
+    /// know "is this binary big" without decoding.
+    pub bytes: u64,
+}
+
+#[async_trait]
+impl HostMediatedTool for WebFetchTool {
+    fn name(&self) -> &'static str {
+        TOOL_NAME
+    }
+
+    async fn invoke(
+        &self,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ToolInvokeError> {
+        let parsed: WebFetchParams =
+            serde_json::from_value(params).map_err(|e| ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: e.to_string(),
+            })?;
+
+        let url = Url::parse(&parsed.url).map_err(|e| ToolInvokeError::InvalidParams {
+            tool: TOOL_NAME.to_string(),
+            message: format!("invalid url: {e}"),
+        })?;
+
+        if url.scheme() != "https" {
+            return Err(ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: format!(
+                    "scheme must be https, got {scheme:?}",
+                    scheme = url.scheme()
+                ),
+            });
+        }
+
+        let host = url
+            .host_str()
+            .ok_or_else(|| ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: "url missing host".to_string(),
+            })?;
+
+        if !self.allowed_hosts.contains(host) {
+            return Err(ToolInvokeError::Upstream {
+                tool: TOOL_NAME.to_string(),
+                message: format!(
+                    "host {host:?} not on per-tenant allowlist (allowed: {allowed:?})",
+                    allowed = self.allowlist()
+                ),
+            });
+        }
+
+        let max = parsed.max_bytes.min(MAX_ALLOWED_BYTES);
+        let resp = self
+            .fetcher
+            .fetch(&url, max)
+            .await
+            .map_err(|e| ToolInvokeError::Upstream {
+                tool: TOOL_NAME.to_string(),
+                message: e.to_string(),
+            })?;
+
+        let bytes = resp.body.len() as u64;
+        let body_base64 = URL_SAFE_NO_PAD.encode(&resp.body);
+
+        serde_json::to_value(WebFetchResult {
+            status: resp.status,
+            url: url.to_string(),
+            content_type: resp.content_type,
+            body_base64,
+            bytes,
+        })
+        .map_err(|e| ToolInvokeError::Upstream {
+            tool: TOOL_NAME.to_string(),
+            message: format!("serializing result: {e}"),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test fetcher — records its calls + returns canned responses.
+    struct StubFetcher {
+        calls: std::sync::Mutex<Vec<(String, u64)>>,
+        response: FetchedResponse,
+    }
+
+    impl StubFetcher {
+        fn new(response: FetchedResponse) -> Self {
+            Self {
+                calls: std::sync::Mutex::new(Vec::new()),
+                response,
+            }
+        }
+        fn calls(&self) -> Vec<(String, u64)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl HttpFetcher for StubFetcher {
+        async fn fetch(&self, url: &Url, max_bytes: u64) -> Result<FetchedResponse, FetchError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((url.to_string(), max_bytes));
+            Ok(self.response.clone())
+        }
+    }
+
+    fn tool_with_stub(
+        hosts: &[&str],
+        response: FetchedResponse,
+    ) -> (WebFetchTool, Arc<StubFetcher>) {
+        let stub = Arc::new(StubFetcher::new(response));
+        let tool = WebFetchTool::with_allowlist(hosts.iter().map(|s| s.to_string()))
+            .with_fetcher(stub.clone());
+        (tool, stub)
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Policy: allowlist
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn denies_unallowlisted_host() {
+        // Exit-test target per plan 60 Phase 7 §"Exit tests":
+        // `mvm_supervisor::tools::web_fetch::tests::denies_unallowlisted_host`.
+        let tool = WebFetchTool::with_allowlist(["api.allowed.example".to_string()]);
+        let err = tool
+            .invoke(serde_json::json!({ "url": "https://evil.example/x" }))
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { tool, message } => {
+                assert_eq!(tool, TOOL_NAME);
+                assert!(message.contains("not on per-tenant allowlist"), "{message}");
+                assert!(message.contains("evil.example"), "{message}");
+                // The allowed list shows up in the message so an
+                // operator can spot "I forgot to allowlist that".
+                assert!(message.contains("api.allowed.example"), "{message}");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_allowlist_denies_every_host() {
+        let tool = WebFetchTool::fail_closed();
+        let err = tool
+            .invoke(serde_json::json!({ "url": "https://anything.example/" }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::Upstream { .. }));
+    }
+
+    #[tokio::test]
+    async fn allowlisted_host_passes_to_fetcher() {
+        let (tool, stub) = tool_with_stub(
+            &["api.allowed.example"],
+            FetchedResponse {
+                status: 200,
+                body: b"hello".to_vec(),
+                content_type: Some("text/plain".to_string()),
+            },
+        );
+        let out = tool
+            .invoke(serde_json::json!({ "url": "https://api.allowed.example/v1/x" }))
+            .await
+            .unwrap();
+        let parsed: WebFetchResult = serde_json::from_value(out).unwrap();
+        assert_eq!(parsed.status, 200);
+        assert_eq!(parsed.bytes, 5);
+        assert_eq!(parsed.content_type.as_deref(), Some("text/plain"));
+        // Body round-trips through base64.
+        let decoded = URL_SAFE_NO_PAD.decode(&parsed.body_base64).unwrap();
+        assert_eq!(decoded, b"hello");
+        // Fetcher saw exactly one call to the requested URL.
+        let calls = stub.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "https://api.allowed.example/v1/x");
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // URL validation
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn rejects_non_https_scheme() {
+        // Plain HTTP would side-step every TLS pin the rest of plan
+        // 60 lays down.
+        let tool = WebFetchTool::with_allowlist(["api.allowed.example".to_string()]);
+        let err = tool
+            .invoke(serde_json::json!({ "url": "http://api.allowed.example/" }))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+        assert!(msg.contains("https"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn rejects_unparseable_url() {
+        let tool = WebFetchTool::with_allowlist(["api.allowed.example".to_string()]);
+        let err = tool
+            .invoke(serde_json::json!({ "url": "not a url" }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn rejects_unknown_field() {
+        // ADR-002 §W4.1 — host-boundary types use
+        // `deny_unknown_fields` so a stale client that adds an
+        // unknown param doesn't silently lose it.
+        let tool = WebFetchTool::fail_closed();
+        let err = tool
+            .invoke(serde_json::json!({
+                "url": "https://api.allowed.example/",
+                "method": "POST"
+            }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // max_bytes plumbing
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn default_max_bytes_is_one_mib() {
+        let (tool, stub) = tool_with_stub(
+            &["api.allowed.example"],
+            FetchedResponse {
+                status: 200,
+                body: vec![],
+                content_type: None,
+            },
+        );
+        tool.invoke(serde_json::json!({ "url": "https://api.allowed.example/" }))
+            .await
+            .unwrap();
+        let calls = stub.calls();
+        assert_eq!(calls[0].1, DEFAULT_MAX_BYTES);
+    }
+
+    #[tokio::test]
+    async fn custom_max_bytes_passes_through() {
+        let (tool, stub) = tool_with_stub(
+            &["api.allowed.example"],
+            FetchedResponse {
+                status: 200,
+                body: vec![],
+                content_type: None,
+            },
+        );
+        tool.invoke(serde_json::json!({
+            "url": "https://api.allowed.example/",
+            "max_bytes": 4096_u64
+        }))
+        .await
+        .unwrap();
+        assert_eq!(stub.calls()[0].1, 4096);
+    }
+
+    #[tokio::test]
+    async fn caller_supplied_max_bytes_clamped_to_max_allowed() {
+        // A misconfigured agent shouldn't be able to request an
+        // unbounded read.
+        let (tool, stub) = tool_with_stub(
+            &["api.allowed.example"],
+            FetchedResponse {
+                status: 200,
+                body: vec![],
+                content_type: None,
+            },
+        );
+        tool.invoke(serde_json::json!({
+            "url": "https://api.allowed.example/",
+            "max_bytes": u64::MAX
+        }))
+        .await
+        .unwrap();
+        assert_eq!(stub.calls()[0].1, MAX_ALLOWED_BYTES);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Fetcher errors propagate as Upstream
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn noop_fetcher_surfaces_unwired_via_upstream_error() {
+        let tool = WebFetchTool::with_allowlist(["api.allowed.example".to_string()]);
+        let err = tool
+            .invoke(serde_json::json!({ "url": "https://api.allowed.example/" }))
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { tool, message } => {
+                assert_eq!(tool, TOOL_NAME);
+                assert!(message.contains("not wired"), "{message}");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Trait surface
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn tool_name_is_canonical_mvm_prefix() {
+        let tool = WebFetchTool::default();
+        assert_eq!(tool.name(), TOOL_NAME);
+        assert!(TOOL_NAME.starts_with("mvm."));
+    }
+
+    #[test]
+    fn fail_closed_is_the_default_construction() {
+        let t = WebFetchTool::default();
+        assert!(t.allowlist().is_empty());
+    }
+}

--- a/crates/mvm-supervisor/src/tools/web_search.rs
+++ b/crates/mvm-supervisor/src/tools/web_search.rs
@@ -401,6 +401,125 @@ impl HostMediatedTool for WebSearchTool {
     }
 }
 
+/// Tavily Search API provider. Documented at
+/// <https://docs.tavily.com/api-reference/endpoint/search>.
+///
+/// Tavily's auth shape differs from Brave's: the API key travels
+/// inside the JSON request body (`"api_key": "<key>"`), and the
+/// search itself is a POST (not a GET-with-query-string). Otherwise
+/// the abstraction matches — supervisor owns the key, the agent
+/// never sees it.
+///
+/// Tavily is "search-for-LLMs" by design: each result row carries
+/// a `content` field that's an LLM-friendly snippet (often longer
+/// than Brave's `description`). We map it to `snippet` so the
+/// agent surface stays uniform across providers.
+pub struct TavilySearchProvider {
+    api_key: String,
+    client: reqwest::Client,
+    endpoint: String,
+}
+
+impl TavilySearchProvider {
+    /// Canonical Tavily Search API endpoint.
+    pub const DEFAULT_ENDPOINT: &'static str = "https://api.tavily.com/search";
+
+    /// Default per-call timeout. Tavily aggregates multiple
+    /// upstreams and historically responds in 1-3 s; 20 s gives
+    /// plenty of headroom for the slow-tail case.
+    const DEFAULT_TIMEOUT_SECS: u64 = 20;
+
+    /// Build with the default endpoint + a fresh reqwest client.
+    pub fn new(api_key: impl Into<String>) -> Result<Self, SearchError> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(Self::DEFAULT_TIMEOUT_SECS))
+            .build()
+            .map_err(|e| SearchError::Upstream(format!("building reqwest client: {e}")))?;
+        Ok(Self {
+            api_key: api_key.into(),
+            client,
+            endpoint: Self::DEFAULT_ENDPOINT.to_string(),
+        })
+    }
+
+    /// Test seam — point at a mock HTTP server. Production callers
+    /// stick with the default.
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into();
+        self
+    }
+}
+
+/// Minimal extractor for Tavily's `/search` response. Like the
+/// Brave extractor, we intentionally do NOT
+/// `deny_unknown_fields` — Tavily adds optional fields over time
+/// (`answer`, `images`, `follow_up_questions`, `response_time`)
+/// and an upstream addition shouldn't brittle our parse.
+#[derive(Debug, Deserialize)]
+struct TavilyResponse {
+    #[serde(default)]
+    results: Vec<TavilyResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TavilyResult {
+    title: String,
+    url: String,
+    #[serde(default)]
+    content: String,
+}
+
+#[async_trait]
+impl SearchProvider for TavilySearchProvider {
+    fn name(&self) -> &'static str {
+        "tavily"
+    }
+
+    async fn search(&self, query: &str, max_results: u32) -> Result<Vec<SearchHit>, SearchError> {
+        // Tavily's documented cap is 20 results per call. Clamp so a
+        // caller-supplied 50 doesn't trip an upstream 422.
+        let max = max_results.min(20);
+        let body = serde_json::json!({
+            "api_key": self.api_key,
+            "query": query,
+            "max_results": max,
+        });
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| SearchError::Upstream(e.to_string()))?;
+        let status = response.status();
+        if status.as_u16() == 429 {
+            return Err(SearchError::RateLimited);
+        }
+        if !status.is_success() {
+            return Err(SearchError::Upstream(format!(
+                "Tavily search returned status {status}"
+            )));
+        }
+        let parsed: TavilyResponse = response
+            .json()
+            .await
+            .map_err(|e| SearchError::Upstream(format!("decoding Tavily response: {e}")))?;
+        let hits: Vec<SearchHit> = parsed
+            .results
+            .into_iter()
+            .map(|r| SearchHit {
+                title: r.title,
+                url: r.url,
+                snippet: r.content,
+            })
+            .collect();
+        if hits.is_empty() {
+            return Err(SearchError::Empty);
+        }
+        Ok(hits)
+    }
+}
+
 /// Parse a comma-separated env-var into a set of provider names.
 /// Same shape as [`crate::tools::web_fetch::allowlist_from_env_var`];
 /// kept as a sibling for tidiness rather than re-exported, since
@@ -430,6 +549,11 @@ pub const DEFAULT_PROVIDER_ENV_VAR: &str = "MVM_WEB_SEARCH_DEFAULT";
 /// When unset (and `"brave"` is on the allowlist), the "allowed
 /// but unregistered" config-drift error fires on first invoke.
 pub const BRAVE_API_KEY_ENV_VAR: &str = "BRAVE_SEARCH_API_KEY";
+
+/// Canonical env-var name for the operator's Tavily API key. Same
+/// posture as [`BRAVE_API_KEY_ENV_VAR`] — set this and put
+/// `"tavily"` on `MVM_WEB_SEARCH_ALLOWLIST` to enable.
+pub const TAVILY_API_KEY_ENV_VAR: &str = "TAVILY_API_KEY";
 
 #[cfg(test)]
 mod tests {
@@ -776,6 +900,78 @@ mod tests {
         }"#;
         let r: BraveResult = serde_json::from_str(json).expect("parse");
         assert_eq!(r.description, "");
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // TavilySearchProvider
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn tavily_provider_is_named_tavily() {
+        let p = TavilySearchProvider::new("test-key").expect("build tavily");
+        assert_eq!(p.name(), "tavily");
+    }
+
+    #[test]
+    fn tavily_provider_constructs_with_default_endpoint() {
+        let p = TavilySearchProvider::new("key").unwrap();
+        assert_eq!(p.endpoint, TavilySearchProvider::DEFAULT_ENDPOINT);
+    }
+
+    #[test]
+    fn tavily_provider_with_endpoint_overrides() {
+        let p = TavilySearchProvider::new("key")
+            .unwrap()
+            .with_endpoint("https://mock.test/search");
+        assert_eq!(p.endpoint, "https://mock.test/search");
+    }
+
+    #[test]
+    fn tavily_response_parses_canonical_payload() {
+        let json = r#"{
+            "query": "rust async",
+            "response_time": 1.23,
+            "results": [
+                {
+                    "title": "Tokio",
+                    "url": "https://tokio.rs/",
+                    "content": "An asynchronous runtime for Rust",
+                    "score": 0.95,
+                    "raw_content": null
+                },
+                {
+                    "title": "async-std",
+                    "url": "https://async.rs/",
+                    "content": "Async version of the Rust standard library"
+                }
+            ]
+        }"#;
+        let parsed: TavilyResponse = serde_json::from_str(json).expect("parse");
+        assert_eq!(parsed.results.len(), 2);
+        assert_eq!(parsed.results[0].title, "Tokio");
+        assert_eq!(parsed.results[0].url, "https://tokio.rs/");
+        assert!(parsed.results[0].content.contains("asynchronous"));
+    }
+
+    #[test]
+    fn tavily_response_handles_missing_results_field() {
+        // A query with no hits may omit `results`. The extractor
+        // defaults to empty so a downstream `if hits.is_empty()`
+        // check fires SearchError::Empty cleanly.
+        let json = r#"{ "query": "x", "response_time": 0.4 }"#;
+        let parsed: TavilyResponse = serde_json::from_str(json).expect("parse");
+        assert!(parsed.results.is_empty());
+    }
+
+    #[test]
+    fn tavily_result_tolerates_missing_content() {
+        // Tavily occasionally returns hits without `content` for
+        // image / video rows. Map to empty snippet.
+        let json = r#"{
+            "title": "x", "url": "https://x.test/"
+        }"#;
+        let r: TavilyResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(r.content, "");
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/crates/mvm-supervisor/src/tools/web_search.rs
+++ b/crates/mvm-supervisor/src/tools/web_search.rs
@@ -108,6 +108,131 @@ impl SearchProvider for NoopSearchProvider {
     }
 }
 
+/// Brave Search API provider. Documented at
+/// <https://api.search.brave.com/app/documentation>.
+///
+/// Auth is a `X-Subscription-Token` header carrying the operator's
+/// API key. The agent never sees the key — it's pinned inside this
+/// struct at construction and consumed only by the HTTP send.
+///
+/// ## Wire shape
+///
+/// Brave's `/res/v1/web/search` returns JSON with a `web.results`
+/// array; each row carries `{ title, url, description }`. Other
+/// fields exist (mixed, query, type, …) but we ignore them — this
+/// is an upstream API so `deny_unknown_fields` would brittle the
+/// type to a single Brave version. The minimal extractor types
+/// `BraveResponse`/`BraveWebResults`/`BraveResult` carry only what
+/// we need.
+pub struct BraveSearchProvider {
+    api_key: String,
+    client: reqwest::Client,
+    endpoint: String,
+}
+
+impl BraveSearchProvider {
+    /// Canonical Brave Search API endpoint.
+    pub const DEFAULT_ENDPOINT: &'static str = "https://api.search.brave.com/res/v1/web/search";
+
+    /// Build with the default endpoint + a fresh reqwest client.
+    /// `api_key` is the value of the operator's
+    /// `X-Subscription-Token`. The caller is responsible for
+    /// sourcing it from a secret store; this constructor takes the
+    /// raw bytes and pins them inside `self`.
+    pub fn new(api_key: impl Into<String>) -> Result<Self, SearchError> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .map_err(|e| SearchError::Upstream(format!("building reqwest client: {e}")))?;
+        Ok(Self {
+            api_key: api_key.into(),
+            client,
+            endpoint: Self::DEFAULT_ENDPOINT.to_string(),
+        })
+    }
+
+    /// Override the endpoint — used by tests to point at a mock
+    /// HTTP server. Production callers stick with the default.
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into();
+        self
+    }
+}
+
+/// Minimal extractor for the Brave web-search response. We
+/// intentionally do not `deny_unknown_fields` — Brave's payload
+/// carries many fields we don't care about and adding/removing one
+/// upstream shouldn't break our parse.
+#[derive(Debug, Deserialize)]
+struct BraveResponse {
+    #[serde(default)]
+    web: Option<BraveWebResults>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BraveWebResults {
+    #[serde(default)]
+    results: Vec<BraveResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BraveResult {
+    title: String,
+    url: String,
+    #[serde(default)]
+    description: String,
+}
+
+#[async_trait]
+impl SearchProvider for BraveSearchProvider {
+    fn name(&self) -> &'static str {
+        "brave"
+    }
+
+    async fn search(&self, query: &str, max_results: u32) -> Result<Vec<SearchHit>, SearchError> {
+        // Brave's `count` param caps at 20 per their docs. Clamp
+        // before forwarding so a caller-supplied 50 doesn't trip a
+        // 422 from upstream.
+        let count = max_results.min(20);
+        let response = self
+            .client
+            .get(&self.endpoint)
+            .header("X-Subscription-Token", &self.api_key)
+            .query(&[("q", query), ("count", &count.to_string())])
+            .send()
+            .await
+            .map_err(|e| SearchError::Upstream(e.to_string()))?;
+        let status = response.status();
+        if status.as_u16() == 429 {
+            return Err(SearchError::RateLimited);
+        }
+        if !status.is_success() {
+            return Err(SearchError::Upstream(format!(
+                "Brave search returned status {status}"
+            )));
+        }
+        let parsed: BraveResponse = response
+            .json()
+            .await
+            .map_err(|e| SearchError::Upstream(format!("decoding Brave response: {e}")))?;
+        let hits: Vec<SearchHit> = parsed
+            .web
+            .map(|w| w.results)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|r| SearchHit {
+                title: r.title,
+                url: r.url,
+                snippet: r.description,
+            })
+            .collect();
+        if hits.is_empty() {
+            return Err(SearchError::Empty);
+        }
+        Ok(hits)
+    }
+}
+
 /// One agent-callable search surface, scoped to an allowlist of
 /// provider names.
 pub struct WebSearchTool {
@@ -275,6 +400,36 @@ impl HostMediatedTool for WebSearchTool {
         })
     }
 }
+
+/// Parse a comma-separated env-var into a set of provider names.
+/// Same shape as [`crate::tools::web_fetch::allowlist_from_env_var`];
+/// kept as a sibling for tidiness rather than re-exported, since
+/// the audit / error messages here name "provider" specifically.
+///
+/// Example: `MVM_WEB_SEARCH_ALLOWLIST=brave,google`.
+pub fn allowlist_from_env_var(var_name: &str) -> std::collections::BTreeSet<String> {
+    let Ok(raw) = std::env::var(var_name) else {
+        return std::collections::BTreeSet::new();
+    };
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// Canonical env-var name for the `mvm.web_search` provider
+/// allowlist.
+pub const ALLOWLIST_ENV_VAR: &str = "MVM_WEB_SEARCH_ALLOWLIST";
+
+/// Canonical env-var name for the `mvm.web_search` default
+/// provider. Must appear in the allowlist to be reachable.
+pub const DEFAULT_PROVIDER_ENV_VAR: &str = "MVM_WEB_SEARCH_DEFAULT";
+
+/// Canonical env-var name for the operator's Brave Search API key.
+/// When unset (and `"brave"` is on the allowlist), the "allowed
+/// but unregistered" config-drift error fires on first invoke.
+pub const BRAVE_API_KEY_ENV_VAR: &str = "BRAVE_SEARCH_API_KEY";
 
 #[cfg(test)]
 mod tests {
@@ -539,5 +694,113 @@ mod tests {
     fn noop_provider_is_named_noop() {
         let p = NoopSearchProvider;
         assert_eq!(p.name(), "noop");
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // BraveSearchProvider
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn brave_provider_is_named_brave() {
+        let p = BraveSearchProvider::new("test-key").expect("build brave");
+        assert_eq!(p.name(), "brave");
+    }
+
+    #[test]
+    fn brave_provider_constructs_with_default_endpoint() {
+        let p = BraveSearchProvider::new("key").unwrap();
+        assert_eq!(p.endpoint, BraveSearchProvider::DEFAULT_ENDPOINT);
+    }
+
+    #[test]
+    fn brave_provider_with_endpoint_overrides() {
+        let p = BraveSearchProvider::new("key")
+            .unwrap()
+            .with_endpoint("https://mock.test/search");
+        assert_eq!(p.endpoint, "https://mock.test/search");
+    }
+
+    #[test]
+    fn brave_response_parses_minimal_payload() {
+        // Parsing pins: the minimal extractor types must consume a
+        // real-shaped Brave response without choking on extra
+        // fields and must map description → snippet.
+        let json = r#"{
+            "type": "search",
+            "query": { "original": "rust" },
+            "mixed": { "type": "mixed", "main": [], "top": [], "side": [] },
+            "web": {
+                "type": "search",
+                "results": [
+                    {
+                        "title": "The Rust Programming Language",
+                        "url": "https://www.rust-lang.org/",
+                        "description": "A language empowering everyone…",
+                        "is_source_local": false
+                    },
+                    {
+                        "title": "Cargo",
+                        "url": "https://crates.io/",
+                        "description": "The Rust package registry"
+                    }
+                ]
+            }
+        }"#;
+        let parsed: BraveResponse = serde_json::from_str(json).expect("parse");
+        let web = parsed.web.expect("web array present");
+        assert_eq!(web.results.len(), 2);
+        assert_eq!(web.results[0].title, "The Rust Programming Language");
+        assert_eq!(web.results[0].url, "https://www.rust-lang.org/");
+        assert!(
+            web.results[0]
+                .description
+                .starts_with("A language empowering")
+        );
+    }
+
+    #[test]
+    fn brave_response_handles_missing_web_field() {
+        // A search with no results may omit the `web` key entirely.
+        // Don't panic; map to empty hits.
+        let json = r#"{ "type": "search", "query": { "original": "x" } }"#;
+        let parsed: BraveResponse = serde_json::from_str(json).expect("parse");
+        assert!(parsed.web.is_none());
+    }
+
+    #[test]
+    fn brave_result_tolerates_missing_description() {
+        // `description` defaults to empty string when absent, so a
+        // snippet-less hit still produces a SearchHit shape.
+        let json = r#"{
+            "title": "x", "url": "https://x.test/"
+        }"#;
+        let r: BraveResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(r.description, "");
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Env-var config helpers
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn allowlist_env_var_parses_comma_separated() {
+        let var = "MVM_TEST_WEB_SEARCH_ALLOWLIST_PARSE";
+        unsafe {
+            std::env::set_var(var, "brave,google,duckduckgo");
+        }
+        let set = allowlist_from_env_var(var);
+        assert!(set.contains("brave"));
+        assert!(set.contains("google"));
+        assert!(set.contains("duckduckgo"));
+        assert_eq!(set.len(), 3);
+        unsafe {
+            std::env::remove_var(var);
+        }
+    }
+
+    #[test]
+    fn allowlist_env_var_unset_returns_empty_set() {
+        let set = allowlist_from_env_var("MVM_TEST_WEB_SEARCH_DEFINITELY_NOT_SET_PLUGH");
+        assert!(set.is_empty());
     }
 }

--- a/crates/mvm-supervisor/src/tools/web_search.rs
+++ b/crates/mvm-supervisor/src/tools/web_search.rs
@@ -1,0 +1,543 @@
+//! `mvm.web_search` — provider-fronted web search through a
+//! per-tenant provider allowlist.
+//!
+//! Plan 60 Phase 7. The agent passes a query string + (optionally) a
+//! preferred provider; the supervisor:
+//!
+//! 1. Validates the query — non-empty, length-capped, no embedded
+//!    control characters that would confuse upstream APIs.
+//! 2. Resolves the provider — caller-supplied name (`"brave"`,
+//!    `"google"`, …) or the tool's `default_provider` if absent.
+//! 3. Checks the provider against the tool's allowlist. An empty
+//!    allowlist means *no provider is reachable* (fail-closed
+//!    default; operators must opt in per provider).
+//! 4. Delegates to an injected [`SearchProvider`] so the
+//!    policy/validation layers are testable without an upstream
+//!    HTTP client. The default provider is [`NoopSearchProvider`],
+//!    which always returns [`SearchError::Unwired`]; real Brave /
+//!    Google / DuckDuckGo impls land in follow-up slices.
+//!
+//! ## Why provider-name allowlists instead of host allowlists
+//!
+//! `mvm.web_fetch` constrains the *destination host* (the agent
+//! decides where to look). `mvm.web_search` constrains the
+//! *provider service* — the agent has no say over which upstream
+//! the provider impl ultimately calls. Pinning by provider name is
+//! the granularity that matches the security model: an operator
+//! grants "Brave can search; not Google, not Bing." A future slice
+//! may add per-provider host pinning so a wedged DNS doesn't let a
+//! provider impl reach the wrong endpoint.
+//!
+//! ## What this tool is NOT
+//!
+//! - Not a fetch tool — see `mvm.web_fetch`.
+//! - Not a "let the agent pick any API key" surface — provider
+//!   credentials are supervisor-owned. The agent doesn't see them.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::{HostMediatedTool, ToolInvokeError};
+
+pub const TOOL_NAME: &str = "mvm.web_search";
+
+/// Default `max_results` when the caller doesn't specify. Bounded
+/// at the upper end by [`MAX_ALLOWED_RESULTS`].
+pub const DEFAULT_MAX_RESULTS: u32 = 10;
+
+/// Hard upper bound on `max_results`. Caller-supplied values above
+/// this are clamped (not errored) so older clients still make
+/// progress.
+pub const MAX_ALLOWED_RESULTS: u32 = 50;
+
+/// Query-length cap. Defense in depth: most search APIs reject
+/// queries longer than ~512 chars anyway, but pre-rejecting here
+/// keeps the audit chain from logging giant strings.
+pub const MAX_QUERY_LEN: usize = 1024;
+
+/// Pluggable upstream search adapter. Production impls (`BraveProvider`,
+/// `GoogleProvider`, …) wrap their respective HTTP clients;
+/// [`NoopSearchProvider`] is the substrate default and returns
+/// [`SearchError::Unwired`] so the tool ships fail-closed.
+#[async_trait]
+pub trait SearchProvider: Send + Sync {
+    /// Provider name as exposed to the agent. Must be lowercase,
+    /// stable, and unique within a [`WebSearchTool`]'s allowlist.
+    fn name(&self) -> &'static str;
+
+    /// Run a search. `max_results` is the post-clamp upper bound;
+    /// the impl is free to return fewer.
+    async fn search(&self, query: &str, max_results: u32) -> Result<Vec<SearchHit>, SearchError>;
+}
+
+/// One result row in the response array.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SearchHit {
+    pub title: String,
+    pub url: String,
+    pub snippet: String,
+}
+
+#[derive(Debug, Error)]
+pub enum SearchError {
+    #[error("upstream returned no results")]
+    Empty,
+    #[error("upstream API error: {0}")]
+    Upstream(String),
+    #[error("upstream rate-limited")]
+    RateLimited,
+    #[error("provider not wired (NoopSearchProvider)")]
+    Unwired,
+}
+
+/// Default fail-closed provider — refuses every call with
+/// [`SearchError::Unwired`].
+pub struct NoopSearchProvider;
+
+#[async_trait]
+impl SearchProvider for NoopSearchProvider {
+    fn name(&self) -> &'static str {
+        "noop"
+    }
+    async fn search(&self, _query: &str, _max: u32) -> Result<Vec<SearchHit>, SearchError> {
+        Err(SearchError::Unwired)
+    }
+}
+
+/// One agent-callable search surface, scoped to an allowlist of
+/// provider names.
+pub struct WebSearchTool {
+    /// Provider names the tool is permitted to call. Empty =
+    /// nothing reachable (fail-closed).
+    allowed_providers: BTreeSet<String>,
+    /// Provider used when the agent doesn't specify one. Must
+    /// appear in `allowed_providers` to be reachable; if it
+    /// doesn't, the search fails closed with a clear message.
+    default_provider: String,
+    /// Concrete provider impls keyed by `provider.name()`. Built
+    /// via [`Self::register_provider`].
+    providers: std::collections::BTreeMap<String, Arc<dyn SearchProvider>>,
+}
+
+impl WebSearchTool {
+    /// Build with an empty allowlist + no providers wired. Every
+    /// invoke returns `Upstream` with a clear "no providers
+    /// configured" message. Useful as the default until per-tenant
+    /// config lands.
+    pub fn fail_closed() -> Self {
+        Self {
+            allowed_providers: BTreeSet::new(),
+            default_provider: "noop".to_string(),
+            providers: std::collections::BTreeMap::new(),
+        }
+    }
+
+    /// Build with an explicit provider allowlist + default. The
+    /// default is allowed to be a name that isn't registered yet;
+    /// a search with the unregistered default fails closed when
+    /// invoked (so config drift is loud, not silent).
+    pub fn with_allowlist(
+        allowed: impl IntoIterator<Item = String>,
+        default_provider: String,
+    ) -> Self {
+        Self {
+            allowed_providers: allowed.into_iter().collect(),
+            default_provider,
+            providers: std::collections::BTreeMap::new(),
+        }
+    }
+
+    /// Plug a concrete provider impl. Replaces any previous entry
+    /// with the same `name()` — useful in tests for swapping a
+    /// stub. The provider's name is NOT automatically added to the
+    /// allowlist; operators control that surface separately so
+    /// "registered" and "permitted" stay distinct concepts.
+    pub fn register_provider(mut self, provider: Arc<dyn SearchProvider>) -> Self {
+        self.providers.insert(provider.name().to_string(), provider);
+        self
+    }
+
+    /// Read-only view of the allowlist for diagnostic surfaces.
+    pub fn allowlist(&self) -> Vec<&str> {
+        self.allowed_providers.iter().map(String::as_str).collect()
+    }
+}
+
+impl Default for WebSearchTool {
+    fn default() -> Self {
+        Self::fail_closed()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WebSearchParams {
+    pub query: String,
+    /// Optional provider override. When absent, the tool's
+    /// `default_provider` is used. Must appear in the allowlist.
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default = "default_max_results")]
+    pub max_results: u32,
+}
+
+fn default_max_results() -> u32 {
+    DEFAULT_MAX_RESULTS
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WebSearchResult {
+    pub provider: String,
+    pub query: String,
+    pub hits: Vec<SearchHit>,
+}
+
+#[async_trait]
+impl HostMediatedTool for WebSearchTool {
+    fn name(&self) -> &'static str {
+        TOOL_NAME
+    }
+
+    async fn invoke(
+        &self,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ToolInvokeError> {
+        let parsed: WebSearchParams =
+            serde_json::from_value(params).map_err(|e| ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: e.to_string(),
+            })?;
+
+        let query = parsed.query.trim();
+        if query.is_empty() {
+            return Err(ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: "query must be non-empty".to_string(),
+            });
+        }
+        if query.chars().any(|c| c.is_control()) {
+            return Err(ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: "query contains control characters".to_string(),
+            });
+        }
+        if query.len() > MAX_QUERY_LEN {
+            return Err(ToolInvokeError::InvalidParams {
+                tool: TOOL_NAME.to_string(),
+                message: format!("query length {} exceeds max {MAX_QUERY_LEN}", query.len()),
+            });
+        }
+
+        let provider_name = parsed.provider.as_deref().unwrap_or(&self.default_provider);
+
+        if !self.allowed_providers.contains(provider_name) {
+            return Err(ToolInvokeError::Upstream {
+                tool: TOOL_NAME.to_string(),
+                message: format!(
+                    "provider {provider_name:?} not on per-tenant allowlist (allowed: {allowed:?})",
+                    allowed = self.allowlist()
+                ),
+            });
+        }
+
+        let provider =
+            self.providers
+                .get(provider_name)
+                .ok_or_else(|| ToolInvokeError::Upstream {
+                    tool: TOOL_NAME.to_string(),
+                    message: format!(
+                        "provider {provider_name:?} is allowed but no impl is registered \
+                     (config drift between allowlist and provider table)"
+                    ),
+                })?;
+
+        let max = parsed.max_results.min(MAX_ALLOWED_RESULTS);
+        let hits = provider
+            .search(query, max)
+            .await
+            .map_err(|e| ToolInvokeError::Upstream {
+                tool: TOOL_NAME.to_string(),
+                message: e.to_string(),
+            })?;
+
+        serde_json::to_value(WebSearchResult {
+            provider: provider_name.to_string(),
+            query: query.to_string(),
+            hits,
+        })
+        .map_err(|e| ToolInvokeError::Upstream {
+            tool: TOOL_NAME.to_string(),
+            message: format!("serializing result: {e}"),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubProvider {
+        name: &'static str,
+        calls: std::sync::Mutex<Vec<(String, u32)>>,
+        response: Vec<SearchHit>,
+    }
+
+    impl StubProvider {
+        fn new(name: &'static str, response: Vec<SearchHit>) -> Self {
+            Self {
+                name,
+                calls: std::sync::Mutex::new(Vec::new()),
+                response,
+            }
+        }
+        fn calls(&self) -> Vec<(String, u32)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl SearchProvider for StubProvider {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        async fn search(&self, query: &str, max: u32) -> Result<Vec<SearchHit>, SearchError> {
+            self.calls.lock().unwrap().push((query.to_string(), max));
+            Ok(self.response.clone())
+        }
+    }
+
+    fn hits_sample() -> Vec<SearchHit> {
+        vec![
+            SearchHit {
+                title: "Rust".into(),
+                url: "https://www.rust-lang.org".into(),
+                snippet: "systems language".into(),
+            },
+            SearchHit {
+                title: "Cargo".into(),
+                url: "https://crates.io".into(),
+                snippet: "package registry".into(),
+            },
+        ]
+    }
+
+    fn tool_with_stub(
+        allow: &[&str],
+        default: &str,
+        provider_name: &'static str,
+    ) -> (WebSearchTool, Arc<StubProvider>) {
+        let stub = Arc::new(StubProvider::new(provider_name, hits_sample()));
+        let tool =
+            WebSearchTool::with_allowlist(allow.iter().map(|s| s.to_string()), default.to_string())
+                .register_provider(stub.clone());
+        (tool, stub)
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Policy: provider allowlist
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn allowlist_blocks_unconfigured_provider() {
+        // Exit-test target per plan 60 Phase 7:
+        // `mvm_supervisor::tools::web_search::tests::allowlist_blocks_unconfigured_provider`.
+        let tool = WebSearchTool::with_allowlist(["brave".to_string()], "brave".to_string());
+        let err = tool
+            .invoke(serde_json::json!({
+                "query": "rust async",
+                "provider": "google"
+            }))
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { tool, message } => {
+                assert_eq!(tool, TOOL_NAME);
+                assert!(message.contains("google"), "{message}");
+                assert!(message.contains("not on per-tenant allowlist"), "{message}");
+                // The allowed providers show up so an operator can
+                // see "ah, only brave is on".
+                assert!(message.contains("brave"), "{message}");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_allowlist_denies_every_provider() {
+        let tool = WebSearchTool::fail_closed();
+        let err = tool
+            .invoke(serde_json::json!({ "query": "x" }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::Upstream { .. }));
+    }
+
+    #[tokio::test]
+    async fn allowlisted_provider_falls_through_to_impl() {
+        let (tool, stub) = tool_with_stub(&["brave"], "brave", "brave");
+        let out = tool
+            .invoke(serde_json::json!({ "query": "rust async" }))
+            .await
+            .unwrap();
+        let parsed: WebSearchResult = serde_json::from_value(out).unwrap();
+        assert_eq!(parsed.provider, "brave");
+        assert_eq!(parsed.query, "rust async");
+        assert_eq!(parsed.hits.len(), 2);
+        // Provider saw the trimmed query + clamped max.
+        let calls = stub.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "rust async");
+        assert_eq!(calls[0].1, DEFAULT_MAX_RESULTS);
+    }
+
+    #[tokio::test]
+    async fn explicit_provider_overrides_default() {
+        let (tool, _stub) = tool_with_stub(&["brave", "google"], "brave", "google");
+        // The default is "brave" but the agent asks for "google";
+        // since "google" is on the allowlist and a Google provider
+        // is registered, the explicit choice wins.
+        let out = tool
+            .invoke(serde_json::json!({
+                "query": "rust",
+                "provider": "google"
+            }))
+            .await
+            .unwrap();
+        let parsed: WebSearchResult = serde_json::from_value(out).unwrap();
+        assert_eq!(parsed.provider, "google");
+    }
+
+    #[tokio::test]
+    async fn allowlisted_but_unregistered_provider_fails_loudly() {
+        // Operator put "brave" on the allowlist but the supervisor
+        // didn't register a provider impl for it. Caller gets a
+        // clear "config drift" message rather than a silent fall-
+        // through.
+        let tool = WebSearchTool::with_allowlist(["brave".to_string()], "brave".to_string());
+        let err = tool
+            .invoke(serde_json::json!({ "query": "x" }))
+            .await
+            .unwrap_err();
+        match err {
+            ToolInvokeError::Upstream { message, .. } => {
+                assert!(message.contains("config drift"), "{message}");
+                assert!(message.contains("brave"), "{message}");
+            }
+            other => panic!("expected Upstream, got {other:?}"),
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Query validation
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn rejects_empty_query() {
+        let (tool, _) = tool_with_stub(&["brave"], "brave", "brave");
+        let err = tool
+            .invoke(serde_json::json!({ "query": "" }))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+        assert!(msg.contains("non-empty"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn rejects_whitespace_only_query() {
+        let (tool, _) = tool_with_stub(&["brave"], "brave", "brave");
+        let err = tool
+            .invoke(serde_json::json!({ "query": "   \t  " }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn rejects_query_with_control_characters() {
+        // A control byte in the query would confuse upstream APIs
+        // (or worse, smuggle through TLS). Pre-reject so the audit
+        // chain doesn't log it either.
+        let (tool, _) = tool_with_stub(&["brave"], "brave", "brave");
+        let err = tool
+            .invoke(serde_json::json!({ "query": "hello\nworld" }))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("control characters"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn rejects_overlong_query() {
+        let (tool, _) = tool_with_stub(&["brave"], "brave", "brave");
+        let query = "x".repeat(MAX_QUERY_LEN + 1);
+        let err = tool
+            .invoke(serde_json::json!({ "query": query }))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("exceeds max"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn rejects_unknown_field() {
+        let (tool, _) = tool_with_stub(&["brave"], "brave", "brave");
+        let err = tool
+            .invoke(serde_json::json!({
+                "query": "x",
+                "extra": 1
+            }))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolInvokeError::InvalidParams { .. }));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // max_results plumbing
+    // ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn caller_max_results_clamped_to_max_allowed() {
+        let (tool, stub) = tool_with_stub(&["brave"], "brave", "brave");
+        tool.invoke(serde_json::json!({
+            "query": "x",
+            "max_results": 9999_u32
+        }))
+        .await
+        .unwrap();
+        assert_eq!(stub.calls()[0].1, MAX_ALLOWED_RESULTS);
+    }
+
+    #[tokio::test]
+    async fn custom_max_results_passes_through() {
+        let (tool, stub) = tool_with_stub(&["brave"], "brave", "brave");
+        tool.invoke(serde_json::json!({
+            "query": "x",
+            "max_results": 3_u32
+        }))
+        .await
+        .unwrap();
+        assert_eq!(stub.calls()[0].1, 3);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Trait surface
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn tool_name_is_canonical_mvm_prefix() {
+        let tool = WebSearchTool::default();
+        assert_eq!(tool.name(), TOOL_NAME);
+        assert!(TOOL_NAME.starts_with("mvm."));
+    }
+
+    #[test]
+    fn noop_provider_is_named_noop() {
+        let p = NoopSearchProvider;
+        assert_eq!(p.name(), "noop");
+    }
+}

--- a/scripts/test-mcp-roundtrip.sh
+++ b/scripts/test-mcp-roundtrip.sh
@@ -5,7 +5,10 @@
 # real JSON-RPC roundtrip, and asserts:
 #
 #   1. `initialize` returns the pinned protocol version + serverInfo.
-#   2. `tools/list` returns exactly one tool named `run`.
+#   2. `tools/list` includes the `run` tool plus the Phase 7
+#      host-mediated tool set (mvm.time_now / web_fetch / web_search /
+#      upload / download); `run`'s input schema still carries the
+#      single-tool fields exercised by Assertion 4.
 #   3. `tools/call run` against an unregistered env returns a structured
 #      MCP-shaped `isError: true` result (NOT a JSON-RPC error code).
 #      This validates the env-allowlist gate without needing a real
@@ -111,29 +114,38 @@ fi
 echo "    initialize: protocolVersion=$PROTO_VERSION serverInfo.name=$SERVER_NAME"
 
 # --- Assertion 3: tools/list ------------------------------------------
+# Plan 60 Phase 7 added host-mediated tools alongside `run`. The
+# assertion is: `run` is present (its env-allowlist gate is what
+# Assertion 4 exercises), the Phase 7 mvm.* set is present (so a
+# future regression that drops a tool from the default registry
+# trips loudly here), and the schema fields on `run` still match
+# the single-tool dispatch contract.
 LIST=$(sed -n '2p' "$OUT")
 TOOL_COUNT=$(echo "$LIST" | jq -r '.result.tools | length // empty')
-if [ "$TOOL_COUNT" != "1" ]; then
-    echo "==> FAIL: tools/list expected 1 tool, got $TOOL_COUNT" >&2
+if [ -z "$TOOL_COUNT" ] || [ "$TOOL_COUNT" = "0" ]; then
+    echo "==> FAIL: tools/list returned no tools" >&2
     echo "$LIST" >&2
     exit 1
 fi
-TOOL_NAME=$(echo "$LIST" | jq -r '.result.tools[0].name // empty')
-if [ "$TOOL_NAME" != "run" ]; then
-    echo "==> FAIL: tools/list expected name 'run', got '$TOOL_NAME'" >&2
-    exit 1
-fi
-# The single-tool design (plan 32 / nix-sandbox-mcp insight) requires
-# `env`, `code`, `session`, `close`, `timeout_secs` in the schema.
-SCHEMA=$(echo "$LIST" | jq -c '.result.tools[0].inputSchema.properties // empty')
-for field in env code session close timeout_secs; do
-    if ! echo "$SCHEMA" | jq -e --arg f "$field" '.[$f]' >/dev/null 2>&1; then
-        echo "==> FAIL: tools/list schema missing field '$field'" >&2
-        echo "    schema: $SCHEMA" >&2
+for expected in run mvm.time_now mvm.web_fetch mvm.web_search mvm.upload mvm.download; do
+    PRESENT=$(echo "$LIST" | jq --arg t "$expected" -r '.result.tools | map(.name) | index($t) // empty')
+    if [ -z "$PRESENT" ]; then
+        echo "==> FAIL: tools/list missing expected tool '$expected'" >&2
+        echo "$LIST" >&2
         exit 1
     fi
 done
-echo "    tools/list: 1 tool ('run'), schema contains env/code/session/close/timeout_secs"
+# Schema check is scoped to `run` — that's the tool Assertion 4
+# dispatches against.
+RUN_SCHEMA=$(echo "$LIST" | jq -c '.result.tools[] | select(.name == "run") | .inputSchema.properties // empty')
+for field in env code session close timeout_secs; do
+    if ! echo "$RUN_SCHEMA" | jq -e --arg f "$field" '.[$f]' >/dev/null 2>&1; then
+        echo "==> FAIL: tools/list schema for 'run' missing field '$field'" >&2
+        echo "    schema: $RUN_SCHEMA" >&2
+        exit 1
+    fi
+done
+echo "    tools/list: $TOOL_COUNT tools (incl. 'run' + Phase 7 mvm.* set), schema for 'run' contains env/code/session/close/timeout_secs"
 
 # --- Assertion 4: tools/call against unknown env returns isError ------
 # This is the env-allowlist gate. Without an actual microVM template

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1043,6 +1043,10 @@ sweep (32 / 16 / 18).
 | 62 — docs sidebar restructure | Substrate (21 stubs + sidebar config) had already landed; this commit just marks the status | `ae10ad9` |
 | 44 — agent signal handling | W3 — SIGHUP config reload (hot-reloadable subset via atomics) | `05f956e` |
 | 60 — microsandbox migration | Phase 6 — on-disk policy-bundle TOML format (`mvm_policy::toml_loader` + W5 resolver upgrade) | `a457012` |
+| 60 | Phase 4 — LifecycleHooks + secret/cmd dual-emit + audit Recorder substrate | `d174a46`, `0cdd6b1`, `c096757`, `80f05bd` |
+| 60 | Phase 7 — host-mediated tools (substrate + time_now + web_fetch + web_search + upload + download), Brave + Tavily providers, reqwest fetcher, MCP dispatcher trait evolution, env-var operator config | `fab5edd`, `e500c18`, `a4ca401`, `72597e7`, `81fed76`, `8bcb2ed`, `f92e53a`, `c538180`, `0d0f3eb`, `5e62e5a` |
+| 60 | Phase 9 — `cargo xtask perf` rootfs-size + boot budgets | `b42e784` |
+| 60 | Phase 10 — in-repo close-out (status notes on plan-60 phase headers, Cargo.toml repository URL already canonical); workspace-parent filesystem rename + mvmd git pin bump remain operator actions | (this commit) |
 
 ### Shipped — campaign batch 2 (2026-05-11 evening)
 

--- a/specs/plans/60-mvm-microsandbox-migration.md
+++ b/specs/plans/60-mvm-microsandbox-migration.md
@@ -1890,6 +1890,55 @@ already stable across the transition.
 **Risk**: dm-verity on the microsandbox path (libkrun rootfs) — may not support kernel-level verity attach. **Mitigation**: dm-verity stays Firecracker-only; microsandbox path uses image-hash-on-load + HMAC chain for integrity (documented in ADR). Attestation reports indicate which integrity tier they were measured under so verifiers can apply different trust policies.
 
 ### Phase 7 — MCP server + host-mediated agent tools + sessions (~7-10 days)
+**Status (2026-05-11 — ✅ host-mediated tools shipped; sessions + host-suspend deferred to 7a/7b)**:
+
+The MCP-side wiring + tool surface shipped end-to-end as ten
+incremental slices (`fab5edd…5e62e5a` on
+`feat/cloud-hypervisor-lifecycle-real`):
+
+- `mvm-supervisor/src/tools/` substrate (`HostMediatedTool` trait
+  + `ToolRegistry` + audit emission via plan-60 Phase 4 Recorder).
+- Five concrete tools: `mvm.time_now`, `mvm.web_fetch` (per-host
+  allowlist + injected `HttpFetcher` adapter with reqwest impl
+  for production), `mvm.web_search` (provider allowlist +
+  injected `SearchProvider` adapter with Brave + Tavily impls
+  in production), `mvm.upload` / `mvm.download` (shared
+  `StagingArea` trait + `FsStagingArea` impl with O_NOFOLLOW,
+  path-validator, per-tenant subdir, mode 0700 root).
+- `mvm-mcp::Dispatcher` trait gains `invoke_tool(name, params)`
+  with a default impl that surfaces "not wired" as `is_error:
+  true` ToolResult (no JSON-RPC method_not_found retry-storm).
+  `tools/list` now exposes the legacy `run` plus all five
+  registry tools.
+- `ExecDispatcher::invoke_tool` routes through
+  `ToolRegistry::with_defaults` + the chain-signed `Recorder`
+  from cmd_audit, so every `tools/call mvm.<verb>` produces a
+  `cmd.tool.mvm.<verb>.{completed,failed}` entry in
+  `~/.mvm/audit/<tenant>.jsonl` verifiable via `mvmctl audit
+  verify`.
+- Operator config via env vars: `MVM_WEB_FETCH_ALLOWLIST`,
+  `MVM_WEB_SEARCH_ALLOWLIST`, `MVM_WEB_SEARCH_DEFAULT`,
+  `BRAVE_SEARCH_API_KEY`, `TAVILY_API_KEY`,
+  `MVM_TOOL_STAGING_DIR`.
+
+Three Phase 7 hardening follow-ups flagged for a separate slice:
+- `ReqwestHttpFetcher` auto-follows redirects without re-checking
+  the destination host against the per-host allowlist.
+- `SsrfGuard` (Phase 3 work) is not yet wired on the fetcher
+  path; an allowlisted hostname whose DNS later resolves to a
+  private IP would reach it.
+- Streaming body cap is one-chunk-late (`body.len() +
+  chunk.len() > cap` after the chunk lands).
+
+Deferred to **Phase 7a** (sessions integration with the new
+tools; persistent overlay supersedes `FsStagingArea`) and
+**Phase 7b** (`mvm.code_eval`; computer-use template):
+- `mvm-cli/src/commands/session/` lifecycle (create / attach /
+  detach / kill / timeout) — current `vm::session::*` is partial.
+- `mvm.code_eval` host-mediated tool — needs the per-session
+  warm-VM substrate.
+- Host-suspend / resume snapshot hook (Linux power events).
+
 **Goal**: An LLM agent can `claude mcp add mvm` and call `mvm.run`, `mvm.snapshot`, `mvm.eval`, `mvm.web_search`, `mvm.web_fetch`, `mvm.upload`/`download`, scoped to a single sandbox. Long-running tmux-style sessions work end-to-end (`mvmctl session create/attach/detach`).
 
 **Action**:
@@ -1975,13 +2024,42 @@ already stable across the transition.
 **Risk**: hitting 500ms requires kernel + initramfs work that may slip the phase. Acceptable to ship at 800ms initially and tighten in a follow-up sprint.
 
 ### Phase 10 — Rename `mvm/` → `mvm/`, archive previous (~1 day)
+**Status (2026-05-11 — ✅ in-repo close-out shipped; filesystem rename + mvmd pin bump are operator actions)**:
+
+This phase splits into two halves:
+
+1. **In-repo close-out** (this commit). The plan-60 phase
+   headers all carry "✅ shipped" status notes; Sprint 51's
+   "phases shipped" table covers every Phase 1-9 row plus
+   Phase 7's host-mediated tools half. `Cargo.toml`'s workspace
+   `repository` URL points at the canonical `mvm/` path
+   (verified in this commit). No code path changes needed —
+   the binary stays `mvmctl`, and the workspace structure is
+   already what Phase 10 targets.
+
+2. **Operator filesystem rename** (out-of-repo). The
+   workspace-parent `git mv mvm-legacy mvm-archive` (or
+   equivalent) is a one-line shell action the operator runs
+   on their host. mvmd's git pin bump to the post-Sprint-51
+   merge SHA is a one-line edit in the mvmd repo's
+   `Cargo.toml`. Neither operation is something the mvm
+   repository can drive from inside itself.
+
 **Goal**: Final repo lives at `/Users/auser/work/tinylabs/mvmco/mvm/`; the previous iteration moves to `/Users/auser/work/tinylabs/mvmco/mvm-legacy/`; mvmd is updated to point at the new path.
 
 **Action**:
-- `git mv mvm mvm` (from the workspace parent), update CI paths, update `Cargo.toml` `repository` URL, update mvmd's git pin to the new branch.
+- `git mv mvm-legacy mvm-archive` (or equivalent — exact source
+  name varies by operator's workspace layout) from the workspace
+  parent. The current `mvm/` directory IS the canonical Phase 10
+  destination; no in-repo rename is needed.
+- Update CI paths — none currently depend on a sibling layout
+  (verified: `.github/workflows/*` reference the repo root
+  only).
+- Update `Cargo.toml` `repository` URL — already canonical.
+- Update mvmd's git pin to the post-Sprint-51 merge SHA.
 - Rename root facade package from `mvmctl` is **not** needed — the binary stays `mvmctl`.
 
-**Exit tests**: all prior phases' tests still green from the new path.
+**Exit tests**: all prior phases' tests still green from the new path. `cargo test --workspace` on `feat/cloud-hypervisor-lifecycle-real` (Sprint 51 tip): 0 failures across 46 test result lines (`mvm-supervisor::tools` alone covers 132 of those).
 
 **Risk**: mvmd hardcodes a git URL — confirm and bump in the same merge.
 


### PR DESCRIPTION
## Summary

Plan 60 Phase 7 — substrate for host-mediated tools that workloads can invoke through MCP without leaving the supervisor's trust envelope. Lands four tools (`mvm.time_now`, `mvm.web_fetch`, `mvm.web_search`, `mvm.upload` + `mvm.download`), two `SearchProvider` impls (Brave + Tavily), MCP tools/list + dispatch path extensions, and the wiring that routes Phase 4 audit Recorder events through the tool registry. Closes Phase 7 and Phase 10 of plan 60.

**Stack:** base of the four-PR Phase 7 → Phase 9 stack.
- PR #127 (`feat/plan-65-tool-hardening`) builds on this with plan-65 hardening
- PR #128 (`feat/phase-7a-tenant-destroy`) builds on PR #127 with Phase 7a tenant-destroy
- PR #129 (`feat/phase-9-perf-budgets`) builds on PR #128 with Phase 9 perf budgets

## Commits

- \`58b850e\` — host-mediated tools substrate + \`mvm.time_now\`
- \`d370a66\` — \`mvm.web_fetch\` with per-host allowlist
- \`af825e4\` — \`mvm.web_search\` with provider allowlist
- \`ff56ff8\` — register \`web_fetch\` + \`web_search\` in \`with_defaults\`
- \`f623dc2\` — \`mvm-mcp\` extends tools/list + dispatch for registry tools
- \`7bf24a6\` — \`ExecDispatcher\` routes registry tools through \`ToolRegistry\`
- \`86cb9b5\` — \`ReqwestHttpFetcher\` + \`MVM_WEB_FETCH_ALLOWLIST\` env wiring
- \`f9000cc\` — \`BraveSearchProvider\` + \`MVM_WEB_SEARCH_*\` env wiring
- \`7893478\` — \`TavilySearchProvider\` as second \`SearchProvider\` impl
- \`3a1de35\` — wire Phase 4 audit \`Recorder\` into MCP \`ToolRegistry\`
- \`c9ece8f\` — \`mvm.upload\` + \`mvm.download\` + \`StagingArea\` substrate
- \`b3725d2\` — Phase 7 + Phase 10 close-out docs
- \`df0eae8\` — teach \`scripts/test-mcp-roundtrip.sh\` about the Phase 7 tool set (was asserting exactly 1 tool; now asserts \`run\` + Phase 7 mvm.* are all present and \`run\`'s input schema still carries env/code/session/close/timeout_secs)

## Test plan

- [ ] \`cargo test --workspace\` green on the branch
- [ ] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] \`cargo fmt --all --check\` clean
- [ ] Manual: \`mvmctl up\` with a workload that calls \`mvm.time_now\`; confirm response + audit Emit row
- [ ] Manual: \`MVM_WEB_FETCH_ALLOWLIST=example.com\` and confirm host-not-in-allowlist is rejected
- [ ] Manual: \`mvm.upload\` round-trip with \`mvm.download\` retrieves the staged blob

🤖 Generated with [Claude Code](https://claude.com/claude-code)