### PR TITLE
Add Firecracker supervisor backend launcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
  "ipnet",
  "libc",
  "mvm",
+ "mvm-backend",
  "mvm-base",
  "mvm-core",
  "mvm-plan",

--- a/crates/mvm-supervisor/Cargo.toml
+++ b/crates/mvm-supervisor/Cargo.toml
@@ -11,6 +11,7 @@ authors.workspace = true
 [dependencies]
 mvm-core.workspace = true
 mvm-base.workspace = true
+mvm-backend.workspace = true
 mvm-plan.workspace = true
 mvm-policy.workspace = true
 # Plan 73 Followup A — admission gate calls

--- a/crates/mvm-supervisor/src/backend.rs
+++ b/crates/mvm-supervisor/src/backend.rs
@@ -9,8 +9,11 @@
 //! `AnyBackend` enum behind this trait.
 
 use async_trait::async_trait;
+use mvm_backend::microvm::FlakeRunConfig;
 use mvm_base::config::VmSlot;
 use mvm_plan::{ExecutionPlan, PlanId};
+use std::collections::BTreeMap;
+use std::sync::Mutex;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -92,6 +95,79 @@ impl BackendLauncher for NoopBackendLauncher {
     }
 }
 
+/// Firecracker-backed launcher for an already-built runtime config.
+///
+/// `FlakeRunConfig` carries the canonical `VmSlot`, so this adapter
+/// can satisfy the supervisor's firewall-before-launch contract
+/// without allocating or synthesizing network identity in the
+/// supervisor layer. `prepare_launch` only exposes metadata; tenant
+/// code starts exclusively in `launch`.
+pub struct FirecrackerRunConfigLauncher {
+    config: FlakeRunConfig,
+    launched: Mutex<BTreeMap<PlanId, String>>,
+}
+
+impl FirecrackerRunConfigLauncher {
+    pub fn new(config: FlakeRunConfig) -> Result<Self, BackendError> {
+        if config.name != config.slot.name {
+            return Err(BackendError::PrepareFailed(format!(
+                "run config name {:?} does not match slot name {:?}",
+                config.name, config.slot.name
+            )));
+        }
+        config
+            .validate()
+            .map_err(|e| BackendError::PrepareFailed(e.to_string()))?;
+        Ok(Self {
+            config,
+            launched: Mutex::new(BTreeMap::new()),
+        })
+    }
+
+    pub fn config(&self) -> &FlakeRunConfig {
+        &self.config
+    }
+}
+
+#[async_trait]
+impl BackendLauncher for FirecrackerRunConfigLauncher {
+    async fn prepare_launch(
+        &self,
+        _plan: &ExecutionPlan,
+    ) -> Result<BackendLaunchSpec, BackendError> {
+        Ok(BackendLaunchSpec::new(self.config.slot.clone()))
+    }
+
+    async fn launch(&self, plan: &ExecutionPlan) -> Result<(), BackendError> {
+        mvm_backend::microvm::run_from_build(&self.config)
+            .map_err(|e| BackendError::LaunchFailed(e.to_string()))?;
+        self.launched
+            .lock()
+            .expect("backend launch map mutex poisoned")
+            .insert(plan.plan_id.clone(), self.config.name.clone());
+        Ok(())
+    }
+
+    async fn stop(&self, plan_id: &PlanId) -> Result<(), BackendError> {
+        let vm_name = self
+            .launched
+            .lock()
+            .expect("backend launch map mutex poisoned")
+            .get(plan_id)
+            .cloned()
+            .ok_or_else(|| BackendError::UnknownPlan {
+                plan_id: plan_id.clone(),
+            })?;
+        mvm_backend::microvm::stop_vm(&vm_name)
+            .map_err(|e| BackendError::StopFailed(e.to_string()))?;
+        self.launched
+            .lock()
+            .expect("backend launch map mutex poisoned")
+            .remove(plan_id);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -99,5 +175,108 @@ mod tests {
     #[test]
     fn noop_backend_launcher_is_constructable() {
         let _: Box<dyn BackendLauncher> = Box::new(NoopBackendLauncher);
+    }
+
+    fn sample_run_config() -> FlakeRunConfig {
+        FlakeRunConfig {
+            name: "vm1".to_string(),
+            slot: VmSlot::new("vm1", 3),
+            vmlinux_path: "/nix/store/kernel/vmlinux".to_string(),
+            initrd_path: None,
+            rootfs_path: "/nix/store/rootfs/rootfs.ext4".to_string(),
+            verity_path: None,
+            roothash: None,
+            revision_hash: "r".repeat(64),
+            flake_ref: "github:example/workload".to_string(),
+            profile: Some("worker".to_string()),
+            cpus: 2,
+            memory: 1024,
+            mem_initial: None,
+            volumes: Vec::new(),
+            config_files: Vec::new(),
+            secret_files: Vec::new(),
+            ports: Vec::new(),
+            network_policy: mvm_core::network_policy::NetworkPolicy::default(),
+        }
+    }
+
+    #[test]
+    fn firecracker_launcher_constructor_rejects_slot_name_mismatch() {
+        let mut config = sample_run_config();
+        config.slot = VmSlot::new("other-vm", 3);
+
+        let err = match FirecrackerRunConfigLauncher::new(config) {
+            Ok(_) => panic!("mismatch must be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(err, BackendError::PrepareFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn firecracker_launcher_prepare_returns_configured_slot_without_launching() {
+        let config = sample_run_config();
+        let expected_slot = config.slot.clone();
+        let launcher = FirecrackerRunConfigLauncher::new(config).expect("valid config");
+        let plan = ExecutionPlan {
+            schema_version: mvm_plan::SCHEMA_VERSION,
+            plan_id: PlanId("01HXTEST0000000000000000".to_string()),
+            plan_version: 1,
+            tenant: mvm_plan::TenantId("tenant-a".to_string()),
+            workload: mvm_plan::WorkloadId("workload-1".to_string()),
+            runtime_profile: mvm_plan::RuntimeProfileRef("firecracker".to_string()),
+            image: mvm_plan::SignedImageRef {
+                name: "tenant-worker-aarch64".to_string(),
+                sha256: "a".repeat(64),
+                cosign_bundle: None,
+            },
+            resources: mvm_plan::Resources {
+                cpus: 2,
+                mem_mib: 1024,
+                disk_mib: 4096,
+                timeouts: mvm_plan::TimeoutSpec {
+                    boot_secs: 30,
+                    exec_secs: 600,
+                },
+            },
+            admission_profile: mvm_plan::AdmissionProfile::local_default(
+                "vm:boot",
+                mvm_plan::PlanSeccompTier::Standard,
+            ),
+            network_policy: mvm_plan::PolicyRef("default-deny".to_string()),
+            fs_policy: mvm_plan::FsPolicyRef("default".to_string()),
+            secrets: vec![],
+            egress_policy: mvm_plan::PolicyRef("agent-l7".to_string()),
+            tool_policy: mvm_plan::PolicyRef("read-only".to_string()),
+            artifact_policy: mvm_plan::ArtifactPolicy {
+                capture_paths: vec!["/artifacts".to_string()],
+                retention_days: 30,
+            },
+            audit_labels: BTreeMap::new(),
+            key_rotation: mvm_plan::KeyRotationSpec { interval_days: 7 },
+            attestation: mvm_plan::AttestationRequirement {
+                mode: mvm_plan::AttestationMode::Noop,
+            },
+            release_pin: None,
+            post_run: mvm_plan::PostRunLifecycle {
+                destroy_on_exit: true,
+                snapshot_on_idle: false,
+                idle_secs: 0,
+            },
+            valid_from: chrono::Utc::now(),
+            valid_until: chrono::Utc::now(),
+            nonce: mvm_plan::Nonce::from_bytes([0xab; 16]),
+            bundle: None,
+            deps_volume: None,
+        };
+
+        let spec = launcher
+            .prepare_launch(&plan)
+            .await
+            .expect("prepare succeeds");
+
+        assert_eq!(spec.vm_slot.name, expected_slot.name);
+        assert_eq!(spec.vm_slot.index, expected_slot.index);
+        assert_eq!(spec.vm_slot.tap_dev, expected_slot.tap_dev);
     }
 }

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -127,6 +127,7 @@ Extends `ShellEnvironment` for fleet orchestration:
 
 - `L4Gate` evaluates policy-bundle `[[network.l4]]` rows with default-deny semantics
 - `BackendLauncher::prepare_launch()` returns backend-owned runtime slot metadata before tenant launch, without starting tenant code
+- `FirecrackerRunConfigLauncher` adapts a prebuilt Firecracker `FlakeRunConfig` into the supervisor backend slot, exposing its `VmSlot` during preparation and calling `run_from_build()` only after firewall install
 - `FirewallSpec::from_vm_slot()` derives VM identity and TAP device from backend runtime `VmSlot` metadata, then validates identifiers before any platform rule generation
 - `FirewallEnforcer` installs per-VM default-deny host firewall rules before backend launch and tears them down on failed launch or stop
 - `LinuxNftFirewall` generates VM-scoped nftables tables that only allow TAP traffic to the supervisor proxy interface

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1066,6 +1066,7 @@ sweep (32 / 16 / 18).
 | 60 | Phase 3 Slice C scaffold — `FirewallEnforcer` contract + fail-closed `NoopFirewallEnforcer` + `LinuxNftFirewall` adapter, now wired into `Supervisor::launch` before backend dispatch with teardown on backend launch failure / `stop` | `509d2c1` |
 | 60 | Phase 3 Slice C follow-on — `FirewallSpec::from_vm_slot` derives VM identity/TAP from Firecracker runtime `VmSlot` metadata and supervisor launch validates specs before firewall install or backend dispatch | `d252f92` |
 | 60 | Phase 3 Slice C follow-on — `BackendLauncher::prepare_launch` returns runtime `VmSlot` metadata before tenant launch; `Supervisor::launch` now derives firewall specs from that backend slot plus the supervisor proxy interface | `ab4a792` |
+| 60 | Phase 3 Slice C follow-on — `FirecrackerRunConfigLauncher` adapts prebuilt Firecracker `FlakeRunConfig` into the supervisor `BackendLauncher` slot without starting tenant code during `prepare_launch` | PR pending |
 | 60 | Phase 3 follow-on — `up.rs::admit_plan_for_boot` calls `resolve_supervisor_components`; typed audit-chain `error_class` per failure mode | `ac87e8d` |
 | 60 | Phase 3 follow-on — `slots_from_bundle` delegates to `build_inspector_chain`, picking up SsrfGuard / SecretsScanner / InjectionGuard / PiiRedactor + honoring `disabled_inspectors` | `bf8079a` |
 | 60 | Phase 3 follow-on — `LiveArtifactCollector::from_policy(&bundle.artifact)` (NotImplemented carries `capture_paths` count + retention) | `72f272f` |


### PR DESCRIPTION
## Summary

- add `FirecrackerRunConfigLauncher`, a concrete supervisor `BackendLauncher` adapter for prebuilt Firecracker `FlakeRunConfig`
- expose the configured `VmSlot` during `prepare_launch` without starting tenant code
- call `microvm::run_from_build()` only from `launch`, after supervisor firewall installation
- keep plan-to-VM stop mapping retryable by removing it only after successful stop
- update architecture docs and sprint status

## Security

This keeps VM identity and TAP allocation owned by the Firecracker runtime config while preserving the firewall-before-launch invariant. Constructor validation rejects mismatched config/slot names and invalid runtime configs before the adapter can be wired.

## Validation

- `cargo fmt --check`
- `cargo test -p mvm-supervisor backend -- --test-threads=1`
- `cargo test -p mvm-supervisor firewall -- --test-threads=1`
- `cargo test -p mvm-supervisor supervisor::tests -- --test-threads=1`
- `cargo clippy -p mvm-supervisor --all-targets -- -D warnings`
- `git diff --check`
