### PR TITLE
plan-65: pause/resume via SnapshotIO + live mock coverage

### DIFF
--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -62,6 +62,18 @@ impl MockBackend {
     pub fn count(&self) -> usize {
         self.state.lock().map(|s| s.len()).unwrap_or(0)
     }
+
+    /// Host-side per-VM directory for a mock VM. Lives under
+    /// `<mvm_data_dir>/mock-vms/<name>/` so it never collides with
+    /// the Lima-era `~/microvm/vms/<name>` path that
+    /// `resolve_running_vm_dir` expects for real Firecracker VMs.
+    /// Plan 65 W1: `pause.rs` and `resume.rs` read the snapshot
+    /// directory through here when `--hypervisor mock` is set.
+    pub fn vm_dir(name: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from(mvm_core::config::mvm_data_dir())
+            .join("mock-vms")
+            .join(name)
+    }
 }
 
 impl VmBackend for MockBackend {
@@ -87,6 +99,13 @@ impl VmBackend for MockBackend {
         if state.contains_key(&config.name) {
             bail!("mock: VM '{}' already running", config.name);
         }
+        // Plan 65 W1: create a host-side per-VM directory so the
+        // verbs that probe `<vm_dir>/...` paths (pause/resume's
+        // snapshot dir; future fs/proc/volume work) find something
+        // real. Best-effort — a failure here doesn't abort start
+        // because not every consumer needs the directory.
+        let vm_dir = Self::vm_dir(&config.name);
+        let _ = std::fs::create_dir_all(&vm_dir);
         state.insert(
             config.name.clone(),
             MockVm {

--- a/crates/mvm-cli/src/commands/vm/pause.rs
+++ b/crates/mvm-cli/src/commands/vm/pause.rs
@@ -18,7 +18,9 @@ use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
 
-use mvm::vm::instance_snapshot::{FirecrackerIO, pause_and_seal, verify_and_resume};
+use mvm::vm::instance_snapshot::{
+    CannedIO, FirecrackerIO, SnapshotIO, pause_and_seal, verify_and_resume,
+};
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
 
@@ -30,6 +32,14 @@ pub(in crate::commands) struct PauseArgs {
     /// Name of the VM to pause
     #[arg(value_parser = clap_vm_name)]
     pub name: String,
+    /// Hypervisor to drive the snapshot through. Defaults to
+    /// `firecracker`. `--hypervisor mock` swaps the FirecrackerIO
+    /// snapshot transport for `CannedIO` (writes deterministic
+    /// stub bytes to vmstate.bin + mem.bin), letting plan 65's
+    /// live tests exercise `WorkloadSleep` without a real
+    /// Firecracker socket.
+    #[arg(long, default_value = "firecracker")]
+    pub hypervisor: String,
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -37,17 +47,48 @@ pub(in crate::commands) struct ResumeArgs {
     /// Name of the VM to resume
     #[arg(value_parser = clap_vm_name)]
     pub name: String,
+    /// Hypervisor to drive the restore through. Defaults to
+    /// `firecracker`. See `pause --help` for the `mock` variant.
+    #[arg(long, default_value = "firecracker")]
+    pub hypervisor: String,
+}
+
+/// Pick the `SnapshotIO` impl matching the hypervisor selector.
+/// Plan 65 W2: `mock` swaps in `CannedIO` for hermetic
+/// `WorkloadSleep` / `WorkloadWake` audit-emit coverage; every
+/// other selector uses `FirecrackerIO` against the running VM's
+/// UDS socket.
+fn snapshot_io_for(hypervisor: &str, vm_name: &str) -> Result<Box<dyn SnapshotIO>> {
+    if hypervisor == "mock" {
+        // The mock VM's per-VM directory lives at
+        // `<mvm_data_dir>/mock-vms/<name>/` and is created by
+        // `MockBackend::start_with_mode`. Nothing to validate here
+        // beyond its existence — `pause_and_seal` writes the
+        // snapshot files into a sibling `snapshot/` directory.
+        let dir = mvm_backend::MockBackend::vm_dir(vm_name);
+        if !dir.exists() {
+            bail!(
+                "mock VM {vm_name:?} is not running (no directory at {})",
+                dir.display()
+            );
+        }
+        return Ok(Box::new(CannedIO {
+            vmstate_bytes: b"mock-vmstate".to_vec(),
+            mem_bytes: b"mock-mem".to_vec(),
+        }));
+    }
+    let vm_dir = mvm_backend::microvm::resolve_running_vm_dir(vm_name)
+        .with_context(|| format!("VM {vm_name:?} is not running"))?;
+    let socket = firecracker_socket(&vm_dir);
+    Ok(Box::new(FirecrackerIO::new(socket)))
 }
 
 pub(in crate::commands) fn run_pause(_cli: &Cli, args: PauseArgs, _cfg: &MvmConfig) -> Result<()> {
     validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
-    let vm_dir = mvm_backend::microvm::resolve_running_vm_dir(&args.name)
-        .with_context(|| format!("VM {:?} is not running", args.name))?;
-    let socket = firecracker_socket(&vm_dir);
-    let io = FirecrackerIO::new(socket);
+    let io = snapshot_io_for(&args.hypervisor, &args.name)?;
 
     let sidecar =
-        pause_and_seal(&args.name, &io).with_context(|| format!("pausing VM {:?}", args.name))?;
+        pause_and_seal(&args.name, &*io).with_context(|| format!("pausing VM {:?}", args.name))?;
 
     let registry_path = mvm::vm::name_registry::registry_path();
     if let Ok(mut registry) = mvm::vm::name_registry::VmNameRegistry::load(&registry_path) {
@@ -58,7 +99,7 @@ pub(in crate::commands) fn run_pause(_cli: &Cli, args: PauseArgs, _cfg: &MvmConf
         "{}: paused (epoch {}, vmstate {} B, mem {} B)",
         args.name, sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
-    mvm_core::audit_emit!(WorkloadSleep, vm: args.name, "epoch={} vmstate={} mem={}" ,
+    mvm_core::audit_emit!(WorkloadSleep, vm: &args.name, "epoch={} vmstate={} mem={}" ,
         sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
     Ok(())
@@ -76,19 +117,13 @@ pub(in crate::commands) fn run_resume(
     // requires the user to have already started a fresh VM
     // shell that's waiting for the snapshot load (Firecracker's
     // restore-into-empty-VMM workflow). The substrate is
-    // ready; the launcher integration is a follow-up.
-    let vm_dir = mvm_backend::microvm::resolve_running_vm_dir(&args.name).with_context(|| {
-        format!(
-            "VM {:?} has no running Firecracker shell; resume currently \
-                 requires a fresh `mvmctl up --resume-from-snapshot` (follow-up). \
-                 Substrate verifies, the launcher integration is pending.",
-            args.name
-        )
-    })?;
-    let socket = firecracker_socket(&vm_dir);
-    let io = FirecrackerIO::new(socket);
+    // ready; the launcher integration is a follow-up. Plan 65
+    // W2: `--hypervisor mock` swaps in `CannedIO` so the
+    // verify-resume path can land its `WorkloadWake` audit emit
+    // without a live Firecracker socket.
+    let io = snapshot_io_for(&args.hypervisor, &args.name)?;
 
-    let sidecar = verify_and_resume(&args.name, &io)
+    let sidecar = verify_and_resume(&args.name, &*io)
         .with_context(|| format!("resuming VM {:?}", args.name))?;
 
     let registry_path = mvm::vm::name_registry::registry_path();
@@ -100,7 +135,7 @@ pub(in crate::commands) fn run_resume(
         "{}: resumed (epoch {}, vmstate {} B, mem {} B)",
         args.name, sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
-    mvm_core::audit_emit!(WorkloadWake, vm: args.name, "epoch={} vmstate={} mem={}" ,
+    mvm_core::audit_emit!(WorkloadWake, vm: &args.name, "epoch={} vmstate={} mem={}" ,
         sidecar.epoch, sidecar.vmstate_len, sidecar.mem_len
     );
     Ok(())

--- a/crates/mvm/src/vm/instance_snapshot.rs
+++ b/crates/mvm/src/vm/instance_snapshot.rs
@@ -117,7 +117,7 @@ pub trait SnapshotIO {
 /// 3. Tighten file modes to 0600.
 /// 4. Bump the per-instance epoch counter.
 /// 5. Seal the HMAC envelope with the new epoch.
-pub fn pause_and_seal<IO: SnapshotIO>(vm_name: &str, io: &IO) -> Result<IntegritySidecar> {
+pub fn pause_and_seal<IO: SnapshotIO + ?Sized>(vm_name: &str, io: &IO) -> Result<IntegritySidecar> {
     let dir = prepare_instance_snapshot_dir(vm_name)?;
     io.create_snapshot(&dir)
         .with_context(|| format!("Firecracker create_snapshot({})", dir.display()))?;
@@ -159,7 +159,10 @@ pub fn pause_and_seal<IO: SnapshotIO>(vm_name: &str, io: &IO) -> Result<Integrit
 ///
 /// Returns the verified sidecar so the caller can audit it before
 /// resuming Firecracker.
-pub fn verify_and_resume<IO: SnapshotIO>(vm_name: &str, io: &IO) -> Result<IntegritySidecar> {
+pub fn verify_and_resume<IO: SnapshotIO + ?Sized>(
+    vm_name: &str,
+    io: &IO,
+) -> Result<IntegritySidecar> {
     let dir = snapshot_dir(vm_name);
     if !dir.exists() {
         bail!(

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -50,6 +50,15 @@
 //! - `mvmctl set-ttl <vm> <duration>` (after `up --hypervisor mock`)
 //!   → `VmTtlSet` (chains off the up-via-mock fixture; the verb
 //!   operates on the persistent name registry that `up` populates)
+//! - `mvmctl pause <vm> --hypervisor mock` (after `up`) →
+//!   `WorkloadSleep` (Plan 65: pause routes through the SnapshotIO
+//!   trait; `--hypervisor mock` swaps in `CannedIO` so the seal
+//!   step writes deterministic 12-byte vmstate + 8-byte mem stubs
+//!   instead of talking to a real Firecracker UDS)
+//! - `mvmctl resume <vm> --hypervisor mock` (after `pause`) →
+//!   `WorkloadWake` (mirrors; verify-and-resume against the sealed
+//!   sidecar succeeds because the seal was written under
+//!   deterministic-stubs round-trip)
 //! - `mvmctl down` (no args, empty sandbox) → `VmStop`
 //!   (`stop_all` is tolerant of an empty VM registry and emits
 //!   with `detail=stop_all_ok`)
@@ -900,6 +909,86 @@ fn set_ttl_clear_emits_vm_ttl_set_with_cleared_detail() {
     assert!(
         log.contains("expires_at=cleared"),
         "set-ttl --clear must record expires_at=cleared. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn pause_emits_workload_sleep_audit_entry() {
+    // Plan 65 W3: `mvmctl pause --hypervisor mock` exercises the
+    // snapshot-and-seal path against `CannedIO` (deterministic
+    // 12-byte vmstate + 8-byte mem stubs). Pre-Plan-65 the verb
+    // would have bailed on `resolve_running_vm_dir` because the
+    // mock VM has no Lima-shaped vm_dir; the `--hypervisor mock`
+    // selector routes through `MockBackend::vm_dir(name)` instead.
+    let sandbox = AuditSandbox::new();
+    bring_up_mock_vm(&sandbox, "pause-vm");
+
+    let output = sandbox
+        .mvmctl()
+        .args(["pause", "pause-vm", "--hypervisor", "mock"])
+        .output()
+        .expect("spawn mvmctl pause");
+    assert!(
+        output.status.success(),
+        "mvmctl pause failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "workload_sleep");
+    assert!(
+        hits >= 1,
+        "expected ≥1 workload_sleep entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"pause-vm\""),
+        "workload_sleep must carry vm_name=pause-vm. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("epoch="),
+        "workload_sleep detail must record the epoch. Full log:\n{log}"
+    );
+}
+
+#[test]
+fn resume_emits_workload_wake_audit_entry() {
+    // Plan 65 W3: pause-then-resume against the mock backend.
+    // The seal-and-verify round-trip works because `CannedIO`
+    // writes its stubs to disk and `verify_and_resume` reads
+    // them back through the same HMAC-sealed sidecar.
+    let sandbox = AuditSandbox::new();
+    bring_up_mock_vm(&sandbox, "resume-vm");
+
+    let pause = sandbox
+        .mvmctl()
+        .args(["pause", "resume-vm", "--hypervisor", "mock"])
+        .output()
+        .expect("spawn mvmctl pause");
+    assert!(
+        pause.status.success(),
+        "mvmctl pause failed: stderr={}",
+        String::from_utf8_lossy(&pause.stderr)
+    );
+    let resume = sandbox
+        .mvmctl()
+        .args(["resume", "resume-vm", "--hypervisor", "mock"])
+        .output()
+        .expect("spawn mvmctl resume");
+    assert!(
+        resume.status.success(),
+        "mvmctl resume failed: stderr={}",
+        String::from_utf8_lossy(&resume.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "workload_wake");
+    assert!(
+        hits >= 1,
+        "expected ≥1 workload_wake entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"vm_name\":\"resume-vm\""),
+        "workload_wake must carry vm_name=resume-vm. Full log:\n{log}"
     );
 }
 


### PR DESCRIPTION
Replacement for #114 (auto-closed when its base `feat/mock-backend` was merged into main). Same content; retargets to main.

See #114 for the full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)