### PR TITLE
plan-70: MVM_UNINSTALL_PATH_PREFIX + positive Uninstall coverage

### DIFF
--- a/crates/mvm-cli/src/commands/env/uninstall.rs
+++ b/crates/mvm-cli/src/commands/env/uninstall.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 use clap::Args as ClapArgs;
+use std::path::PathBuf;
 
 use crate::ui;
 
@@ -9,6 +10,28 @@ use mvm_backend::microvm;
 use mvm_core::user_config::MvmConfig;
 
 use super::Cli;
+
+/// Optionally rewrite an absolute system path under a sandbox prefix.
+/// Plan 70: when `MVM_UNINSTALL_PATH_PREFIX` is set, the verb's
+/// `/var/lib/mvm` and `/usr/local/bin/mvmctl` targets relocate under
+/// the prefix and the sudo invocation is skipped (plain
+/// `std::fs::remove_*`) because the rewritten paths live in
+/// test-owned territory. Logs a `ui::warn` on bypass so the
+/// override is visible.
+///
+/// Returns `(rewritten_path, use_sudo)`. `use_sudo == false` means
+/// the caller should bypass `sudo` because either (a) the override
+/// is set, or (b) future caller logic may want to drop sudo for
+/// some other reason — currently only (a) is wired.
+fn sandbox_path(p: &str) -> (PathBuf, bool) {
+    match std::env::var("MVM_UNINSTALL_PATH_PREFIX") {
+        Ok(prefix) if !prefix.trim().is_empty() => {
+            let stripped = p.strip_prefix('/').unwrap_or(p);
+            (PathBuf::from(prefix.trim()).join(stripped), false)
+        }
+        _ => (PathBuf::from(p), true),
+    }
+}
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -55,6 +78,20 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         }
     }
 
+    // Plan 70: when MVM_UNINSTALL_PATH_PREFIX is set the system
+    // paths below get rewritten under that prefix and sudo is
+    // skipped. Surface the bypass loudly so a misconfigured
+    // production caller can't miss it.
+    let prefix_set = std::env::var("MVM_UNINSTALL_PATH_PREFIX")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false);
+    if prefix_set {
+        ui::warn(
+            "MVM_UNINSTALL_PATH_PREFIX set; rewriting system paths under \
+             the prefix and skipping sudo (test path).",
+        );
+    }
+
     // Stop running microVMs first (best-effort). Plan-60 / ADR-013
     // dropped Lima; there is no Lima VM to destroy.
     if let Err(e) = microvm::stop() {
@@ -62,16 +99,21 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     }
 
     // Remove /var/lib/mvm/.
-    let state_dir = std::path::Path::new("/var/lib/mvm");
+    let (state_dir, use_sudo) = sandbox_path("/var/lib/mvm");
     if state_dir.exists() {
-        ui::info("Removing /var/lib/mvm/...");
-        let status = std::process::Command::new("sudo")
-            .args(["rm", "-rf", "/var/lib/mvm"])
-            .status();
-        match status {
-            Ok(s) if s.success() => {}
-            Ok(s) => tracing::warn!("sudo rm /var/lib/mvm exited with status {s}"),
-            Err(e) => tracing::warn!("failed to remove /var/lib/mvm: {e}"),
+        ui::info(&format!("Removing {}...", state_dir.display()));
+        if use_sudo {
+            let status = std::process::Command::new("sudo")
+                .args(["rm", "-rf"])
+                .arg(&state_dir)
+                .status();
+            match status {
+                Ok(s) if s.success() => {}
+                Ok(s) => tracing::warn!("sudo rm {} exited with status {s}", state_dir.display()),
+                Err(e) => tracing::warn!("failed to remove {}: {e}", state_dir.display()),
+            }
+        } else if let Err(e) = std::fs::remove_dir_all(&state_dir) {
+            tracing::warn!("failed to remove {}: {e}", state_dir.display());
         }
     }
 
@@ -88,16 +130,21 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         }
 
         // Remove /usr/local/bin/mvmctl.
-        let bin = std::path::Path::new("/usr/local/bin/mvmctl");
+        let (bin, use_sudo) = sandbox_path("/usr/local/bin/mvmctl");
         if bin.exists() {
-            ui::info("Removing /usr/local/bin/mvmctl...");
-            let status = std::process::Command::new("sudo")
-                .args(["rm", "-f", "/usr/local/bin/mvmctl"])
-                .status();
-            match status {
-                Ok(s) if s.success() => {}
-                Ok(s) => tracing::warn!("sudo rm mvmctl exited with status {s}"),
-                Err(e) => tracing::warn!("failed to remove /usr/local/bin/mvmctl: {e}"),
+            ui::info(&format!("Removing {}...", bin.display()));
+            if use_sudo {
+                let status = std::process::Command::new("sudo")
+                    .args(["rm", "-f"])
+                    .arg(&bin)
+                    .status();
+                match status {
+                    Ok(s) if s.success() => {}
+                    Ok(s) => tracing::warn!("sudo rm {} exited with status {s}", bin.display()),
+                    Err(e) => tracing::warn!("failed to remove {}: {e}", bin.display()),
+                }
+            } else if let Err(e) = std::fs::remove_file(&bin) {
+                tracing::warn!("failed to remove {}: {e}", bin.display());
             }
         }
     }

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -92,6 +92,12 @@
 //!   `update::update` exits early with "already up to date" and
 //!   the outer wrapper emits `UpdateInstall`. No real network, no
 //!   binary swap.)
+//! - `mvmctl uninstall --yes --all` (with `MVM_UNINSTALL_PATH_PREFIX`
+//!   pointing at a sandbox sub-dir) → `Uninstall` (Plan 70: the
+//!   override rewrites `/var/lib/mvm` and `/usr/local/bin/mvmctl`
+//!   under the prefix and skips sudo, so the positive path is
+//!   exercised end-to-end without sudo prompts or destruction of
+//!   a developer's real install)
 //! - `mvmctl uninstall --yes --dry-run` → **no** audit entry
 //!   (the positive `Uninstall` path is real-system-destructive
 //!   and not safely-hermetic, but the dry-run path is read-only
@@ -1341,6 +1347,54 @@ fn update_check_does_not_emit_audit_entry() {
         hits, 0,
         "read-only `update --check` must not emit; got {hits}. \
          Full log:\n{log}"
+    );
+}
+
+#[test]
+fn uninstall_yes_all_emits_uninstall_audit_entry_via_prefix_override() {
+    // Plan 70: the positive `Uninstall` path mutates real system
+    // paths (`/var/lib/mvm`, `/usr/local/bin/mvmctl`) via sudo —
+    // not safely-hermetic on a developer's machine. The
+    // `MVM_UNINSTALL_PATH_PREFIX` env-var rewrites the targets
+    // under a sandbox sub-dir and skips sudo. The audit emit fires
+    // unconditionally at the end of the verb, so the test pins the
+    // emit + the on-disk side-effect (the rewritten paths are
+    // gone).
+    let sandbox = AuditSandbox::new();
+    let prefix = sandbox.home_path().join("system-root");
+    let stub_state_dir = prefix.join("var/lib/mvm");
+    let stub_bin = prefix.join("usr/local/bin/mvmctl");
+    std::fs::create_dir_all(&stub_state_dir).expect("mkdir state stub");
+    std::fs::create_dir_all(stub_bin.parent().unwrap()).expect("mkdir bin dir");
+    std::fs::write(&stub_bin, b"#!/bin/sh\nexit 0\n").expect("write stub binary");
+
+    let output = sandbox
+        .mvmctl()
+        .env("MVM_UNINSTALL_PATH_PREFIX", &prefix)
+        .args(["uninstall", "--yes", "--all"])
+        .output()
+        .expect("spawn mvmctl uninstall");
+    assert!(
+        output.status.success(),
+        "mvmctl uninstall failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "uninstall");
+    assert!(
+        hits >= 1,
+        "expected ≥1 uninstall entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        !stub_state_dir.exists(),
+        "stub state dir at {} must be removed",
+        stub_state_dir.display()
+    );
+    assert!(
+        !stub_bin.exists(),
+        "stub binary at {} must be removed",
+        stub_bin.display()
     );
 }
 


### PR DESCRIPTION
Replacement for #119 (auto-closed in cascade). Same content; retargets to main.

See #119 for full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)