### PR TITLE
feat(ci): plan 57 W5 — cloud-hypervisor Linux bootcheck lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,6 +489,11 @@ jobs:
         # not require microsandbox. Output gets staged at
         # $GITHUB_WORKSPACE/ci-artifacts/{vmlinux, rootfs.ext4}; the
         # next step points the bootcheck at those paths via env vars.
+        #
+        # chmod after cp: nix/store files come back mode 0444. CH opens
+        # the rootfs RW by default and fails with
+        # `VmBoot(DeviceManager(Disk(... PermissionDenied)))` against a
+        # read-only file. The runner owns the copy, so 0644 is fine.
         run: |
           set -euo pipefail
           nix build "./nix/images/builder#packages.x86_64-linux.default" \
@@ -497,6 +502,7 @@ jobs:
           mkdir -p ci-artifacts
           cp "$STORE_PATH/vmlinux"     ci-artifacts/vmlinux
           cp "$STORE_PATH/rootfs.ext4" ci-artifacts/rootfs.ext4
+          chmod 0644 ci-artifacts/vmlinux ci-artifacts/rootfs.ext4
           ls -la ci-artifacts/
 
       - name: Build ch-bootcheck example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,3 +384,134 @@ jobs:
       - name: Clippy mvm-libkrun --features libkrun-sys --all-targets
         if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
         run: cargo clippy -p mvm-libkrun --features libkrun-sys --all-targets -- -D warnings
+
+  # ── Lane: cloud-hypervisor (Linux x86_64, paths-gated) ──
+  #
+  # Companion to `libkrun-macos`: validates the Linux half of the
+  # cross-platform VMM matrix. ubuntu-latest exposes /dev/kvm (with
+  # a chmod widening for the runner user), so cloud-hypervisor can
+  # actually boot a guest — unlike libkrun-macos, which builds + tests
+  # but can't reach `krun_start_enter` because GitHub's macOS VMs
+  # don't allow nested HVF.
+  #
+  # What this lane proves:
+  #   - cloud-hypervisor boots a Nix-built Linux kernel + ext4 rootfs
+  #     on a real KVM host (Linux side of "is the VMM viable?").
+  #   - The dev-image flake at `nix/images/builder` builds via host
+  #     Nix on a fresh runner with NO microsandbox involvement —
+  #     proving the artifact pipeline doesn't need microsandbox.
+  #     Together with the libkrun-macos lane, the two-lane gate
+  #     covers the empirical premise behind retiring microsandbox.
+  #
+  # KernelBooted (kernel reaches boot diagnostics but rootfs/init
+  # fails) counts as PASS by default — the gate is "VMM viable",
+  # not "rootfs complete". Set MVM_CH_BOOTCHECK_STRICT=1 to flip.
+  #
+  # Security: only workflow-internal expressions used in `run:` blocks
+  # (`steps.filter.outputs.*`, `github.ref`, `github.workspace`,
+  # `hashFiles(...)`). No user-controlled inputs like pr-title or
+  # head_ref reach a shell.
+  ch-linux:
+    name: cloud-hypervisor (Linux x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect ch-touching paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            ch:
+              - 'crates/mvm-backend/src/cloud_hypervisor.rs'
+              - 'crates/mvm-backend/src/ch_runtime.rs'
+              - 'crates/mvm-backend/examples/ch-bootcheck.rs'
+              - 'crates/mvm-backend/Cargo.toml'
+              - 'nix/images/builder/**'
+              - 'nix/lib/**'
+              - 'specs/plans/57-libkrun-spike.md'
+              - 'specs/plans/72-builder-vm-via-libkrun.md'
+              - '.github/workflows/ci.yml'
+
+      - name: Install Rust toolchain
+        if: steps.filter.outputs.ch == 'true' || github.ref == 'refs/heads/main'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Nix
+        if: steps.filter.outputs.ch == 'true' || github.ref == 'refs/heads/main'
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Install cloud-hypervisor
+        if: steps.filter.outputs.ch == 'true' || github.ref == 'refs/heads/main'
+        # Pin to a known release — auto-tracking `latest` is how this
+        # lane would surprise-break on an unrelated CH cut.
+        env:
+          CH_VERSION: v40.0
+        run: |
+          set -euo pipefail
+          curl -fL -o cloud-hypervisor \
+            "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${CH_VERSION}/cloud-hypervisor-static"
+          chmod +x cloud-hypervisor
+          sudo install -m 0755 cloud-hypervisor /usr/local/bin/cloud-hypervisor
+          cloud-hypervisor --version
+
+      - name: Grant /dev/kvm access for the job
+        if: steps.filter.outputs.ch == 'true' || github.ref == 'refs/heads/main'
+        # ubuntu-latest's /dev/kvm is root:kvm 0660 by default and the
+        # runner user isn't in the kvm group, so CH would get EACCES
+        # from hv_vm_create. `sudo chmod 666` is the canonical GHA fix;
+        # the runner is ephemeral so the looser mode is confined to
+        # this job's VM lifetime.
+        run: |
+          set -euo pipefail
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm missing on this runner — cloud-hypervisor can't run." >&2
+            exit 1
+          fi
+          sudo chmod 666 /dev/kvm
+          ls -la /dev/kvm
+
+      - name: Cache cargo
+        if: steps.filter.outputs.ch == 'true' || github.ref == 'refs/heads/main'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-ch-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-ch-
+
+      - name: Build dev image via host Nix (no microsandbox)
+        if: steps.filter.outputs.ch == 'true' || github.ref == 'refs/heads/main'
+        # Mirrors release.yml's dev-image job for x86_64 — this is the
+        # load-bearing existence proof that the artifact pipeline does
+        # not require microsandbox. Output gets staged at
+        # $GITHUB_WORKSPACE/ci-artifacts/{vmlinux, rootfs.ext4}; the
+        # next step points the bootcheck at those paths via env vars.
+        run: |
+          set -euo pipefail
+          nix build "./nix/images/builder#packages.x86_64-linux.default" \
+            --no-link --print-out-paths > /tmp/store-path.txt
+          STORE_PATH=$(head -1 /tmp/store-path.txt)
+          mkdir -p ci-artifacts
+          cp "$STORE_PATH/vmlinux"     ci-artifacts/vmlinux
+          cp "$STORE_PATH/rootfs.ext4" ci-artifacts/rootfs.ext4
+          ls -la ci-artifacts/
+
+      - name: Build ch-bootcheck example
+        if: steps.filter.outputs.ch == 'true' || github.ref == 'refs/heads/main'
+        run: cargo build --example ch-bootcheck -p mvm-backend
+
+      - name: Run ch-bootcheck
+        if: steps.filter.outputs.ch == 'true' || github.ref == 'refs/heads/main'
+        # Outcome legend (mirrored in the example's --help):
+        #   0  — PASS (VMM viable; kernel booted or reached userspace)
+        #   1  — strict-mode partial (gate not flipped here)
+        #   2  — FAIL (no kernel output, VMM rejected boot)
+        #   74 — cloud-hypervisor not on PATH (install step failed)
+        #   75 — artifacts missing (build-image step failed silently)
+        env:
+          MVM_CH_BOOTCHECK_KERNEL: ${{ github.workspace }}/ci-artifacts/vmlinux
+          MVM_CH_BOOTCHECK_ROOTFS: ${{ github.workspace }}/ci-artifacts/rootfs.ext4
+        run: cargo run --example ch-bootcheck -p mvm-backend

--- a/crates/mvm-backend/examples/ch-bootcheck.rs
+++ b/crates/mvm-backend/examples/ch-bootcheck.rs
@@ -1,0 +1,273 @@
+//! Plan 57 W3 / Plan 72 — cross-platform companion to
+//! `crates/mvm-libkrun/examples/libkrun-smoke.rs`: validates that
+//! cloud-hypervisor boots a Nix-built Linux kernel + ext4 rootfs on a
+//! Linux host. This is the gate the `vmm-bootcheck` CI lane consumes
+//! to prove the Linux side of the microsandbox-free artifact pipeline.
+//!
+//! Run (Linux host with KVM available + `cloud-hypervisor` on PATH —
+//! `just setup-cloud-hypervisor` covers the install):
+//!
+//! ```text
+//! cargo run --example ch-bootcheck -p mvm-backend
+//! ```
+//!
+//! Artifact discovery: defaults to
+//! `nix/images/dev-prebuilt/<host-arch>/{vmlinux, rootfs.ext4}`,
+//! matching the in-repo dev-image layout. Override per-path with
+//! `MVM_CH_BOOTCHECK_KERNEL` / `MVM_CH_BOOTCHECK_ROOTFS`. The CI
+//! workflow builds the dev-image flake on the runner (host Nix, no
+//! microsandbox) and points the env vars at the freshly built files.
+//!
+//! Exit codes:
+//!
+//! - `0` — PASS: VMM viable. Either the kernel reached userspace OR
+//!   it booted far enough to panic at a later stage (kernel panic at
+//!   `mount_root` still proves CH did its job). Set
+//!   `MVM_CH_BOOTCHECK_STRICT=1` to require userspace markers.
+//! - `1` — PARTIAL (strict-mode only): kernel booted but did not
+//!   reach userspace.
+//! - `2` — FAIL: no kernel output observed. Either CH rejected the
+//!   config or the kernel never started.
+//! - `74` — `cloud-hypervisor` not on PATH (install step missing).
+//! - `75` — artifacts missing.
+//!
+//! No mvm-backend symbols are linked from here — the example shells
+//! out to the standalone `cloud-hypervisor` binary so it doesn't
+//! drag the backend's heavier deps into the CI job's build closure.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+const KERNEL_ENV: &str = "MVM_CH_BOOTCHECK_KERNEL";
+const ROOTFS_ENV: &str = "MVM_CH_BOOTCHECK_ROOTFS";
+const CMDLINE_ENV: &str = "MVM_CH_BOOTCHECK_CMDLINE";
+const CH_BIN_ENV: &str = "MVM_CH_BIN";
+
+const BOOT_TIMEOUT: Duration = Duration::from_secs(30);
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Default kernel cmdline. CH's `--serial file=…` routes the guest's
+/// 8250 UART to the host file, so `console=ttyS0` is correct here.
+/// `panic=1` makes panics exit fast; `loglevel=7` keeps DEBUG-level
+/// messages visible so a stuck early boot still emits a usable trace.
+const DEFAULT_CMDLINE: &str = "console=ttyS0 root=/dev/vda rw panic=1 loglevel=7";
+
+fn main() {
+    std::process::exit(run());
+}
+
+fn run() -> i32 {
+    let ch_bin = std::env::var(CH_BIN_ENV).unwrap_or_else(|_| "cloud-hypervisor".to_string());
+    if Command::new(&ch_bin).arg("--version").output().is_err() {
+        eprintln!("ch-bootcheck: `{ch_bin}` not on PATH.");
+        eprintln!();
+        eprintln!("Install cloud-hypervisor:");
+        eprintln!("  just setup-cloud-hypervisor");
+        eprintln!("Or set {CH_BIN_ENV}=<path> to point elsewhere.");
+        return 74;
+    }
+
+    let kernel = resolve_artifact(KERNEL_ENV, "vmlinux");
+    let rootfs = resolve_artifact(ROOTFS_ENV, "rootfs.ext4");
+    if !kernel.is_file() || !rootfs.is_file() {
+        eprintln!("ch-bootcheck: artifacts missing");
+        eprintln!(
+            "  kernel: {} ({})",
+            kernel.display(),
+            if kernel.is_file() { "ok" } else { "MISSING" }
+        );
+        eprintln!(
+            "  rootfs: {} ({})",
+            rootfs.display(),
+            if rootfs.is_file() { "ok" } else { "MISSING" }
+        );
+        eprintln!();
+        eprintln!("Defaults to nix/images/dev-prebuilt/<arch>/. Set");
+        eprintln!("  {KERNEL_ENV}=<path>  {ROOTFS_ENV}=<path>");
+        eprintln!("to override.");
+        return 75;
+    }
+
+    let serial_path =
+        std::env::temp_dir().join(format!("mvm-ch-bootcheck-{}.log", std::process::id()));
+    let _ = std::fs::remove_file(&serial_path);
+    std::fs::File::create(&serial_path).expect("create serial tempfile");
+
+    let cmdline = std::env::var(CMDLINE_ENV).unwrap_or_else(|_| DEFAULT_CMDLINE.to_string());
+
+    eprintln!("[ch-bootcheck] ch: {ch_bin}");
+    eprintln!("[ch-bootcheck] kernel: {}", kernel.display());
+    eprintln!("[ch-bootcheck] rootfs: {}", rootfs.display());
+    eprintln!("[ch-bootcheck] cmdline: {cmdline}");
+    eprintln!("[ch-bootcheck] serial -> {}", serial_path.display());
+    eprintln!("[ch-bootcheck] timeout: {}s", BOOT_TIMEOUT.as_secs());
+
+    // CH's stderr carries pre-boot rejection details (kernel format
+    // mismatch, /dev/kvm EACCES, etc.) that don't reach the guest
+    // serial file. Capture it so a NoOutput failure can be diagnosed
+    // from the CI log alone — the first version of this example
+    // discarded stderr and the failure mode was unclassifiable.
+    let mut child = match Command::new(&ch_bin)
+        .args([
+            "--cpus",
+            "boot=1",
+            "--memory",
+            "size=256M",
+            "--kernel",
+            kernel.to_str().expect("kernel path utf-8"),
+            "--cmdline",
+            &cmdline,
+            "--disk",
+            &format!("path={}", rootfs.display()),
+            "--serial",
+            &format!("file={}", serial_path.display()),
+            "--console",
+            "off",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[ch-bootcheck] failed to spawn {ch_bin}: {e}");
+            let _ = std::fs::remove_file(&serial_path);
+            return 70;
+        }
+    };
+    eprintln!("[ch-bootcheck] spawned cloud-hypervisor pid={}", child.id());
+
+    let outcome = tail_for_boot_markers(&serial_path);
+
+    // CH stays running after the guest exits (waiting for API
+    // commands); we never talk to its API here so always kill.
+    let _ = child.kill();
+    let exit_status = child.wait().ok();
+
+    let mut ch_stdout = String::new();
+    let mut ch_stderr = String::new();
+    if let Some(mut s) = child.stdout.take() {
+        let _ = s.read_to_string(&mut ch_stdout);
+    }
+    if let Some(mut s) = child.stderr.take() {
+        let _ = s.read_to_string(&mut ch_stderr);
+    }
+
+    let serial = std::fs::read_to_string(&serial_path).unwrap_or_default();
+    let _ = std::fs::remove_file(&serial_path);
+
+    if !ch_stdout.trim().is_empty() {
+        eprintln!("\n──── cloud-hypervisor stdout ────");
+        eprintln!("{}", ch_stdout.trim_end());
+        eprintln!("──── end stdout ────");
+    }
+    if !ch_stderr.trim().is_empty() {
+        eprintln!("\n──── cloud-hypervisor stderr ────");
+        eprintln!("{}", ch_stderr.trim_end());
+        eprintln!("──── end stderr ────");
+    }
+
+    eprintln!("\n──── guest serial tail (last 1024 bytes) ────");
+    let tail = if serial.len() > 1024 {
+        &serial[serial.len() - 1024..]
+    } else {
+        &serial
+    };
+    eprintln!("{tail}");
+    eprintln!("──── end guest serial tail ────\n");
+
+    eprintln!("[ch-bootcheck] child exit: {exit_status:?}");
+    eprintln!("[ch-bootcheck] outcome: {outcome:?}");
+
+    // The gate question is "is the VMM viable on this host?" —
+    // KernelBooted (kernel reached boot diagnostics but rootfs/init
+    // failed) is a VMM success. Strict mode tightens to require
+    // userspace markers — used by smoke tests that also validate
+    // the rootfs.
+    let strict = std::env::var("MVM_CH_BOOTCHECK_STRICT").is_ok();
+    match outcome {
+        Outcome::ReachedUserspace => {
+            println!("PASS — cloud-hypervisor booted Linux to userspace on this host");
+            0
+        }
+        Outcome::KernelBooted if !strict => {
+            println!(
+                "PASS — cloud-hypervisor booted the Linux kernel (rootfs/init incomplete; \
+                 not part of the VMM-viability gate)"
+            );
+            0
+        }
+        Outcome::KernelBooted => {
+            println!(
+                "PARTIAL — kernel booted but did not reach userspace. \
+                 (strict mode set MVM_CH_BOOTCHECK_STRICT=1)"
+            );
+            1
+        }
+        Outcome::NoOutput => {
+            println!(
+                "FAIL — no kernel output observed. Cmdline / serial mis-routed, \
+                 or CH never started the guest."
+            );
+            2
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Outcome {
+    ReachedUserspace,
+    KernelBooted,
+    NoOutput,
+}
+
+fn tail_for_boot_markers(path: &PathBuf) -> Outcome {
+    let start = Instant::now();
+    let mut seen_kernel = false;
+    let mut seen_panic = false;
+
+    while start.elapsed() < BOOT_TIMEOUT {
+        let content = std::fs::read_to_string(path).unwrap_or_default();
+        if content.contains("Run /init as init process")
+            || content.contains("Run /sbin/init as init process")
+            || content.contains("Welcome to")
+            || content.contains("/init started")
+            || content.contains("BusyBox v")
+        {
+            return Outcome::ReachedUserspace;
+        }
+        if content.contains("Linux version") || content.contains("Booting Linux") {
+            seen_kernel = true;
+        }
+        if content.contains("Kernel panic") || content.contains("end Kernel panic") {
+            seen_panic = true;
+            break;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+
+    if seen_panic || seen_kernel {
+        Outcome::KernelBooted
+    } else {
+        Outcome::NoOutput
+    }
+}
+
+fn resolve_artifact(env_var: &str, default_basename: &str) -> PathBuf {
+    if let Ok(v) = std::env::var(env_var) {
+        return PathBuf::from(v);
+    }
+    let arch = if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    };
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    cwd.join("nix")
+        .join("images")
+        .join("dev-prebuilt")
+        .join(arch)
+        .join(default_basename)
+}

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -390,6 +390,13 @@ let
     # exec it. Mode 0555 so the agent can't rewrite itself; ownership
     # is the build-time user (Nix sandbox has no root) — Phase 6 W2.2
     # binds /etc + /usr read-only at boot to make this load-bearing.
+    #
+    # mkdir before the cp: when `packages = []` the directory-creation
+    # block below is a no-op, so /usr/local/bin doesn't exist yet and
+    # the cp fails with "No such file or directory". That was the
+    # latent bug that broke release.yml's dev-image lane and the
+    # ch-linux bootcheck before this fix.
+    mkdir -p "$out/usr/local/bin"
     cp ${agentBinary} "$out/usr/local/bin/mvm-guest-agent"
     chmod 0555 "$out/usr/local/bin/mvm-guest-agent"
 


### PR DESCRIPTION
## Summary

Companion to PR #161 (libkrun-macos CI lane). Adds the Linux half of the cross-platform VMM gate so we have empirical CI proof that:

1. **cloud-hypervisor on Linux/KVM boots a Linux kernel** produced by our flake.
2. **The dev-image flake builds via host Nix on a fresh CI runner with NO microsandbox involvement** — the load-bearing existence proof for retiring microsandbox in Plan 72.

Together with #161, the two-lane gate (`libkrun-macos` build/lint/test + `ch-linux` end-to-end boot) covers the cross-platform VMM viability question.

## Changes

- **`crates/mvm-backend/examples/ch-bootcheck.rs`** — host-side bootcheck. Shells out to `cloud-hypervisor`, tails guest serial output, captures CH's own stdout/stderr so pre-boot failures (kernel format mismatch, `/dev/kvm` EACCES, etc.) surface in CI logs. Outcome classifier with three states — `ReachedUserspace`, `KernelBooted`, `NoOutput`. `KernelBooted` counts as PASS by default (gate is \"VMM viable\", not \"rootfs complete\"); `MVM_CH_BOOTCHECK_STRICT=1` flips to require userspace.
- **`.github/workflows/ci.yml`** — `ch-linux` job mirroring #161's paths-filter shape. Pins cloud-hypervisor to v40.0, `chmod 666 /dev/kvm` for the runner user, builds the dev-image flake via `DeterminateSystems/nix-installer-action`, runs the bootcheck against the freshly built artifacts.

## Why this replaces the closed #155

PR #155 attempted to land this gate alongside duplicate work that ended up on main via #154–#159. This PR is the trimmed re-do against current main's API — just the two unique, load-bearing files. No KrunContext / start_enter / examples-restructure churn.

## Test plan

- [x] `cargo build --example ch-bootcheck -p mvm-backend` clean locally
- [x] `cargo clippy --example ch-bootcheck -p mvm-backend -- -D warnings` clean
- [x] `cargo run --example ch-bootcheck -p mvm-backend` on macOS (no CH installed) → exits 74 with `just setup-cloud-hypervisor` hint, as designed
- [ ] CI run on this PR: `ch-linux` lane should turn green; other lanes unaffected (paths filter is narrow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)