### PR TITLE
plan-68: MVM_BUILD_STUB_OUTDIR + hermetic template_build coverage

### DIFF
--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -275,6 +275,37 @@ pub fn dev_build(
     profile: Option<&str>,
     mode: BuildMode,
 ) -> Result<DevBuildResult> {
+    // Plan 68: `MVM_BUILD_STUB_OUTDIR` lets the live test suite
+    // skip the Nix build entirely and treat the env-var's value as
+    // the build output directory. The directory must contain
+    // `vmlinux` + `rootfs.ext4`. Same env-var-escape-hatch shape
+    // `MVM_DIRECT_BOOT` uses for `mvmctl up`. Logged loudly so a
+    // production misconfiguration can't go silent.
+    if let Ok(stub) = std::env::var("MVM_BUILD_STUB_OUTDIR")
+        && !stub.trim().is_empty()
+    {
+        env.log_warn(&format!(
+            "MVM_BUILD_STUB_OUTDIR={stub} set; skipping nix build (test path)."
+        ));
+        let _ = (flake_ref, profile, mode);
+        let stub_path = std::path::PathBuf::from(stub.trim());
+        let revision_hash = stub_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(String::from)
+            .unwrap_or_else(|| "stub".to_string());
+        return Ok(DevBuildResult {
+            build_dir: stub_path.display().to_string(),
+            vmlinux_path: stub_path.join("vmlinux").display().to_string(),
+            rootfs_path: stub_path.join("rootfs.ext4").display().to_string(),
+            initrd_path: None,
+            revision_hash,
+            cached: false,
+            runner_dir: None,
+            artifact_sizes: mvm_core::pool::ArtifactSizes::default(),
+        });
+    }
+
     // W7.x.2 dispatch: if the `env` channel has `nix` on PATH, run
     // the build there (host on Linux+host-Nix, Apple Container dev
     // VM on macOS 26+, etc.). Otherwise spawn a microsandbox builder
@@ -850,6 +881,17 @@ pub fn ensure_guest_agent_if_needed(
     env: &dyn ShellEnvironment,
     build_result: &DevBuildResult,
 ) -> Result<()> {
+    // Plan 68: same stub-outdir escape-hatch as `dev_build`. When the
+    // build itself was a stub, the rootfs is a placeholder file, not
+    // an ext4 image — attempting to `sudo mount` it would prompt for
+    // a password and hang the test. Skip injection in that mode.
+    if std::env::var("MVM_BUILD_STUB_OUTDIR")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
+    {
+        env.log_warn("MVM_BUILD_STUB_OUTDIR set; skipping guest-agent injection (test path).");
+        return Ok(());
+    }
     let mvm_src = match detect_mvm_src() {
         Some(p) => p,
         None => {

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -1801,3 +1801,67 @@ fn secret_rm_emits_delete_action_in_secret_audit_log() {
         "expected an 'action':'delete' entry in secrets audit log. Full log:\n{log}"
     );
 }
+
+#[test]
+fn build_emits_template_build_audit_entry_against_stub_outdir() {
+    // Plan 68: `mvmctl build --flake <stub-flake> --profile minimal`
+    // reaches `mvm_build::dev_build::dev_build`, which normally
+    // shells out to `nix build`. With `MVM_BUILD_STUB_OUTDIR` set,
+    // dev_build returns a synthetic `DevBuildResult` pointing at
+    // the stub directory and skips both the Nix invocation and the
+    // guest-agent injection step. The outer build_flake wrapper
+    // still calls `audit_build_ok("flake", &resolved, "", &revision)`,
+    // which emits one `template_build` record. Hermetic — no Nix,
+    // no Lima, no Apple Container, no sudo.
+    let sandbox = AuditSandbox::new();
+
+    // Stub build output: a directory whose basename becomes the
+    // revision hash (per dev_build's stub branch). `vmlinux` and
+    // `rootfs.ext4` are placeholders so any downstream caller that
+    // statted them sees real files.
+    let stub_out = sandbox.home_path().join("stub-out");
+    std::fs::create_dir_all(&stub_out).expect("mkdir stub_out");
+    std::fs::write(stub_out.join("vmlinux"), b"fake-kernel").expect("write stub kernel");
+    std::fs::write(stub_out.join("rootfs.ext4"), b"fake-rootfs").expect("write stub rootfs");
+
+    // Stub flake source. `validate_flake_ref` accepts a local path
+    // containing `flake.nix`; the stub-outdir branch never reads
+    // it.
+    let flake_dir = sandbox.home_path().join("flake");
+    std::fs::create_dir_all(&flake_dir).expect("mkdir flake_dir");
+    std::fs::write(flake_dir.join("flake.nix"), b"# stub\n").expect("write stub flake");
+
+    let output = sandbox
+        .mvmctl()
+        .env("MVM_BUILD_STUB_OUTDIR", &stub_out)
+        .args([
+            "build",
+            "--flake",
+            flake_dir.to_str().expect("utf-8 flake path"),
+            "--profile",
+            "minimal",
+        ])
+        .output()
+        .expect("spawn mvmctl build");
+    assert!(
+        output.status.success(),
+        "mvmctl build failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = read_audit_log(&sandbox.audit_log_path());
+    let hits = count_entries_with_kind(&log, "template_build");
+    assert!(
+        hits >= 1,
+        "expected ≥1 template_build entry, got {hits}. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("mode=flake"),
+        "expected detail to record mode=flake. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("artifact=stub-out"),
+        "expected detail to record artifact=stub-out (the stub-outdir basename). Full log:\n{log}"
+    );
+}


### PR DESCRIPTION
Replacement for #120 (auto-closed in cascade). Same content; retargets to main.

See #120 for full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)