### PR TITLE
feat(doctor): plan 52 W3 follow-on — surface claim 10 in security posture

### DIFF
--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -164,6 +164,7 @@ pub fn run(json: bool) -> Result<()> {
     checks.push(security_dev_image_check());
     checks.push(security_deny_config_check());
     checks.push(security_default_network_check());
+    checks.push(security_network_policy_default_check());
     checks.push(security_snapshot_key_check());
     checks.push(security_snapshot_dirs_check());
 
@@ -1099,6 +1100,38 @@ fn security_default_network_check() -> Check {
     }
 }
 
+/// ADR-002 claim 10: *no untrusted workload reaches the network unless
+/// explicitly admitted by policy.* Sprint 52 W3 flipped
+/// `NetworkPolicy::default()` from `unrestricted()` to `deny_all()` so
+/// the safe posture is the one workloads get without opting in. This
+/// check makes the runtime default visible in `mvmctl doctor` so the
+/// claim is observably enforced rather than implicit in the codepath.
+///
+/// Pure read of the policy default — no I/O, no platform branching.
+/// A future regression that flipped the default back to `unrestricted`
+/// would surface here loudly.
+fn security_network_policy_default_check() -> Check {
+    use mvm_core::policy::network_policy::NetworkPolicy;
+    let default = NetworkPolicy::default();
+    // `NetworkPolicy::deny_all()` constructs the canonical deny-all
+    // shape; equality against that is the load-bearing assertion.
+    // Comparing against the constructor rather than introspecting
+    // variants keeps this check resilient to future variant adds.
+    let is_deny_all = default == NetworkPolicy::deny_all();
+    Check {
+        name: "network policy default (claim 10)",
+        category: "security",
+        ok: is_deny_all,
+        info: if is_deny_all {
+            "deny_all (claim 10 holds — egress refused unless explicitly admitted)".to_string()
+        } else {
+            "unrestricted — claim 10 does NOT hold; ADR-002 §10 regression. \
+             Workloads boot with open egress unless --network-preset is set explicitly."
+                .to_string()
+        },
+    }
+}
+
 /// `~/.mvm/snapshot.key` should be mode 0600 (ADR-007 §W4 / M9).
 ///
 /// Absence is informational — the file is created lazily on first
@@ -1532,6 +1565,28 @@ mod tests {
         assert!(
             c.info.contains("0700"),
             "info should report the data dir's mode, got: {}",
+            c.info
+        );
+    }
+
+    #[test]
+    fn security_network_policy_default_check_reports_claim_10_holding() {
+        // Sprint 52 W3 invariant: `NetworkPolicy::default()` returns
+        // `deny_all`. If a future regression flips it back to
+        // `unrestricted`, this check fails loudly in doctor — pinning
+        // claim 10 against silent drift.
+        let c = security_network_policy_default_check();
+        assert_eq!(c.category, "security");
+        assert!(c.ok, "claim 10 must hold; doctor saw: {}", c.info);
+        assert!(
+            c.info.contains("deny_all"),
+            "info should call out deny_all; got: {}",
+            c.info
+        );
+        assert!(
+            c.info.contains("claim 10 holds"),
+            "info should name claim 10 so operators searching the doctor \
+             output for the claim find it; got: {}",
             c.info
         );
     }

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -45,7 +45,9 @@ thiserror = "1"
 # production DnsResolver impl. Tests use only `macros + rt`, the
 # proxy needs `net` for lookup. `rt-multi-thread` lands when the
 # TCP listener loop ships in 2.6 chunk (c).
-tokio = { workspace = true, features = ["net", "rt"] }
+# Sprint 52 W1 follow-on: balloon_runtime spawns a periodic
+# `tokio::time::sleep`-driven tick loop, hence the `time` feature.
+tokio = { workspace = true, features = ["net", "rt", "time", "sync"] }
 tracing.workspace = true
 
 # Sampler (A3) reads `/proc/<pid>/stat` and uses `sysconf(_SC_CLK_TCK)` /
@@ -57,7 +59,7 @@ libc.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "io-util", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "io-util", "time", "sync", "test-util"] }
 
 [lints]
 workspace = true

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -57,6 +57,13 @@ tracing.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]
 libc.workspace = true
 
+# Sprint 52 W1 follow-on (PSI/vm_pressure): `VmPressureLevelSource`
+# on macOS calls `sysctlbyname("kern.memorystatus_vm_pressure_level")`
+# via libc to get the kernel's discrete pressure level (Normal/Warn/
+# Critical) — a stronger signal than the sysinfo used/total ratio.
+[target.'cfg(target_os = "macos")'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "io-util", "time", "sync", "test-util"] }

--- a/crates/mvm-supervisor/src/balloon.rs
+++ b/crates/mvm-supervisor/src/balloon.rs
@@ -200,6 +200,224 @@ impl HostPressureSource for SysinfoPressureSource {
     }
 }
 
+/// Linux PSI-backed pressure source.
+///
+/// Reads `/proc/pressure/memory` and reports the 10-second
+/// percentage that *every* runnable task spent stalled on memory
+/// (`full avg10`), divided by 100 to land in `[0.0, 1.0]`. PSI is
+/// the stronger signal on Linux because it distinguishes "host has
+/// caches it could drop" (low PSI) from "host is actively stalled
+/// freeing pages" (high PSI). sysinfo's `used/total` conflates the
+/// two.
+///
+/// Some kernels (containers without `CONFIG_PSI=y`, or hosts where
+/// the file lacks the `full` line) only expose `some`; this impl
+/// falls back to the `some avg10` value in that case, which still
+/// captures memory-pressure stalls on *at least one* task and is
+/// strictly more informative than no signal at all.
+///
+/// Construction succeeds eagerly so callers can wire the source
+/// up at process boot without an `Option<Box<dyn …>>`; the file
+/// existence + parse round-trip is re-checked on every `current()`
+/// call to gracefully tolerate transient I/O hiccups.
+pub struct PsiPressureSource {
+    path: std::path::PathBuf,
+}
+
+impl PsiPressureSource {
+    /// Construct, defaulting to `/proc/pressure/memory`. Use
+    /// [`from_path`](Self::from_path) for tests that point at a
+    /// tempfile fixture.
+    pub fn new() -> Self {
+        Self::from_path("/proc/pressure/memory")
+    }
+
+    /// Construct from an explicit path. The path can be any file
+    /// whose contents match Linux's PSI memory format —
+    /// fixture-driven tests use this to drive deterministic
+    /// pressure values without poking real procfs.
+    pub fn from_path<P: Into<std::path::PathBuf>>(path: P) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+impl Default for PsiPressureSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HostPressureSource for PsiPressureSource {
+    fn current(&self) -> anyhow::Result<HostPressure> {
+        let contents = std::fs::read_to_string(&self.path)
+            .map_err(|e| anyhow::anyhow!("read {}: {e}", self.path.display()))?;
+        let avg10 = parse_psi_full_avg10(&contents)
+            .or_else(|| parse_psi_some_avg10(&contents))
+            .ok_or_else(|| {
+                anyhow::anyhow!("could not parse `full avg10` or `some avg10` from PSI file")
+            })?;
+        // PSI reports a percentage 0..100; the controller expects
+        // a fraction 0..1.
+        Ok(HostPressure::clamped(avg10 / 100.0))
+    }
+}
+
+/// Parse the `full avg10=NN.NN` value from PSI memory output.
+fn parse_psi_full_avg10(contents: &str) -> Option<f32> {
+    parse_psi_avg10_for_prefix(contents, "full ")
+}
+
+/// Parse the `some avg10=NN.NN` value from PSI memory output.
+fn parse_psi_some_avg10(contents: &str) -> Option<f32> {
+    parse_psi_avg10_for_prefix(contents, "some ")
+}
+
+fn parse_psi_avg10_for_prefix(contents: &str, prefix: &str) -> Option<f32> {
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix(prefix) {
+            for kv in rest.split_whitespace() {
+                if let Some(v) = kv.strip_prefix("avg10=") {
+                    return v.parse().ok();
+                }
+            }
+        }
+    }
+    None
+}
+
+/// macOS pressure source backed by the
+/// `kern.memorystatus_vm_pressure_level` sysctl.
+///
+/// macOS exposes a discrete pressure state — 1 (Normal), 2 (Warn),
+/// 4 (Critical) — rather than a continuous fraction. The mapping
+/// to a 0..1 value is approximate: Normal → 0.30 (controller sits
+/// well below the inflate threshold), Warn → 0.70 (still under the
+/// 0.80 inflate trigger but above the deflate floor, so the
+/// controller holds), Critical → 0.95 (well above inflate, so
+/// the controller actively reclaims).
+///
+/// Construction always succeeds; `current()` returns the live
+/// reading or falls back to sysinfo if the sysctl call fails
+/// (older macOS, unusual sandbox restrictions, etc.).
+#[cfg(target_os = "macos")]
+pub struct VmPressureLevelSource {
+    fallback: SysinfoPressureSource,
+}
+
+#[cfg(target_os = "macos")]
+impl VmPressureLevelSource {
+    pub fn new() -> Self {
+        Self {
+            fallback: SysinfoPressureSource::new(),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Default for VmPressureLevelSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl HostPressureSource for VmPressureLevelSource {
+    fn current(&self) -> anyhow::Result<HostPressure> {
+        match read_macos_pressure_level() {
+            Ok(level) => Ok(HostPressure::clamped(macos_level_to_pressure(level))),
+            Err(_) => {
+                // Sysctl unavailable on this build / sandbox /
+                // macOS version: degrade to sysinfo's used/total
+                // rather than failing the whole tick. The
+                // controller's dead-band absorbs the difference.
+                self.fallback.current()
+            }
+        }
+    }
+}
+
+/// Read `kern.memorystatus_vm_pressure_level` via sysctl. The
+/// kernel publishes one of: 1 (Normal), 2 (Warn), 4 (Critical).
+#[cfg(target_os = "macos")]
+fn read_macos_pressure_level() -> anyhow::Result<i32> {
+    use std::ffi::CString;
+
+    let name = CString::new("kern.memorystatus_vm_pressure_level")
+        .expect("sysctl name has no interior NULs");
+    let mut value: i32 = 0;
+    let mut size: libc::size_t = std::mem::size_of::<i32>();
+    let rc = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            &mut value as *mut i32 as *mut libc::c_void,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 {
+        anyhow::bail!(
+            "sysctlbyname(kern.memorystatus_vm_pressure_level) failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(value)
+}
+
+/// Map the discrete macOS pressure level to a fraction in `[0,1]`.
+///
+/// The thresholds chosen line up with `BalloonPolicy`'s defaults
+/// (`inflate_above = 0.80`, `deflate_below = 0.60`):
+///
+/// - Normal (1) → 0.30: below `deflate_below`, controller releases
+///   memory.
+/// - Warn (2)   → 0.70: inside the dead-band, controller holds.
+/// - Critical (4) → 0.95: above `inflate_above`, controller
+///   reclaims aggressively.
+///
+/// Unknown values default to Normal (0.30) — the conservative
+/// choice when the kernel reports a level the controller doesn't
+/// recognise, since over-deflating is recoverable but over-
+/// inflating risks OOM-killing the workload.
+#[cfg(target_os = "macos")]
+fn macos_level_to_pressure(level: i32) -> f32 {
+    match level {
+        1 => 0.30,
+        2 => 0.70,
+        4 => 0.95,
+        _ => 0.30,
+    }
+}
+
+/// Pick the best-available pressure source for the current host.
+///
+/// - Linux with PSI available → [`PsiPressureSource`].
+/// - macOS → [`VmPressureLevelSource`] (which itself falls back
+///   to sysinfo on sysctl failure).
+/// - Anything else → [`SysinfoPressureSource`].
+///
+/// The return type is `Box<dyn HostPressureSource>` so the caller
+/// can plumb a single value into `BalloonController` without
+/// per-platform generics.
+pub fn default_pressure_source() -> Box<dyn HostPressureSource> {
+    #[cfg(target_os = "linux")]
+    {
+        let psi = PsiPressureSource::new();
+        // Probe once: if the file exists + parses, prefer PSI;
+        // otherwise fall through to sysinfo so a container without
+        // `CONFIG_PSI=y` still gets a working signal.
+        if psi.current().is_ok() {
+            return Box::new(psi);
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return Box::new(VmPressureLevelSource::new());
+    }
+    #[allow(unreachable_code)]
+    Box::new(SysinfoPressureSource::new())
+}
+
 // ---------------------------------------------------------------------------
 // BalloonController — pressure-driven reclaim tick
 // ---------------------------------------------------------------------------
@@ -561,5 +779,131 @@ mod tests {
             1,
             "pressure should be read once per tick, not once per VM"
         );
+    }
+
+    // ── PsiPressureSource tests ─────────────────────────────────────
+
+    #[test]
+    fn psi_parses_full_avg10() {
+        // Real-shape PSI content with both `some` and `full`. The
+        // controller prefers `full avg10` because it captures the
+        // stronger "every task stalled" signal.
+        let raw = "some avg10=12.34 avg60=23.45 avg300=34.56 total=12345\n\
+                   full avg10=42.50 avg60=12.34 avg300=5.67 total=2345\n";
+        let pressure = parse_psi_full_avg10(raw).expect("parse");
+        assert!((pressure - 42.50).abs() < 0.001);
+    }
+
+    #[test]
+    fn psi_falls_back_to_some_when_full_absent() {
+        // Container kernels without CONFIG_PSI=y sometimes expose
+        // only the `some` line. The source must still produce a
+        // signal.
+        let raw = "some avg10=7.50 avg60=5.00 avg300=3.00 total=999\n";
+        assert!(parse_psi_full_avg10(raw).is_none());
+        let pressure = parse_psi_some_avg10(raw).expect("parse some");
+        assert!((pressure - 7.50).abs() < 0.001);
+    }
+
+    #[test]
+    fn psi_returns_none_for_garbage() {
+        // Malformed input shouldn't panic — return None so the
+        // source surfaces an error instead.
+        assert!(parse_psi_full_avg10("nope\nnothing\nuseful").is_none());
+        assert!(parse_psi_some_avg10("nope\nnothing\nuseful").is_none());
+    }
+
+    #[test]
+    fn psi_source_reads_from_fixture_path() {
+        // Drive the full source against a tempfile so we can pin
+        // behaviour without poking real procfs (which may not
+        // exist on macOS / BSD test runners).
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(
+            tmp.path(),
+            "some avg10=80.00 avg60=70.00 avg300=60.00 total=100\n\
+             full avg10=85.50 avg60=70.00 avg300=60.00 total=100\n",
+        )
+        .expect("write fixture");
+        let src = PsiPressureSource::from_path(tmp.path());
+        let p = src.current().expect("current");
+        // 85.50 / 100 = 0.855 (clamped to <=1.0).
+        assert!((p.0 - 0.855).abs() < 0.001);
+    }
+
+    #[test]
+    fn psi_source_clamps_percentage_above_100() {
+        // PSI is well-defined as 0..100 but the parser doesn't
+        // reject out-of-range values — clamping is the source's
+        // responsibility so the controller never sees a >1.0
+        // pressure that would break its 0..1 contract.
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(
+            tmp.path(),
+            "full avg10=150.00 avg60=10.00 avg300=10.00 total=1\n",
+        )
+        .expect("write fixture");
+        let src = PsiPressureSource::from_path(tmp.path());
+        let p = src.current().expect("current");
+        assert_eq!(p.0, 1.0);
+    }
+
+    #[test]
+    fn psi_source_surfaces_io_error_when_path_missing() {
+        let src = PsiPressureSource::from_path("/this/path/does/not/exist");
+        let err = src.current().unwrap_err();
+        assert!(err.to_string().contains("read"));
+    }
+
+    // ── macOS VmPressureLevelSource tests ───────────────────────────
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_level_mapping_lines_up_with_policy_thresholds() {
+        // Defaults: inflate at 0.80, deflate at 0.60.
+        // Normal (1) → 0.30 sits below deflate threshold (controller releases).
+        // Warn (2)   → 0.70 sits in the dead-band (controller holds).
+        // Critical (4) → 0.95 sits above inflate threshold (controller reclaims).
+        let default_policy = BalloonPolicy::default();
+        assert!(macos_level_to_pressure(1) < default_policy.deflate_below);
+        let warn = macos_level_to_pressure(2);
+        assert!(warn > default_policy.deflate_below);
+        assert!(warn < default_policy.inflate_above);
+        assert!(macos_level_to_pressure(4) > default_policy.inflate_above);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_unknown_level_maps_to_normal() {
+        // Unknown values default to the conservative (Normal)
+        // mapping — over-deflating is recoverable, over-inflating
+        // risks OOM.
+        let expected = macos_level_to_pressure(1);
+        assert_eq!(macos_level_to_pressure(99), expected);
+        assert_eq!(macos_level_to_pressure(-1), expected);
+        assert_eq!(macos_level_to_pressure(0), expected);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_vm_pressure_source_returns_in_range() {
+        // Live sysctl call — every macOS host returns a valid
+        // level. Test asserts the resulting pressure is bounded
+        // in [0, 1] (the clamp covers any future kernel returning
+        // an unmapped value).
+        let src = VmPressureLevelSource::new();
+        let p = src.current().expect("sysctl read");
+        assert!(p.0 >= 0.0 && p.0 <= 1.0);
+    }
+
+    // ── default_pressure_source() tests ─────────────────────────────
+
+    #[test]
+    fn default_pressure_source_returns_something_callable() {
+        // Smoke test: the factory returns a working source on
+        // every platform the test suite runs on.
+        let src = default_pressure_source();
+        let p = src.current().expect("current");
+        assert!(p.0 >= 0.0 && p.0 <= 1.0);
     }
 }

--- a/crates/mvm-supervisor/src/balloon_runtime.rs
+++ b/crates/mvm-supervisor/src/balloon_runtime.rs
@@ -1,0 +1,515 @@
+//! Periodic-tick driver for [`BalloonController`].
+//!
+//! Sprint 52 W1 shipped `BalloonController::tick` as a pure-logic
+//! decision function. Production callers want it called on a
+//! schedule against the live `VmBackend`. This module is the
+//! adapter: it queries the backend for running VMs, reads each
+//! one's `BalloonState`, hands the snapshot to the controller, and
+//! wires the apply closure to `VmBackend::balloon_set_target`.
+//!
+//! The supervisor's eventual daemon binary spawns
+//! [`run_balloon_loop`] at boot; library consumers can also spawn
+//! it directly. The loop honours a `tokio::sync::watch` shutdown
+//! signal so callers can stop it cleanly.
+//!
+//! Why an async function and not a struct: the tick logic itself
+//! is fully synchronous (sysinfo reads + backend RPCs); the only
+//! reason for async at this level is the periodic sleep + the
+//! shutdown select. A free async function pushes the entire shape
+//! into one `tokio::spawn`-able awaitable without inventing a
+//! ContextManager.
+//!
+//! Tests cover both the pure-helper tick (`run_one_tick`) and the
+//! loop driver (with `tokio::time::pause` so the suite doesn't
+//! sleep for real).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use mvm_core::vm_backend::{VmBackend, VmStatus};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use tokio::sync::watch;
+
+use crate::balloon::{BalloonController, HostPressureSource, TickOutcome};
+use crate::reaper::jittered_interval;
+
+/// Tuning for the periodic balloon tick loop.
+#[derive(Debug, Clone)]
+pub struct BalloonRuntimeConfig {
+    /// Nominal interval between ticks.
+    pub base_interval: Duration,
+    /// Maximum +/- jitter applied to each interval. Zero disables
+    /// jitter and produces deterministic ticking — useful for
+    /// tests, suboptimal in production where coordinated ticking
+    /// across many supervisors would amplify host pressure.
+    pub jitter: Duration,
+}
+
+impl Default for BalloonRuntimeConfig {
+    fn default() -> Self {
+        // 10 s base + ±2 s jitter: responsive enough that a
+        // pressure spike doesn't sit unresolved for long, slow
+        // enough that `sysinfo::refresh_memory` (the current default
+        // pressure source) doesn't dominate the supervisor's CPU
+        // budget. Step-aligned with `BalloonPolicy::step_mib = 64`.
+        Self {
+            base_interval: Duration::from_secs(10),
+            jitter: Duration::from_secs(2),
+        }
+    }
+}
+
+/// Run a single tick against `backend`: list running VMs that
+/// advertise balloon support, read each one's state, run the
+/// controller, apply the resulting targets.
+///
+/// Pure-async-free synchronous helper so callers (and tests) can
+/// drive a single tick without a tokio runtime. Returns the empty
+/// outcome set when the backend doesn't advertise balloon support
+/// — no point in reading state from a backend that can't apply
+/// the result anyway.
+pub fn run_one_tick<P>(
+    backend: &dyn VmBackend,
+    controller: &BalloonController<P>,
+) -> anyhow::Result<Vec<TickOutcome>>
+where
+    P: HostPressureSource,
+{
+    if !backend.capabilities().balloon {
+        // Honest no-op: a balloon-less backend can't act on
+        // decisions, so skip the pressure read + state scan
+        // entirely. Empty outcome set is the natural return.
+        return Ok(Vec::new());
+    }
+
+    let infos = backend.list()?;
+    let mut states = Vec::new();
+    for info in infos {
+        if info.status != VmStatus::Running {
+            continue;
+        }
+        match backend.balloon_state(&info.id) {
+            Ok(state) => states.push((info.id, state)),
+            Err(e) => {
+                // A single VM's state-read failure doesn't sink
+                // the whole tick — record at warn and skip the VM
+                // so the others still get evaluated. A backend
+                // that hasn't created a balloon device for this
+                // particular VM (mem_initial wasn't set) hits this
+                // path with the per-backend "no balloon device"
+                // error.
+                tracing::warn!(
+                    vm = %info.name,
+                    "balloon_state read failed; skipping VM in this tick: {e:#}",
+                );
+            }
+        }
+    }
+
+    controller.tick(&states, |vm, target| backend.balloon_set_target(vm, target))
+}
+
+/// Async loop: every `config.base_interval` (± `config.jitter`),
+/// run a tick. Exits cleanly when `shutdown` flips to `true`.
+///
+/// Errors from `run_one_tick` are logged at `error!` and the loop
+/// continues — a transient backend failure shouldn't kill the
+/// supervisor's reclaim machinery. Non-`Hold` outcomes are logged
+/// at `info!` so an operator tailing the supervisor's logs sees
+/// "inflate vm-a to 256 MiB" lines while pressure is high.
+///
+/// The first tick fires after one interval, not immediately, so a
+/// freshly-spawned supervisor doesn't ballon-thrash on a still-
+/// settling pressure reading. Pass a [`watch::Receiver<bool>`] that
+/// can be set to `true` to stop the loop; the loop also exits if
+/// the sender side is dropped (treated as shutdown).
+pub async fn run_balloon_loop<P>(
+    backend: Arc<dyn VmBackend + Send + Sync>,
+    controller: BalloonController<P>,
+    config: BalloonRuntimeConfig,
+    mut shutdown: watch::Receiver<bool>,
+) where
+    P: HostPressureSource,
+{
+    let mut rng = StdRng::from_entropy();
+    loop {
+        let sleep_for = jittered_interval(&mut rng, config.base_interval, config.jitter);
+        let sleep = tokio::time::sleep(sleep_for);
+        tokio::pin!(sleep);
+        tokio::select! {
+            _ = &mut sleep => {}
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    tracing::info!("balloon loop received shutdown signal; exiting");
+                    return;
+                }
+            }
+        }
+
+        match run_one_tick(backend.as_ref(), &controller) {
+            Ok(outcomes) => {
+                for outcome in &outcomes {
+                    log_outcome(outcome);
+                }
+            }
+            Err(e) => {
+                tracing::error!("balloon tick failed (pressure read error or similar): {e:#}");
+            }
+        }
+    }
+}
+
+fn log_outcome(outcome: &TickOutcome) {
+    use crate::balloon::BalloonAction;
+    if let Some(err) = &outcome.error {
+        tracing::warn!(vm = %outcome.vm.0, "balloon apply failed: {err}");
+        return;
+    }
+    match &outcome.action {
+        BalloonAction::Hold => {
+            // Hold is the steady state — log at trace so an
+            // operator can confirm ticks are running but the
+            // signal doesn't flood the log under quiet pressure.
+            tracing::trace!(vm = %outcome.vm.0, "balloon hold");
+        }
+        BalloonAction::Inflate {
+            target_inflate_mib, ..
+        } => {
+            tracing::info!(
+                vm = %outcome.vm.0,
+                target_mib = *target_inflate_mib,
+                "balloon inflate",
+            );
+        }
+        BalloonAction::Deflate {
+            target_inflate_mib, ..
+        } => {
+            tracing::info!(
+                vm = %outcome.vm.0,
+                target_mib = *target_inflate_mib,
+                "balloon deflate",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Mutex;
+
+    use anyhow::bail;
+    use mvm_core::vm_backend::{
+        BackendSecurityProfile, BalloonState, ClaimStatus, LayerCoverage, VmCapabilities,
+        VmExitStatus, VmId, VmInfo, VmStartConfig, VmStatus,
+    };
+
+    use crate::balloon::{BalloonAction, BalloonPolicy, HostPressure};
+
+    // ── Test fixtures ──────────────────────────────────────────────
+
+    /// Minimal `HostPressureSource` returning a fixed value. Used
+    /// throughout the tests so policy decisions are deterministic.
+    struct FixedPressure(f32);
+    impl HostPressureSource for FixedPressure {
+        fn current(&self) -> anyhow::Result<HostPressure> {
+            Ok(HostPressure::clamped(self.0))
+        }
+    }
+
+    /// Pressure source that always errors — used to assert the
+    /// loop surfaces pressure-read failures.
+    struct ErrPressure;
+    impl HostPressureSource for ErrPressure {
+        fn current(&self) -> anyhow::Result<HostPressure> {
+            bail!("pressure read failed by fixture")
+        }
+    }
+
+    /// Minimal `VmBackend` impl for the tick-loop tests. Records
+    /// `balloon_set_target` calls so assertions can inspect what
+    /// the controller decided. All other methods are stubbed —
+    /// only the surfaces the tick uses are real.
+    struct TestBackend {
+        balloon_supported: bool,
+        vms: Vec<TestVm>,
+        applies: Mutex<Vec<(VmId, u32)>>,
+        /// When set, `balloon_set_target` returns Err for the
+        /// listed VM names. Tests use this to drive the "apply
+        /// failure surfaces in TickOutcome" path.
+        apply_fails_for: Vec<String>,
+    }
+
+    #[derive(Clone)]
+    struct TestVm {
+        id: VmId,
+        status: VmStatus,
+        state: BalloonState,
+    }
+
+    impl TestBackend {
+        fn new(balloon_supported: bool) -> Self {
+            Self {
+                balloon_supported,
+                vms: Vec::new(),
+                applies: Mutex::new(Vec::new()),
+                apply_fails_for: Vec::new(),
+            }
+        }
+        fn with_vm(mut self, id: &str, status: VmStatus, max: u32, inflated: u32) -> Self {
+            self.vms.push(TestVm {
+                id: VmId(id.to_string()),
+                status,
+                state: BalloonState {
+                    max_mib: max,
+                    inflated_mib: inflated,
+                    host_committed_mib: max.saturating_sub(inflated),
+                },
+            });
+            self
+        }
+        fn fail_apply_for(mut self, id: &str) -> Self {
+            self.apply_fails_for.push(id.to_string());
+            self
+        }
+        fn applied(&self) -> Vec<(VmId, u32)> {
+            self.applies.lock().unwrap().clone()
+        }
+    }
+
+    impl VmBackend for TestBackend {
+        fn name(&self) -> &str {
+            "test"
+        }
+        fn capabilities(&self) -> VmCapabilities {
+            VmCapabilities {
+                pause_resume: true,
+                snapshots: false,
+                vsock: false,
+                tap_networking: false,
+                balloon: self.balloon_supported,
+            }
+        }
+        fn start_with_mode(
+            &self,
+            _config: &VmStartConfig,
+            _mode: mvm_core::vm_backend::StartMode,
+        ) -> anyhow::Result<VmId> {
+            unimplemented!("test backend: start")
+        }
+        fn wait(&self, _id: &VmId) -> anyhow::Result<VmExitStatus> {
+            unimplemented!("test backend: wait")
+        }
+        fn stop(&self, _id: &VmId) -> anyhow::Result<()> {
+            unimplemented!("test backend: stop")
+        }
+        fn stop_all(&self) -> anyhow::Result<()> {
+            unimplemented!("test backend: stop_all")
+        }
+        fn pause(&self, _id: &VmId) -> anyhow::Result<()> {
+            unimplemented!("test backend: pause")
+        }
+        fn resume(&self, _id: &VmId) -> anyhow::Result<()> {
+            unimplemented!("test backend: resume")
+        }
+        fn status(&self, id: &VmId) -> anyhow::Result<VmStatus> {
+            for vm in &self.vms {
+                if vm.id == *id {
+                    return Ok(vm.status.clone());
+                }
+            }
+            Ok(VmStatus::Stopped)
+        }
+        fn list(&self) -> anyhow::Result<Vec<VmInfo>> {
+            Ok(self
+                .vms
+                .iter()
+                .map(|vm| VmInfo {
+                    id: vm.id.clone(),
+                    name: vm.id.0.clone(),
+                    status: vm.status.clone(),
+                    guest_ip: None,
+                    cpus: 1,
+                    memory_mib: vm.state.max_mib,
+                    profile: None,
+                    revision: None,
+                    flake_ref: None,
+                    ports: Vec::new(),
+                })
+                .collect())
+        }
+        fn logs(&self, _id: &VmId, _lines: u32, _hypervisor: bool) -> anyhow::Result<String> {
+            unimplemented!("test backend: logs")
+        }
+        fn is_available(&self) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+        fn install(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn balloon_set_target(&self, id: &VmId, target_inflate_mib: u32) -> anyhow::Result<()> {
+            if self.apply_fails_for.iter().any(|n| n == &id.0) {
+                bail!("test fixture: apply failure for {}", id.0);
+            }
+            self.applies
+                .lock()
+                .unwrap()
+                .push((id.clone(), target_inflate_mib));
+            Ok(())
+        }
+        fn balloon_state(&self, id: &VmId) -> anyhow::Result<BalloonState> {
+            for vm in &self.vms {
+                if vm.id == *id {
+                    return Ok(vm.state);
+                }
+            }
+            bail!("test backend: no state for {}", id.0)
+        }
+        fn security_profile(&self) -> BackendSecurityProfile {
+            BackendSecurityProfile {
+                claims: [ClaimStatus::DoesNotHold; 7],
+                layer_coverage: LayerCoverage::default(),
+                tier: "Tier 3 (test-only)",
+                notes: &[],
+            }
+        }
+    }
+
+    fn controller_pressure(p: f32) -> BalloonController<FixedPressure> {
+        BalloonController::new(BalloonPolicy::default(), FixedPressure(p))
+    }
+
+    // ── Synchronous tick tests ─────────────────────────────────────
+
+    #[test]
+    fn run_one_tick_skips_unsupported_backend() {
+        // Backend that doesn't advertise balloon support => the
+        // tick must not even read VM state, let alone call apply.
+        let backend = TestBackend::new(false).with_vm("vm-a", VmStatus::Running, 1024, 0);
+        let controller = controller_pressure(0.95);
+        let outcomes = run_one_tick(&backend, &controller).expect("tick");
+        assert!(outcomes.is_empty(), "unsupported backend must yield empty");
+        assert!(backend.applied().is_empty(), "must not call apply");
+    }
+
+    #[test]
+    fn run_one_tick_filters_to_running_vms() {
+        // Mix running + stopped; only running participates.
+        let backend = TestBackend::new(true)
+            .with_vm("running-vm", VmStatus::Running, 1024, 0)
+            .with_vm("stopped-vm", VmStatus::Stopped, 1024, 0);
+        // High pressure => inflate.
+        let controller = controller_pressure(0.95);
+        let outcomes = run_one_tick(&backend, &controller).expect("tick");
+        assert_eq!(outcomes.len(), 1, "only running VMs participate");
+        assert_eq!(outcomes[0].vm.0, "running-vm");
+        let applied = backend.applied();
+        assert_eq!(applied.len(), 1);
+        assert_eq!(applied[0].0.0, "running-vm");
+    }
+
+    #[test]
+    fn run_one_tick_propagates_pressure_read_error() {
+        // ErrPressure short-circuits the tick at the pressure read.
+        let backend = TestBackend::new(true).with_vm("vm-a", VmStatus::Running, 1024, 0);
+        let controller = BalloonController::new(BalloonPolicy::default(), ErrPressure);
+        let err = run_one_tick(&backend, &controller).unwrap_err();
+        assert!(err.to_string().contains("pressure read failed"));
+        assert!(backend.applied().is_empty());
+    }
+
+    #[test]
+    fn run_one_tick_records_apply_errors_per_vm() {
+        // Two VMs, one fails to apply — outcome must surface the
+        // error for the failing VM and still succeed for the
+        // healthy one.
+        let backend = TestBackend::new(true)
+            .with_vm("good", VmStatus::Running, 1024, 0)
+            .with_vm("bad", VmStatus::Running, 1024, 0)
+            .fail_apply_for("bad");
+        let controller = controller_pressure(0.95);
+        let outcomes = run_one_tick(&backend, &controller).expect("tick");
+        assert_eq!(outcomes.len(), 2);
+        let bad = outcomes.iter().find(|o| o.vm.0 == "bad").unwrap();
+        assert!(!bad.applied, "bad VM apply must report not applied");
+        assert!(bad.error.is_some());
+        let good = outcomes.iter().find(|o| o.vm.0 == "good").unwrap();
+        assert!(good.applied, "good VM apply must succeed");
+        assert!(good.error.is_none());
+    }
+
+    #[test]
+    fn run_one_tick_holds_in_dead_band() {
+        // Pressure between deflate_below (0.6) and inflate_above
+        // (0.8) => Hold.
+        let backend = TestBackend::new(true).with_vm("vm-a", VmStatus::Running, 1024, 256);
+        let controller = controller_pressure(0.70);
+        let outcomes = run_one_tick(&backend, &controller).expect("tick");
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(outcomes[0].action, BalloonAction::Hold));
+        assert!(!outcomes[0].applied, "Hold must not call apply");
+        assert!(backend.applied().is_empty());
+    }
+
+    // ── Async loop tests ───────────────────────────────────────────
+
+    /// Counts how many ticks ran by wrapping `TestBackend` in an
+    /// `Arc` and watching `applied()` grow.
+    #[tokio::test(start_paused = true)]
+    async fn run_balloon_loop_calls_tick_periodically() {
+        // High pressure + one running VM => every tick inflates
+        // (until ceiling). With base 1 s + jitter 0, three ticks
+        // in 3.5 s paused time. Drive the loop by advancing time
+        // one tick at a time and yielding so the runtime gets to
+        // resume the spawned task after each advance.
+        let backend = Arc::new(TestBackend::new(true).with_vm("vm-a", VmStatus::Running, 1024, 0));
+        let controller = controller_pressure(0.95);
+        let (tx, rx) = watch::channel(false);
+        let config = BalloonRuntimeConfig {
+            base_interval: Duration::from_secs(1),
+            jitter: Duration::ZERO,
+        };
+        let backend_loop: Arc<dyn VmBackend + Send + Sync> = backend.clone();
+        let task = tokio::spawn(run_balloon_loop(backend_loop, controller, config, rx));
+        // Advance time tick-by-tick and poll the apply counter
+        // until we've observed three ticks. Bounded by a hard
+        // ceiling so a wedged loop doesn't spin forever.
+        let mut iterations = 0;
+        while backend.applied().len() < 3 {
+            tokio::time::advance(Duration::from_secs(1)).await;
+            for _ in 0..8 {
+                tokio::task::yield_now().await;
+            }
+            iterations += 1;
+            assert!(
+                iterations < 50,
+                "loop didn't reach 3 ticks within 50 iterations; got {}",
+                backend.applied().len()
+            );
+        }
+        tx.send(true).expect("send shutdown");
+        let _ = tokio::time::timeout(Duration::from_secs(1), task).await;
+        assert!(backend.applied().len() >= 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_balloon_loop_exits_on_shutdown() {
+        // No advance => no tick fires, but shutdown signal still
+        // exits the loop within bounded time.
+        let backend: Arc<dyn VmBackend + Send + Sync> = Arc::new(TestBackend::new(true));
+        let controller = controller_pressure(0.5);
+        let (tx, rx) = watch::channel(false);
+        let config = BalloonRuntimeConfig {
+            base_interval: Duration::from_secs(60),
+            jitter: Duration::ZERO,
+        };
+        let task = tokio::spawn(run_balloon_loop(backend, controller, config, rx));
+        tx.send(true).expect("send shutdown");
+        let res = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("loop must exit within 1 s of shutdown");
+        res.expect("task panicked");
+    }
+}

--- a/crates/mvm-supervisor/src/lib.rs
+++ b/crates/mvm-supervisor/src/lib.rs
@@ -72,6 +72,12 @@ pub use audit_recorder::{
     UNBOUND_PLAN_ID,
 };
 pub use backend::{BackendError, BackendLauncher, NoopBackendLauncher};
+#[cfg(target_os = "macos")]
+pub use balloon::VmPressureLevelSource;
+pub use balloon::{
+    BalloonAction, BalloonController, BalloonPolicy, HostPressure, HostPressureSource,
+    PsiPressureSource, SysinfoPressureSource, TickOutcome, default_pressure_source,
+};
 pub use balloon_runtime::{BalloonRuntimeConfig, run_balloon_loop, run_one_tick};
 pub use circuit_breaker::{
     CircuitBreaker, CircuitBreakerConfig, CircuitState, Clock as CircuitBreakerClock,

--- a/crates/mvm-supervisor/src/lib.rs
+++ b/crates/mvm-supervisor/src/lib.rs
@@ -38,6 +38,7 @@ pub mod audit_file;
 pub mod audit_recorder;
 pub mod backend;
 pub mod balloon;
+pub mod balloon_runtime;
 pub mod circuit_breaker;
 pub mod destination;
 pub mod egress;
@@ -71,6 +72,7 @@ pub use audit_recorder::{
     UNBOUND_PLAN_ID,
 };
 pub use backend::{BackendError, BackendLauncher, NoopBackendLauncher};
+pub use balloon_runtime::{BalloonRuntimeConfig, run_balloon_loop, run_one_tick};
 pub use circuit_breaker::{
     CircuitBreaker, CircuitBreakerConfig, CircuitState, Clock as CircuitBreakerClock,
     InspectorReporter, SystemClock as CircuitBreakerSystemClock,


### PR DESCRIPTION
## Summary

Sprint 52 W3's deferred follow-up: `NetworkPolicy::default()` flipped from `unrestricted()` to `deny_all()`, but `mvmctl doctor` never mentioned it. The claim was load-bearing yet invisible — an operator auditing posture would have to read source.

Adds a `security_network_policy_default_check()` Check that calls `NetworkPolicy::default()` and compares against the canonical `deny_all()` shape. Comparing against the constructor (rather than introspecting variants) keeps the check resilient to future variant additions.

## Output

- **OK**: `deny_all (claim 10 holds — egress refused unless explicitly admitted)`
- **FAIL**: names the regression + points at ADR-002 §10.

## Stacked on

Stacks on **#139** (PSI + vm_pressure sources). Retarget to `main` once #138 → #139 land.

## Test plan

- [x] 1 new unit test pins the invariant (regression that flips default back red-lines CI before doctor even runs)
- [x] `cargo test -p mvm-cli doctor::` — 25 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Manual: `mvmctl doctor` shows the new line under Security posture

🤖 Generated with [Claude Code](https://claude.com/claude-code)