### PR TITLE
just(setup): one-command host install for libkrun + cloud-hypervisor

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -191,6 +191,152 @@ docs-dev:
 docs-build:
     cd public && pnpm build
 
+# ── VMM setup ────────────────────────────────────────────────────────────
+
+# Install both libkrun and cloud-hypervisor (the two VMMs mvm targets)
+setup: setup-libkrun setup-cloud-hypervisor
+    @echo
+    @echo "Both VMMs installed. Validate with:"
+    @echo "  cargo run --example libkrun-bootcheck --features libkrun-sys   (macOS)"
+    @echo "  cargo run --example ch-bootcheck                              (Linux)"
+
+# Install libkrun (macOS via slp/krun tap; Linux via apt/dnf/pacman)
+setup-libkrun:
+    #!/usr/bin/env bash
+    # macOS:   brew install slp/krun/libkrun  (libkrun is not in core; the
+    #                                          qualified form auto-taps)
+    # Linux:   apt install libkrun-dev        (Debian/Ubuntu, drags libkrun1)
+    #          dnf install libkrun-devel      (Fedora/RHEL)
+    #          pacman -S libkrun              (Arch / community)
+    # Other:   build from source at https://github.com/containers/libkrun
+    set -euo pipefail
+    EXISTING=""
+    for p in \
+        /opt/homebrew/lib/libkrun.dylib \
+        /usr/local/lib/libkrun.dylib \
+        /usr/lib/x86_64-linux-gnu/libkrun.so \
+        /usr/lib/aarch64-linux-gnu/libkrun.so \
+        /usr/lib64/libkrun.so \
+        /usr/local/lib/libkrun.so
+    do
+        if [ -f "$p" ]; then
+            EXISTING="$p"
+            break
+        fi
+    done
+    if [ -n "$EXISTING" ]; then
+        echo "libkrun already installed at $EXISTING — skipping."
+        exit 0
+    fi
+    case "$(uname -s)" in
+        Darwin)
+            if ! command -v brew >/dev/null; then
+                echo "error: Homebrew not found. Install: https://brew.sh" >&2
+                exit 1
+            fi
+            echo "→ brew install slp/krun/libkrun"
+            brew install slp/krun/libkrun
+            ;;
+        Linux)
+            if command -v apt-get >/dev/null; then
+                echo "→ apt install libkrun-dev"
+                sudo apt-get update
+                sudo apt-get install -y libkrun-dev
+            elif command -v dnf >/dev/null; then
+                echo "→ dnf install libkrun-devel"
+                sudo dnf install -y libkrun-devel
+            elif command -v pacman >/dev/null; then
+                echo "→ pacman -S libkrun"
+                sudo pacman -S --needed libkrun
+            else
+                echo "error: no recognized package manager (apt / dnf / pacman)." >&2
+                echo "       Build from source: https://github.com/containers/libkrun" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            echo "error: libkrun is not supported on $(uname -s)." >&2
+            exit 1
+            ;;
+    esac
+    echo "Verifying install…"
+    for p in \
+        /opt/homebrew/lib/libkrun.dylib \
+        /usr/local/lib/libkrun.dylib \
+        /usr/lib/x86_64-linux-gnu/libkrun.so \
+        /usr/lib/aarch64-linux-gnu/libkrun.so \
+        /usr/lib64/libkrun.so \
+        /usr/local/lib/libkrun.so
+    do
+        if [ -f "$p" ]; then
+            echo "  ✓ $p"
+            exit 0
+        fi
+    done
+    echo "  ! libkrun shared library not found at the standard locations." >&2
+    exit 1
+
+# Install cloud-hypervisor (apt/dnf on Linux; upstream static binary fallback)
+setup-cloud-hypervisor:
+    #!/usr/bin/env bash
+    # Linux:   apt install cloud-hypervisor    (Debian 13+ / Ubuntu 24.04+)
+    #          dnf install cloud-hypervisor    (Fedora/RHEL)
+    # Fallback: download the upstream static binary from the GitHub
+    #          releases — works on any Linux with curl + sudo.
+    # macOS:   cloud-hypervisor has experimental macOS support (HVF) but
+    #          mvm targets libkrun for the macOS lane; skip CH on Darwin.
+    set -euo pipefail
+    if command -v cloud-hypervisor >/dev/null; then
+        ver="$(cloud-hypervisor --version 2>/dev/null | head -1 || true)"
+        echo "cloud-hypervisor already on PATH — skipping. ($ver)"
+        exit 0
+    fi
+    case "$(uname -s)" in
+        Darwin)
+            echo "skip: macOS uses libkrun, not cloud-hypervisor. (run \`just setup-libkrun\`)"
+            exit 0
+            ;;
+        Linux)
+            if command -v apt-get >/dev/null && apt-cache show cloud-hypervisor >/dev/null 2>&1; then
+                echo "→ apt install cloud-hypervisor"
+                sudo apt-get update
+                sudo apt-get install -y cloud-hypervisor
+            elif command -v dnf >/dev/null && dnf info cloud-hypervisor >/dev/null 2>&1; then
+                echo "→ dnf install cloud-hypervisor"
+                sudo dnf install -y cloud-hypervisor
+            else
+                # Upstream static binary fallback. Pin to a known version
+                # — auto-tracking `latest` is how CI flakes manifest.
+                CH_VERSION="${CH_VERSION:-v40.0}"
+                arch="$(uname -m)"
+                case "$arch" in
+                    x86_64)   asset="cloud-hypervisor-static" ;;
+                    aarch64)  asset="cloud-hypervisor-static-aarch64" ;;
+                    *)        echo "error: no upstream CH static binary for arch $arch" >&2; exit 1 ;;
+                esac
+                url="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${CH_VERSION}/${asset}"
+                echo "→ curl $url"
+                tmp="$(mktemp)"
+                curl -fL -o "$tmp" "$url"
+                chmod +x "$tmp"
+                sudo install -m 0755 "$tmp" /usr/local/bin/cloud-hypervisor
+                rm -f "$tmp"
+            fi
+            ;;
+        *)
+            echo "error: cloud-hypervisor is not supported on $(uname -s)." >&2
+            exit 1
+            ;;
+    esac
+    echo "Verifying install…"
+    if command -v cloud-hypervisor >/dev/null; then
+        echo "  ✓ $(command -v cloud-hypervisor)"
+        cloud-hypervisor --version | head -1
+    else
+        echo "  ! cloud-hypervisor not on PATH after install." >&2
+        exit 1
+    fi
+
 # ── Utilities ────────────────────────────────────────────────────────────
 
 # Clean build artifacts


### PR DESCRIPTION
## Summary
Adds three recipes under a new \"VMM setup\" Justfile section:

- **`just setup-libkrun`** — `brew install slp/krun/libkrun` on macOS (qualified form auto-taps); `apt install libkrun-dev` / `dnf install libkrun-devel` / `pacman -S libkrun` on Linux. Idempotent: probes standard library paths first, skips when already installed. Self-verifies the `.dylib`/`.so` actually landed.
- **`just setup-cloud-hypervisor`** — `apt install` / `dnf install` when distros package it; falls back to the upstream `cloud-hypervisor-static` release binary (pinned to v40.0, override via `CH_VERSION` env var). Cleanly skips on macOS with a note pointing at `setup-libkrun`.
- **`just setup`** — composite that runs both; works on any host because CH is a no-op skip on Darwin.

Each step is self-checking — \"package manager said okay\" is not the exit criterion, the shared library / binary actually being present on disk is.

## Why
Contributors and CI both need libkrun (macOS lane) and/or cloud-hypervisor (Linux lane) on PATH to exercise the Plan 57 W3 / Plan 72 boot validation examples. Hand-rolled instructions in onboarding docs drift; a `just` recipe is single-source.

## Test plan
- [x] `just --list` shows all three recipes with one-line descriptions in the new \"VMM setup\" section.
- [x] `just setup-libkrun` on macOS with libkrun pre-installed → \"already installed at /opt/homebrew/lib/libkrun.dylib — skipping.\"
- [x] `just setup-cloud-hypervisor` on macOS → \"skip: macOS uses libkrun, not cloud-hypervisor.\"
- [x] `just setup` on macOS → runs both in dependency order; emits validation hint at the end.
- [ ] On a Linux host: each lane installs the right package and verifies binary/library presence (not exercised in this PR — runs in the `vmm-bootcheck` workflow once that lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)