### PR TITLE
Fix dev source checkout prebuilt fallback

### DIFF
--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -562,6 +562,20 @@ fn prepare_dev_image_out_dir(out_dir: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "contributor-bootstrap"))]
+fn source_checkout_requires_contributor_bootstrap(flake_dir: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Local dev-image flake found at {flake_dir}, but this mvmctl binary was built without \
+         the `contributor-bootstrap` feature.\n\n\
+         Refusing to download the published prebuilt because `mvmctl dev up` from a source \
+         checkout must reflect local flakes and rootfs changes.\n\n\
+         Re-run with:\n\
+           cargo run --features contributor-bootstrap -- dev up\n\n\
+         Or install a contributor binary with:\n\
+           cargo install --path . --features contributor-bootstrap"
+    )
+}
+
 /// Resolve the dev image (kernel + rootfs) to absolute paths.
 ///
 /// In a source checkout: prefers the libkrun-backed builder VM
@@ -579,6 +593,11 @@ fn prepare_dev_image_out_dir(out_dir: &str) -> Result<()> {
 /// rootfs changes.
 fn ensure_dev_image() -> Result<(String, String)> {
     let local_flake = find_dev_image_flake().ok();
+
+    #[cfg(not(feature = "contributor-bootstrap"))]
+    if let Some(flake_dir) = &local_flake {
+        return Err(source_checkout_requires_contributor_bootstrap(flake_dir));
+    }
 
     // Plan 72 W5.B — source-checkout dispatch.
     //
@@ -623,7 +642,7 @@ fn ensure_dev_image() -> Result<(String, String)> {
                 }
                 Err(e) => {
                     anyhow::bail!(
-                        "libkrun builder VM build failed (source checkout: {flake_dir}).\n{e}\n\n\
+                        "libkrun builder VM build failed (source checkout: {flake_dir}).\n{e:#}\n\n\
                          Refusing to fall back to the published prebuilt because it would mask\n\
                          local rootfs changes, and refusing to fall back to microsandbox because\n\
                          the dev-shell rustc closure overflows microsandbox's 4 GiB overlay\n\
@@ -645,7 +664,7 @@ fn ensure_dev_image() -> Result<(String, String)> {
             }
             Err(e) => {
                 anyhow::bail!(
-                    "Dev image build failed (source checkout: {flake_dir}).\n{e}\n\n\
+                    "Dev image build failed (source checkout: {flake_dir}).\n{e:#}\n\n\
                      Refusing to fall back to the published prebuilt because it would mask\n\
                      local rootfs changes. To force the prebuilt anyway, move or delete\n\
                      nix/images/builder/flake.nix so the source-checkout heuristic stops matching."
@@ -660,16 +679,7 @@ fn ensure_dev_image() -> Result<(String, String)> {
     // automatically invalidates older caches. We sweep older version
     // dirs on every miss so disk usage tracks the *current* version,
     // not the union of every version ever installed.
-    if local_flake.is_none() {
-        ui::info("No local dev-image flake found; downloading published prebuilt.");
-    } else {
-        // `contributor-bootstrap` is off — library-consumer build that
-        // never owns a dev VM. The only path forward is the prebuilt.
-        ui::info(
-            "Builder-VM backend compiled out (no `contributor-bootstrap` feature); \
-             downloading published prebuilt instead of local build.",
-        );
-    }
+    ui::info("No local dev-image flake found; downloading published prebuilt.");
     let version = env!("CARGO_PKG_VERSION");
     let prebuilt_root = format!("{}/dev/prebuilt", mvm_core::config::mvm_data_dir());
     let prebuilt_dir = format!("{prebuilt_root}/v{version}");
@@ -1945,7 +1955,7 @@ fn bootstrap_builder_vm_image() -> Result<()> {
                 Ok(())
             }
             Err(e) => Err(anyhow::anyhow!(
-                "Stage 0 microsandbox build of the builder-vm flake at {flake_dir} failed: {e}\n\
+                "Stage 0 microsandbox build of the builder-vm flake at {flake_dir} failed: {e:#}\n\
                  The builder-vm rootfs closure is meant to fit in microsandbox's 4 GiB overlay \
                  (no rustc, no cargo crates — see Plan 72 §W2). If it doesn't, the package list \
                  in nix/images/builder-vm/flake.nix needs trimming."
@@ -2514,6 +2524,21 @@ mod builder_vm_bootstrap_tests {
         assert!(
             std::path::Path::new(&path).join("flake.nix").is_file(),
             "flake.nix missing under {path}"
+        );
+    }
+
+    #[cfg(not(feature = "contributor-bootstrap"))]
+    #[test]
+    fn source_checkout_dev_image_errors_without_contributor_bootstrap() {
+        let err =
+            source_checkout_requires_contributor_bootstrap("/repo/nix/images/builder").to_string();
+        assert!(
+            err.contains("Refusing to download the published prebuilt"),
+            "error must make the no-download invariant explicit: {err}"
+        );
+        assert!(
+            err.contains("cargo run --features contributor-bootstrap -- dev up"),
+            "error should include the contributor rebuild command: {err}"
         );
     }
 

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -32,7 +32,7 @@ This single command detects your platform and handles everything. **Builds run i
 Inside the dev shell your project directory is bind-mounted at `/work`. Exit with `exit` or `Ctrl+D` -- background services keep running.
 
 :::note
-First run downloads the builder image (~200MB) and the dev microVM image. Subsequent runs start in seconds.
+Release binaries download the builder image (~200MB) and dev microVM image on first run. From a source checkout, `mvmctl dev up` builds from the in-repo flakes; source builds must enable `contributor-bootstrap` for that local builder path.
 :::
 
 ## 2. Day-to-Day Commands

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -38,6 +38,7 @@ Recent maintenance:
 
 - [x] `mvmctl dev status` now reports the same Apple Container dev image paths that `dev up` boots (`~/.mvm/dev/current`, versioned prebuilts, or launchd-provided paths), instead of only checking the legacy cache location.
 - [x] Added an opt-in `runtime_boot_bench` live test for already-built runtime images, covering serial boots and three-way concurrent fan-out against a 200 ms per-VM budget.
+- [x] Source-checkout `mvmctl dev up` now refuses to download published prebuilts when the binary was built without `contributor-bootstrap`; it exits with the local-build feature hint instead, preserving the "dev reflects local flakes" invariant.
 
 ## In-flight workstreams
 


### PR DESCRIPTION
## Summary
- Refuse published dev-image prebuilt fallback when a source checkout is detected but contributor-bootstrap is not enabled.
- Preserve full Stage 0/libkrun error chains so dev bootstrap failures show the underlying cause.
- Update quickstart and sprint notes for the source-checkout behavior.

## Verification
- cargo test -p mvm-cli builder_vm_bootstrap_tests
- cargo check -p mvm-cli
- cargo check --workspace
- cargo clippy --workspace -- -D warnings

Full cargo test --workspace was attempted; unrelated mvm-guest macOS tests failed around timing/setuid behavior.