### PR TITLE
chore: slim default dependency graph

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  MVMCTL_RELEASE_FEATURES: backends-microsandbox,template-registry-s3,dev-watch,custom-dns,manifest-verify
 
 jobs:
   build:
@@ -43,6 +44,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
+      - name: Install microsandbox build deps (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcap-ng-dev
+
       - name: Set linker for aarch64-unknown-linux-gnu
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
@@ -58,7 +65,7 @@ jobs:
           # Use vendored OpenSSL for cross-compilation to avoid linking issues
           OPENSSL_STATIC: 1
           OPENSSL_VENDORED: 1
-        run: cargo build --release --target "${TARGET}"
+        run: cargo build --release --target "${TARGET}" --features "${MVMCTL_RELEASE_FEATURES}"
 
       - name: Smoke test binary (native targets only)
         if: matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-apple-darwin' || matrix.target == 'x86_64-apple-darwin'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -152,7 +152,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Build A
-        run: cargo build --release --locked --bin mvmctl
+        run: cargo build --release --locked --bin mvmctl --features backends-microsandbox,template-registry-s3,dev-watch,custom-dns,manifest-verify
 
       - name: Hash A
         run: sha256sum target/release/mvmctl | tee /tmp/hash-a.txt
@@ -161,7 +161,7 @@ jobs:
         run: cargo clean
 
       - name: Build B
-        run: cargo build --release --locked --bin mvmctl
+        run: cargo build --release --locked --bin mvmctl --features backends-microsandbox,template-registry-s3,dev-watch,custom-dns,manifest-verify
 
       - name: Hash B
         run: sha256sum target/release/mvmctl | tee /tmp/hash-b.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,28 +832,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,25 +1164,6 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1620,12 +1579,6 @@ dependencies = [
  "syn 2.0.117",
  "unicode-xid",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "difflib"
@@ -2329,17 +2282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags 2.11.0",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,15 +2658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,22 +2889,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]
@@ -3548,16 +3465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3937,15 +3844,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4258,7 +4156,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "tera",
  "thiserror 1.0.69",
  "tokio",
  "toml",
@@ -4304,7 +4201,6 @@ dependencies = [
  "sha2 0.10.9",
  "tar",
  "tempfile",
- "tera",
  "tokio",
  "toml",
  "tracing",
@@ -4494,7 +4390,6 @@ dependencies = [
  "chrono",
  "clap",
  "httpmock",
- "mimalloc",
  "mvm",
  "mvm-backend",
  "mvm-build",
@@ -5173,15 +5068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5228,49 +5114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5289,35 +5132,6 @@ dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -7016,16 +6830,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "smallstr"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7484,28 +7288,6 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tera"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
-dependencies = [
- "chrono",
- "chrono-tz",
- "globwalk",
- "humansize",
- "lazy_static",
- "percent-encoding",
- "pest",
- "pest_derive",
- "rand 0.8.6",
- "regex",
- "serde",
- "serde_json",
- "slug",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -7985,12 +7767,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,14 +91,8 @@ colored = "3"
 indicatif = "0.17"
 inquire = "0.7"
 
-# Template engine
-tera = "1"
-
 # Object storage abstraction (used for dev template registry)
 opendal = { version = "0.50", features = ["services-s3"] }
-
-# Allocator
-mimalloc = "0.1"
 
 # HTTP client (for CLI upgrade)
 reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
@@ -115,7 +109,7 @@ libc = "0.2"
 # the service binary).
 seccompiler = "0.5"
 
-# File watching
+# File watching (dev-watch feature only)
 notify = "7"
 notify-debouncer-mini = "0.5"
 
@@ -125,10 +119,7 @@ notify-debouncer-mini = "0.5"
 # format the policy bundle TOML uses.
 ipnet = { version = "2", features = ["serde"] }
 
-# Pure-Rust DNS resolver — replaces the host's libc getaddrinfo (which
-# `TokioDnsResolver` calls into) when operators want allow-listed
-# resolvers, per-VM resolver configs, or DoT/DoH upstreams. Plan 60
-# Phase 3 Slice B.
+# Pure-Rust DNS resolver, used only by the opt-in custom-dns feature.
 hickory-resolver = "0.24"
 
 # Utilities
@@ -198,20 +189,15 @@ path = "src/main.rs"
 [dependencies]
 mvm-core.workspace = true
 mvm-security.workspace = true
-# `default-features = false` propagates the off-switch down to the leaf
-# crates that pull microsandbox. The `backends-microsandbox` feature on
-# this crate (default-on so the binary build is unchanged) re-activates
-# it through the forwarding chain. Library consumers (e.g. mvmd) do
-# `mvmctl = { path = "../mvm", default-features = false }` to skip the
-# microsandbox dep entirely and avoid its sqlx-sqlite pull-in, which
-# collides with rusqlite via `links = "sqlite3"`.
+# `default-features = false` keeps the heavy microsandbox stack out of the
+# lean default binary. Operators who need the libkrun/microsandbox path opt in
+# with `--features backends-microsandbox`.
 mvm = { workspace = true, default-features = false }
 mvm-backend = { workspace = true, default-features = false }
 mvm-build = { workspace = true, default-features = false }
 mvm-guest.workspace = true
 mvm-cli = { workspace = true, default-features = false }
 anyhow.workspace = true
-mimalloc.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-foundation = { version = "0.3", features = ["NSRunLoop", "NSDate", "NSAutoreleasePool"] }
@@ -231,23 +217,24 @@ serde_json.workspace = true
 tempfile.workspace = true
 
 [features]
-# DRIFT-001 (Plan 31 Track A): `backends-microsandbox` controls whether
-# the upstream `microsandbox` crate is compiled into the chain. It pulls
-# sqlx-sqlite -> libsqlite3-sys (links = "sqlite3"), which collides with
-# library consumers that already link sqlite via a different version
-# (notably mvmd-gateway's rusqlite). Default-on keeps the mvmctl binary
-# unchanged; library consumers do `default-features = false` to opt out.
-default = ["backends-microsandbox"]
+# Keep the default production build lean. Heavy integrations remain opt-in.
+default = []
 backends-microsandbox = [
     "mvm/backends-microsandbox",
     "mvm-backend/backends-microsandbox",
     "mvm-build/backends-microsandbox",
     "mvm-cli/backends-microsandbox",
 ]
+custom-dns = ["mvm-cli/custom-dns"]
+dev-watch = ["mvm-cli/dev-watch"]
 manifest-verify = [
     "mvm/manifest-verify",
     "mvm-cli/manifest-verify",
     "mvm-security/manifest-verify",
+]
+template-registry-s3 = [
+    "mvm/template-registry-s3",
+    "mvm-cli/template-registry-s3",
 ]
 
 [profile.release]

--- a/Justfile
+++ b/Justfile
@@ -154,11 +154,11 @@ release VERSION:
 
 # Build optimized release binary
 release-build:
-    cargo build --release
+    cargo build --release --features backends-microsandbox,template-registry-s3,dev-watch,custom-dns,manifest-verify
 
 # Cross-compile release binary for a target
 release-build-target TARGET:
-    cargo build --release --target {{TARGET}}
+    cargo build --release --target {{TARGET}} --features backends-microsandbox,template-registry-s3,dev-watch,custom-dns,manifest-verify
 
 # Dry-run crates.io publish (all crates in dependency order)
 publish-dry-run:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Override with `--hypervisor`:
 | Backend | Host | Tier | Notes |
 |---|---|---|---|
 | [Firecracker](https://firecracker-microvm.github.io/) | Linux + `/dev/kvm`, WSL2 | 1 | Default on KVM hosts; snapshots, dm-verity, full security posture |
-| [microsandbox](https://github.com/microsandbox/microsandbox) (libkrun) | macOS (HVF), Linux without KVM | 2 | Cross-platform default; bundled libkrun |
+| [microsandbox](https://github.com/microsandbox/microsandbox) (libkrun) | macOS (HVF), Linux without KVM | 2 | Cross-platform backend; enable with `--features backends-microsandbox` when building from source |
 | [Apple Container](https://developer.apple.com/documentation/virtualization) | macOS 26+ Apple Silicon | 2 | Native Virtualization.framework |
 | [Cloud Hypervisor](https://www.cloudhypervisor.org/) | Linux + KVM | 1 (opt-in) | Wider device model than Firecracker — VFIO, virtio-fs, larger guests |
 
@@ -34,6 +34,9 @@ curl -fsSL https://raw.githubusercontent.com/tinylabscom/mvm/main/install.sh | s
 git clone https://github.com/tinylabscom/mvm.git && cd mvm
 cargo build --release
 cp target/release/mvmctl ~/.local/bin/
+
+# Include the microsandbox/libkrun backend in a source build
+cargo build --release --features backends-microsandbox
 
 # Via Cargo (after first crates.io release of 0.14.0)
 cargo install mvmctl
@@ -75,13 +78,13 @@ runtime enforcement of security claim 4 (CLAUDE.md "Security model").
 ```
 Layer 1: Host (Linux, macOS, Windows-via-WSL2 in progress)
   mvmctl runs natively. Direct host shell on Linux+KVM.
-  On macOS, Nix builds happen in MicrosandboxBuilderVm
-  (an OCI nix:2.24.10 sandbox) if host Nix isn't present.
+  On macOS source builds, enable `backends-microsandbox` to use
+  MicrosandboxBuilderVm when host Nix isn't present.
 
 Layer 2: VM backend (auto-selected per ADR-013)
   Firecracker  ─── KVM microVMs (Tier 1; default on Linux+KVM)
   Cloud Hypervisor ─ KVM, wider device model (Tier 1; opt-in)
-  microsandbox ──── libkrun (Tier 2; cross-platform default)
+  microsandbox ──── libkrun (Tier 2; opt-in source-build feature)
   Apple Container ─ Virtualization.framework (macOS 26+ AS)
 
 Layer 3: Guest

--- a/crates/mvm-backend/Cargo.toml
+++ b/crates/mvm-backend/Cargo.toml
@@ -45,9 +45,8 @@ anyhow.workspace = true
 # which collides with library consumers that already link sqlite via a
 # different libsqlite3-sys version (notably mvmd-gateway's rusqlite per
 # its ADR-0003). Gating the dep on `backends-microsandbox` lets those
-# consumers do `default-features = false` on `mvmctl` and skip the
-# collision; the mvm binary keeps the backend by leaving the feature
-# default-on through the forwarding chain in mvm-cli + mvmctl.
+# consumers skip the collision in lean builds. The backend remains available
+# via `--features backends-microsandbox`.
 microsandbox = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
@@ -61,12 +60,8 @@ tracing.workspace = true
 mvm-build.workspace = true
 
 [features]
-# `backends-microsandbox` is default-on so `cargo {build,test} -p mvm-backend`
-# exercises the same code paths the mvmctl binary does. The mvmctl facade,
-# mvm-cli, and the mvm crate all declare `default-features = false` on their
-# mvm-backend dep and re-forward the feature, so library consumers (e.g. mvmd)
-# can disable the whole chain via `mvmctl { default-features = false }`.
-default = ["backends-microsandbox"]
+# Heavy microsandbox support is opt-in for lean default builds.
+default = []
 backends-microsandbox = ["dep:microsandbox"]
 
 [lints]

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -251,11 +251,9 @@ pub enum AnyBackend {
     /// libkrun (plan 53 §"Plan E") — Linux KVM / macOS HVF, including
     /// macOS Intel where Apple Container is unavailable.
     Libkrun(LibkrunBackend),
-    /// microsandbox (plan 60 — ADR-013) — higher-level libkrun wrapper;
-    /// the cross-platform Phase 1 default for macOS/Windows. Linux still
-    /// prefers Firecracker when KVM is available. Gated on
-    /// `backends-microsandbox` (default-on for the mvmctl binary; library
-    /// consumers can opt out to avoid the sqlx-sqlite link conflict).
+    /// microsandbox (plan 60 — ADR-013) — higher-level libkrun wrapper.
+    /// Linux still prefers Firecracker when KVM is available. Gated on
+    /// `backends-microsandbox`, which lean default builds leave disabled.
     #[cfg(feature = "backends-microsandbox")]
     Microsandbox(MicrosandboxBackend),
     /// Cloud Hypervisor — rust-vmm peer of Firecracker at Tier 1. Adds
@@ -317,10 +315,9 @@ impl AnyBackend {
     /// Select the best backend for the current platform.
     ///
     /// Firecracker is the production target — it always wins when KVM
-    /// is available. When KVM isn't available (macOS host, Linux without
-    /// KVM, etc.), microsandbox is the cross-platform default per
-    /// ADR-013; the legacy fallbacks below it exist for the narrow
-    /// case where microsandbox itself is feature-gated out.
+    /// is available. When `backends-microsandbox` is enabled and KVM is
+    /// not available, microsandbox is the cross-platform Tier 2 choice.
+    /// Lean default builds skip it and continue down the fallback ladder.
     ///
     /// Priority:
     /// 1. **Firecracker** (if `/dev/kvm` available — production Tier 1)
@@ -344,7 +341,7 @@ impl AnyBackend {
             return Self::Firecracker(FirecrackerBackend);
         }
 
-        // 2. microsandbox — ADR-013 cross-platform default. Vendors
+        // 2. microsandbox — ADR-013 cross-platform backend. Vendors
         //    libkrunfw so works on macOS arm64/x86_64 + Linux no-KVM
         //    without a separate libkrun install. Sits above Apple
         //    Container in the ladder because plan 60 schedules
@@ -380,11 +377,9 @@ impl AnyBackend {
             return Self::Docker(DockerBackend);
         }
 
-        // Final default. Reachable only when has_microsandbox is
-        // feature-gated off AND no other tier is available; the
-        // start() call then fails with the production-path error
-        // message rather than silently picking a backend the
-        // caller didn't ask for.
+        // Final default. Reachable when no tier is available; start()
+        // then fails with the production-path error message rather than
+        // silently picking a backend the caller didn't ask for.
         Self::Firecracker(FirecrackerBackend)
     }
 

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -24,7 +24,6 @@ microsandbox = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-tera.workspace = true
 thiserror = "1"
 tokio.workspace = true
 toml.workspace = true
@@ -35,12 +34,8 @@ which = "6"
 tempfile.workspace = true
 
 [features]
-# `backends-microsandbox` is default-on so `cargo {build,test} -p mvm-build`
-# exercises `MicrosandboxBuilderVm`. The mvmctl facade, mvm-cli, and the mvm
-# crate all declare `default-features = false` on their mvm-build dep and
-# re-forward the feature, so library consumers (e.g. mvmd) can disable the
-# whole chain via `mvmctl { default-features = false }`.
-default = ["backends-microsandbox"]
+# Heavy microsandbox support is opt-in for lean default builds.
+default = []
 backends-microsandbox = ["dep:microsandbox"]
 
 [lints]

--- a/crates/mvm-build/README.md
+++ b/crates/mvm-build/README.md
@@ -13,7 +13,7 @@ Nix builder pipeline for producing Firecracker microVM images. Supports two buil
 | `firecracker` | Firecracker-specific build configuration generation |
 | `nix_manifest` | `NixManifest` parsing from `mvm-profiles.toml` |
 | `orchestrator` | Ephemeral builder VM lifecycle management |
-| `scripts` | Bash script templates (rendered via Tera) |
+| `scripts` | Bash script templates (small placeholder renderer) |
 | `template_reuse` | Template-based build optimization |
 | `vsock_builder` | Vsock-based communication with builder VMs |
 | `backend` | Storage backend implementations |

--- a/crates/mvm-build/src/nix/mod.rs
+++ b/crates/mvm-build/src/nix/mod.rs
@@ -1,5 +1,5 @@
 //! Nix-specific helpers — flake/profile manifest schema and builder script
-//! templates rendered through Tera.
+//! templates rendered through the small placeholder renderer in `scripts`.
 
 pub mod manifest;
 pub mod scripts;

--- a/crates/mvm-build/src/nix/scripts.rs
+++ b/crates/mvm-build/src/nix/scripts.rs
@@ -1,13 +1,8 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use std::collections::BTreeMap;
-use std::sync::OnceLock;
 
-// NOTE: Builder script templates use Tera's `{{ var }}` syntax.
-// If you need to embed a literal `{{...}}` string (e.g. Go templates like `{{.Status}}`)
-// inside a builder script, wrap it in a raw block:
-//   {% raw %}{{.Status}}{% endraw %}
-
-static TERA: OnceLock<Result<tera::Tera>> = OnceLock::new();
+// NOTE: Builder script templates support only simple `{{ var }}` placeholders.
+// Keep script logic in shell and pass pre-rendered values through the context.
 
 fn script_source(name: &str) -> Option<&'static str> {
     match name {
@@ -51,6 +46,7 @@ fn script_source(name: &str) -> Option<&'static str> {
     }
 }
 
+#[cfg(test)]
 fn script_names() -> &'static [&'static str] {
     &[
         "ensure_builder_artifacts",
@@ -68,46 +64,52 @@ fn script_names() -> &'static [&'static str] {
     ]
 }
 
-fn build_tera() -> Result<tera::Tera> {
-    let mut tera = tera::Tera::default();
-    // Shell scripts must not be HTML-escaped.
-    tera.autoescape_on(vec![]);
-
-    for name in script_names() {
-        let src = script_source(name)
-            .ok_or_else(|| anyhow!("builder script template source not found: {name}"))?;
-        tera.add_raw_template(name, src)
-            .map_err(anyhow::Error::new)
-            .with_context(|| format!("Failed to parse builder script template {name}"))?;
-    }
-
-    Ok(tera)
-}
-
-fn tera_instance() -> Result<&'static tera::Tera> {
-    match TERA.get_or_init(build_tera) {
-        Ok(t) => Ok(t),
-        Err(e) => {
-            Err(anyhow!(e.to_string())).context("Failed to initialize builder script templates")
-        }
-    }
-}
-
 pub fn render_script(name: &str, context: &BTreeMap<&str, String>) -> Result<String> {
-    let tera = tera_instance()?;
+    let src = script_source(name).ok_or_else(|| anyhow!("unknown script template: {name}"))?;
+    validate_template(name, src)?;
 
-    if script_source(name).is_none() {
-        return Err(anyhow!("unknown script template: {name}"));
+    let mut rendered = String::with_capacity(src.len());
+    let mut rest = src;
+    while let Some(start) = rest.find("{{") {
+        rendered.push_str(&rest[..start]);
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find("}}") else {
+            bail!("unterminated template placeholder in script {name}");
+        };
+        let key = after_start[..end].trim();
+        if key.is_empty() {
+            bail!("empty template placeholder in script {name}");
+        }
+        let value = context
+            .get(key)
+            .ok_or_else(|| anyhow!("missing template variable {key:?} for script {name}"))?;
+        rendered.push_str(value);
+        rest = &after_start[end + 2..];
     }
+    rendered.push_str(rest);
+    Ok(rendered)
+}
 
-    let mut ctx = tera::Context::new();
-    for (k, v) in context {
-        ctx.insert(*k, v);
+fn validate_template(name: &str, src: &str) -> Result<()> {
+    let mut rest = src;
+    while let Some(start) = rest.find("{{") {
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find("}}") else {
+            bail!("unterminated template placeholder in script {name}");
+        };
+        let key = after_start[..end].trim();
+        if key.is_empty() {
+            bail!("empty template placeholder in script {name}");
+        }
+        if !key
+            .chars()
+            .all(|c| c == '_' || c == '-' || c.is_ascii_alphanumeric())
+        {
+            bail!("unsupported template placeholder {key:?} in script {name}");
+        }
+        rest = &after_start[end + 2..];
     }
-
-    tera.render(name, &ctx)
-        .map_err(anyhow::Error::new)
-        .with_context(|| format!("Failed to render script {name}"))
+    Ok(())
 }
 
 #[cfg(test)]
@@ -116,7 +118,10 @@ mod tests {
 
     #[test]
     fn test_templates_parse() {
-        build_tera().expect("builder templates should parse");
+        for name in script_names() {
+            let src = script_source(name).expect("script listed in script_names should exist");
+            validate_template(name, src).expect("builder templates should parse");
+        }
     }
 
     #[test]
@@ -128,8 +133,7 @@ mod tests {
         let msg = format!("{err:#}");
         eprintln!("{msg}");
         assert!(msg.contains("launch_firecracker_ssh"));
-        // Don't overfit the exact wording, but ensure it's a render-time failure surfaced via Tera.
-        assert!(msg.contains("Failed to render script launch_firecracker_ssh"));
+        assert!(msg.contains("missing template variable"));
     }
 
     #[test]

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -44,10 +44,9 @@ serde_json.workspace = true
 sha2.workspace = true
 tar = "0.4"
 tempfile.workspace = true
-tera.workspace = true
 toml.workspace = true
-notify.workspace = true
-notify-debouncer-mini.workspace = true
+notify = { workspace = true, optional = true }
+notify-debouncer-mini = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
@@ -60,16 +59,19 @@ predicates.workspace = true
 rand.workspace = true
 
 [features]
-default = ["backends-microsandbox"]
+default = []
 backends-microsandbox = [
     "mvm/backends-microsandbox",
     "mvm-build/backends-microsandbox",
     "mvm-backend/backends-microsandbox",
 ]
+custom-dns = ["mvm-supervisor/custom-dns"]
+dev-watch = ["dep:notify", "dep:notify-debouncer-mini"]
 manifest-verify = [
     "mvm/manifest-verify",
     "mvm-security/manifest-verify",
 ]
+template-registry-s3 = ["mvm/template-registry-s3"]
 
 [lints]
 workspace = true

--- a/crates/mvm-cli/src/config_watcher.rs
+++ b/crates/mvm-cli/src/config_watcher.rs
@@ -1,9 +1,11 @@
 use std::path::Path;
 use std::sync::mpsc;
+#[cfg(feature = "dev-watch")]
 use std::time::Duration;
 
 use anyhow::Result;
 use mvm_core::user_config::MvmConfig;
+#[cfg(feature = "dev-watch")]
 use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
 
 /// Events sent from the background watcher thread.
@@ -27,11 +29,21 @@ impl ConfigWatcher {
     /// Start watching `path`.  Returns immediately; the debouncer runs on a
     /// background thread managed by `notify`.
     pub fn start(path: &Path) -> Result<Self> {
+        #[cfg(not(feature = "dev-watch"))]
+        {
+            let _ = path;
+            anyhow::bail!(
+                "config watch support is disabled in this build; rebuild with --features dev-watch"
+            );
+        }
+
+        #[cfg(feature = "dev-watch")]
         Self::start_with_debounce(path, Duration::from_millis(500))
     }
 
     /// Like [`start`] but with a configurable debounce duration.  Useful in
     /// tests where a shorter debounce keeps suites fast.
+    #[cfg(feature = "dev-watch")]
     pub fn start_with_debounce(path: &Path, debounce: Duration) -> Result<Self> {
         // Canonicalize so that event.path comparisons work reliably.
         let watch_file = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
@@ -121,12 +133,14 @@ mod tests {
     use super::*;
     use mvm_core::user_config::MvmConfig;
 
+    #[cfg(feature = "dev-watch")]
     fn write_config(path: &Path, cfg: &MvmConfig) {
         let text = toml::to_string_pretty(cfg).unwrap();
         std::fs::write(path, text).unwrap();
     }
 
     #[test]
+    #[cfg(feature = "dev-watch")]
     fn test_config_watcher_detects_change() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("config.toml");
@@ -169,6 +183,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "dev-watch")]
     fn test_config_watcher_invalid_toml_sends_parse_error() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("config.toml");

--- a/crates/mvm-cli/src/shell_init.rs
+++ b/crates/mvm-cli/src/shell_init.rs
@@ -10,20 +10,12 @@ const MARKER_END: &str = "# <<< mvmctl <<<";
 /// Generate the shell init block with completions and dev aliases.
 ///
 /// The block template lives in `resources/shell_init.sh.tera` and is
-/// embedded at compile time, then rendered via Tera at runtime.
+/// embedded at compile time. It uses only three fixed placeholders.
 pub fn generate_block(kv_root: &str) -> String {
-    let mut tera = tera::Tera::default();
-    tera.add_raw_template(
-        "shell_init",
-        include_str!("../resources/shell_init.sh.tera"),
-    )
-    .expect("embedded shell_init template should parse");
-    let mut ctx = tera::Context::new();
-    ctx.insert("kv_root", kv_root);
-    ctx.insert("marker_start", MARKER_START);
-    ctx.insert("marker_end", MARKER_END);
-    tera.render("shell_init", &ctx)
-        .expect("shell_init template should render")
+    include_str!("../resources/shell_init.sh.tera")
+        .replace("{{ marker_start }}", MARKER_START)
+        .replace("{{ marker_end }}", MARKER_END)
+        .replace("{{ kv_root }}", kv_root)
         .trim()
         .to_string()
 }

--- a/crates/mvm-cli/src/watch.rs
+++ b/crates/mvm-cli/src/watch.rs
@@ -1,8 +1,11 @@
 use std::path::{Path, PathBuf};
+#[cfg(feature = "dev-watch")]
 use std::sync::mpsc;
+#[cfg(feature = "dev-watch")]
 use std::time::Duration;
 
 use anyhow::Result;
+#[cfg(feature = "dev-watch")]
 use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
 
 /// Wait for filesystem changes in the given flake directory.
@@ -14,38 +17,50 @@ use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
 /// inotify on Linux) instead of polling. Changes are debounced by 500ms to
 /// avoid redundant rebuilds from rapid file saves.
 pub fn wait_for_changes(flake_dir: &str) -> Result<PathBuf> {
-    let flake_path = Path::new(flake_dir).canonicalize()?;
+    #[cfg(not(feature = "dev-watch"))]
+    {
+        let _ = flake_dir;
+        anyhow::bail!(
+            "file watch support is disabled in this build; rebuild with --features dev-watch"
+        );
+    }
 
-    let (tx, rx) = mpsc::channel();
+    #[cfg(feature = "dev-watch")]
+    {
+        let flake_path = Path::new(flake_dir).canonicalize()?;
 
-    let mut debouncer = new_debouncer(Duration::from_millis(500), tx)?;
+        let (tx, rx) = mpsc::channel();
 
-    // Watch the flake directory recursively for .nix and .lock changes
-    debouncer
-        .watcher()
-        .watch(&flake_path, notify::RecursiveMode::Recursive)?;
+        let mut debouncer = new_debouncer(Duration::from_millis(500), tx)?;
 
-    // Wait for a relevant change
-    loop {
-        match rx.recv() {
-            Ok(Ok(events)) => {
-                for event in &events {
-                    if event.kind == DebouncedEventKind::Any && is_nix_file(&event.path) {
-                        return Ok(event.path.clone());
+        // Watch the flake directory recursively for .nix and .lock changes
+        debouncer
+            .watcher()
+            .watch(&flake_path, notify::RecursiveMode::Recursive)?;
+
+        // Wait for a relevant change
+        loop {
+            match rx.recv() {
+                Ok(Ok(events)) => {
+                    for event in &events {
+                        if event.kind == DebouncedEventKind::Any && is_nix_file(&event.path) {
+                            return Ok(event.path.clone());
+                        }
                     }
                 }
-            }
-            Ok(Err(e)) => {
-                tracing::warn!("watch error: {e}");
-            }
-            Err(e) => {
-                anyhow::bail!("watch channel closed: {e}");
+                Ok(Err(e)) => {
+                    tracing::warn!("watch error: {e}");
+                }
+                Err(e) => {
+                    anyhow::bail!("watch channel closed: {e}");
+                }
             }
         }
     }
 }
 
 /// Check if a path is a Nix-related file we care about.
+#[cfg(any(feature = "dev-watch", test))]
 fn is_nix_file(path: &Path) -> bool {
     let Some(ext) = path.extension() else {
         // flake.lock has no extension — check by filename

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -30,7 +30,7 @@ ipnet.workspace = true
 # Plan 60 Phase 3 Slice B — pure-Rust DNS resolver, alternative to
 # the host libc's `getaddrinfo`. Opt-in; `TokioDnsResolver` stays the
 # default until consumers explicitly switch.
-hickory-resolver = { workspace = true, features = ["tokio-runtime"] }
+hickory-resolver = { workspace = true, features = ["tokio-runtime"], optional = true }
 # `rand` in main deps (not dev-only): the TTL reaper (G6 of the parity
 # plan, "TTL reaper precision as side channel") applies ±10 s jitter
 # to its tick interval via a `Rng` so observers can't use TTL expiry
@@ -66,6 +66,10 @@ libc.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "io-util", "time"] }
+
+[features]
+default = []
+custom-dns = ["dep:hickory-resolver"]
 
 [lints]
 workspace = true

--- a/crates/mvm-supervisor/src/lib.rs
+++ b/crates/mvm-supervisor/src/lib.rs
@@ -43,6 +43,7 @@ pub mod destination;
 pub mod egress;
 pub mod event_bus;
 pub mod firewall;
+#[cfg(feature = "custom-dns")]
 pub mod hickory_dns;
 pub mod injection_guard;
 pub mod inspector;
@@ -79,6 +80,7 @@ pub use circuit_breaker::{
 pub use destination::DestinationPolicy;
 pub use egress::{EgressDecision, EgressError, EgressProxy, NoopEgressProxy};
 pub use event_bus::{DEFAULT_CAPACITY as EVENT_BUS_DEFAULT_CAPACITY, EventBus, LifecycleEvent};
+#[cfg(feature = "custom-dns")]
 pub use hickory_dns::HickoryDnsResolver;
 pub use injection_guard::{InjectionGuard, InjectionRule, RuleFamily};
 pub use inspector::{Inspector, InspectorChain, InspectorVerdict, RequestCtx};

--- a/crates/mvm/Cargo.toml
+++ b/crates/mvm/Cargo.toml
@@ -14,11 +14,8 @@ mvm-core.workspace = true
 mvm-plan.workspace = true
 mvm-security.workspace = true
 mvm-guest.workspace = true
-# `default-features = false` + the feature-forwarding block below lets
-# library consumers of the `mvmctl` facade (e.g. mvmd) disable the
-# microsandbox backend via `default-features = false`. The mvm binary
-# stays unchanged because mvm-cli + mvmctl keep `backends-microsandbox`
-# in their default features.
+# `default-features = false` + the feature-forwarding block below keeps the
+# heavy microsandbox backend out of lean production builds unless requested.
 mvm-build = { workspace = true, default-features = false }
 mvm-backend = { workspace = true, default-features = false }
 mvm-base.workspace = true
@@ -31,7 +28,7 @@ rand.workspace = true
 secrecy.workspace = true
 indicatif.workspace = true
 inquire.workspace = true
-opendal.workspace = true
+opendal = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -43,12 +40,13 @@ mvm-providers.workspace = true
 libc.workspace = true
 
 [features]
-default = ["backends-microsandbox"]
+default = []
 backends-microsandbox = [
     "mvm-build/backends-microsandbox",
     "mvm-backend/backends-microsandbox",
 ]
 manifest-verify = ["mvm-security/manifest-verify"]
+template-registry-s3 = ["dep:opendal"]
 
 [lints]
 workspace = true

--- a/crates/mvm/src/bin/mvm-hostd.rs
+++ b/crates/mvm/src/bin/mvm-hostd.rs
@@ -1,9 +1,5 @@
 use anyhow::Result;
 use clap::Parser;
-use mimalloc::MiMalloc;
-
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
 
 #[derive(Parser)]
 #[command(name = "mvm-hostd", about = "mvm privileged executor daemon")]

--- a/crates/mvm/src/vm/template/registry.rs
+++ b/crates/mvm/src/vm/template/registry.rs
@@ -1,13 +1,22 @@
-use anyhow::{Context, Result, anyhow, bail};
+#[cfg(feature = "template-registry-s3")]
+use anyhow::Context;
+use anyhow::{Result, anyhow, bail};
 
+#[cfg(feature = "template-registry-s3")]
 use opendal::Operator;
+#[cfg(feature = "template-registry-s3")]
 use opendal::services::S3;
 
+#[cfg(feature = "template-registry-s3")]
 pub struct TemplateRegistry {
     op: opendal::BlockingOperator,
     prefix: String,
 }
 
+#[cfg(not(feature = "template-registry-s3"))]
+pub struct TemplateRegistry;
+
+#[cfg(feature = "template-registry-s3")]
 impl TemplateRegistry {
     pub fn from_env() -> Result<Option<Self>> {
         let endpoint = match std::env::var("MVM_TEMPLATE_REGISTRY_ENDPOINT") {
@@ -115,5 +124,55 @@ impl TemplateRegistry {
             bail!("Template registry prefix is empty");
         }
         Ok(())
+    }
+}
+
+#[cfg(not(feature = "template-registry-s3"))]
+impl TemplateRegistry {
+    pub fn from_env() -> Result<Option<Self>> {
+        match std::env::var("MVM_TEMPLATE_REGISTRY_ENDPOINT") {
+            Ok(v) if !v.trim().is_empty() => bail!(
+                "S3 template registry support is disabled in this build; rebuild with \
+                 --features template-registry-s3"
+            ),
+            _ => Ok(None),
+        }
+    }
+
+    pub fn key_current(&self, template_id: &str) -> String {
+        format!("templates/{}/current", template_id.trim_matches('/'))
+    }
+
+    pub fn key_revision_base(&self, template_id: &str, revision: &str) -> String {
+        format!(
+            "templates/{}/revisions/{}",
+            template_id.trim_matches('/'),
+            revision
+        )
+    }
+
+    pub fn key_revision_file(&self, template_id: &str, revision: &str, file: &str) -> String {
+        format!("{}/{}", self.key_revision_base(template_id, revision), file)
+    }
+
+    pub fn put_bytes(&self, _key: &str, _data: Vec<u8>) -> Result<()> {
+        bail!("S3 template registry support is disabled in this build")
+    }
+
+    pub fn get_bytes(&self, _key: &str) -> Result<Vec<u8>> {
+        bail!("S3 template registry support is disabled in this build")
+    }
+
+    pub fn put_text(&self, key: &str, text: &str) -> Result<()> {
+        self.put_bytes(key, text.as_bytes().to_vec())
+    }
+
+    pub fn get_text(&self, key: &str) -> Result<String> {
+        let bytes = self.get_bytes(key)?;
+        String::from_utf8(bytes).map_err(|e| anyhow!("invalid utf-8 in object {}: {}", key, e))
+    }
+
+    pub fn require_configured(&self) -> Result<()> {
+        bail!("S3 template registry support is disabled in this build")
     }
 }

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -3,7 +3,7 @@ title: "Install mvm on macOS"
 description: "mvm on macOS runs natively via microsandbox + libkrun on Hypervisor.framework — no Lima, no Docker Desktop. Apple Silicon (arm64) is the primary target; Intel Macs work too."
 ---
 
-mvm on macOS uses **microsandbox** as the backend — a libkrun wrapper that boots microVMs on Apple's Hypervisor.framework. There's no Lima VM in the loop, no Docker Desktop, no Apple Container detour. The choice is recorded in [ADR-013](/contributing/adr/013-microsandbox-pivot/) and ADR-031.
+mvm on macOS can use **microsandbox** as the backend — a libkrun wrapper that boots microVMs on Apple's Hypervisor.framework. Source builds keep this dependency-heavy backend behind the `backends-microsandbox` feature; release builds that include macOS microsandbox support are built with that feature enabled. The choice is recorded in [ADR-013](/contributing/adr/013-microsandbox-pivot/) and ADR-031.
 
 Apple Silicon (M-series) is the primary target. Intel Macs (x86_64) work but the upstream microsandbox path on Intel is less exercised — file an issue if anything misbehaves.
 
@@ -11,7 +11,7 @@ Apple Silicon (M-series) is the primary target. Intel Macs (x86_64) work but the
 
 - macOS 13 (Ventura) or newer. macOS 12 might work but isn't tested; macOS 11 lacks the Hypervisor.framework features microsandbox needs.
 
-You **do not need Nix on your Mac**. mvm bootstraps a small Linux builder microVM (microsandbox-backed) on first build, runs `nix build` inside it, and extracts the resulting rootfs back to the host. This is the zero-config default — no `nix-darwin`, no remote `nix-daemon`, no host-side configuration. See [§"Linux builds on macOS"](#linux-builds-on-macos--zero-config-by-default) below for the design.
+You **do not need Nix on your Mac** when using a build that includes `backends-microsandbox`. mvm bootstraps a small Linux builder microVM (microsandbox-backed) on first build, runs `nix build` inside it, and extracts the resulting rootfs back to the host. See [§"Linux builds on macOS"](#linux-builds-on-macos--zero-config-by-default) below for the design.
 
 ## Install mvmctl
 
@@ -33,6 +33,13 @@ MVM_VERSION=v0.13.0 curl -fsSL https://raw.githubusercontent.com/tinylabscom/mvm
 git clone https://github.com/tinylabscom/mvm.git
 cd mvm
 cargo build --release
+install -m 0755 target/release/mvmctl ~/.local/bin/mvmctl
+```
+
+To include the microsandbox/libkrun backend in a source build:
+
+```bash
+cargo build --release --features backends-microsandbox
 install -m 0755 target/release/mvmctl ~/.local/bin/mvmctl
 ```
 
@@ -88,7 +95,7 @@ mvmctl run
 
 **`mvmctl run` boots but `mvmctl console` fails to attach** — the `console` subcommand is only enabled for *accessible* images. If your `entrypoint.command = [ ... ]`, the build is *sealed* and console attach is rejected. Switch to `entrypoint.shell = "/bin/sh"` or pass `dev = true` in your `mkGuest` call. See [Building MicroVM Images](/guides/building-microvm-images).
 
-**"microsandbox: libkrunfw not found"** — microsandbox 0.4.5 vendors libkrunfw, so this should never happen on a normal `cargo install`. If you see it, check that your `mvmctl` binary wasn't compiled with `--no-default-features`; `microsandbox` is in the default feature set.
+**"microsandbox backend unavailable"** — source builds omit microsandbox unless built with `--features backends-microsandbox`. Rebuild with that feature if you need the libkrun-backed macOS path.
 
 ## Apple Silicon vs Intel notes
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,3 @@
-use mimalloc::MiMalloc;
-
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
 fn main() -> anyhow::Result<()> {
     // On macOS, Virtualization.framework requires the main thread to pump
     // NSRunLoop for VM lifecycle callbacks. Run the CLI on a background


### PR DESCRIPTION
## Summary
- make heavy integrations opt-in by default: microsandbox, S3 template registry, dev watch, custom DNS, and manifest verification
- replace Tera usage with narrow renderers and remove mimalloc global allocators
- keep release/reproducibility builds on the full feature set so shipped binaries do not lose existing behavior

## Dependency impact
- default mvmctl normal dependency graph: 225 unique packages
- Cargo.lock package entries: 832, because optional/dev/workspace integrations remain represented in the lockfile
- default mvmctl graph excludes microsandbox, opendal, notify, hickory-resolver, tera, mimalloc, and sigstore

## Verification
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo check -p mvmctl
- cargo check -p mvmctl --features backends-microsandbox,template-registry-s3,dev-watch,custom-dns,manifest-verify
- targeted tests: mvm-build nix::scripts, mvm-cli shell_init, mvm-cli watch, mvm-cli config_watcher with dev-watch