### PR TITLE
chore(gitignore): ignore nix/images/dev-prebuilt/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ man/*.1
 nixos.qcow2
 .ash_history
 keys
+# Local dev-image build output. The sibling `nix/images/builder/` and
+# `nix/images/builder-vm/` directories are flake sources and stay
+# tracked; this one is a build artifact that can run into the hundreds
+# of megabytes per arch.
+nix/images/dev-prebuilt/
 
 # Override the user's global gitignore for this specific path. The CLI
 # crate has a `build/` subdirectory that hosts the `mvmctl build`


### PR DESCRIPTION
## Summary
- `nix/images/dev-prebuilt/` is a local build-output directory (~hundreds of MB per arch) that's been surfacing in every `git status`
- Sibling dirs `nix/images/builder/` and `nix/images/builder-vm/` are flake sources and stay tracked

## Test plan
- [x] `git status` no longer lists `nix/images/dev-prebuilt/`
- [ ] Confirm no contributor was relying on the directory being trackable

🤖 Generated with [Claude Code](https://claude.com/claude-code)