### PR TITLE
feat(supervisor): plan 52 W1 follow-on — PSI + vm_pressure HostPressureSource

### DIFF
--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -62,7 +62,10 @@ tracing.workspace = true
 
 # Plan 60 Phase 7 staging tools: `O_NOFOLLOW` on read/write opens
 # defends the upload + download path validators against a symlink
-# planted inside the staging dir. Unix-wide (macOS + Linux); the
+# planted inside the staging dir. Sprint 52 W1 follow-on also
+# leans on this unix-wide libc dep for macOS's
+# `sysctlbyname("kern.memorystatus_vm_pressure_level")` reader in
+# `VmPressureLevelSource`. Unix-wide (macOS + Linux); the
 # Windows branch in `staging.rs` falls back to a `symlink_metadata`
 # check.
 [target.'cfg(unix)'.dependencies]

--- a/crates/mvm-supervisor/src/balloon.rs
+++ b/crates/mvm-supervisor/src/balloon.rs
@@ -200,6 +200,224 @@ impl HostPressureSource for SysinfoPressureSource {
     }
 }
 
+/// Linux PSI-backed pressure source.
+///
+/// Reads `/proc/pressure/memory` and reports the 10-second
+/// percentage that *every* runnable task spent stalled on memory
+/// (`full avg10`), divided by 100 to land in `[0.0, 1.0]`. PSI is
+/// the stronger signal on Linux because it distinguishes "host has
+/// caches it could drop" (low PSI) from "host is actively stalled
+/// freeing pages" (high PSI). sysinfo's `used/total` conflates the
+/// two.
+///
+/// Some kernels (containers without `CONFIG_PSI=y`, or hosts where
+/// the file lacks the `full` line) only expose `some`; this impl
+/// falls back to the `some avg10` value in that case, which still
+/// captures memory-pressure stalls on *at least one* task and is
+/// strictly more informative than no signal at all.
+///
+/// Construction succeeds eagerly so callers can wire the source
+/// up at process boot without an `Option<Box<dyn …>>`; the file
+/// existence + parse round-trip is re-checked on every `current()`
+/// call to gracefully tolerate transient I/O hiccups.
+pub struct PsiPressureSource {
+    path: std::path::PathBuf,
+}
+
+impl PsiPressureSource {
+    /// Construct, defaulting to `/proc/pressure/memory`. Use
+    /// [`from_path`](Self::from_path) for tests that point at a
+    /// tempfile fixture.
+    pub fn new() -> Self {
+        Self::from_path("/proc/pressure/memory")
+    }
+
+    /// Construct from an explicit path. The path can be any file
+    /// whose contents match Linux's PSI memory format —
+    /// fixture-driven tests use this to drive deterministic
+    /// pressure values without poking real procfs.
+    pub fn from_path<P: Into<std::path::PathBuf>>(path: P) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+impl Default for PsiPressureSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HostPressureSource for PsiPressureSource {
+    fn current(&self) -> anyhow::Result<HostPressure> {
+        let contents = std::fs::read_to_string(&self.path)
+            .map_err(|e| anyhow::anyhow!("read {}: {e}", self.path.display()))?;
+        let avg10 = parse_psi_full_avg10(&contents)
+            .or_else(|| parse_psi_some_avg10(&contents))
+            .ok_or_else(|| {
+                anyhow::anyhow!("could not parse `full avg10` or `some avg10` from PSI file")
+            })?;
+        // PSI reports a percentage 0..100; the controller expects
+        // a fraction 0..1.
+        Ok(HostPressure::clamped(avg10 / 100.0))
+    }
+}
+
+/// Parse the `full avg10=NN.NN` value from PSI memory output.
+fn parse_psi_full_avg10(contents: &str) -> Option<f32> {
+    parse_psi_avg10_for_prefix(contents, "full ")
+}
+
+/// Parse the `some avg10=NN.NN` value from PSI memory output.
+fn parse_psi_some_avg10(contents: &str) -> Option<f32> {
+    parse_psi_avg10_for_prefix(contents, "some ")
+}
+
+fn parse_psi_avg10_for_prefix(contents: &str, prefix: &str) -> Option<f32> {
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix(prefix) {
+            for kv in rest.split_whitespace() {
+                if let Some(v) = kv.strip_prefix("avg10=") {
+                    return v.parse().ok();
+                }
+            }
+        }
+    }
+    None
+}
+
+/// macOS pressure source backed by the
+/// `kern.memorystatus_vm_pressure_level` sysctl.
+///
+/// macOS exposes a discrete pressure state — 1 (Normal), 2 (Warn),
+/// 4 (Critical) — rather than a continuous fraction. The mapping
+/// to a 0..1 value is approximate: Normal → 0.30 (controller sits
+/// well below the inflate threshold), Warn → 0.70 (still under the
+/// 0.80 inflate trigger but above the deflate floor, so the
+/// controller holds), Critical → 0.95 (well above inflate, so
+/// the controller actively reclaims).
+///
+/// Construction always succeeds; `current()` returns the live
+/// reading or falls back to sysinfo if the sysctl call fails
+/// (older macOS, unusual sandbox restrictions, etc.).
+#[cfg(target_os = "macos")]
+pub struct VmPressureLevelSource {
+    fallback: SysinfoPressureSource,
+}
+
+#[cfg(target_os = "macos")]
+impl VmPressureLevelSource {
+    pub fn new() -> Self {
+        Self {
+            fallback: SysinfoPressureSource::new(),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Default for VmPressureLevelSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl HostPressureSource for VmPressureLevelSource {
+    fn current(&self) -> anyhow::Result<HostPressure> {
+        match read_macos_pressure_level() {
+            Ok(level) => Ok(HostPressure::clamped(macos_level_to_pressure(level))),
+            Err(_) => {
+                // Sysctl unavailable on this build / sandbox /
+                // macOS version: degrade to sysinfo's used/total
+                // rather than failing the whole tick. The
+                // controller's dead-band absorbs the difference.
+                self.fallback.current()
+            }
+        }
+    }
+}
+
+/// Read `kern.memorystatus_vm_pressure_level` via sysctl. The
+/// kernel publishes one of: 1 (Normal), 2 (Warn), 4 (Critical).
+#[cfg(target_os = "macos")]
+fn read_macos_pressure_level() -> anyhow::Result<i32> {
+    use std::ffi::CString;
+
+    let name = CString::new("kern.memorystatus_vm_pressure_level")
+        .expect("sysctl name has no interior NULs");
+    let mut value: i32 = 0;
+    let mut size: libc::size_t = std::mem::size_of::<i32>();
+    let rc = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            &mut value as *mut i32 as *mut libc::c_void,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 {
+        anyhow::bail!(
+            "sysctlbyname(kern.memorystatus_vm_pressure_level) failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(value)
+}
+
+/// Map the discrete macOS pressure level to a fraction in `[0,1]`.
+///
+/// The thresholds chosen line up with `BalloonPolicy`'s defaults
+/// (`inflate_above = 0.80`, `deflate_below = 0.60`):
+///
+/// - Normal (1) → 0.30: below `deflate_below`, controller releases
+///   memory.
+/// - Warn (2)   → 0.70: inside the dead-band, controller holds.
+/// - Critical (4) → 0.95: above `inflate_above`, controller
+///   reclaims aggressively.
+///
+/// Unknown values default to Normal (0.30) — the conservative
+/// choice when the kernel reports a level the controller doesn't
+/// recognise, since over-deflating is recoverable but over-
+/// inflating risks OOM-killing the workload.
+#[cfg(target_os = "macos")]
+fn macos_level_to_pressure(level: i32) -> f32 {
+    match level {
+        1 => 0.30,
+        2 => 0.70,
+        4 => 0.95,
+        _ => 0.30,
+    }
+}
+
+/// Pick the best-available pressure source for the current host.
+///
+/// - Linux with PSI available → [`PsiPressureSource`].
+/// - macOS → [`VmPressureLevelSource`] (which itself falls back
+///   to sysinfo on sysctl failure).
+/// - Anything else → [`SysinfoPressureSource`].
+///
+/// The return type is `Box<dyn HostPressureSource>` so the caller
+/// can plumb a single value into `BalloonController` without
+/// per-platform generics.
+pub fn default_pressure_source() -> Box<dyn HostPressureSource> {
+    #[cfg(target_os = "linux")]
+    {
+        let psi = PsiPressureSource::new();
+        // Probe once: if the file exists + parses, prefer PSI;
+        // otherwise fall through to sysinfo so a container without
+        // `CONFIG_PSI=y` still gets a working signal.
+        if psi.current().is_ok() {
+            return Box::new(psi);
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return Box::new(VmPressureLevelSource::new());
+    }
+    #[allow(unreachable_code)]
+    Box::new(SysinfoPressureSource::new())
+}
+
 // ---------------------------------------------------------------------------
 // BalloonController — pressure-driven reclaim tick
 // ---------------------------------------------------------------------------
@@ -561,5 +779,131 @@ mod tests {
             1,
             "pressure should be read once per tick, not once per VM"
         );
+    }
+
+    // ── PsiPressureSource tests ─────────────────────────────────────
+
+    #[test]
+    fn psi_parses_full_avg10() {
+        // Real-shape PSI content with both `some` and `full`. The
+        // controller prefers `full avg10` because it captures the
+        // stronger "every task stalled" signal.
+        let raw = "some avg10=12.34 avg60=23.45 avg300=34.56 total=12345\n\
+                   full avg10=42.50 avg60=12.34 avg300=5.67 total=2345\n";
+        let pressure = parse_psi_full_avg10(raw).expect("parse");
+        assert!((pressure - 42.50).abs() < 0.001);
+    }
+
+    #[test]
+    fn psi_falls_back_to_some_when_full_absent() {
+        // Container kernels without CONFIG_PSI=y sometimes expose
+        // only the `some` line. The source must still produce a
+        // signal.
+        let raw = "some avg10=7.50 avg60=5.00 avg300=3.00 total=999\n";
+        assert!(parse_psi_full_avg10(raw).is_none());
+        let pressure = parse_psi_some_avg10(raw).expect("parse some");
+        assert!((pressure - 7.50).abs() < 0.001);
+    }
+
+    #[test]
+    fn psi_returns_none_for_garbage() {
+        // Malformed input shouldn't panic — return None so the
+        // source surfaces an error instead.
+        assert!(parse_psi_full_avg10("nope\nnothing\nuseful").is_none());
+        assert!(parse_psi_some_avg10("nope\nnothing\nuseful").is_none());
+    }
+
+    #[test]
+    fn psi_source_reads_from_fixture_path() {
+        // Drive the full source against a tempfile so we can pin
+        // behaviour without poking real procfs (which may not
+        // exist on macOS / BSD test runners).
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(
+            tmp.path(),
+            "some avg10=80.00 avg60=70.00 avg300=60.00 total=100\n\
+             full avg10=85.50 avg60=70.00 avg300=60.00 total=100\n",
+        )
+        .expect("write fixture");
+        let src = PsiPressureSource::from_path(tmp.path());
+        let p = src.current().expect("current");
+        // 85.50 / 100 = 0.855 (clamped to <=1.0).
+        assert!((p.0 - 0.855).abs() < 0.001);
+    }
+
+    #[test]
+    fn psi_source_clamps_percentage_above_100() {
+        // PSI is well-defined as 0..100 but the parser doesn't
+        // reject out-of-range values — clamping is the source's
+        // responsibility so the controller never sees a >1.0
+        // pressure that would break its 0..1 contract.
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(
+            tmp.path(),
+            "full avg10=150.00 avg60=10.00 avg300=10.00 total=1\n",
+        )
+        .expect("write fixture");
+        let src = PsiPressureSource::from_path(tmp.path());
+        let p = src.current().expect("current");
+        assert_eq!(p.0, 1.0);
+    }
+
+    #[test]
+    fn psi_source_surfaces_io_error_when_path_missing() {
+        let src = PsiPressureSource::from_path("/this/path/does/not/exist");
+        let err = src.current().unwrap_err();
+        assert!(err.to_string().contains("read"));
+    }
+
+    // ── macOS VmPressureLevelSource tests ───────────────────────────
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_level_mapping_lines_up_with_policy_thresholds() {
+        // Defaults: inflate at 0.80, deflate at 0.60.
+        // Normal (1) → 0.30 sits below deflate threshold (controller releases).
+        // Warn (2)   → 0.70 sits in the dead-band (controller holds).
+        // Critical (4) → 0.95 sits above inflate threshold (controller reclaims).
+        let default_policy = BalloonPolicy::default();
+        assert!(macos_level_to_pressure(1) < default_policy.deflate_below);
+        let warn = macos_level_to_pressure(2);
+        assert!(warn > default_policy.deflate_below);
+        assert!(warn < default_policy.inflate_above);
+        assert!(macos_level_to_pressure(4) > default_policy.inflate_above);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_unknown_level_maps_to_normal() {
+        // Unknown values default to the conservative (Normal)
+        // mapping — over-deflating is recoverable, over-inflating
+        // risks OOM.
+        let expected = macos_level_to_pressure(1);
+        assert_eq!(macos_level_to_pressure(99), expected);
+        assert_eq!(macos_level_to_pressure(-1), expected);
+        assert_eq!(macos_level_to_pressure(0), expected);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_vm_pressure_source_returns_in_range() {
+        // Live sysctl call — every macOS host returns a valid
+        // level. Test asserts the resulting pressure is bounded
+        // in [0, 1] (the clamp covers any future kernel returning
+        // an unmapped value).
+        let src = VmPressureLevelSource::new();
+        let p = src.current().expect("sysctl read");
+        assert!(p.0 >= 0.0 && p.0 <= 1.0);
+    }
+
+    // ── default_pressure_source() tests ─────────────────────────────
+
+    #[test]
+    fn default_pressure_source_returns_something_callable() {
+        // Smoke test: the factory returns a working source on
+        // every platform the test suite runs on.
+        let src = default_pressure_source();
+        let p = src.current().expect("current");
+        assert!(p.0 >= 0.0 && p.0 <= 1.0);
     }
 }

--- a/crates/mvm-supervisor/src/lib.rs
+++ b/crates/mvm-supervisor/src/lib.rs
@@ -73,6 +73,12 @@ pub use audit_recorder::{
     UNBOUND_PLAN_ID,
 };
 pub use backend::{BackendError, BackendLauncher, NoopBackendLauncher};
+#[cfg(target_os = "macos")]
+pub use balloon::VmPressureLevelSource;
+pub use balloon::{
+    BalloonAction, BalloonController, BalloonPolicy, HostPressure, HostPressureSource,
+    PsiPressureSource, SysinfoPressureSource, TickOutcome, default_pressure_source,
+};
 pub use balloon_runtime::{BalloonRuntimeConfig, run_balloon_loop, run_one_tick};
 pub use circuit_breaker::{
     CircuitBreaker, CircuitBreakerConfig, CircuitState, Clock as CircuitBreakerClock,


### PR DESCRIPTION
Replacement for #139 (auto-closed when its base `feat/balloon-supervisor-tick-loop` was deleted on the #138 merge). Same content, retargets to `main`.

See #139 for the full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)