### PR TITLE
Prepare backend launch before firewall install

### DIFF
--- a/crates/mvm-supervisor/src/backend.rs
+++ b/crates/mvm-supervisor/src/backend.rs
@@ -9,6 +9,7 @@
 //! `AnyBackend` enum behind this trait.
 
 use async_trait::async_trait;
+use mvm_base::config::VmSlot;
 use mvm_plan::{ExecutionPlan, PlanId};
 use thiserror::Error;
 
@@ -20,6 +21,9 @@ pub enum BackendError {
     #[error("backend launch failed: {0}")]
     LaunchFailed(String),
 
+    #[error("backend launch preparation failed: {0}")]
+    PrepareFailed(String),
+
     #[error("backend stop failed: {0}")]
     StopFailed(String),
 
@@ -27,11 +31,33 @@ pub enum BackendError {
     UnknownPlan { plan_id: PlanId },
 }
 
+/// Runtime metadata the backend owns before the supervisor installs
+/// host-side policy. The VM slot is the canonical source for VM
+/// identity and TAP allocation; callers must not synthesize those
+/// names separately.
+#[derive(Debug, Clone)]
+pub struct BackendLaunchSpec {
+    pub vm_slot: VmSlot,
+}
+
+impl BackendLaunchSpec {
+    pub fn new(vm_slot: VmSlot) -> Self {
+        Self { vm_slot }
+    }
+}
+
 /// Async because real backends drive Firecracker's HTTP API or
 /// Apple Container's vsock RPC, both of which the supervisor will
 /// eventually pump from a tokio runtime.
 #[async_trait]
 pub trait BackendLauncher: Send + Sync {
+    /// Reserve or derive runtime metadata needed before backend
+    /// launch. This must not start tenant code. The supervisor uses
+    /// the returned slot to install firewall policy before calling
+    /// [`BackendLauncher::launch`].
+    async fn prepare_launch(&self, plan: &ExecutionPlan)
+    -> Result<BackendLaunchSpec, BackendError>;
+
     /// Issue the start request. Returns when the backend has
     /// accepted the request — not necessarily when the guest is
     /// ready. The supervisor's state machine separately transitions
@@ -50,6 +76,13 @@ pub struct NoopBackendLauncher;
 
 #[async_trait]
 impl BackendLauncher for NoopBackendLauncher {
+    async fn prepare_launch(
+        &self,
+        _plan: &ExecutionPlan,
+    ) -> Result<BackendLaunchSpec, BackendError> {
+        Err(BackendError::NotWired)
+    }
+
     async fn launch(&self, _plan: &ExecutionPlan) -> Result<(), BackendError> {
         Err(BackendError::NotWired)
     }

--- a/crates/mvm-supervisor/src/supervisor.rs
+++ b/crates/mvm-supervisor/src/supervisor.rs
@@ -83,8 +83,8 @@ pub enum SupervisorError {
     #[error("firewall error: {0}")]
     Firewall(#[from] FirewallError),
 
-    #[error("firewall spec not configured")]
-    FirewallSpecMissing,
+    #[error("firewall proxy interface not configured")]
+    FirewallProxyIfaceMissing,
 
     #[error("egress proxy error: {0}")]
     Egress(String),
@@ -167,10 +167,11 @@ pub struct Supervisor {
     /// [`mvm_core::config::mvm_deps_volumes_dir`] at admit time;
     /// tests inject a tempdir.
     pub deps_volumes_root: Option<PathBuf>,
-    /// Per-supervisor firewall wiring for the next launched runtime
-    /// VM. The execution plan does not carry host interface names,
-    /// so the backend/supervisor builder supplies this out-of-band.
-    pub firewall_spec: Option<FirewallSpec>,
+    /// Supervisor-owned proxy interface for default-deny firewall
+    /// rules. VM identity and TAP allocation come from backend
+    /// launch preparation; this is the only network identifier the
+    /// supervisor still owns directly.
+    pub firewall_proxy_iface: Option<String>,
     /// VM-scoped firewall installs keyed by plan id. Used to tear
     /// down the same rules if backend launch fails or on normal stop.
     pub installed_firewalls: BTreeMap<PlanId, FirewallSpec>,
@@ -195,7 +196,7 @@ impl Default for Supervisor {
             nonce_store: Arc::new(Mutex::new(NonceStore::new())),
             circuit_breakers: None,
             deps_volumes_root: None,
-            firewall_spec: None,
+            firewall_proxy_iface: None,
             installed_firewalls: BTreeMap::new(),
         }
     }
@@ -319,20 +320,37 @@ impl Supervisor {
             SupervisorError::from(e)
         })?;
 
-        // Step 3: host firewall. This happens after the plan is
-        // verified/admitted but before backend dispatch. Missing or
-        // broken firewall wiring fails closed, so no VM can boot with
-        // silent unrestricted TAP egress.
-        let firewall_spec = match self.firewall_spec.clone() {
-            Some(spec) => spec,
+        // Step 3: derive backend runtime networking metadata, then
+        // install host firewall policy. Backend launch preparation
+        // must not start tenant code; it only returns the VM slot the
+        // backend will use. This keeps VM id + TAP allocation owned by
+        // the backend while preserving firewall-before-launch ordering.
+        let proxy_iface = match self.firewall_proxy_iface.clone() {
+            Some(proxy_iface) => proxy_iface,
             None => {
                 self.emit_audit_then_fail(
                     &plan,
                     "plan.rejected.firewall",
-                    "firewall spec not configured",
+                    "firewall proxy interface not configured",
                 )
                 .await?;
-                return Err(SupervisorError::FirewallSpecMissing);
+                return Err(SupervisorError::FirewallProxyIfaceMissing);
+            }
+        };
+        let launch_spec = match self.backend.prepare_launch(&plan).await {
+            Ok(spec) => spec,
+            Err(e) => {
+                self.emit_audit_then_fail(&plan, "plan.rejected.backend", &e.to_string())
+                    .await?;
+                return Err(SupervisorError::from(e));
+            }
+        };
+        let firewall_spec = match FirewallSpec::from_vm_slot(&launch_spec.vm_slot, proxy_iface) {
+            Ok(spec) => spec,
+            Err(e) => {
+                self.emit_audit_then_fail(&plan, "plan.rejected.firewall", &e.to_string())
+                    .await?;
+                return Err(SupervisorError::from(e));
             }
         };
         if let Err(e) = firewall_spec.validate() {
@@ -911,7 +929,7 @@ pub fn build_inspector_chain_with_pii(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::BackendLauncher;
+    use crate::backend::{BackendLaunchSpec, BackendLauncher};
     use async_trait::async_trait;
     use chrono::{TimeZone, Utc};
     use ed25519_dalek::SigningKey;
@@ -923,8 +941,11 @@ mod tests {
     /// Test backend that records every call and lets the test pick
     /// success or failure per method.
     struct MockBackend {
+        prepare_calls: Mutex<Vec<PlanId>>,
         launch_calls: Mutex<Vec<PlanId>>,
         stop_calls: Mutex<Vec<PlanId>>,
+        slot: mvm_base::config::VmSlot,
+        prepare_should_fail: bool,
         launch_should_fail: bool,
         stop_should_fail: bool,
     }
@@ -932,11 +953,18 @@ mod tests {
     impl MockBackend {
         fn new() -> Self {
             Self {
+                prepare_calls: Mutex::new(Vec::new()),
                 launch_calls: Mutex::new(Vec::new()),
                 stop_calls: Mutex::new(Vec::new()),
+                slot: mvm_base::config::VmSlot::new("vm1", 0),
+                prepare_should_fail: false,
                 launch_should_fail: false,
                 stop_should_fail: false,
             }
+        }
+
+        fn prepares(&self) -> Vec<PlanId> {
+            self.prepare_calls.lock().unwrap().clone()
         }
 
         fn launches(&self) -> Vec<PlanId> {
@@ -950,6 +978,20 @@ mod tests {
 
     #[async_trait]
     impl BackendLauncher for MockBackend {
+        async fn prepare_launch(
+            &self,
+            plan: &ExecutionPlan,
+        ) -> Result<BackendLaunchSpec, BackendError> {
+            self.prepare_calls
+                .lock()
+                .unwrap()
+                .push(plan.plan_id.clone());
+            if self.prepare_should_fail {
+                return Err(BackendError::PrepareFailed("mock prepare".into()));
+            }
+            Ok(BackendLaunchSpec::new(self.slot.clone()))
+        }
+
         async fn launch(&self, plan: &ExecutionPlan) -> Result<(), BackendError> {
             self.launch_calls.lock().unwrap().push(plan.plan_id.clone());
             if self.launch_should_fail {
@@ -1105,7 +1147,7 @@ mod tests {
         let mut s = Supervisor::new();
         s.backend = b;
         s.firewall = Arc::new(MockFirewall::new());
-        s.firewall_spec = Some(sample_firewall_spec());
+        s.firewall_proxy_iface = Some("mvmtun0".to_string());
         // Default to a clock inside the sample plan's window so
         // happy-path tests don't depend on the wall clock.
         s.clock = fixed_clock_inside_window();
@@ -1125,7 +1167,7 @@ mod tests {
         let mut s = Supervisor::new();
         s.backend = b;
         s.firewall = Arc::new(MockFirewall::new());
-        s.firewall_spec = Some(sample_firewall_spec());
+        s.firewall_proxy_iface = Some("mvmtun0".to_string());
         s.clock = fixed_clock_inside_window();
         s.audit = audit.clone();
         (s, audit)
@@ -1151,6 +1193,7 @@ mod tests {
         s.launch(&signed, &[("test", &vk)]).await.unwrap();
 
         assert_eq!(s.state.current(), PlanState::Running);
+        assert_eq!(backend.prepares(), vec![plan.plan_id.clone()]);
         assert_eq!(backend.launches(), vec![plan.plan_id.clone()]);
         assert!(backend.stops().is_empty());
         assert_eq!(firewall.installs(), vec![sample_firewall_spec()]);
@@ -1234,19 +1277,61 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_supervisor_fails_closed_without_firewall_spec() {
+    async fn default_supervisor_fails_closed_without_firewall_proxy_iface() {
         let plan = sample_plan();
         let (signed, _sk, vk) = sign_sample(&plan);
         let mut s = Supervisor::new();
-        // No firewall spec — default launch fails closed before backend.
+        // No firewall proxy interface — default launch fails closed before backend.
         // Pin the clock inside the plan window so validity passes and
         // the test exercises the firewall-fails-closed path it's
         // supposed to.
         s.clock = fixed_clock_inside_window();
 
         let result = s.launch(&signed, &[("test", &vk)]).await;
-        assert!(matches!(result, Err(SupervisorError::FirewallSpecMissing)));
+        assert!(matches!(
+            result,
+            Err(SupervisorError::FirewallProxyIfaceMissing)
+        ));
         assert_eq!(s.state.current(), PlanState::Failed);
+    }
+
+    #[tokio::test]
+    async fn missing_firewall_proxy_iface_blocks_before_backend_prepare() {
+        let plan = sample_plan();
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let backend = Arc::new(MockBackend::new());
+        let mut s = make_supervisor_with_backend(backend.clone());
+        s.firewall_proxy_iface = None;
+
+        let result = s.launch(&signed, &[("test", &vk)]).await;
+
+        assert!(matches!(
+            result,
+            Err(SupervisorError::FirewallProxyIfaceMissing)
+        ));
+        assert_eq!(s.state.current(), PlanState::Failed);
+        assert!(backend.prepares().is_empty());
+        assert!(backend.launches().is_empty());
+    }
+
+    #[tokio::test]
+    async fn backend_prepare_failure_blocks_firewall_install_and_backend_launch() {
+        let plan = sample_plan();
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let mut backend = MockBackend::new();
+        backend.prepare_should_fail = true;
+        let backend = Arc::new(backend);
+        let firewall = Arc::new(MockFirewall::new());
+        let mut s = make_supervisor_with_firewall(backend.clone(), firewall.clone());
+
+        let result = s.launch(&signed, &[("test", &vk)]).await;
+
+        assert!(matches!(result, Err(SupervisorError::Backend(_))));
+        assert_eq!(s.state.current(), PlanState::Failed);
+        assert_eq!(backend.prepares(), vec![plan.plan_id.clone()]);
+        assert!(backend.launches().is_empty());
+        assert!(firewall.installs().is_empty());
+        assert!(firewall.teardowns().is_empty());
     }
 
     #[tokio::test]
@@ -1263,24 +1348,27 @@ mod tests {
 
         assert!(matches!(result, Err(SupervisorError::Firewall(_))));
         assert_eq!(s.state.current(), PlanState::Failed);
+        assert_eq!(backend.prepares(), vec![plan.plan_id.clone()]);
         assert!(backend.launches().is_empty());
         assert_eq!(firewall.installs(), vec![sample_firewall_spec()]);
         assert!(firewall.teardowns().is_empty());
     }
 
     #[tokio::test]
-    async fn invalid_firewall_spec_blocks_before_install_and_backend_launch() {
+    async fn invalid_backend_slot_blocks_before_install_and_backend_launch() {
         let plan = sample_plan();
         let (signed, _sk, vk) = sign_sample(&plan);
-        let backend = Arc::new(MockBackend::new());
+        let mut backend = MockBackend::new();
+        backend.slot = mvm_base::config::VmSlot::new("vm/1", 0);
+        let backend = Arc::new(backend);
         let firewall = Arc::new(MockFirewall::new());
         let mut s = make_supervisor_with_firewall(backend.clone(), firewall.clone());
-        s.firewall_spec = Some(FirewallSpec::new("vm1", "tap; rm", "mvmtun0"));
 
         let result = s.launch(&signed, &[("test", &vk)]).await;
 
         assert!(matches!(result, Err(SupervisorError::Firewall(_))));
         assert_eq!(s.state.current(), PlanState::Failed);
+        assert_eq!(backend.prepares(), vec![plan.plan_id.clone()]);
         assert!(backend.launches().is_empty());
         assert!(firewall.installs().is_empty());
         assert!(firewall.teardowns().is_empty());

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -127,6 +127,7 @@ Extends `ShellEnvironment` for fleet orchestration:
 `mvm-supervisor` owns the host-side policy slots used after plan admission:
 
 - `L4Gate` evaluates policy-bundle `[[network.l4]]` rows with default-deny semantics
+- `BackendLauncher::prepare_launch()` returns backend-owned runtime slot metadata before tenant launch, without starting tenant code
 - `FirewallSpec::from_vm_slot()` derives VM identity and TAP device from backend runtime `VmSlot` metadata, then validates identifiers before any platform rule generation
 - `FirewallEnforcer` installs per-VM default-deny host firewall rules before backend launch and tears them down on failed launch or stop
 - `LinuxNftFirewall` generates VM-scoped nftables tables that only allow TAP traffic to the supervisor proxy interface

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1064,7 +1064,8 @@ sweep (32 / 16 / 18).
 | 60 — libkrun migration | Phase 6 — `mvm_security::attestation` (`IdentityKey` lifecycle + signed report) + feature-gated `HwAttestationProvider` stubs (TPM2 / SEV-SNP / TDX) + `mvmctl attest {export, verify, status}` CLI | `d0ba736` |
 | 60 | Phase 3 Slice B — `mvm-policy::L4RuleSpec` + `mvm_supervisor::proxy::l4` (`L4Gate` trait, `LiveL4Gate::from_specs`) + `HickoryDnsResolver` + W5 resolver wires `slots.network` | `51581a8` |
 | 60 | Phase 3 Slice C scaffold — `FirewallEnforcer` contract + fail-closed `NoopFirewallEnforcer` + `LinuxNftFirewall` adapter, now wired into `Supervisor::launch` before backend dispatch with teardown on backend launch failure / `stop` | `509d2c1` |
-| 60 | Phase 3 Slice C follow-on — `FirewallSpec::from_vm_slot` derives VM identity/TAP from Firecracker runtime `VmSlot` metadata and supervisor launch validates specs before firewall install or backend dispatch | PR pending |
+| 60 | Phase 3 Slice C follow-on — `FirewallSpec::from_vm_slot` derives VM identity/TAP from Firecracker runtime `VmSlot` metadata and supervisor launch validates specs before firewall install or backend dispatch | `d252f92` |
+| 60 | Phase 3 Slice C follow-on — `BackendLauncher::prepare_launch` returns runtime `VmSlot` metadata before tenant launch; `Supervisor::launch` now derives firewall specs from that backend slot plus the supervisor proxy interface | PR pending |
 | 60 | Phase 3 follow-on — `up.rs::admit_plan_for_boot` calls `resolve_supervisor_components`; typed audit-chain `error_class` per failure mode | `ac87e8d` |
 | 60 | Phase 3 follow-on — `slots_from_bundle` delegates to `build_inspector_chain`, picking up SsrfGuard / SecretsScanner / InjectionGuard / PiiRedactor + honoring `disabled_inspectors` | `bf8079a` |
 | 60 | Phase 3 follow-on — `LiveArtifactCollector::from_policy(&bundle.artifact)` (NotImplemented carries `capture_paths` count + retention) | `72f272f` |


### PR DESCRIPTION
## Summary

- add `BackendLauncher::prepare_launch` and `BackendLaunchSpec` so backends expose runtime `VmSlot` metadata before tenant launch
- have `Supervisor::launch` derive firewall specs from backend-owned slot metadata plus the supervisor proxy interface
- replace manual supervisor-side firewall spec injection with fail-closed proxy-interface wiring
- update architecture docs and sprint status

## Security

The supervisor now blocks before backend preparation if no proxy interface is configured, blocks before firewall install and backend launch if preparation fails, and rejects unsafe backend slot metadata before any rule install. Firewall install still happens before `BackendLauncher::launch`.

## Validation

- `cargo fmt --check`
- `cargo test -p mvm-supervisor backend -- --test-threads=1`
- `cargo test -p mvm-supervisor firewall -- --test-threads=1`
- `cargo test -p mvm-supervisor supervisor::tests -- --test-threads=1`
- `cargo clippy -p mvm-supervisor --all-targets -- -D warnings`
- `git diff --check`
