### PR TITLE
plan-66 W1+W2: MockGuestAgent over per-VM v.sock

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -50,6 +50,12 @@ jobs:
   #   5. Ephemeral port discovery — `TcpListener::bind("127.0.0.1:0")`
   #      in `crates/mvm-cli/src/template_cmd.rs`. Binds to find a free
   #      port; drops the listener immediately. Not a daemon.
+  #   6. Test-only mock guest-agent
+  #      (`crates/mvm-backend/src/mock_guest_agent.rs`). Mirrors the
+  #      in-guest vsock agent on the host side via Unix-domain socket
+  #      so `mvmctl fs *` / `proc *` are hermetically testable against
+  #      `MockBackend`. Tier-3 / test-only; never selected by
+  #      `AnyBackend::auto_select`. Production callers can't reach it.
   #
   # The in-guest vsock agent in `mvm-guest` is also excluded — it
   # runs *inside* the microVM, not on the host.
@@ -96,6 +102,7 @@ jobs:
               --glob '!crates/mvm-providers/src/apple_container/**' \
               --glob '!crates/mvm-cli/src/metrics_server.rs' \
               --glob '!crates/mvm-cli/src/template_cmd.rs' \
+              --glob '!crates/mvm-backend/src/mock_guest_agent.rs' \
               -e "$PATTERNS" \
               crates/ src/ \
               || true)

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -47,6 +47,7 @@ pub mod libkrun;
 pub mod microvm;
 pub mod microvm_nix;
 pub mod mock;
+pub mod mock_guest_agent;
 pub mod network;
 
 // `microsandbox` is the only self-contained backend integration that

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -30,6 +30,8 @@ use mvm_core::vm_backend::{
     VmCapabilities, VmExitStatus, VmId, VmInfo, VmNetworkInfo, VmStartConfig, VmStatus,
 };
 
+use crate::mock_guest_agent::MockGuestAgent;
+
 /// Per-VM state held by [`MockBackend`].
 #[derive(Debug, Clone)]
 struct MockVm {
@@ -47,9 +49,15 @@ struct MockVm {
 /// The interior `Mutex<HashMap>` is wrapped in an `Arc` so cloning the
 /// backend (e.g. across an `AnyBackend::Mock(MockBackend)` enum copy)
 /// shares state. The `Default` impl returns an empty registry.
+///
+/// `agents` holds one [`MockGuestAgent`] per VM. Plan 66 W1/W2 — the
+/// agent listens on `<vm_dir>/runtime/v.sock` so host-side `fs` and
+/// `proc` callers find a working endpoint at the same path
+/// Firecracker exposes for the real vsock UDS.
 #[derive(Debug, Default, Clone)]
 pub struct MockBackend {
     state: std::sync::Arc<Mutex<HashMap<String, MockVm>>>,
+    agents: std::sync::Arc<Mutex<HashMap<String, MockGuestAgent>>>,
 }
 
 impl MockBackend {
@@ -106,6 +114,25 @@ impl VmBackend for MockBackend {
         // because not every consumer needs the directory.
         let vm_dir = Self::vm_dir(&config.name);
         let _ = std::fs::create_dir_all(&vm_dir);
+        // Plan 66 W1/W2: spawn the mock vsock guest-agent on
+        // `<vm_dir>/runtime/v.sock`. Failure to start the agent is
+        // *not* fatal — the audit-emit tests that don't touch
+        // fs/proc still want the VM to come up. The fs/proc tests
+        // will see a clearer "connect failed" error than they
+        // would from a missing agent.
+        match MockGuestAgent::start(&vm_dir) {
+            Ok(agent) => {
+                if let Ok(mut agents) = self.agents.lock() {
+                    agents.insert(config.name.clone(), agent);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "mock: failed to start MockGuestAgent for '{}': {e}",
+                    config.name
+                );
+            }
+        }
         state.insert(
             config.name.clone(),
             MockVm {
@@ -134,6 +161,17 @@ impl VmBackend for MockBackend {
             .lock()
             .map_err(|_| anyhow::anyhow!("mock backend state mutex poisoned"))?;
         state.remove(&id.0);
+        // Drop the agent (which joins its thread + removes the socket)
+        // and the on-disk VM dir. Plan 66 W1/W2.
+        if let Ok(mut agents) = self.agents.lock()
+            && let Some(agent) = agents.remove(&id.0)
+        {
+            agent.stop();
+        }
+        let vm_dir = Self::vm_dir(&id.0);
+        if vm_dir.exists() {
+            let _ = std::fs::remove_dir_all(&vm_dir);
+        }
         Ok(())
     }
 
@@ -142,7 +180,19 @@ impl VmBackend for MockBackend {
             .state
             .lock()
             .map_err(|_| anyhow::anyhow!("mock backend state mutex poisoned"))?;
+        let names: Vec<String> = state.keys().cloned().collect();
         state.clear();
+        if let Ok(mut agents) = self.agents.lock() {
+            for (_, agent) in agents.drain() {
+                agent.stop();
+            }
+        }
+        for name in names {
+            let vm_dir = Self::vm_dir(&name);
+            if vm_dir.exists() {
+                let _ = std::fs::remove_dir_all(&vm_dir);
+            }
+        }
         Ok(())
     }
 

--- a/crates/mvm-backend/src/mock_guest_agent.rs
+++ b/crates/mvm-backend/src/mock_guest_agent.rs
@@ -1,0 +1,512 @@
+//! In-process mock of the in-guest `mvm-guest-agent` vsock surface.
+//!
+//! Plan 66 W2. Pairs with [`crate::mock::MockBackend`]: every mock VM
+//! gets its own `MockGuestAgent` listening on `<vm_dir>/runtime/v.sock`,
+//! the same Unix-domain socket path Firecracker exposes for the
+//! vsock UDS multiplexer. The host-side fs/proc helpers in
+//! `mvm_guest::vsock` connect to that path, send the
+//! `CONNECT <port>\n` line, then exchange length-prefixed JSON
+//! `GuestRequest` / `GuestResponse` frames. The mock implements that
+//! protocol faithfully enough for the audit-emit live tests in
+//! `tests/audit_emissions_live.rs` to exercise `mvmctl fs *` and
+//! `mvmctl proc *` end-to-end without a real microVM.
+//!
+//! ## What the mock answers
+//!
+//! - **Fs verbs** (`FsWrite`, `FsMkdir`, `FsRemove`, `FsMove`) return
+//!   the matching success variant of [`FsResult`]. Byte counts and
+//!   entry counts reflect the input so audit-detail strings (`bytes=N`,
+//!   `entries=N`) line up with what a real agent would emit.
+//! - **Proc verbs** (`ProcStart`, `ProcSignal`, `ProcSendInput`,
+//!   `ProcKill`) return the matching success variant of [`ProcResult`].
+//!   `ProcStart` mints a deterministic `proc-<N>` token from an atomic
+//!   counter.
+//! - **Read-only verbs** (`FsRead`, `FsStat`, `FsList`, `ProcList`,
+//!   `ProcWait`) return empty / zero-state responses — they exist to
+//!   keep the wire surface complete for the pinned no-emit tests in
+//!   plan 66 W4, not to model real filesystem / proc state.
+//! - **Everything else** comes back as `GuestResponse::Error` so a
+//!   future verb that lands without a matching mock arm fails loud
+//!   instead of hanging.
+//!
+//! ## Security profile
+//!
+//! Tier 3 / test-only. The mock accepts every request, never
+//! validates signatures, and never enforces policy. It mirrors
+//! [`MockBackend`]'s posture — never selectable from
+//! `AnyBackend::auto_select`, only via `--hypervisor mock`.
+
+use std::io::{Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use mvm_guest::vsock::{
+    FsErrorKind, FsResult, GuestRequest, GuestResponse, ProcResult, ProcWaitEvent,
+};
+
+/// Maximum frame size accepted by the mock agent — matches the
+/// host-side `MAX_FRAME_SIZE` (256 KiB) so the mock breaks loud
+/// rather than silent if a caller exceeds the production cap.
+const MAX_FRAME_SIZE: usize = 256 * 1024;
+
+/// How long the accept loop waits between shutdown-flag checks.
+/// Short enough that `MockGuestAgent::stop()` returns promptly,
+/// long enough to keep idle CPU near zero.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Per-VM mock agent. Owns the listener thread and shuts it down
+/// when dropped or when [`stop`](Self::stop) is called.
+pub struct MockGuestAgent {
+    socket_path: PathBuf,
+    shutdown: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for MockGuestAgent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MockGuestAgent")
+            .field("socket_path", &self.socket_path)
+            .field("running", &!self.shutdown.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+impl MockGuestAgent {
+    /// Start a new mock agent listening on `<vm_dir>/runtime/v.sock`.
+    ///
+    /// Creates the `runtime` subdirectory if missing and removes any
+    /// stale socket file at the target path. The accept loop runs
+    /// on a background thread; callers must hold the returned handle
+    /// for the agent's lifetime.
+    pub fn start(vm_dir: &Path) -> Result<Self> {
+        let runtime_dir = vm_dir.join("runtime");
+        std::fs::create_dir_all(&runtime_dir)
+            .with_context(|| format!("creating runtime dir at {}", runtime_dir.display()))?;
+        let socket_path = runtime_dir.join("v.sock");
+        // Stale socket from a previous run would make `bind` fail
+        // with EADDRINUSE. Best-effort removal.
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path)
+            .with_context(|| format!("binding mock agent at {}", socket_path.display()))?;
+        listener
+            .set_nonblocking(true)
+            .with_context(|| "setting listener non-blocking")?;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = Arc::clone(&shutdown);
+        let next_token = Arc::new(AtomicU64::new(1));
+        let next_token_clone = Arc::clone(&next_token);
+
+        let thread = std::thread::Builder::new()
+            .name(format!(
+                "mock-guest-agent-{}",
+                vm_dir.file_name().and_then(|s| s.to_str()).unwrap_or("vm")
+            ))
+            .spawn(move || run_accept_loop(listener, shutdown_clone, next_token_clone))
+            .with_context(|| "spawning mock guest-agent thread")?;
+
+        Ok(Self {
+            socket_path,
+            shutdown,
+            thread: Some(thread),
+        })
+    }
+
+    /// Path of the Unix socket the agent is listening on.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    /// Signal the accept loop to exit, join the thread, and remove
+    /// the socket file. Idempotent — subsequent calls are no-ops.
+    pub fn stop(mut self) {
+        self.shutdown_inner();
+    }
+
+    fn shutdown_inner(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+impl Drop for MockGuestAgent {
+    fn drop(&mut self) {
+        self.shutdown_inner();
+    }
+}
+
+fn run_accept_loop(listener: UnixListener, shutdown: Arc<AtomicBool>, next_token: Arc<AtomicU64>) {
+    while !shutdown.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((stream, _addr)) => {
+                // The listener is non-blocking (so accept can return
+                // WouldBlock for the shutdown poll). On some
+                // platforms the accepted socket inherits non-blocking
+                // mode; force it back to blocking + a generous read
+                // timeout so a misbehaving client can't wedge the
+                // worker forever.
+                if let Err(e) = stream.set_nonblocking(false) {
+                    tracing::warn!("mock-guest-agent: set_nonblocking(false) failed: {e}");
+                    continue;
+                }
+                let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+                let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
+                let token_counter = Arc::clone(&next_token);
+                // One worker per connection. Tests bring up at most
+                // a handful of VMs with one in-flight call each;
+                // unbounded spawn is fine at this scale.
+                let _ = std::thread::Builder::new()
+                    .name("mock-guest-agent-worker".to_string())
+                    .spawn(move || handle_connection(stream, token_counter));
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(_) => {
+                // Listener dropped (socket file removed during stop)
+                // or other unrecoverable error — exit cleanly.
+                break;
+            }
+        }
+    }
+}
+
+/// Handle one client connection: CONNECT handshake, then one
+/// request/response cycle, then close. Matches the host-side
+/// `connect_to_port` + `send_request` shape.
+fn handle_connection(mut stream: UnixStream, next_token: Arc<AtomicU64>) {
+    // Read the CONNECT line one byte at a time. A `BufReader` would
+    // be more idiomatic but it pre-buffers from the underlying
+    // stream, which means it can swallow the length-prefix bytes
+    // the client immediately writes after `CONNECT <port>\n`. The
+    // byte-by-byte loop guarantees the next read on `stream`
+    // starts exactly at the length-prefix.
+    let connect_line = match read_line_byte_by_byte(&mut stream) {
+        Some(line) => line,
+        None => return,
+    };
+    let port = parse_connect_line(&connect_line).unwrap_or(0);
+
+    if writeln!(stream, "OK {}", port).is_err() {
+        return;
+    }
+    if stream.flush().is_err() {
+        return;
+    }
+
+    // Read one length-prefixed JSON request.
+    let mut len_buf = [0u8; 4];
+    if stream.read_exact(&mut len_buf).is_err() {
+        return;
+    }
+    let frame_len = u32::from_be_bytes(len_buf) as usize;
+    if frame_len == 0 || frame_len > MAX_FRAME_SIZE {
+        return;
+    }
+    let mut body = vec![0u8; frame_len];
+    if stream.read_exact(&mut body).is_err() {
+        return;
+    }
+    let req: GuestRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(_) => {
+            let _ = write_error(&mut stream, "mock: failed to deserialize GuestRequest");
+            return;
+        }
+    };
+
+    let resp = dispatch(req, &next_token);
+    let _ = write_frame(&mut stream, &resp);
+}
+
+fn parse_connect_line(line: &str) -> Option<u32> {
+    let trimmed = line.trim();
+    let rest = trimmed.strip_prefix("CONNECT ")?;
+    rest.parse().ok()
+}
+
+/// Read a single line (terminated by `\n`) from `stream` one byte at
+/// a time. Used in place of `BufReader::read_line` so the worker
+/// can switch to length-prefixed framing on the next read without
+/// any pre-buffered bytes left over. Caps at 128 bytes — the line
+/// the client sends is `"CONNECT <decimal-u32>\n"`, comfortably
+/// shorter than that.
+fn read_line_byte_by_byte(stream: &mut UnixStream) -> Option<String> {
+    let mut out = Vec::with_capacity(32);
+    let mut byte = [0u8; 1];
+    while out.len() < 128 {
+        match stream.read_exact(&mut byte) {
+            Ok(()) => {
+                out.push(byte[0]);
+                if byte[0] == b'\n' {
+                    return String::from_utf8(out).ok();
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+    None
+}
+
+fn write_frame(stream: &mut UnixStream, resp: &GuestResponse) -> Result<()> {
+    let data = serde_json::to_vec(resp).context("serialize GuestResponse")?;
+    let len = (data.len() as u32).to_be_bytes();
+    stream.write_all(&len)?;
+    stream.write_all(&data)?;
+    stream.flush()?;
+    Ok(())
+}
+
+fn write_error(stream: &mut UnixStream, message: &str) -> Result<()> {
+    write_frame(
+        stream,
+        &GuestResponse::Error {
+            message: message.to_string(),
+        },
+    )
+}
+
+/// Translate one `GuestRequest` into the matching success-shaped
+/// `GuestResponse`. Centralised so the protocol surface is auditable
+/// in one place.
+fn dispatch(req: GuestRequest, next_token: &AtomicU64) -> GuestResponse {
+    match req {
+        // ── Filesystem verbs ────────────────────────────────────────
+        GuestRequest::FsWrite { content, .. } => GuestResponse::FsResult(FsResult::Write {
+            bytes_written: content.len() as u64,
+        }),
+        GuestRequest::FsMkdir { .. } => GuestResponse::FsResult(FsResult::Mkdir),
+        GuestRequest::FsRemove { .. } => {
+            // Real agent reports actual entry count; the mock has no
+            // tree to walk, so always report a single entry removed.
+            // The audit emit only asserts `entries=<N>` exists, not
+            // the value.
+            GuestResponse::FsResult(FsResult::Remove { entries_removed: 1 })
+        }
+        GuestRequest::FsMove { .. } => GuestResponse::FsResult(FsResult::Move),
+        GuestRequest::FsList { .. } => GuestResponse::FsResult(FsResult::List {
+            entries: Vec::new(),
+            truncated: false,
+        }),
+        GuestRequest::FsRead { .. } | GuestRequest::FsStat { .. } => {
+            GuestResponse::FsResult(FsResult::Error {
+                kind: FsErrorKind::Other,
+                message: "mock guest-agent: read/stat not implemented".to_string(),
+            })
+        }
+
+        // ── Process verbs ───────────────────────────────────────────
+        GuestRequest::ProcStart { .. } => {
+            let n = next_token.fetch_add(1, Ordering::Relaxed);
+            GuestResponse::ProcResult(ProcResult::Started {
+                pid_token: format!("proc-{n}"),
+            })
+        }
+        GuestRequest::ProcSignal { .. } => GuestResponse::ProcResult(ProcResult::Signaled),
+        GuestRequest::ProcSendInput { bytes, .. } => {
+            GuestResponse::ProcResult(ProcResult::InputAccepted {
+                bytes_accepted: bytes.len() as u64,
+            })
+        }
+        GuestRequest::ProcKill { .. } => GuestResponse::ProcResult(ProcResult::Killed),
+        GuestRequest::ProcList => GuestResponse::ProcResult(ProcResult::List {
+            processes: Vec::new(),
+        }),
+        GuestRequest::ProcWait { .. } => {
+            GuestResponse::ProcWaitEvent(ProcWaitEvent::Exit { code: 0 })
+        }
+
+        // ── Catch-all: every other verb fails loud ──────────────────
+        other => GuestResponse::Error {
+            message: format!(
+                "mock guest-agent: verb {:?} is not implemented",
+                std::mem::discriminant(&other)
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_guest::vsock::{send_fs_request, send_proc_request};
+    use std::collections::BTreeMap;
+    use tempfile::TempDir;
+
+    fn make_vm_dir() -> TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn write_file_round_trip() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent; // keep alive
+
+        let req = GuestRequest::FsWrite {
+            path: "/tmp/hello".to_string(),
+            content: b"hi there".to_vec(),
+            mode: 0o644,
+            create_parents: false,
+            follow_symlinks: false,
+        };
+        let result = send_fs_request(&dir.path().to_string_lossy(), req).expect("send_fs_request");
+        match result {
+            FsResult::Write { bytes_written } => assert_eq!(bytes_written, 8),
+            other => panic!("expected Write, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mkdir_and_remove_round_trip() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+        let mk = send_fs_request(
+            &dir.path().to_string_lossy(),
+            GuestRequest::FsMkdir {
+                path: "/tmp/x".to_string(),
+                mode: 0o755,
+                parents: false,
+            },
+        )
+        .expect("mkdir");
+        assert!(matches!(mk, FsResult::Mkdir));
+        let rm = send_fs_request(
+            &dir.path().to_string_lossy(),
+            GuestRequest::FsRemove {
+                path: "/tmp/x".to_string(),
+                recursive: false,
+                follow_symlinks: false,
+            },
+        )
+        .expect("remove");
+        assert!(matches!(rm, FsResult::Remove { entries_removed: 1 }));
+    }
+
+    #[test]
+    fn proc_start_assigns_deterministic_tokens() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+
+        let req = || GuestRequest::ProcStart {
+            argv: vec!["/bin/true".to_string()],
+            env: BTreeMap::new(),
+            cwd: None,
+            stdin: Vec::new(),
+            timeout_secs: None,
+        };
+        let path = dir.path().to_string_lossy();
+        let r1 = send_proc_request(&path, req()).expect("start 1");
+        let r2 = send_proc_request(&path, req()).expect("start 2");
+        match (r1, r2) {
+            (ProcResult::Started { pid_token: t1 }, ProcResult::Started { pid_token: t2 }) => {
+                assert_eq!(t1, "proc-1");
+                assert_eq!(t2, "proc-2");
+            }
+            other => panic!("expected Started + Started, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn proc_signal_and_kill_return_success_variants() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+        let path = dir.path().to_string_lossy();
+        let sig = send_proc_request(
+            &path,
+            GuestRequest::ProcSignal {
+                pid_token: "proc-anything".to_string(),
+                signum: 15,
+            },
+        )
+        .expect("signal");
+        assert!(matches!(sig, ProcResult::Signaled));
+        let kill = send_proc_request(
+            &path,
+            GuestRequest::ProcKill {
+                pid_token: "proc-anything".to_string(),
+            },
+        )
+        .expect("kill");
+        assert!(matches!(kill, ProcResult::Killed));
+    }
+
+    #[test]
+    fn proc_send_input_reports_accepted_bytes() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+        let result = send_proc_request(
+            &dir.path().to_string_lossy(),
+            GuestRequest::ProcSendInput {
+                pid_token: "proc-1".to_string(),
+                bytes: vec![1, 2, 3, 4, 5],
+            },
+        )
+        .expect("send input");
+        match result {
+            ProcResult::InputAccepted { bytes_accepted } => assert_eq!(bytes_accepted, 5),
+            other => panic!("expected InputAccepted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stop_removes_socket() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let socket = agent.socket_path().to_path_buf();
+        assert!(socket.exists(), "socket must exist while agent is up");
+        agent.stop();
+        assert!(
+            !socket.exists(),
+            "socket must be removed by MockGuestAgent::stop"
+        );
+    }
+
+    #[test]
+    fn two_agents_on_separate_vm_dirs_do_not_collide() {
+        let dir_a = make_vm_dir();
+        let dir_b = make_vm_dir();
+        let agent_a = MockGuestAgent::start(dir_a.path()).expect("start a");
+        let agent_b = MockGuestAgent::start(dir_b.path()).expect("start b");
+        let _ = (&agent_a, &agent_b);
+
+        let write_a = send_fs_request(
+            &dir_a.path().to_string_lossy(),
+            GuestRequest::FsWrite {
+                path: "/tmp/a".to_string(),
+                content: b"a".to_vec(),
+                mode: 0o644,
+                create_parents: false,
+                follow_symlinks: false,
+            },
+        )
+        .expect("write a");
+        let write_b = send_fs_request(
+            &dir_b.path().to_string_lossy(),
+            GuestRequest::FsWrite {
+                path: "/tmp/b".to_string(),
+                content: b"bb".to_vec(),
+                mode: 0o644,
+                create_parents: false,
+                follow_symlinks: false,
+            },
+        )
+        .expect("write b");
+        match (write_a, write_b) {
+            (FsResult::Write { bytes_written: 1 }, FsResult::Write { bytes_written: 2 }) => {}
+            other => panic!("expected 1-byte / 2-byte writes, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
Replacement for #122 (auto-closed in cascade). Same content; retargets to main.

See #122 for full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)