### PR TITLE
Derive firewall spec from runtime slot metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
  "ipnet",
  "libc",
  "mvm",
+ "mvm-base",
  "mvm-core",
  "mvm-plan",
  "mvm-policy",

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 
 [dependencies]
 mvm-core.workspace = true
+mvm-base.workspace = true
 mvm-plan.workspace = true
 mvm-policy.workspace = true
 # Plan 73 Followup A — admission gate calls

--- a/crates/mvm-supervisor/src/firewall/mod.rs
+++ b/crates/mvm-supervisor/src/firewall/mod.rs
@@ -46,12 +46,38 @@ impl FirewallSpec {
             proxy_iface: proxy_iface.into(),
         }
     }
+
+    /// Derive firewall wiring from the Firecracker backend's runtime
+    /// slot metadata. `VmSlot` owns VM identity + TAP allocation; the
+    /// supervisor still supplies the proxy interface because that is
+    /// owned by the L4/L7 enforcement layer, not by the backend slot.
+    pub fn from_vm_slot(
+        slot: &mvm_base::config::VmSlot,
+        proxy_iface: impl Into<String>,
+    ) -> Result<Self, FirewallError> {
+        let spec = Self::new(&slot.name, &slot.tap_dev, proxy_iface);
+        spec.validate()?;
+        Ok(spec)
+    }
+
+    /// Validate identifiers before they reach platform-specific rule
+    /// formatters. This duplicates the nft-side guard intentionally:
+    /// supervisor wiring rejects unsafe runtime metadata before any
+    /// backend-specific script generation is attempted.
+    pub fn validate(&self) -> Result<(), FirewallError> {
+        validate_slug("vm_id", &self.vm_id)?;
+        validate_slug("tap_iface", &self.tap_iface)?;
+        validate_slug("proxy_iface", &self.proxy_iface)?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum FirewallError {
     #[error("firewall enforcer not wired (Noop slot)")]
     NotWired,
+    #[error("invalid firewall spec field {field}: {value:?} (only [A-Za-z0-9_-] permitted)")]
+    InvalidSpec { field: &'static str, value: String },
     #[error("firewall backend failed: {0}")]
     Backend(String),
 }
@@ -79,6 +105,20 @@ impl FirewallEnforcer for NoopFirewallEnforcer {
     }
 }
 
+fn validate_slug(field: &'static str, value: &str) -> Result<(), FirewallError> {
+    if value.is_empty()
+        || !value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(FirewallError::InvalidSpec {
+            field,
+            value: value.to_string(),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -89,6 +129,41 @@ mod tests {
         assert_eq!(spec.vm_id, "vm1");
         assert_eq!(spec.tap_iface, "mvmtap0");
         assert_eq!(spec.proxy_iface, "mvmtun0");
+    }
+
+    #[test]
+    fn firewall_spec_derives_from_vm_slot() {
+        let slot = mvm_base::config::VmSlot::new("worker-1", 7);
+        let spec = FirewallSpec::from_vm_slot(&slot, "mvmtun0").expect("valid slot");
+
+        assert_eq!(spec.vm_id, "worker-1");
+        assert_eq!(spec.tap_iface, "tap7");
+        assert_eq!(spec.proxy_iface, "mvmtun0");
+    }
+
+    #[test]
+    fn firewall_spec_from_vm_slot_rejects_unsafe_proxy_iface() {
+        let slot = mvm_base::config::VmSlot::new("worker-1", 7);
+        let err = FirewallSpec::from_vm_slot(&slot, "tun; rm").unwrap_err();
+
+        assert!(matches!(
+            err,
+            FirewallError::InvalidSpec {
+                field: "proxy_iface",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn firewall_spec_from_vm_slot_rejects_unsafe_vm_name() {
+        let slot = mvm_base::config::VmSlot::new("worker/1", 7);
+        let err = FirewallSpec::from_vm_slot(&slot, "mvmtun0").unwrap_err();
+
+        assert!(matches!(
+            err,
+            FirewallError::InvalidSpec { field: "vm_id", .. }
+        ));
     }
 
     #[test]

--- a/crates/mvm-supervisor/src/supervisor.rs
+++ b/crates/mvm-supervisor/src/supervisor.rs
@@ -335,6 +335,11 @@ impl Supervisor {
                 return Err(SupervisorError::FirewallSpecMissing);
             }
         };
+        if let Err(e) = firewall_spec.validate() {
+            self.emit_audit_then_fail(&plan, "plan.rejected.firewall", &e.to_string())
+                .await?;
+            return Err(SupervisorError::from(e));
+        }
         if let Err(e) = self.firewall.install_default_deny(&firewall_spec) {
             self.emit_audit_then_fail(&plan, "plan.rejected.firewall", &e.to_string())
                 .await?;
@@ -1007,7 +1012,8 @@ mod tests {
     }
 
     fn sample_firewall_spec() -> FirewallSpec {
-        FirewallSpec::new("vm1", "mvmtap0", "mvmtun0")
+        FirewallSpec::from_vm_slot(&mvm_base::config::VmSlot::new("vm1", 0), "mvmtun0")
+            .expect("valid sample firewall spec")
     }
 
     fn sample_plan() -> ExecutionPlan {
@@ -1259,6 +1265,24 @@ mod tests {
         assert_eq!(s.state.current(), PlanState::Failed);
         assert!(backend.launches().is_empty());
         assert_eq!(firewall.installs(), vec![sample_firewall_spec()]);
+        assert!(firewall.teardowns().is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_firewall_spec_blocks_before_install_and_backend_launch() {
+        let plan = sample_plan();
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let backend = Arc::new(MockBackend::new());
+        let firewall = Arc::new(MockFirewall::new());
+        let mut s = make_supervisor_with_firewall(backend.clone(), firewall.clone());
+        s.firewall_spec = Some(FirewallSpec::new("vm1", "tap; rm", "mvmtun0"));
+
+        let result = s.launch(&signed, &[("test", &vk)]).await;
+
+        assert!(matches!(result, Err(SupervisorError::Firewall(_))));
+        assert_eq!(s.state.current(), PlanState::Failed);
+        assert!(backend.launches().is_empty());
+        assert!(firewall.installs().is_empty());
         assert!(firewall.teardowns().is_empty());
     }
 

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -127,6 +127,7 @@ Extends `ShellEnvironment` for fleet orchestration:
 `mvm-supervisor` owns the host-side policy slots used after plan admission:
 
 - `L4Gate` evaluates policy-bundle `[[network.l4]]` rows with default-deny semantics
+- `FirewallSpec::from_vm_slot()` derives VM identity and TAP device from backend runtime `VmSlot` metadata, then validates identifiers before any platform rule generation
 - `FirewallEnforcer` installs per-VM default-deny host firewall rules before backend launch and tears them down on failed launch or stop
 - `LinuxNftFirewall` generates VM-scoped nftables tables that only allow TAP traffic to the supervisor proxy interface
 - `NoopFirewallEnforcer` fails closed when no platform firewall is wired

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1063,7 +1063,8 @@ sweep (32 / 16 / 18).
 |---|---|---|
 | 60 — libkrun migration | Phase 6 — `mvm_security::attestation` (`IdentityKey` lifecycle + signed report) + feature-gated `HwAttestationProvider` stubs (TPM2 / SEV-SNP / TDX) + `mvmctl attest {export, verify, status}` CLI | `d0ba736` |
 | 60 | Phase 3 Slice B — `mvm-policy::L4RuleSpec` + `mvm_supervisor::proxy::l4` (`L4Gate` trait, `LiveL4Gate::from_specs`) + `HickoryDnsResolver` + W5 resolver wires `slots.network` | `51581a8` |
-| 60 | Phase 3 Slice C scaffold — `FirewallEnforcer` contract + fail-closed `NoopFirewallEnforcer` + `LinuxNftFirewall` adapter, now wired into `Supervisor::launch` before backend dispatch with teardown on backend launch failure / `stop` | PR pending |
+| 60 | Phase 3 Slice C scaffold — `FirewallEnforcer` contract + fail-closed `NoopFirewallEnforcer` + `LinuxNftFirewall` adapter, now wired into `Supervisor::launch` before backend dispatch with teardown on backend launch failure / `stop` | `509d2c1` |
+| 60 | Phase 3 Slice C follow-on — `FirewallSpec::from_vm_slot` derives VM identity/TAP from Firecracker runtime `VmSlot` metadata and supervisor launch validates specs before firewall install or backend dispatch | PR pending |
 | 60 | Phase 3 follow-on — `up.rs::admit_plan_for_boot` calls `resolve_supervisor_components`; typed audit-chain `error_class` per failure mode | `ac87e8d` |
 | 60 | Phase 3 follow-on — `slots_from_bundle` delegates to `build_inspector_chain`, picking up SsrfGuard / SecretsScanner / InjectionGuard / PiiRedactor + honoring `disabled_inspectors` | `bf8079a` |
 | 60 | Phase 3 follow-on — `LiveArtifactCollector::from_policy(&bundle.artifact)` (NotImplemented carries `capture_paths` count + retention) | `72f272f` |


### PR DESCRIPTION
## Summary

- derive `FirewallSpec` from Firecracker runtime `VmSlot` metadata for VM identity and TAP allocation
- validate firewall spec identifiers in supervisor launch before firewall install or backend dispatch
- document supervisor enforcement and update the sprint ledger for the merged firewall scaffold plus this follow-on

## Security

This keeps firewall rule inputs tied to backend-owned runtime metadata and rejects unsafe identifiers before platform-specific rule formatting. The existing nft-side validation remains as defense in depth.

## Validation

- `cargo fmt --check`
- `cargo test -p mvm-supervisor firewall -- --test-threads=1`
- `cargo test -p mvm-supervisor supervisor::tests -- --test-threads=1`
- `cargo clippy -p mvm-supervisor --all-targets -- -D warnings`
- `git diff --check`
