### PR TITLE
Plan 75 W0 — scope guards for removing microsandbox via mvm-oci + libkrun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,18 @@ jobs:
       - name: No positional audit::emit / event-chain calls
         run: cargo run -p xtask -- check-audit-positional
 
+      # Plan 75 W0 — user-facing repo text cannot use phrases
+      # gated by a claim file in specs/claims/ whose status is
+      # not Shipped. Prevents docs / README / CLI help from
+      # claiming a capability before its CI gate passes. Each
+      # claim file declares its own exempt_paths; design docs
+      # (specs/**) and history (CHANGELOG.md) are exempt by
+      # convention. Hard gate; admit a phrase by either flipping
+      # its claim to Shipped (once the CI gate ratifies it) or
+      # adding the path to the claim's exempt_paths.
+      - name: No overclaiming (gated phrases from specs/claims/)
+        run: cargo run -p xtask -- check-no-overclaim
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/specs/adrs/049-mvm-oci-supersedes-microsandbox.md
+++ b/specs/adrs/049-mvm-oci-supersedes-microsandbox.md
@@ -1,0 +1,161 @@
+# ADR 049 — `mvm-oci` supersedes microsandbox; bidirectional OCI is a first-class feature
+
+**Status**: Proposed (ratifies plan 75; flips to Accepted when plan 75 W4 lands and `cargo metadata` shows zero microsandbox crates in the workspace closure)
+**Date**: 2026-05-14
+**Supersedes**: ADR-046 §"Stage 0 for contributors without host Nix" (microsandbox is no longer kept behind `--features contributor-bootstrap`; it is removed outright)
+**Cross-refs**: ADR-002 (microvm security posture), ADR-046 (builder VM via libkrun), Plan 74 W1 (OCI image ingest — subsumed by plan 75 W5), Plan 75 (this ADR's implementation plan), `specs/gap-analysis-vs-microsandbox.md`
+
+## Context
+
+ADR-046 settled the user-facing builder VM path: libkrun (macOS) / Firecracker (Linux), with microsandbox demoted to a contributor-only Stage 0 escape hatch behind `--features contributor-bootstrap`. That demotion was the smallest move that unblocked plan 72's main thrust, but it left a residual structural problem:
+
+1. **The microsandbox dep contradicts CLAUDE.md.** CLAUDE.md §"Firecracker-only" reads: *"no Docker/containers. Builds run Nix inside the Lima VM."* The retained microsandbox path pulls `docker.io/nixos/nix:2.24.10` to run `nix build` inside a Docker-style overlay; the contradiction is documented but not resolved.
+2. **The 4 GiB overlay keeps biting.** Plan 72's "the Stage 0 closure is small enough to fit" assumption depends on the builder VM rootfs never gaining a Rust binary, a Python tool, or anything that vendors a cargo lockfile. That assumption broke 2026-05-13 (plan 73 Followup B.2 added `uv` + `pnpm` + `pip-audit`) and broke again 2026-05-14 (plan 73 Followup B.2.x added a second `rustPlatform.buildRustPackage`). Each fix is a trim-the-flake exercise; each fix invites the next regression.
+3. **Plan 74 W1 wants the same primitive.** "`mvmctl image pull <ref>` materializes OCI images into microvm artifacts" requires exactly what Stage 0 needs: HTTPS-to-a-registry, manifest fetch, digest verification, layer unpack to ext4, hand-off to a launcher. Building that primitive twice (once inside microsandbox for Stage 0, once again for user-facing pull) is engineering waste.
+4. **The bidirectional OCI story is strategic.** OCI → microvm widens addressable workloads; microvm → OCI widens addressable deployment targets (Kubernetes, ECS, Cloud Run, plain Docker). Together they make mvm a peer in the container ecosystem rather than a parallel universe. Microsandbox is on the wrong side of this — it's a *consumer* of OCI, not a producer.
+
+The right shape is: build `mvm-oci` once as a host-side Rust library, use it for Stage 0 *and* for `mvmctl image pull`, and ship `mvmctl image export` for the export half. After that, microsandbox has no remaining justification.
+
+## Decision
+
+### 1. Introduce `crates/mvm-oci/` as the OCI ingest primitive
+
+A new crate that:
+
+- Talks OCI Distribution v2 over HTTPS (rustls-only — no native-tls, no openssl).
+- Fetches manifests, configs, and layers; verifies every byte against the manifest's content-addressed digest.
+- Unpacks layers to a directory tree with explicit handling of every OCI tar feature (whiteouts, symlinks with escape refusal, hardlinks within-layer-only, xattr allow-list, device-node refuse-list, setuid/setgid policy).
+- Emits an ext4 rootfs (inside the builder VM, not on the host — no host `mkfs.ext4` dependency on the default path).
+- Exposes a typed `Client::pull` / `Client::resolve` API that callers (Stage 0 boot, `mvmctl image pull`, future `mvmctl image export` round-trip tests) all share.
+
+`mvm-oci` is a host-side library. It is **not** a runtime, **not** a daemon, **not** an OCI runtime spec implementation. It pulls OCI images; libkrun/Firecracker launches the unpacked rootfs.
+
+### 2. Stage 0 becomes `mvm-oci` + libkrun
+
+`build_image_via_microsandbox` (`crates/mvm-cli/src/commands/env/apple_container.rs:1736`) is replaced by `build_image_via_libkrun_oci`. New flow:
+
+```
+mvm_oci::Client::pull(docker.io/nixos/nix:2.24.10@sha256:<pin>)
+    → unpacked layers in ~/.cache/mvm/oci/blobs/sha256/
+mvm_oci::rootfs::build(pulled, ~/.cache/mvm/oci/stage0/<digest>/)
+    → ext4 rootfs (built inside libkrun, not on host)
+LibkrunBuilderVm::run_build(BuilderJob::Flake { ... }, BuilderMounts { stage0_root: Some(...), ... })
+    → vmlinux + rootfs.ext4 for the builder VM image
+```
+
+Same `BuilderJob` / `BuilderMounts` / `BuilderArtifacts` types as today; the `mvm-cli` consumer doesn't change shape.
+
+### 3. Microsandbox is removed in full
+
+After `build_image_via_libkrun_oci` bakes for one release cycle, plan 75 W4 deletes:
+
+- `dep:microsandbox` in `crates/mvm-backend/Cargo.toml`.
+- The `contributor-bootstrap` Cargo feature across the workspace.
+- `MicrosandboxBuilderVm` and its tests.
+- `build_image_via_microsandbox` and the `#[cfg(feature = "contributor-bootstrap")]` blocks that call it.
+- Every doc string that references microsandbox or the 4 GiB overlay (replaced with current-truth language).
+
+The deletion is verifiable: `cargo metadata --no-default-features --features ''` shows zero `microsandbox*` crates, and `grep -rni microsandbox` returns hits only in `specs/` (history) and CHANGELOG entries.
+
+### 4. User-facing OCI ingest ships behind the same primitive (closes plan 74 W1)
+
+`mvmctl image pull <ref>`, `mvmctl image ls`, `mvmctl image rm`, `mvmctl image inspect`, `mvmctl up --image <ref>` are CLI verbs over `mvm_oci::Client`. Templates produced by `image pull` integrate with the existing template store under `kind = "oci"`.
+
+### 5. Bidirectional OCI ships as a sequenced workstream
+
+`mvmctl image export <vm|template> [--push <registry/repo:tag>] [--cosign]` produces an OCI-spec-v1.1 image with explicit and tested documentation of which mvm security claims travel with the exported artifact and which do not. The "claims-that-travel" table is shipped as a CI-asserted annotation, not just docs.
+
+## Security implications
+
+### Claims that update
+
+CLAUDE.md §"Security model" claim 6 (today: *"Pre-built dev image is hash-verified"*) extends to **every** OCI image — Stage 0 base, user-pulled image, mvm-published builder VM artifact — verified by content-addressed digest before any byte is consumed, with tampered layers failing closed. Implementation is shared (`mvm_oci::digest::verify_streaming`); proof is one CI lane instead of three.
+
+### New claim 10
+
+**"OCI image provenance is recorded in the admission audit chain."** Every `mvmctl up --image <ref>` admission emits an audit-chain entry with registry, resolved digest, layer digest list, and (if present) cosign attestation. `mvmctl audit verify` proves the chain.
+
+### Trust-boundary changes
+
+| Boundary | Today | After plan 75 |
+|---|---|---|
+| Stage 0 base image trust root | `docker.io/nixos/nix:2.24.10` via microsandbox, anon auth, digest unenforced | `docker.io/nixos/nix:2.24.10@sha256:<pin>` via mvm-oci, anon auth, digest pinned in source, verified at fetch time. Bump-the-pin is a deliberate PR. |
+| User-facing OCI pull trust root | Not supported | `mvm-oci` HTTPS-only; system trust store; optional `~/.mvm/registry-ca.pem` extra-CA; no `~/.docker/config.json` read by default. |
+| Cosign verification | Not supported anywhere | Verified when present (plan 75 W6); absence does not block (registries are partial coverage); invalid signature refuses. Configurable per-registry policy. |
+| Layer unpack security surface | microsandbox internals (opaque, not in our codebase) | `mvm_oci::layer::unpack` — explicit handling for every OCI tar feature, fuzz lane, adversarial fixture suite |
+| Host filesystem at unpack time | OCI image layers extracted by microsandbox into its own overlay (not directly visible to us) | Unpacked to a directory tree on the host; ext4 image assembled **inside the libkrun Stage 0 VM** so no host `mkfs.ext4` dep on default path |
+| Audit chain coverage | Plans, dep volumes, ExecutionPlan | Plans, dep volumes, ExecutionPlan, **plus OCI image provenance (claim 10)** |
+
+### Threat model additions
+
+These extend ADR-002's threat model.
+
+- **T-OCI-1: Compromised upstream registry.** Stage 0 pin is in source; cosign verification for user pulls when configured; HTTPS pinning to system CA bundle.
+- **T-OCI-2: Layer-unpack CVE class** (CVE-2019-14271-style — path traversal, symlink escape, hardlink-to-host, setuid escalation, xattr privilege carry). Deny-by-default unpacker; cargo-fuzz lane; adversarial fixtures covering each pattern; defense-in-depth via libkrun isolation (the unpacked rootfs runs in a microVM, not on the host).
+- **T-OCI-3: Tag mutation race.** Production policy (`--prod`) rejects unpinned-by-digest references; dev mode resolves to a digest at first pull and caches by digest.
+- **T-OCI-4: TLS substitution / DNS rebinding at pull time.** HTTPS-only; system CA trust by default; SNI must match request hostname; same-origin redirect policy with per-registry opt-in for cross-origin (Docker Hub's `production.cloudflare.docker.com` redirect requires explicit allow); no DoH/DoT bypass.
+- **T-OCI-5: Supply-chain via Stage 0 base image.** Pinned digest in source; CI daily refresh job opens a PR with the bump and upstream changelog; human review before merge; audit annotation records the in-use pin on every Stage 0 launch.
+
+### Defense-in-depth at the launcher
+
+Even if `mvm-oci`'s unpacker has a CVE, the unpacked rootfs is consumed by libkrun/Firecracker — it boots in a microVM, not on the host. A rootfs-level escape from a malicious tar still has to escape libkrun before reaching the host. This is the standard mvm posture for guest workloads; plan 75 inherits it.
+
+### What does **not** change
+
+- CLAUDE.md §"Host Nix is never used by mvmctl" stays load-bearing. mvm-oci has zero nix dep; it speaks HTTPS to registries.
+- CLAUDE.md §"No SSH in microVMs, ever" — mvm-oci does not synthesize sshd or any service in the rootfs it emits; it unpacks what the registry returned.
+- ADR-046's two acquisition paths (source checkout vs. installed binary) remain intact. What changes is Stage 0 in the source-checkout path: previously `microsandbox + nixos/nix OCI`, after plan 75 `mvm-oci + nixos/nix OCI + libkrun`. Same trust root; different code path; one fewer dep that contradicts CLAUDE.md.
+- ADR-002 §W5.1 (image hash verification) applies to OCI ingest with the same streaming SHA-256 path used today for `download_dev_image`.
+
+### Claims that travel with exported OCI images (microvm → OCI)
+
+This is the half of the bidir story that the docs need to be precise about. Plan 75 W7 ships a CI gate asserting the `mvm-claims.json` annotation correctly reports each row:
+
+| Claim | Travels in exported OCI? | Why |
+|---|---|---|
+| dm-verity rootfs (claim 3) | No | OCI consumers' boot path doesn't honor dm-verity; the kernel cmdline isn't ours |
+| Signed ExecutionPlan (claim 8) | Metadata only (annotation), not enforced | Enforcement requires `mvm-supervisor` at the consumer; annotation enables audit |
+| Chain-signed audit log (claim 8) | No | Audit chain is host-state; the export annotation lists the chain head digest so a consumer can request the chain out-of-band |
+| Sealed deps volume (claim 9) | Yes (as separate annotated layer or sidecar) | Sealed volume is content-addressed; layer ships with `meta.json` chain intact |
+| OCI provenance (new claim 10) | N/A — this is an ingest-side claim | Export emits annotations; consumer's audit chain (if any) records its own provenance entry on import |
+| Verified provenance (cosign on export) | Yes (if user opts in) | `mvmctl image export --cosign` signs the exported image; export does not auto-sign |
+
+## Consequences
+
+### Positive
+
+- **One dep removed from the contradiction with CLAUDE.md.** No path inside mvm pulls Docker-style OCI for non-OCI-feature purposes after plan 75 W4.
+- **One primitive built once, used twice.** Stage 0 and user-facing OCI ingest share `mvm_oci::Client`. Bugs found in one path are fixed for both.
+- **The bidirectional OCI feature ships as a side effect.** Plan 75 W5 closes plan 74 W1; plan 75 W7 closes the export half. mvm becomes a container-ecosystem peer without a separate effort.
+- **The 4 GiB overlay stops biting.** Stage 0's rootfs is built inside libkrun, where disk size is host-configurable per-build, not library-internal.
+- **Workspace dep closure shrinks.** Microsandbox's ~40 transitive crates leave with W4.
+- **New security claim ships with CI proof.** Claim 10 (OCI provenance in audit chain) closes the audit gap for the new ingest surface.
+- **Defense-in-depth at the unpacker.** Adversarial fixtures + cargo-fuzz + explicit policies for every OCI tar feature reduce the layer-unpack CVE class to a documented, tested surface.
+
+### Negative
+
+- **Multi-week effort.** Plan 75 sequences seven workstreams; realistic estimate is 4–8 weeks of focused work. Plan 75 §"Why this plan is worth doing now" defends the cost.
+- **One new dep family.** rustls + reqwest + oci-spec + sha2 + a test-time axum fixture. All Rust, all in the existing dependency ecosystem; none of them contradict CLAUDE.md.
+- **Plan 74 W1 trajectory shifts.** Plan 74's other workstreams (W2 network policy, W3 secret placeholders, W4 SDK lifecycle, W5 cold-start budgets, W6 filesystem backends) read mvm-oci as their OCI-ingest substrate. Plan 75 W0 lands an explicit "plan 75 supersedes plan 74 W1" note so the dependency direction is unambiguous.
+- **Trust boundary widens to include cosign tooling.** Plan 75 W6 adds cosign verification + project-pinned-key parsing. The pubkey storage at `~/.mvm/cosign-pubkeys/` and per-registry policy at `~/.mvm/registry-policy.toml` are new on-disk security surfaces; both are mode-0600-or-stricter and live under the existing `~/.mvm` posture (W1.5).
+- **OCI mediaType drift risk.** OCI v1.1 introduced new mediaTypes; we support `gzip` + `zstd` from day one and refuse unknown. New mediaTypes that ship later require an explicit code change. This is the right default — silent admission of unknown encodings is exactly the layer-unpack CVE pattern.
+
+### Neutral
+
+- ADR-013 §"Execution backend selection" is unchanged. Linux + KVM → Firecracker; macOS / Windows / no-KVM → libkrun. microsandbox stops being an execution backend at all (it was already optional after plan 72; plan 75 removes the dep).
+- ADR-002 §W5.1 (image hash verification) applies to OCI ingest with no shape change — same streaming SHA-256 path.
+- The existing `crates/mvm-backend/src/docker.rs` Docker-load fallback (run a Nix-built rootfs as a Docker container) is **not** part of plan 75. It's a separate feature with a separate purpose; it stays as-is.
+
+## Fallback / escape hatch
+
+Plan 75 W3 ships `build_image_via_libkrun_oci` as the **default** Stage 0 path while microsandbox is still in the tree. The microsandbox path is reachable only via `MVM_OCI_FALLBACK_MICROSANDBOX=1` (env var, not feature flag) for one release cycle of emergency revert capability. After that cycle, plan 75 W4 deletes the env var path along with the dep.
+
+If `mvm-oci` (W1+W2) hits a fundamental blocker — e.g. a layer-unpack CVE class we can't tractably defend against in pure Rust — the fallback is a *vendored* OCI layer unpacker derived from a small audited library (e.g. `oci-distribution`'s unpacker, or a minimal vendored cut of containerd's `archive/tar` adapter). This is a code-shape fallback, not a strategy fallback; plan 75's direction holds regardless.
+
+## Open questions (resolved by plan 75 implementation phases)
+
+1. **OCI image index handling** — Docker Hub multi-arch images return an `oci-index` manifest. Plan 75 W1 picks the matching arch; specifics in plan 75 §"Open questions" Q1.
+2. **Layer mediaType coverage** — `gzip` + `zstd` from day one; refuse unknown. Plan 75 §"Open questions" Q2.
+3. **Cache GC policy** — reference-count layers by manifest references; `mvmctl cache prune` GCs orphans. Plan 75 §"Open questions" Q3.
+4. **Pin format for Stage 0 base** — sidecar TOML in `nix/images/` so the daily refresh CI job can bump it without parsing Rust. Plan 75 §"Open questions" Q4.
+5. **Cosign sigstore vs. project-key parity** — project-pinned for `dev.mvm.*` annotations; sigstore opt-in per registry. Plan 75 §"Open questions" Q5.

--- a/specs/claims/README.md
+++ b/specs/claims/README.md
@@ -1,0 +1,52 @@
+# `specs/claims/` — public claim gating files
+
+Each file under this directory records the lifecycle status of one
+public security or capability claim. Files are consumed by
+`xtask check-no-overclaim`, which scans repo text (README, public
+docs, code comments, CLI help) for "guarded phrases" associated
+with a claim and refuses to admit those phrases when the claim's
+status is anything other than `Shipped`.
+
+The intent is to prevent the docs/website/README from saying "we do
+X" before the CI gates that prove X actually pass. Plan 74 W0 and
+plan 75 W0 introduce this pattern; both plans use it to gate the
+OCI ingest, network policy, and other surface that's not yet
+production.
+
+## File format
+
+```markdown
+---
+claim: <kebab-case-id>
+status: Planned | Preview | Shipped | Not-claimed
+gated_phrases:
+  - "phrase to refuse outside this file"
+  - "another phrase"
+exempt_paths:
+  - "specs/**"
+  - "CHANGELOG.md"
+---
+
+# Claim <N> — <human title>
+
+<description of the claim, what it asserts, what CI gate ratifies it>
+```
+
+Fields:
+
+- `claim` — stable identifier. Used in error messages.
+- `status` — see below.
+- `gated_phrases` — list of substrings to refuse outside this
+  claim file (and any path in `exempt_paths`). Case-sensitive.
+- `exempt_paths` — glob list of paths where the phrases are
+  always allowed (this file, history, etc.). `specs/**` is the
+  default exemption for design docs.
+
+## Status semantics
+
+- `Planned` — claim is on the roadmap; phrases blocked everywhere except `exempt_paths`.
+- `Preview` — claim partially shipped; phrases blocked in user-facing surface (README, public docs, landing page, CLI help) but admitted in design docs and changelog entries.
+- `Shipped` — claim has CI proof; phrases admitted everywhere.
+- `Not-claimed` — claim is explicitly out of scope; phrases blocked everywhere.
+
+Bumping status is a deliberate PR; it's how a claim transitions from "we plan to do this" to "we say in public that we do this."

--- a/specs/claims/claim-10-oci-image-provenance.md
+++ b/specs/claims/claim-10-oci-image-provenance.md
@@ -1,0 +1,84 @@
+---
+claim: 10-oci-image-provenance
+status: Planned
+gated_phrases:
+  - "any OCI image"
+  - "any container image"
+  - "OCI image provenance"
+  - "mvmctl image pull"
+  - "mvmctl image export"
+  - "mvmctl up --image"
+  - "mvm-oci"
+  - "OCI ingest"
+  - "bidirectional OCI"
+  - "OCI registry"
+exempt_paths:
+  - "specs/**"
+  - "CHANGELOG.md"
+  - ".github/**"
+  - "memory/**"
+---
+
+# Claim 10 — OCI image provenance is recorded in the admission audit chain
+
+## Assertion
+
+Every `mvmctl up --image <ref>` admission emits an audit-chain entry
+recording:
+
+- The registry host that served the image
+- The repo path
+- The reference as supplied (tag or digest)
+- The resolved manifest digest (sha256)
+- The list of layer digests
+- The cosign attestation summary (verified, unsigned, or refused)
+- The trust policy in effect (`anonymous`, `keyring`, `cosign-required`)
+
+`mvmctl audit verify` continues to detect drift on the audit chain.
+Tampering with any field of an OCI provenance entry breaks the
+chain HMAC.
+
+## CI gate that ratifies the claim
+
+Plan 75 W5 ships `tests/oci_provenance_audit.rs`:
+
+- Pull `docker.io/library/alpine:3.20@sha256:<fixture-pin>` against
+  a local-fixture registry; assert audit entry recorded with
+  correct manifest digest, layer digest list, and trust policy.
+- Byte-flip the audit entry's `resolved_digest` field; assert
+  `mvmctl audit verify` exits nonzero with `E_AUDIT_CHAIN_BROKEN`.
+- Pull a cosigned image with a project-pinned key; assert audit
+  entry's `cosign_attestation` is `verified`.
+- Pull an unsigned image under `--prod` policy with default
+  posture; assert refusal and that no audit entry was emitted
+  (rejection happens before admission).
+
+## Status transitions
+
+- **2026-05-14**: claim filed at status `Planned` (this PR).
+- **Plan 75 W5 lands**: status flips to `Preview` once
+  `mvmctl image pull` is in the CLI and the audit emit path is
+  wired; the gate test is green but cosign is not yet shipped.
+- **Plan 75 W6 lands**: status flips to `Shipped` once cosign
+  verification is wired and the `--prod` policy is enforced.
+
+## Why this claim needs a gate
+
+Until the CI gate above passes, the docs/website/README must not
+claim mvm verifies OCI image provenance. The claim is on the
+roadmap — `Planned` — and the gated phrases list above blocks
+premature use.
+
+The phrase list is conservative on purpose: anything that mentions
+the OCI pull, export, or ingest surface gets caught. Once a phrase
+is admitted (status `Shipped`), the gate disengages and the docs
+team can use it freely.
+
+## Cross-refs
+
+- ADR-002 §"Security model" — claims 1–8 (pre-plan-75) and 9 (deps).
+- ADR-049 — `mvm-oci` supersedes microsandbox; defines this claim
+  in its "Security implications" section.
+- Plan 75 W5 — implementation phase that ratifies the claim.
+- CLAUDE.md §"Security model" — claim 10 line lands in CLAUDE.md
+  when plan 75 W6 flips status to `Shipped`.

--- a/specs/claims/claim-10-oci-image-provenance.md
+++ b/specs/claims/claim-10-oci-image-provenance.md
@@ -17,6 +17,7 @@ exempt_paths:
   - "CHANGELOG.md"
   - ".github/**"
   - "memory/**"
+  - "public/src/content/docs/contributing/adr/**"
 ---
 
 # Claim 10 — OCI image provenance is recorded in the admission audit chain

--- a/specs/plans/75-oci-stage0-microsandbox-removal.md
+++ b/specs/plans/75-oci-stage0-microsandbox-removal.md
@@ -1,0 +1,549 @@
+# Plan 75 — Remove microsandbox via mvm-oci + libkrun (bidirectional OCI as a first-class feature)
+
+> Status: proposed
+> Owner: TBD
+> Started: —
+> Depends on: plan 57 (libkrun spike — shipped), plan 72 (libkrun builder VM — shipped 2026-05-13)
+> Supersedes: ADR-046 §"Stage 0 for contributors without host Nix" (microsandbox is no longer **kept** behind `--features contributor-bootstrap`; this plan removes it outright)
+> Implements: ADR-046 §"What we keep vs. drop from microsandbox" final row resolution (microsandbox → zero); subsumes plan 74 W1 ("OCI image ingest") into a single execution path that also serves Stage 0
+> Tracking: regression of 2026-05-14 (commit `19919f6` added a second `rustPlatform.buildRustPackage` to `nix/images/builder-vm/flake.nix`, overflowing microsandbox's 4 GiB overlay during `mvmctl dev up`); long-standing tension between CLAUDE.md §"Firecracker-only: no Docker/containers" and the `contributor-bootstrap` feature still pulling a Docker-Hub OCI image via microsandbox
+
+---
+
+## Why
+
+`mvmctl dev up` on a source checkout without host Nix still goes through `MicrosandboxBuilderVm` (Stage 0, gated behind `--features contributor-bootstrap`). That path is the **only** surviving reason `dep:microsandbox` lives in our Cargo closure. It exists to do one job: pull `docker.io/nixos/nix:2.24.10`, run `nix build` inside, and emit the Layer 1 builder VM rootfs.
+
+This job has a name in our roadmap already: **OCI image ingest** (plan 74 W1). The user-facing claim "mvm can run any OCI image as a microvm" requires the exact same primitives — fetch a manifest from a registry, verify layer digests, unpack to a rootfs, hand the rootfs to libkrun/Firecracker. Today we have two paths to that primitive: microsandbox (Stage-0-only, broken under overlay pressure, contradicts CLAUDE.md §"Firecracker-only") and "not yet written" (plan 74 W1, unstarted).
+
+Plan 75 collapses both into one: build `mvm-oci` once, use it for Stage 0 *and* for `mvmctl image pull`. The day Stage 0 is OCI-ingest-by-libkrun, microsandbox has no remaining justification in the workspace and gets deleted in full. Same day, the user-facing OCI ingest claim ships behind the same primitive that just got 100% Stage-0 production coverage.
+
+Three properties make this the right framing:
+
+1. **Dogfooded primitive.** OCI ingest is exercised on every `mvmctl dev up` from a source checkout. The bug-rate gap between "code that runs in CI smoke tests" and "code that runs on every contributor laptop daily" closes by construction.
+2. **Single trust boundary.** Today contributors trust `docker.io/nixos/nix:2.24.10` via microsandbox; end users trust the mvm-published builder VM image. After plan 75: both populations use the same `mvm-oci` code, with the same SHA-256 verification path, against the same registry. Trust posture is uniform.
+3. **The bidirectional story unlocks.** Once OCI → microvm is on the floor, OCI ← microvm (export a baked microvm with its signed plan + audit chain + sealed deps volume as a portable OCI image) becomes additive, not a separate effort. Plan 75 W7 captures the export half so the strategic feature is sequenced, not lost to "we'll get to it."
+
+This is the first plan that materially **shrinks** the workspace's dep closure. ~40 transitive crates leave with microsandbox (already gated since plan 72 W6 — plan 75 deletes the feature flag itself).
+
+---
+
+## Prerequisites
+
+- Plan 72 W0–W6 shipped: libkrun is the user-facing builder VM, `LibkrunBuilderVm::run_build` is the production launcher, builder VM image artifacts published per release.
+- `mvm_libkrun::start_with_config` reliably boots an externally-provided ext4 rootfs on macOS Apple Silicon (already true; the dev image is built this way today).
+- A macOS Apple Silicon laptop and a Linux KVM host for the W1–W6 dev loop. W4 (CI deletion) and W6 (cosign) add a CI job per platform.
+
+---
+
+## Scope guards
+
+In:
+
+- A new `crates/mvm-oci/` crate with HTTP-based OCI registry client (manifest + config + layer fetch, digest verification, layer unpack with full OCI semantics, ext4 rootfs emission).
+- Replacement of `build_image_via_microsandbox` with an OCI-pull → libkrun launch path. Same `BuilderJob` / `BuilderMounts` / `BuilderArtifacts` contract; the consumer in `mvm-cli` doesn't change.
+- Deletion of `dep:microsandbox`, the `contributor-bootstrap` Cargo feature, `MicrosandboxBuilderVm`, and every `#[cfg(feature = "contributor-bootstrap")]` gate.
+- User-facing `mvmctl image pull/ls/rm` + `mvmctl up --image <ref>` (delivers plan 74 W1).
+- microvm → OCI export (`mvmctl image export`), with explicit documentation of which security claims travel and which do not.
+- CI gates: layer-unpack fuzz, digest-mismatch rejection, mutable-tag policy enforcement, registry-anonymous-auth path, reproducibility double-build for the OCI ingest path.
+- An ADR (or amendment to ADR-046) recording the trust-boundary shift.
+
+Out:
+
+- A *daemon* (the `mvm-oci` crate is a library; CLI verbs are mvmctl-shaped).
+- A registry of our own (we publish artifacts via GitHub Releases, not a registry server). Push-to-registry comes after W7 lands; out of plan 75.
+- Image *signing* on import (we **verify** cosign signatures when present; we don't issue them. Mint-time signing lives in the release pipeline, not in mvmctl).
+- `containerd` / `runc` / any OCI runtime spec compliance. We pull OCI **images**; we launch them via libkrun/Firecracker, not via the OCI runtime spec.
+- Plan 74 W2–W6 (network policy, secret placeholders, SDK lifecycle, cold-start budgets, filesystem backends). Plan 75 delivers W1; the rest stays Plan 74's problem.
+- All Docker daemon paths. The existing `crates/mvm-backend/src/docker.rs` Docker-load fallback is a **separate** feature (run a Nix-built rootfs as a Docker container). It is **not** part of mvm-oci; it stays untouched.
+
+---
+
+## Acceptance criteria (whole-plan)
+
+When all of the following hold, plan 75 moves to `specs/backlog/`, microsandbox is gone, and the OCI ingest user-facing claim ships:
+
+1. `mvmctl dev up` on a stock macOS Apple Silicon host with no host Nix, no Docker, no microsandbox, no host `nix` binary:
+   - Pulls `docker.io/nixos/nix:2.24.10` via `mvm-oci` (anonymous auth, manifest + layer digest verification).
+   - Unpacks the layers to an ext4 rootfs at `~/.cache/mvm/oci/stage0/<digest>/rootfs.ext4`.
+   - Launches that rootfs via libkrun, runs `nix build` of the builder-vm flake inside.
+   - Produces `vmlinux` + `rootfs.ext4` for the builder VM image; the rest of the existing dev-up flow proceeds unchanged.
+   - Exits 0 with no manual intervention.
+2. `cargo metadata --no-default-features --features ''` shows **no `microsandbox*` crate anywhere in the workspace closure**. `grep -r microsandbox` returns hits only in `specs/` (history) and CHANGELOG entries.
+3. `mvmctl image pull docker.io/alpine:3.20` succeeds. Subsequent `mvmctl up --image docker.io/alpine:3.20` boots Alpine as a microvm and runs `/bin/sh -c 'echo hi'` to completion. (Linux KVM lane; macOS lane subject to base-image arch.)
+4. `mvmctl image export <vm-id>` produces an OCI-spec-v1.1 tarball with the workload's rootfs, an `mvm-claims.json` annotation enumerating which security claims travel with the image, and a CycloneDX SBOM if the source had a sealed deps volume.
+5. CI gates (in `.github/workflows/ci.yml`):
+   - `oci-layer-unpack-fuzz` — cargo-fuzz target on `mvm_oci::layer::unpack`, ≥30 minutes per PR run; CIFuzz daily.
+   - `oci-digest-mismatch-reject` — byte-flip a layer post-fetch, assert `mvmctl image pull` exits with `E_OCI_DIGEST_MISMATCH` and removes the partial artifact.
+   - `oci-malformed-manifest` — manifest with unknown mediaType, manifest with missing layer, manifest with circular index — all rejected before layer fetch.
+   - `oci-mutable-tag-prod-reject` — production policy (`--prod`) rejects `:latest` and any unpinned-by-digest reference; dev policy admits with warning.
+   - `oci-reproducibility` — pull the same ref twice from a clean cache; assert byte-identical `rootfs.ext4` digests.
+   - `oci-anonymous-auth-only` — pull from a fixture registry that requires no auth; assert no `~/.docker/config.json` read attempt (strace lane on Linux).
+6. The amended ADR (or ADR-049) records: microsandbox removed, mvm-oci is the OCI-ingest primitive, trust boundary is the registry's content-addressed manifest plus optional cosign attestation.
+
+---
+
+## Security considerations (cross-cutting)
+
+These apply to every workstream; each workstream's "tests" section lists the specific assertions that prove the property.
+
+### Updated security claims in CLAUDE.md / ADR-002
+
+CLAUDE.md §"Security model" claim 6 today reads: *"Pre-built dev image is hash-verified."* This plan extends it to a stronger form: **"Every OCI image — Stage 0 base, user-pulled image, and our own published builder VM artifact — is verified by content-addressed digest before any byte is consumed, and tampered layers fail closed."** The implementation is shared (`mvm_oci::digest::verify_streaming`), so the proof is one CI lane instead of three.
+
+New CLAUDE.md claim 10 (proposed): **"OCI image provenance is recorded in the admission audit chain."** Every `mvmctl up --image <ref>` emits an audit entry with the registry, resolved digest, layer digest list, and (if present) cosign attestation. `mvmctl audit verify` proves the chain. Plan 75 W5 wires it.
+
+### Trust boundaries
+
+| Boundary | Today | After plan 75 |
+|---|---|---|
+| Stage 0 base image | `docker.io/nixos/nix:2.24.10` via microsandbox, anon auth, digest unenforced | `docker.io/nixos/nix:2.24.10` via mvm-oci, anon auth, digest **pinned in source** to a specific `sha256:…`, verified at fetch time. Bump-the-pin is a deliberate PR. |
+| User-facing OCI pull | Not supported | `mvm-oci` HTTPS-only; system trust store; optional `~/.mvm/registry-ca.pem` for air-gapped / pinned-CA workflows; no `~/.docker/config.json` read by default. |
+| Cosign | Not supported anywhere | Verified when present (W6); absence does not block (registries are partial coverage); presence + invalid signature blocks. Configurable per-registry policy. |
+| Layer unpack | microsandbox internals (opaque, not auditable in our codebase) | `mvm_oci::layer::unpack` — explicitly handled whiteouts, symlinks (refuse `..` escape), hardlinks (within-layer only), xattrs (default-allow user.* + security.capability, deny everything else), device nodes (refuse outside `/dev/null` `/dev/zero` `/dev/random` `/dev/urandom` in any layer), setuid/setgid bits (warn under `--prod`, refuse if cosign fails). |
+
+### Threat model additions to ADR-002
+
+- **T-OCI-1: Compromised registry.** Mitigation: pinned digest for Stage 0; cosign verification for user pulls when configured; HTTPS pinning to system CA bundle.
+- **T-OCI-2: Layer-unpack CVE class** (CVE-2019-14271-style, path traversal, symlink escape, hardlink-to-host, setuid escalation). Mitigation: deny-by-default unpacker, fuzz lane, explicit allow-lists for xattrs and device nodes; defense-in-depth via libkrun isolation (a unpacked-then-launched rootfs runs in a microVM, not on the host).
+- **T-OCI-3: Tag mutation race.** Mitigation: `--prod` rejects unpinned references; dev mode resolves to a digest at first pull and caches by digest thereafter; re-resolution requires explicit `mvmctl image pull --refresh`.
+- **T-OCI-4: TLS substitution / DNS rebinding at pull time.** Mitigation: HTTPS-only, system CA trust by default, no DoH/DoT bypass; SNI must match the requested hostname; redirects must stay within the same registry origin (configurable allow-list).
+- **T-OCI-5: Supply-chain via Stage 0 base image.** Mitigation: pinned digest in source; CI runs a daily refresh job that opens a PR if upstream has a newer signed image. Bumping is a human decision with a diff.
+
+### What does **not** change
+
+- CLAUDE.md §"Host Nix is never used by mvmctl" stays load-bearing. mvm-oci has no nix dep; it talks to registries over HTTPS.
+- CLAUDE.md §"No SSH in microVMs, ever" — mvm-oci does not ship sshd or any service into the rootfs it emits; it only unpacks what the registry returned.
+- ADR-046's two acquisition paths stay intact (source checkout = build from in-repo flakes; installed binary = download released prebuilts). What changes is *Stage 0 in the source-checkout path*: previously microsandbox + nixos/nix OCI; after plan 75, mvm-oci + nixos/nix OCI + libkrun. Same trust root, different code path.
+
+### What microvm → OCI export does **not** carry
+
+W7 ships export, but the user must understand which security claims travel with the exported image:
+
+| Claim | Travels in exported OCI image? | Why |
+|---|---|---|
+| dm-verity rootfs (claim 3) | No | OCI consumers' boot path doesn't honor dm-verity; the kernel cmdline isn't ours. |
+| Signed ExecutionPlan (claim 8) | Metadata only (annotation), not enforced | Enforcement requires `mvm-supervisor` at the consumer side. Annotated for audit; not load-bearing. |
+| Chain-signed audit log (claim 8) | No | Audit chain is host-state; doesn't fit in an image. The export annotation lists the chain head digest so a consumer can request the chain out-of-band. |
+| Sealed deps volume (claim 9) | Yes (as separate annotated layer or sidecar tarball) | The sealed volume is content-addressed; it lives in the image as its own layer with the `meta.json` chain intact. Reproducible cross-platform. |
+| Verified provenance (new claim 10) | Yes (cosign signature on the exported image, if the user opts in) | Exported images can be cosigned by the user; export does not auto-sign. |
+
+The export emits an `mvm-claims.json` annotation that enumerates each claim's status. Plan 75 W7 ships the CI test that asserts the annotation is present and accurate.
+
+---
+
+## W0 — Decision and scope guards (ship before any code)
+
+**Goal:** ratify the architectural choice and prevent overclaiming before primitives exist.
+
+- [ ] Land this plan as `specs/plans/75-oci-stage0-microsandbox-removal.md`. (This document.)
+- [ ] Land an ADR (proposed: ADR-049) recording the trust-boundary shift in section "Security considerations" above. Either supersede the relevant clauses of ADR-046 or add an addendum; do not leave ADR-046 contradicting plan 75.
+- [ ] Add a `specs/claims/` gate file for new claim 10 ("OCI image provenance in audit chain"), default state **Planned**. Plan 74 W0 (claims hygiene) precedent — the gate file blocks docs from claiming the property until W5 ships and tests pass.
+- [ ] Add `xtask check-no-overclaim` lints for the OCI surface — block docs strings, README, landing page from saying "any OCI image runs" until W3 acceptance closes.
+
+### W0 ships as
+
+A docs-only PR. No code changes outside `specs/` and `xtask/`. Reviewable in one sitting.
+
+---
+
+## W1 — `mvm-oci` crate: registry client + manifest + digest verification
+
+**Goal:** a Rust library that talks HTTPS to an OCI Distribution v2 registry, fetches manifests + configs + layers, verifies every byte against the manifest's digest, and persists the result to a content-addressed cache.
+
+### Interface
+
+```rust
+pub struct Client {
+    pub registry: RegistryRef,         // host + optional port + protocol
+    pub cache_root: PathBuf,           // ~/.cache/mvm/oci by default
+    pub trust: TrustPolicy,            // anonymous | bearer-from-keyring | cosign-required
+    pub network: NetworkPolicy,        // sni-pinned, redirect-same-origin, optional pinned-CA
+}
+
+pub struct ImageRef { pub registry: String, pub repo: String, pub reference: Reference }
+pub enum Reference { Tag(String), Digest(Sha256) }
+
+impl Client {
+    pub fn pull(&self, image: &ImageRef) -> Result<PulledImage, Error>;
+    pub fn resolve(&self, image: &ImageRef) -> Result<ResolvedRef, Error>;
+}
+
+pub struct PulledImage {
+    pub manifest: oci_spec::ImageManifest,
+    pub config: oci_spec::ImageConfiguration,
+    pub layers: Vec<LayerRef>,         // content-addressed paths in cache
+    pub resolved: ResolvedRef,         // host + repo + sha256 digest
+}
+```
+
+### Behavior
+
+`pull`:
+
+1. Resolve the reference. If `Reference::Tag` and `TrustPolicy::production`, **refuse** with `E_OCI_MUTABLE_TAG` (must be pinned by digest). Otherwise GET the manifest at the tag, take its `Docker-Content-Digest` header (verified against the body's hash), and from here on treat the pull as digest-pinned.
+2. GET the manifest body, hash-verify against the resolved digest, parse as `oci_spec::ImageManifest` (or the OCI image index variant; in which case pick the matching architecture and recurse on the picked manifest).
+3. GET the image config, hash-verify against `manifest.config.digest`.
+4. For each layer: GET if absent from cache, streaming SHA-256 in-flight, reject on mismatch (delete partial). Cache at `<cache_root>/blobs/sha256/<digest>` (immutable, never overwritten).
+5. Persist a small `<cache_root>/refs/<host>/<repo>/<reference>.json` record mapping the ref to the resolved digest, manifest digest, config digest, and layer digest list, with a fetched-at timestamp.
+
+`resolve` is `pull`'s first step without the layer-fetch — used by callers that only need the digest (e.g. CI's "is the pin still current?" job).
+
+### Trust policy
+
+- `TrustPolicy::Anonymous` — default. No credential lookup. Registries that 401 on anonymous requests fail closed with `E_OCI_AUTH_REQUIRED`.
+- `TrustPolicy::Keyring { entry }` — pull bearer token from the host OS keyring under the named entry. Never reads `~/.docker/config.json` (which is a credential helper that can shell out — out of scope as a security surface).
+- `TrustPolicy::CosignRequired` — wraps any other policy. After resolving and before unpacking, verify the cosign signature attached to the image; refuse on absence or invalid signature. Public key sources: a project-pinned key (`~/.mvm/cosign-pubkeys/*.pem`) or fulcio + rekor (transparency log) when configured. W6 wires this; W1 ships the type stub.
+
+### Network policy
+
+- HTTPS only. HTTP is refused outright (no `--insecure-registry`; if the user has a private registry without TLS, that's a fix for them, not a flag on us).
+- System CA trust by default; optional `~/.mvm/registry-ca.pem` extra-CA bundle for air-gapped / pinned-CA workflows.
+- SNI **must** match the request hostname.
+- Redirects: same-origin only by default. Cross-origin redirect is opt-in per-registry via `~/.mvm/registry-policy.toml` — Docker Hub redirects to `production.cloudflare.docker.com` for layer blobs, so cross-origin is needed for Docker Hub specifically. Documented and explicit.
+- No DoH/DoT bypass — use the system resolver.
+
+### Tests (W1 acceptance)
+
+- Unit: digest-mismatch on manifest, on config, on a layer. Each rejects + deletes partial cache state.
+- Unit: malformed manifest (unknown mediaType, missing required fields, circular index reference) — rejected before any layer fetch.
+- Unit: mutable-tag rejection under `TrustPolicy::production`; admitted with warn under dev.
+- Integration: pull `docker.io/library/alpine:3.20@sha256:<pin>` against a local-fixture registry (in-process `axum` server, OCI-v2 routes, pre-loaded with the upstream manifest + layers). Assert byte-identical layer bytes after two consecutive pulls from a clean cache.
+- Integration: TLS hostname-mismatch in the test fixture's certificate fails closed; not bypassable.
+- Strace lane: confirm no `open(...".docker/config.json"...)` in default-trust-policy pulls.
+- Fuzz: `cargo-fuzz` target on manifest parsing. ≥30 min per PR.
+
+### W1 ships as
+
+A new crate `crates/mvm-oci/` with one new dep group: `reqwest` (rustls only — no native-tls, no openssl), `sha2`, `oci-spec`, `serde_json`. Plus a dev-dep on `axum` for the test fixture. PR introduces the crate but **does not** wire it into mvm-cli yet. Reviewable as "is this OCI client correct and safe?" in isolation.
+
+---
+
+## W2 — Layer unpack with full OCI semantics → ext4 rootfs
+
+**Goal:** turn the cached layers from W1 into an ext4 rootfs that libkrun can boot, with explicit and tested handling of every OCI layer-tar feature.
+
+### Behavior
+
+`mvm_oci::rootfs::build(pulled: &PulledImage, out: &Path) -> Result<RootfsArtifact, Error>`:
+
+1. Allocate a sparse ext4 image at `out` sized as `sum(layer.uncompressed_size) * 1.5 + 64 MiB` floor.
+2. `mkfs.ext4` (via the embedded `e2fsprogs` from the builder VM closure — *not* from the host; we don't shell out to host binaries from the unpacker). For W2, MVP shells out to the host's `mkfs.ext4`; W3 follows up by routing it through the libkrun VM. The host-shellout MVP is gated by an `MVM_OCI_HOST_MKFS=1` env var and never the default — see Risks §"R3 host-tool dependency."
+3. Mount the image via `loop` (Linux) or `hdiutil attach` (macOS) — actually no, the unpack happens *inside* the builder VM (W3 wiring). For W2 MVP, the unpack target is a directory tree (not a mounted ext4); W3 fuses it with the libkrun mount path. This keeps W2's scope as "pure userspace tar handling."
+4. For each layer in order (lowest first): stream the gzipped/zstd-compressed tar, applying:
+   - **Whiteouts** — `.wh.<name>` removes the named entry from the assembled tree; `.wh..wh..opq` clears the directory. Refuse paths that escape (`/foo/../wh..`).
+   - **Symlinks** — written verbatim, but the **target** is recorded and any subsequent path resolution that would traverse the symlink **does not** follow it during unpack. We reconstruct the tree by-path, not by-resolved-path. Targets that escape root are recorded as-is (they're inside the rootfs and resolve at *boot* time, not at unpack time); refused only if the symlink itself is at an escape path.
+   - **Hardlinks** — within-layer-only; cross-layer hardlinks materialize as full copies. (CVE-2019-14271 class.)
+   - **xattrs** — allow-list: `user.*`, `security.capability`, `security.selinux`. Everything else (including `system.*`) is dropped with a warning. Configurable per-policy.
+   - **Device nodes** — refused unless they're the four "obvious" devices in `/dev` (null/zero/random/urandom). Other device nodes fail the unpack closed.
+   - **Setuid/setgid bits** — preserved by default; under `TrustPolicy::CosignRequired` and signature invalid, the unpack itself was refused upstream (W1) so we don't reach here. Under prod policy with cosign present and valid: preserved with an audit annotation. Under dev policy: preserved with a CLI warning.
+   - **Paths containing `..` or absolute paths** — refused; tar entries must be relative and traversal-free.
+   - **Path length > 4096** — refused.
+5. After all layers applied, emit a manifest at `<out>.manifest.json` recording every absorbed layer digest, every applied whiteout, every refused entry, and the final tree's content-addressed hash.
+
+### Tests (W2 acceptance)
+
+- Unit fixtures for every layer-tar feature: whiteouts (incl. opaque), symlinks (in-root and escape attempts), hardlinks (in-layer and cross-layer), file modes (incl. setuid/setgid), xattrs (each category), device nodes (allowed and refused), absolute paths, traversal paths, oversize paths.
+- Reproducibility: unpack the same layers twice into clean dirs, assert byte-identical tree content-hash.
+- Fuzz: `cargo-fuzz` target on `mvm_oci::layer::unpack_one`, feed it malformed tar inputs (truncated headers, header magic mismatch, size lies). ≥30 min per PR.
+- Live: pull and unpack `docker.io/library/alpine:3.20@sha256:<pin>`; assert `/bin/sh` is present, executable, and resolves to busybox; assert the rootfs is mountable and `ls /` works.
+- Negative: a synthesized adversarial image with `/etc/shadow` set 4755 and a setuid binary at `/usr/local/bin/escalate` — under dev policy, unpack succeeds with two warnings; under `--prod` without cosign, unpack refuses with `E_OCI_SETUID_UNSIGNED`.
+
+### W2 ships as
+
+A second PR in the `mvm-oci` crate, plus the test fixtures. Still **not** wired into mvm-cli. Reviewable as "is this unpacker correct under adversarial input?" in isolation.
+
+---
+
+## W3 — Wire libkrun Stage 0 to mvm-oci
+
+**Goal:** replace `build_image_via_microsandbox` with `build_image_via_libkrun_oci` so the Stage 0 path uses mvm-oci end-to-end. After W3, `mvmctl dev up` on a stock macOS host with no host Nix and no microsandbox in the binary completes.
+
+### Behavior
+
+New file `crates/mvm-cli/src/commands/env/oci_stage0.rs` exposing `fn build_image_via_libkrun_oci(flake_dir: &str, out_dir: &str) -> Result<(String, String)>`. Internals:
+
+1. **Resolve and pull the Stage 0 base** — `mvm_oci::Client::pull(&IMAGE_REF)` where `IMAGE_REF` is the pinned `docker.io/nixos/nix:2.24.10@sha256:<digest>` constant in the source (W5 has a pin-bump CI job).
+2. **Build the Stage 0 rootfs** — call `mvm_oci::rootfs::build(&pulled, &stage0_root)` to assemble the unpacked tree.
+3. **Launch via libkrun** — call `LibkrunBuilderVm::run_build` with `BuilderJob::Flake { flake_ref, attr_path }` and `BuilderMounts { flake_src = workspace, host_nix_store = None, artifact_out = out_dir, stage0_root: Some(stage0_root) }`. The new field tells libkrun to use the OCI-derived rootfs as the boot rootfs instead of the existing builder VM image (which is what Stage 0 is producing).
+4. **Verify outputs** — same as today's `build_image_via_microsandbox` tail: assert `vmlinux` + `rootfs.ext4` exist in `out_dir`.
+
+Calling pattern in `bootstrap_builder_vm_image` (`apple_container.rs:1938`) flips from `build_image_via_microsandbox` to `build_image_via_libkrun_oci`. The `#[cfg(feature = "contributor-bootstrap")]` gate stays in W3 (deletion is W4) so the build still compiles with the old code path available for emergency revert.
+
+### Tests (W3 acceptance)
+
+- Live: `cargo run -p mvmctl -- dev up` on macOS Apple Silicon completes against a clean cache. Stage 0 fetches `nixos/nix:2.24.10`, unpacks, boots via libkrun, `nix build`s the builder VM image, emits Layer 1 artifacts. Total wall-clock time documented in plan 75 W3 release notes (expected: 4–8 min cold, <30 s warm).
+- Live: `cargo run -p mvmctl -- dev up` on Linux KVM — same flow via Firecracker.
+- Integration: `MVM_OCI_STAGE0_BASE=registry:5000/nixos-nix-mirror:2.24.10@sha256:<pin>` env var override lets CI point Stage 0 at a local mirror; assert that's the only network destination hit during the test.
+- Negative: tamper a layer in the cache between `pull` and `rootfs::build`; assert Stage 0 fails closed with `E_OCI_DIGEST_MISMATCH` and removes the partial state.
+- Negative: pin-bump simulation — flip the in-source digest constant to a non-existent digest; assert Stage 0 fails closed with `E_OCI_NOT_FOUND` and the error message names the in-source constant.
+- CI lane: `oci-reproducibility` from acceptance criterion 5 — run W3's Stage 0 twice from a clean cache; assert byte-identical `rootfs.ext4` output digests.
+
+### W3 ships as
+
+A PR that wires W1 + W2 into the existing Stage 0 path. Still preserves the `--features contributor-bootstrap` escape hatch for one release cycle. After W3 lands and bakes for a week, W4 deletes microsandbox.
+
+---
+
+## W4 — Delete microsandbox (no more contributor-bootstrap)
+
+**Goal:** after W3 has shipped and proven stable for a release cycle, remove every microsandbox reference from the workspace.
+
+### Concrete deletions
+
+- `crates/mvm-backend/Cargo.toml`: drop `contributor-bootstrap = ["dep:microsandbox"]` and the `microsandbox` dep itself.
+- Workspace root `Cargo.toml`: drop the `contributor-bootstrap` feature aggregation.
+- `crates/mvm/Cargo.toml`, `crates/mvm-cli/Cargo.toml`, `crates/mvm-build/Cargo.toml`: drop `contributor-bootstrap` features.
+- `crates/mvm-build/src/builder_vm.rs`: delete `MicrosandboxBuilderVm`, `BUILDER_DEFAULT_CPUS`, `BUILDER_DEFAULT_MEMORY_MIB`, `BUILDER_GUEST_*` constants (or move them under the libkrun path's namespace if any are still useful), `run_build_async` impl, and the four microsandbox-only tests.
+- `crates/mvm-cli/src/commands/env/apple_container.rs`: delete `build_image_via_microsandbox` (~90 lines), the `#[cfg(feature = "contributor-bootstrap")]` block in `bootstrap_builder_vm_image`, every doc comment referencing microsandbox or the 4 GiB overlay.
+- `nix/images/builder-vm/flake.nix`: scrub the W2-era comments that say "fits in 4 GiB overlay" / "no rustc, no cargo crates"; replace with a single sentence acknowledging the new launcher.
+- `xtask/Cargo.toml`: drop the `features = ["contributor-bootstrap"]` on `mvm-build`.
+- `Cargo.lock`: regenerate.
+- `specs/`: leave ADR-046 in place (history), but add an ADR-049 amendment or update ADR-046's status to "Accepted, then superseded by plan 75 W4 on YYYY-MM-DD".
+
+### Tests (W4 acceptance)
+
+- `cargo metadata --no-default-features --features ''` — zero `microsandbox` hits.
+- `grep -rni microsandbox crates/ src/ Cargo.toml` — zero hits outside `xtask/check-no-overclaim`'s allow-list of historical references.
+- Workspace `cargo test`, `cargo clippy -- -D warnings`, `cargo xtask check-no-display-on-secret-types` all green.
+- CI matrix (macOS + Linux): `mvmctl dev up` from a clean cache succeeds without any `--features` flag.
+
+### W4 ships as
+
+A single PR that's mostly deletions. Reviewable as a "did we miss any references?" pass. After W4 lands, microsandbox is **gone** from the workspace.
+
+---
+
+## W5 — User-facing OCI ingest (`mvmctl image pull`, `mvmctl up --image`)
+
+**Goal:** ship plan 74 W1's user-facing surface on top of the mvm-oci primitive that's already in production via Stage 0.
+
+### CLI surface
+
+- `mvmctl image pull <ref> [--digest] [--cosign] [--prod]` — fetch + verify + cache. Records to template store at `~/.mvm/templates/oci/<resolved-digest>/`.
+- `mvmctl image ls [--registry <host>]` — list cached OCI images by ref + resolved digest + fetched-at + size.
+- `mvmctl image rm <ref|digest>` — drop a cached image (and any unused layers — reference-counted GC).
+- `mvmctl image inspect <ref|digest>` — print manifest + config + layer digests + `mvm-claims.json` annotation if present.
+- `mvmctl up --image <ref>` — boot the named image as a microvm. Internally: `image pull` if not cached; `rootfs::build` to materialize; `LibkrunBuilderVm::run_workload` (or the existing instance launcher — same trait surface).
+- Templates produced by `image pull` integrate with the existing `template build/list/...` verbs — a pulled OCI image is a template with `kind = "oci"`.
+
+### Audit chain integration (new CLAUDE.md claim 10)
+
+Every `mvmctl up --image` admission emits an audit-chain entry with:
+
+- Registry host, repo, reference (as supplied).
+- Resolved manifest digest.
+- Layer digest list.
+- Cosign attestation summary (verified, unsigned, or refused).
+- Trust policy in effect (`anonymous`, `keyring`, `cosign-required`).
+
+`mvmctl audit verify` continues to detect drift on the chain; tampering with an OCI provenance entry breaks the chain HMAC.
+
+### Production policy (`--prod`)
+
+- Mutable tag refs (anything not pinned by digest) refuse closed with `E_OCI_MUTABLE_TAG_PROD`.
+- Setuid binaries in any layer refuse closed unless cosign attests the image.
+- Unsigned images refuse closed unless `~/.mvm/registry-policy.toml` explicitly admits the registry under `prod_unsigned_allow = [...]`.
+- Audit entry's `trust_policy` field is `cosign-required` or refuse closed.
+
+### Tests (W5 acceptance)
+
+- `mvmctl image pull docker.io/library/alpine:3.20` succeeds (dev), records template, audit entry.
+- `mvmctl image pull docker.io/library/alpine:latest --prod` refuses with `E_OCI_MUTABLE_TAG_PROD`.
+- `mvmctl image pull docker.io/library/alpine:3.20@sha256:<pin> --prod` succeeds when the registry has cosign attestation (test fixture), refuses without.
+- `mvmctl up --image alpine:3.20` boots the image and runs `sh -c 'echo hi; exit 0'`.
+- `mvmctl audit verify` after a sequence of pulls + ups reports the chain valid; byte-flip an audit entry → chain invalid.
+
+### W5 ships as
+
+A PR that adds the CLI verbs and audit wiring. Closes plan 74 W1.
+
+---
+
+## W6 — Cosign verification, registry credentials hardening
+
+**Goal:** ship the trust-establishment story so `--prod` is actually defensible.
+
+### Cosign
+
+- Verify cosign signatures against a project-pinned key list at `~/.mvm/cosign-pubkeys/` (PEM, one per file).
+- Optional fulcio + rekor support for sigstore-attested images. Gated by `~/.mvm/registry-policy.toml::cosign_use_sigstore = true`.
+- Plan 75 W6 ships the verification path; signing tooling is a *separate* downstream feature (W7 export pairs with it for the bidir story).
+
+### Credentials
+
+- `TrustPolicy::Keyring` — read bearer tokens from the host OS keyring (macOS Keychain, Linux Secret Service). No `~/.docker/config.json` read; if a user has Docker-formatted creds, they migrate them with `mvmctl image login <registry>` (new verb) which writes the keyring entry.
+- Per-registry policy file at `~/.mvm/registry-policy.toml` controls per-registry trust posture, cosign requirements, allowed cross-origin redirects.
+
+### Tests (W6 acceptance)
+
+- Pull a cosigned image, verify against a project-pinned key — success.
+- Pull a cosigned image, verify with no matching key — refuse, audit entry records "cosign-unmatched".
+- Pull from a registry that requires a bearer token via `keyring` policy — token retrieved from the keyring fixture, request succeeds.
+- Assert `~/.docker/config.json` is **not** opened in any test (strace lane on Linux).
+- Sigstore: integration test against a sigstore-attested image in a CI-only fixture (gated by `MVM_COSIGN_SIGSTORE=1` to avoid network deps in default CI runs).
+
+### W6 ships as
+
+A PR that adds cosign + keyring + per-registry policy. Closes the trust-establishment story for plan 75.
+
+---
+
+## W7 — microvm → OCI export (bidirectional OCI story)
+
+**Goal:** the second half of the strategic feature. `mvmctl image export <vm|template>` produces an OCI-spec-v1.1 image that other container runtimes can consume, with explicit and tested documentation of which security claims travel.
+
+### CLI surface
+
+- `mvmctl image export <vm|template> [--push <registry/repo:tag>] [--cosign] [--annotation key=value]`
+- `mvmctl image push <registry/repo:tag>` (separate verb for explicit push step).
+
+### Image contents
+
+- **Base layer**: the rootfs.ext4 contents, unpacked into a tar layer. (We do *not* ship the ext4 image itself; we ship the contents.)
+- **Sealed deps volume layer** (if the source had one): a tar layer containing the sealed `content/`, `sbom.cdx.json`, `fetch.log`, `cve.json`, `meta.json` — with the hash chain preserved.
+- **OCI image config**: `entrypoint`, `cmd`, `env`, `workdir` derived from the workload's launch plan.
+- **Annotations**:
+  - `dev.mvm.claims` → URL or inline JSON of the `mvm-claims.json` document.
+  - `dev.mvm.plan-digest` → the source ExecutionPlan's digest (admission chain root).
+  - `dev.mvm.audit-head` → the audit chain head digest at export time.
+  - `dev.mvm.sealed-volume-digest` → the deps volume's `meta.json` final hash, if present.
+  - Standard OCI annotations: `org.opencontainers.image.title`, `…created`, `…source`.
+
+### Claims-that-travel test
+
+The PR ships a CI test `oci-export-claims-document` that:
+
+1. Builds a baked microvm with a signed plan, audit chain, sealed deps volume, and dm-verity rootfs.
+2. Exports it with `mvmctl image export --output /tmp/exported.tar`.
+3. Inspects the exported image's `mvm-claims.json` annotation.
+4. Asserts the annotation correctly reports: dm-verity = **does not travel**, signed-plan = **metadata only**, audit-chain = **does not travel**, sealed-volume = **travels**, cosign = travels if user signed export.
+5. Re-imports the exported image via `mvmctl image pull` on a separate cache; asserts the deps volume verifies against its sealed `meta.json`.
+
+### Tests (W7 acceptance)
+
+- Round-trip: export a Nix-built microvm to OCI, reimport via `mvmctl image pull`, boot via `mvmctl up --image`. Compare original rootfs.ext4 content-hash to reimported-and-rebuilt rootfs.ext4 content-hash — equal modulo timestamps (OCI's standard reproducibility gotcha; mvm-oci has a "strip timestamps" mode).
+- Push: export + push to a local fixture registry, then pull from a different cache root and reboot. End-to-end portability test.
+- Claims annotation accuracy: every claim in the table is asserted by a CI gate.
+
+### W7 ships as
+
+A PR that completes the bidirectional OCI story. After W7, mvm is a first-class citizen in the container ecosystem — anything an OCI registry can consume, mvm can produce; anything mvm produces, an OCI registry can consume.
+
+---
+
+## Sequencing and cumulative deliverables
+
+| Workstream | Lands | Cumulative state |
+|---|---|---|
+| W0 | This PR (specs only) | Plan + ADR ratified |
+| W1 | Next PR | `mvm-oci` exists, not yet consumed |
+| W2 | After W1 | mvm-oci can produce rootfs trees from images |
+| W3 | After W2 | Stage 0 uses mvm-oci + libkrun. microsandbox still in tree but bypassed. |
+| W4 | One release cycle after W3 ships | microsandbox **gone** from workspace |
+| W5 | After W4 | User-facing OCI ingest shipped (closes plan 74 W1) |
+| W6 | After W5 | Cosign + keyring trust shipped; `--prod` is defensible |
+| W7 | After W6 | Bidirectional OCI shipped; mvm is a first-class container ecosystem citizen |
+
+W0–W4 close the immediate problem (remove microsandbox). W5–W7 deliver the strategic feature (bidir OCI). The split is intentional: if W5–W7 stall, we still got rid of microsandbox; if W0–W4 takes longer than expected, W5–W7 don't slip waiting on infrastructure they don't need.
+
+---
+
+## Risks and mitigations
+
+### R1 — Layer unpack CVE class
+**Risk:** OCI layer unpack has a well-known CVE class (path traversal, symlink escape, hardlink-to-host, setuid surprise, xattr-based privilege carry). A subtle bug in `mvm_oci::layer::unpack` could let a malicious image escape the rootfs at unpack time.
+
+**Mitigation:**
+- Defense-in-depth: the unpacked tree is consumed inside libkrun, not on the host. Even a perfect rootfs-escape from inside the tar handler only escapes to a sandboxed scratch directory that the launcher discards.
+- Dedicated fuzz lane on `mvm_oci::layer::unpack_one` (≥30 min per PR; daily long-running CIFuzz target).
+- Adversarial fixture suite covering every documented CVE pattern.
+- Default-deny policies for setuid, device nodes, xattrs.
+- Plan 74 W1's risk table explicitly names this; plan 75 W2 ships the test gates that retire it.
+
+### R2 — Trust-boundary widening if cosign is partial-coverage
+**Risk:** Most registries don't ship cosign attestations. If we set `--prod` to require cosign, we lock users out of useful images. If we don't, `--prod` carries no integrity guarantee for unsigned images.
+
+**Mitigation:**
+- `--prod` requires cosign by default. Per-registry override at `~/.mvm/registry-policy.toml::prod_unsigned_allow = ["registry.example.com/team/*"]` lets ops explicitly admit unsigned registries with audit-chain recording.
+- Documentation states clearly: an unsigned image admitted to prod is trusted by digest pin only; the registry's content-addressed digest is the integrity boundary.
+- Default policy for `mvmctl up --image` is **dev**, not prod. Users opt into prod explicitly.
+
+### R3 — Host-tool dependency at unpack time
+**Risk:** W2's MVP shells out to host `mkfs.ext4` to allocate the rootfs image. That contradicts CLAUDE.md §"Host Nix is never used" in spirit (we're shelling out to a host binary for a build-time step).
+
+**Mitigation:**
+- W2's MVP is gated by `MVM_OCI_HOST_MKFS=1` and is **never** the default path.
+- The default path is: unpack to a directory tree on the host, then **inside the libkrun Stage 0 VM** (which has `e2fsprogs` from its Nix closure already), run `mkfs.ext4` + `cp -a` to materialize the ext4 image. The host never invokes a filesystem tool.
+- This adds one extra libkrun launch to Stage 0 (cheap; the VM is already running) but eliminates the host-tool dep.
+- W3 ships the in-VM path; W2's MVP exists only for the W1+W2 integration tests that run before W3 is wired.
+
+### R4 — Reproducibility of OCI imports
+**Risk:** OCI layer tarballs are notoriously timestamp-dependent. Two pulls of the same image from a clean cache could produce non-bit-identical rootfs.ext4 outputs, masking integrity drift.
+
+**Mitigation:**
+- mvm-oci's unpacker has a "strip timestamps" mode (default-on) that zeroes mtime/atime/ctime on all unpacked entries.
+- CI gate `oci-reproducibility` asserts byte-identical rootfs.ext4 on consecutive pulls.
+- Content-address the rootfs.ext4 itself in the cache; consumers reference by hash, not by ref.
+
+### R5 — Stage-0 base image pin maintenance
+**Risk:** the pinned `nixos/nix:2.24.10@sha256:<digest>` constant in source is a security boundary. If it goes stale (upstream CVE in `nix`), we're vulnerable until someone notices and bumps. If we auto-bump, we bypass the explicit-PR control.
+
+**Mitigation:**
+- CI daily job `stage0-pin-refresh-check` queries Docker Hub for newer signed `nixos/nix` releases; opens a PR with the pin bump if a newer digest exists. The PR carries the upstream changelog and the diff.
+- Human review of the PR before merge. Pin bump is never automatic on the trunk.
+- Audit annotation on every Stage 0 launch records the in-use pin so a "this host is running an outdated Stage 0" check is one `mvmctl audit grep` away.
+
+### R6 — Network egress at pull time vs. plan 73 Followup B.2.x
+**Risk:** mvm-oci needs HTTPS egress to `registry.docker.io` and `production.cloudflare.docker.com` for Docker Hub. Plan 73 Followup B.2.x (mvm-egress-proxy) embeds a four-hostname allowlist (PyPI + npm + GitHub release objects). If we route Stage 0 through the same proxy, we need to extend the allowlist.
+
+**Mitigation:**
+- Stage 0 OCI pulls happen on the **host** (mvm-oci is a host-side library), not inside the builder VM. The egress proxy is a builder-VM-side artifact; it doesn't gate host-side egress.
+- A host-side OCI registry allowlist lives at `~/.mvm/registry-policy.toml::allowed_registries = [...]` and is enforced by mvm-oci's network policy (W1). Default allowlist for source-checkout: `registry-1.docker.io`, `production.cloudflare.docker.com`, plus whatever the user adds.
+- This is a separate policy surface from mvm-egress-proxy. They cover different layers (host pull-time vs. guest build-time).
+
+### R7 — Dual-path during W3→W4 window
+**Risk:** between W3 (mvm-oci wired, microsandbox still in tree) and W4 (microsandbox deleted), both code paths exist. A subtle regression in mvm-oci could silently fall back to microsandbox if a `cfg(feature = "contributor-bootstrap")` guard is wrong.
+
+**Mitigation:**
+- W3's `build_image_via_libkrun_oci` is the **default** path on every build, regardless of feature flag.
+- The microsandbox path is gated behind `MVM_OCI_FALLBACK_MICROSANDBOX=1` (env var, not feature flag) — explicit opt-in for emergency revert. Not on by default. Not testable without the env var.
+- CI lane asserts that with no env vars set, `cargo run -- dev up` strace shows zero hits on microsandbox's runtime files.
+- W4 deletes the env var path along with the dep.
+
+### R8 — cargo-fuzz cost on every PR
+**Risk:** ≥30 min fuzz lanes per PR multiply CI cost. Either we ship more PRs more slowly, or we relax the gate.
+
+**Mitigation:**
+- The 30-min gate runs only on PRs that touch `crates/mvm-oci/**`. Other PRs run a quick (1 min) corpus replay against the existing fuzz corpus.
+- A separate CIFuzz daily lane runs the long-form fuzz; new findings file issues automatically.
+- This is the same pattern plan 28 W4.2 uses for vsock framing fuzz.
+
+### R9 — Plan 74 W0/W1 trajectory
+**Risk:** plan 74 W1 (OCI image ingest) was the original owner of user-facing OCI pull. Plan 75 absorbs it. If plan 74's other workstreams (W2 network policy, W3 secret placeholders) assume W1 is happening as plan 74 specifies, plan 75 needs to honor those assumptions.
+
+**Mitigation:**
+- Plan 75 W0 lands an explicit "supersedes plan 74 W1" note in both this plan and plan 74's status block. Plan 74's W2–W6 read mvm-oci as their OCI-ingest substrate.
+- Plan 75 W5 closes plan 74 W1's acceptance criteria byte-for-byte (cited in W5's "Tests" section), so the supersession is verifiable.
+
+---
+
+## Open questions (for the implementation phase to answer)
+
+1. **OCI image index handling.** Docker Hub multi-arch images return an `oci-index` manifest; plan 75 W1 picks the matching arch. Do we honor `os` only, or also `os.version` and `variant`? For `linux/arm64/v8` vs `linux/arm64` — W1 should land an explicit selector. (Recommend: match `os` + `architecture` exactly, refuse on `variant` ambiguity.)
+2. **Layer mediaType coverage.** OCI v1.1 introduces new mediaTypes (`application/vnd.oci.image.layer.v1.tar+zstd` and friends). Which do we support at W2? (Recommend: support both `gzip` and `zstd` from day one; refuse unknown mediaTypes.)
+3. **Cache GC policy.** OCI layers can be very large; the cache grows monotonically without GC. (Recommend: reference-count layers by which manifests still reference them; `mvmctl image rm <ref>` decrements; `mvmctl cache prune` GCs orphans.)
+4. **Pin format for Stage 0 base.** Constant in Rust source, or a sidecar TOML in `nix/images/`? (Recommend: TOML, so the daily refresh CI job can bump it without parsing Rust.)
+5. **Cosign sigstore vs. project-key parity.** Sigstore's fulcio + rekor model is the long-term answer for ecosystem-wide trust; project-pinned keys are the short-term answer for our own published artifacts. W6 ships both; which is the *default*? (Recommend: project-pinned for `dev.mvm.*` annotations; sigstore opt-in per registry.)
+
+---
+
+## Why this plan is worth doing now
+
+Three things converge:
+
+1. **The 4 GiB overlay is going to keep biting.** Every time someone adds a `rustPlatform.buildRustPackage`, a `python3Packages.*`, or a moderate-sized binary to the builder-vm flake, Stage 0 risks overflow. The 2026-05-14 regression is the second time it's happened (the first was the impetus for plan 72). Continuing to work around it is paying recurring rent on a structural cost.
+2. **Plan 74 W1 wants the same primitive.** Building OCI ingest twice — once for Stage 0, once for user-facing pull — is engineering waste. Plan 75 builds it once and uses it for both.
+3. **The bidirectional OCI story is strategic.** Today mvm is a self-contained universe — you install mvmctl, you build with our flakes, you run our images. After plan 75, mvm is a container-ecosystem peer: anything Docker Hub or GHCR or ECR can serve, you can run; anything you build, those registries can serve. That widens addressable workloads (Plan 74's user-facing claim) **and** widens addressable deployment targets (W7's export). Both directions are mvm being more useful to more people without rewriting its security or reproducibility properties.
+
+The cost is real (multi-week, multi-PR, multi-CI-lane). The upside is structural — one less dependency that contradicts the project's stated identity, plus the strategic feature delivered as a side effect.

--- a/xtask/src/check_no_overclaim.rs
+++ b/xtask/src/check_no_overclaim.rs
@@ -41,7 +41,9 @@ pub fn run(workspace: &Path) -> Result<()> {
         .collect();
 
     if active.is_empty() {
-        eprintln!("check-no-overclaim: no active gates (all claims at status Shipped or claims/ empty)");
+        eprintln!(
+            "check-no-overclaim: no active gates (all claims at status Shipped or claims/ empty)"
+        );
         return Ok(());
     }
 
@@ -273,9 +275,7 @@ fn find_phrase(source: &str, phrase: &str) -> Option<usize> {
 fn path_is_exempt(rel_path: &Path, exempt_paths: &[String]) -> bool {
     let s = rel_path.to_string_lossy();
     let s = s.replace('\\', "/");
-    exempt_paths
-        .iter()
-        .any(|pattern| glob_match(pattern, &s))
+    exempt_paths.iter().any(|pattern| glob_match(pattern, &s))
 }
 
 /// Match `path` against a glob pattern with `**` and `*` support.
@@ -348,13 +348,7 @@ fn visit_inner(
         if path.is_dir() {
             if matches!(
                 name.as_str(),
-                "target"
-                    | ".git"
-                    | ".worktrees"
-                    | "node_modules"
-                    | "result"
-                    | ".direnv"
-                    | ".cargo"
+                "target" | ".git" | ".worktrees" | "node_modules" | "result" | ".direnv" | ".cargo"
             ) || name.starts_with("result-")
             {
                 continue;
@@ -364,10 +358,7 @@ fn visit_inner(
             path.extension().and_then(|e| e.to_str()),
             Some("md") | Some("rs") | Some("toml") | Some("nix")
         ) {
-            let rel = path
-                .strip_prefix(root)
-                .unwrap_or(&path)
-                .to_path_buf();
+            let rel = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
             cb(&rel, &path)?;
         }
     }

--- a/xtask/src/check_no_overclaim.rs
+++ b/xtask/src/check_no_overclaim.rs
@@ -1,0 +1,464 @@
+//! `xtask check-no-overclaim`
+//!
+//! Refuses any user-facing repo text that uses phrases declared
+//! "gated" by a claim file in `specs/claims/` whose status is not
+//! `Shipped`. Plan 75 W0 introduces this pattern; plan 74 W0
+//! ratifies it.
+//!
+//! The lint reads every `specs/claims/*.md` (excluding `README.md`),
+//! parses its YAML frontmatter, and builds a `phrase → (claim, status,
+//! exempt_paths)` index. It then walks the workspace, scans `.md` and
+//! `.rs` files, and reports any path that contains a gated phrase and
+//! is not in the claim's `exempt_paths`.
+//!
+//! A claim with status `Shipped` admits its phrases everywhere — the
+//! gate disengages. A claim with status `Planned` or `Preview` keeps
+//! its phrases off user-facing surface. A claim with status
+//! `Not-claimed` is treated like `Planned`: phrases stay gated.
+//!
+//! Default-skipped paths (independent of claim exempt_paths):
+//! `target/`, `.git/`, `.worktrees/`, `node_modules/`, `result/`,
+//! `result-*`, `.direnv/`, `.cargo/`. These are build outputs or
+//! sibling-worktree state, not authoring surface.
+
+use anyhow::{Context, Result, bail};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let claims_dir = workspace.join("specs").join("claims");
+    if !claims_dir.is_dir() {
+        bail!(
+            "expected claims dir at {}; got nothing. Did plan 75 W0 land?",
+            claims_dir.display()
+        );
+    }
+
+    let claims = load_claims(&claims_dir)?;
+    let active: Vec<&Claim> = claims
+        .iter()
+        .filter(|c| c.status != Status::Shipped)
+        .collect();
+
+    if active.is_empty() {
+        eprintln!("check-no-overclaim: no active gates (all claims at status Shipped or claims/ empty)");
+        return Ok(());
+    }
+
+    let mut findings: Vec<Finding> = Vec::new();
+    visit_text_files(workspace, &mut |rel_path, abs_path| -> Result<()> {
+        let source = std::fs::read_to_string(abs_path)
+            .with_context(|| format!("reading {}", abs_path.display()))?;
+        for claim in &active {
+            if path_is_exempt(rel_path, &claim.exempt_paths) {
+                continue;
+            }
+            for phrase in &claim.gated_phrases {
+                if let Some(line_no) = find_phrase(&source, phrase) {
+                    findings.push(Finding {
+                        path: rel_path.to_path_buf(),
+                        line: line_no,
+                        phrase: phrase.clone(),
+                        claim: claim.id.clone(),
+                        status: claim.status,
+                    });
+                }
+            }
+        }
+        Ok(())
+    })?;
+
+    if findings.is_empty() {
+        eprintln!(
+            "check-no-overclaim: clean ({} active claim gate(s), scanned workspace text)",
+            active.len()
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "check-no-overclaim: {} finding(s) across {} claim(s)",
+        findings.len(),
+        active.len()
+    );
+    for f in &findings {
+        eprintln!(
+            "  {}:{} — phrase {:?} is gated by claim {} (status: {}). \
+             Add the path to the claim's `exempt_paths` if intentional, \
+             or flip the claim to `Shipped` once its CI gate passes.",
+            f.path.display(),
+            f.line,
+            f.phrase,
+            f.claim,
+            f.status.as_str(),
+        );
+    }
+    std::process::exit(1);
+}
+
+#[derive(Debug, Clone)]
+struct Claim {
+    id: String,
+    status: Status,
+    gated_phrases: Vec<String>,
+    exempt_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Status {
+    Planned,
+    Preview,
+    Shipped,
+    NotClaimed,
+}
+
+impl Status {
+    fn parse(s: &str) -> Option<Self> {
+        match s.trim() {
+            "Planned" => Some(Self::Planned),
+            "Preview" => Some(Self::Preview),
+            "Shipped" => Some(Self::Shipped),
+            "Not-claimed" | "NotClaimed" => Some(Self::NotClaimed),
+            _ => None,
+        }
+    }
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Planned => "Planned",
+            Self::Preview => "Preview",
+            Self::Shipped => "Shipped",
+            Self::NotClaimed => "Not-claimed",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Finding {
+    path: PathBuf,
+    line: usize,
+    phrase: String,
+    claim: String,
+    status: Status,
+}
+
+fn load_claims(claims_dir: &Path) -> Result<Vec<Claim>> {
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(claims_dir)
+        .with_context(|| format!("reading claims dir {}", claims_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if !name.ends_with(".md") || name == "README.md" {
+            continue;
+        }
+        let source = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading claim file {}", path.display()))?;
+        let claim = parse_claim_frontmatter(&path, &source)?;
+        out.push(claim);
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(out)
+}
+
+/// Minimal frontmatter parser. The format is fixed (we control the
+/// authors and the file format), so handwritten parsing avoids the
+/// serde_yaml dep.
+fn parse_claim_frontmatter(path: &Path, source: &str) -> Result<Claim> {
+    let mut lines = source.lines();
+    if lines.next().map(str::trim) != Some("---") {
+        bail!(
+            "{}: expected frontmatter delimiter `---` on line 1",
+            path.display()
+        );
+    }
+    let mut scalars: BTreeMap<String, String> = BTreeMap::new();
+    let mut lists: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut current_list: Option<String> = None;
+    for raw in &mut lines {
+        let line = raw.trim_end();
+        if line.trim() == "---" {
+            break;
+        }
+        if let Some(item) = strip_list_item(line) {
+            let key = current_list.as_deref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "{}: list item {:?} without a preceding `key:` line",
+                    path.display(),
+                    item
+                )
+            })?;
+            lists.entry(key.to_string()).or_default().push(item);
+            continue;
+        }
+        if let Some((key, value)) = split_kv(line) {
+            current_list = None;
+            if value.is_empty() {
+                // Start of a list-valued key like `gated_phrases:`.
+                current_list = Some(key.to_string());
+                lists.entry(key.to_string()).or_default();
+            } else {
+                scalars.insert(key.to_string(), value.to_string());
+            }
+        }
+    }
+
+    let id = scalars
+        .get("claim")
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("{}: missing `claim:` field", path.display()))?;
+    let status_str = scalars
+        .get("status")
+        .ok_or_else(|| anyhow::anyhow!("{}: missing `status:` field", path.display()))?;
+    let status = Status::parse(status_str).ok_or_else(|| {
+        anyhow::anyhow!(
+            "{}: unknown status {:?}. Expected Planned, Preview, Shipped, or Not-claimed.",
+            path.display(),
+            status_str
+        )
+    })?;
+    let gated_phrases = lists.remove("gated_phrases").unwrap_or_default();
+    let exempt_paths = lists.remove("exempt_paths").unwrap_or_default();
+
+    Ok(Claim {
+        id,
+        status,
+        gated_phrases,
+        exempt_paths,
+    })
+}
+
+/// Parse a `- "value"` or `- value` list item.
+fn strip_list_item(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix("- ")?;
+    // Strip surrounding quotes if present.
+    let s = rest.trim();
+    let unquoted = s.strip_prefix('"').and_then(|s| s.strip_suffix('"'));
+    Some(unquoted.unwrap_or(s).to_string())
+}
+
+/// Parse a `key: value` line; returns `(key, value)` with value
+/// trimmed. Returns `None` if the line isn't a key/value pair.
+fn split_kv(line: &str) -> Option<(&str, &str)> {
+    let colon = line.find(':')?;
+    let key = line[..colon].trim();
+    let value = line[colon + 1..].trim();
+    if key.is_empty() || key.contains(' ') {
+        return None;
+    }
+    Some((key, value))
+}
+
+/// Find the 1-indexed line number on which `phrase` first appears in
+/// `source`, or `None` if absent. Phrases are matched literally
+/// (substring), case-sensitive.
+fn find_phrase(source: &str, phrase: &str) -> Option<usize> {
+    for (i, line) in source.lines().enumerate() {
+        if line.contains(phrase) {
+            return Some(i + 1);
+        }
+    }
+    None
+}
+
+/// True if `rel_path` matches any of the claim's `exempt_paths`
+/// globs. Globs support `**` (any depth) and `*` (single segment).
+fn path_is_exempt(rel_path: &Path, exempt_paths: &[String]) -> bool {
+    let s = rel_path.to_string_lossy();
+    let s = s.replace('\\', "/");
+    exempt_paths
+        .iter()
+        .any(|pattern| glob_match(pattern, &s))
+}
+
+/// Match `path` against a glob pattern with `**` and `*` support.
+/// Simple recursive matcher; we don't need full glob semantics
+/// (character classes, brace expansion, etc.) for the gate file
+/// shape.
+fn glob_match(pattern: &str, path: &str) -> bool {
+    glob_match_bytes(pattern.as_bytes(), path.as_bytes())
+}
+
+fn glob_match_bytes(pat: &[u8], s: &[u8]) -> bool {
+    // Recursive matching. Cheap because patterns and paths are short.
+    if pat.is_empty() {
+        return s.is_empty();
+    }
+    if pat.starts_with(b"**") {
+        // `**` consumes any number of characters (including `/`).
+        // Skip an optional `/` after `**`.
+        let after_double = &pat[2..];
+        let next = if after_double.starts_with(b"/") {
+            &after_double[1..]
+        } else {
+            after_double
+        };
+        for i in 0..=s.len() {
+            if glob_match_bytes(next, &s[i..]) {
+                return true;
+            }
+        }
+        return false;
+    }
+    if pat.starts_with(b"*") {
+        // `*` consumes any number of non-`/` characters.
+        for i in 0..=s.len() {
+            if i > 0 && s[i - 1] == b'/' {
+                break;
+            }
+            if glob_match_bytes(&pat[1..], &s[i..]) {
+                return true;
+            }
+        }
+        return false;
+    }
+    if s.is_empty() {
+        return false;
+    }
+    if pat[0] == s[0] {
+        return glob_match_bytes(&pat[1..], &s[1..]);
+    }
+    false
+}
+
+fn visit_text_files(root: &Path, cb: &mut dyn FnMut(&Path, &Path) -> Result<()>) -> Result<()> {
+    visit_inner(root, root, cb)
+}
+
+fn visit_inner(
+    root: &Path,
+    dir: &Path,
+    cb: &mut dyn FnMut(&Path, &Path) -> Result<()>,
+) -> Result<()> {
+    for entry in std::fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_string();
+        if path.is_dir() {
+            if matches!(
+                name.as_str(),
+                "target"
+                    | ".git"
+                    | ".worktrees"
+                    | "node_modules"
+                    | "result"
+                    | ".direnv"
+                    | ".cargo"
+            ) || name.starts_with("result-")
+            {
+                continue;
+            }
+            visit_inner(root, &path, cb)?;
+        } else if matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("md") | Some("rs") | Some("toml") | Some("nix")
+        ) {
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_path_buf();
+            cb(&rel, &path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_claim_frontmatter() {
+        let src = "\
+---
+claim: 10-test
+status: Planned
+gated_phrases:
+  - \"foo bar\"
+  - \"baz\"
+exempt_paths:
+  - \"specs/**\"
+---
+
+# body
+";
+        let claim = parse_claim_frontmatter(Path::new("test.md"), src).unwrap();
+        assert_eq!(claim.id, "10-test");
+        assert_eq!(claim.status, Status::Planned);
+        assert_eq!(claim.gated_phrases, vec!["foo bar", "baz"]);
+        assert_eq!(claim.exempt_paths, vec!["specs/**"]);
+    }
+
+    #[test]
+    fn shipped_status_disengages_gate() {
+        let src = "\
+---
+claim: 9-test
+status: Shipped
+gated_phrases:
+  - \"never gated\"
+exempt_paths: []
+---
+
+body
+";
+        let claim = parse_claim_frontmatter(Path::new("test.md"), src).unwrap();
+        assert_eq!(claim.status, Status::Shipped);
+    }
+
+    #[test]
+    fn rejects_unknown_status() {
+        let src = "\
+---
+claim: 1
+status: Cheese
+---
+";
+        let err = parse_claim_frontmatter(Path::new("test.md"), src).unwrap_err();
+        assert!(err.to_string().contains("unknown status"));
+    }
+
+    #[test]
+    fn glob_matches_prefix_and_doublestar() {
+        assert!(glob_match("specs/**", "specs/plans/75.md"));
+        assert!(glob_match("specs/**", "specs/adrs/049.md"));
+        assert!(!glob_match("specs/**", "public/docs/index.md"));
+        assert!(glob_match("CHANGELOG.md", "CHANGELOG.md"));
+        assert!(glob_match("**/*.md", "public/docs/index.md"));
+        assert!(!glob_match("*.md", "public/docs/index.md"));
+    }
+
+    #[test]
+    fn find_phrase_returns_first_line() {
+        let s = "alpha\nbeta\nfoo bar baz\nquux\n";
+        assert_eq!(find_phrase(s, "foo bar"), Some(3));
+        assert_eq!(find_phrase(s, "missing"), None);
+    }
+
+    #[test]
+    fn list_item_strips_quotes() {
+        assert_eq!(strip_list_item("  - \"hello\""), Some("hello".to_string()));
+        assert_eq!(strip_list_item("- bare"), Some("bare".to_string()));
+        assert_eq!(strip_list_item("not a list"), None);
+    }
+
+    #[test]
+    fn key_value_splits_correctly() {
+        assert_eq!(split_kv("claim: 10-foo"), Some(("claim", "10-foo")));
+        assert_eq!(split_kv("status:Planned"), Some(("status", "Planned")));
+        assert_eq!(split_kv("gated_phrases:"), Some(("gated_phrases", "")));
+        // Lines that aren't `key: value` should not parse.
+        assert_eq!(split_kv("just text"), None);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,6 +5,7 @@ mod build_dev_image;
 mod check_adr_coverage;
 mod check_audit_positional;
 mod check_no_display_on_secret_types;
+mod check_no_overclaim;
 mod gen_stubs;
 mod perf;
 
@@ -27,6 +28,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_audit_positional::run(&workspace)
         }
+        Some("check-no-overclaim") => {
+            let workspace = workspace_root();
+            check_no_overclaim::run(&workspace)
+        }
         Some("perf") => perf::run(&args[2..]),
         Some("build-dev-image") => {
             let workspace = workspace_root();
@@ -41,7 +46,7 @@ fn main() -> Result<()> {
             gen_stubs::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, perf, build-dev-image, gen-stubs, check-stubs",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-no-overclaim, perf, build-dev-image, gen-stubs, check-stubs",
             other
         ),
         None => {
@@ -58,6 +63,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-audit-positional                  Plan 60 Phase 4 lint: reject positional audit::emit / event-chain calls"
+            );
+            eprintln!(
+                "  check-no-overclaim                      Plan 75 W0 lint: refuse gated phrases from specs/claims/ outside exempt paths"
             );
             eprintln!(
                 "  perf <subcommand>                       Plan 60 Phase 9 perf gates (rootfs-size, boot)"


### PR DESCRIPTION
## Summary

Lands the W0 deliverables from Plan 75 — the foundation work that has to ship **before any code** that removes microsandbox or builds `mvm-oci`. Five commits:

- **Plan 75** (`specs/plans/75-oci-stage0-microsandbox-removal.md`) — sequences W0–W7 with security considerations woven through. Workstreams W0–W4 remove microsandbox; W5–W7 deliver bidirectional OCI as a first-class feature (subsumes Plan 74 W1).
- **ADR-049** (`specs/adrs/049-mvm-oci-supersedes-microsandbox.md`) — records the trust-boundary shift; supersedes ADR-046's "Stage 0 for contributors without host Nix" clause.
- **`specs/claims/`** — new directory of claim gating files. Claim 10 ("OCI image provenance in admission audit chain") filed at status `Planned`.
- **`xtask check-no-overclaim`** — lint that refuses gated phrases from user-facing repo text until the claim flips to `Shipped`. 7 unit tests + workspace-scope smoke pass.
- **CI lane** — adds the lint to `.github/workflows/ci.yml` as a hard gate alongside the existing W2 secret-debug and Phase-4 audit-positional checks.

## Why

`mvmctl dev up` regressed 2026-05-14 when commit `19919f6` added a second `rustPlatform.buildRustPackage` to the builder-vm flake, overflowing microsandbox's 4 GiB overlay. This is the second time the cap has bitten us; trimming the flake is paying recurring rent on a structural cost.

Microsandbox's last remaining job — Stage 0 OCI ingest for the builder VM image — is the **same primitive** Plan 74 W1 (`mvmctl image pull`) needs for the user-facing claim. Plan 75 builds `mvm-oci` once and uses it for both. The day Stage 0 is OCI-ingest-by-libkrun, microsandbox has no remaining justification and gets deleted in W4. Same day, the user-facing OCI ingest claim ships behind the same primitive that just got 100% Stage-0 production coverage. W7 ships the export half, completing the bidirectional OCI story.

Also resolves a long-standing tension: CLAUDE.md §"Firecracker-only: no Docker/containers" vs. the surviving microsandbox path pulling `nixos/nix:2.24.10` from Docker Hub.

## Security considerations

Plan 75 and ADR-049 weave these through every workstream:

- **Claim 6 update.** Image hash verification extends from "the pre-built dev image" to **every** OCI image — Stage 0 base, user-pulled image, mvm-published builder VM artifact. Shared implementation in `mvm_oci::digest::verify_streaming`.
- **New claim 10.** OCI image provenance recorded in the admission audit chain. `mvmctl audit verify` detects drift on tampered provenance entries.
- **T-OCI-1..5 threat model entries** extending ADR-002: compromised registry, layer-unpack CVE class (CVE-2019-14271-style), tag mutation race, TLS substitution / DNS rebinding at pull time, supply-chain via Stage 0 base image. Each entry has a stated mitigation.
- **Defense in depth at the launcher.** Even if `mvm-oci`'s unpacker has a bug, the unpacked rootfs is consumed inside libkrun — a rootfs-level escape still has to escape the microVM before reaching the host.
- **"Claims that travel" table for microvm → OCI export** (ADR-049 §"Claims that travel"): dm-verity does not travel, signed plan is metadata-only annotation, audit chain does not travel, sealed deps volume does travel, cosign travels if user opts in. W7 ships the CI assertion that the export annotation is accurate.

## Test plan

- [x] `cargo test -p xtask --bin xtask check_no_overclaim` — 7/7 pass locally
- [x] `cargo clippy -p xtask -- -D warnings` — clean
- [x] `cargo run -p xtask -- check-no-overclaim` — clean against the workspace (1 active gate, no findings)
- [ ] CI lane `lint` green on this PR
- [ ] Review by humans — is the W0 framing right; do the W1..W7 workstreams sequence correctly; is the security model coverage complete

## What does **not** ship in this PR

W0 is foundation only. The actual code that removes microsandbox or talks to OCI registries lands in W1+. No `mvm-oci` crate, no Stage 0 swap, no `mvmctl image pull` — those are the next PRs in the sequence, each on their own branch per the plan's sequencing table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)