### PR TITLE
Docs: host-orchestrated builder VM flow + scratch-dir gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ nix/images/dev-prebuilt/
 # Worktree-local dev env (use .envrc.example as template)
 /.envrc
 /.mvm-test/
+.worktrees/
+graphify-out/

--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -90,6 +90,7 @@ export default defineConfig({
             { label: "Writing Nix Flakes", slug: "guides/nix-flakes" },
             { label: "From Workload IR to MicroVM Image", slug: "guides/ir-to-image" },
             { label: "Building MicroVM Images", slug: "guides/building-microvm-images" },
+            { label: "Builder VM", slug: "guides/builder-vm" },
             { label: "Sandboxed Exec", slug: "guides/exec" },
             { label: "Config & Secrets", slug: "guides/config-secrets" },
             { label: "Manifests", slug: "guides/manifests" },

--- a/public/src/content/docs/contributing/adr/013-libkrun-pivot.md
+++ b/public/src/content/docs/contributing/adr/013-libkrun-pivot.md
@@ -11,19 +11,15 @@ Proposed. Implementation tracked in [Plan 60](https://github.com/tinylabscom/mvm
 
 `mvmctl` runs on a stock host. **Nix is not a prerequisite.** On first build, mvm bootstraps a small Linux builder microVM (libkrun-backed), runs `nix build` inside it, and extracts the resulting rootfs to the host. The runtime path stays Nix-free; the builder path keeps Nix inside the sandbox where it belongs.
 
-Host-side Nix is an opt-in power-user path:
+Host-side Nix is optional and only affects commands users run themselves:
 
-- contributors hacking on mvm itself who want a shared `/nix/store`,
-- users with [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary) already configured (mvm detects and uses it),
-- users with a remote `nix-daemon` URL.
+- contributors hacking on mvm itself may want Nix for editor tooling or direct `nix build` debugging;
+- users with [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary) can use it for direct Nix commands;
+- users with a remote `nix-daemon` URL can use it outside mvm's normal build path.
 
 The full design is in [§"Linux builder via libkrun (no Lima)"](#linux-builder-via-libkrun-no-lima) below.
 
-> **Current status (2026-05-08):** the bootstrap is in flight on the
-> `feat/micro` branch as part of W6.x. Until it lands, contributors
-> building rootfs images still need host-side Nix (or `nix-darwin`'s
-> `linux-builder` on macOS). The docs describe the target user-facing
-> shape; the in-flight gap is a footnote, not the headline.
+The user-facing contract is documented in [Builder VM](/guides/builder-vm/): `mvmctl build` is a host command, while Nix evaluation and image construction happen inside the builder VM.
 
 ## Context
 
@@ -50,7 +46,6 @@ Three coupled choices:
 3. macOS Container         → AppleContainerBackend (legacy; scheduled for removal)
 4. raw libkrun             → LibkrunBackend (legacy; scheduled for removal)
 5. Docker                  → DockerBackend (Tier 3 fallback; banner emitted)
-6. Firecracker via Lima    → legacy macOS fallback
 ```
 
 `mvmctl run --hypervisor libkrun <flake>` always selects libkrun explicitly regardless of the host's KVM status.
@@ -59,22 +54,20 @@ Three coupled choices:
 
 macOS hosts can't `nix build` Linux derivations natively. The previous iteration solved that with a Lima VM as the Linux builder; this iteration drops Lima entirely. The replacement: **bootstrap a Linux builder inside libkrun itself**.
 
-On a host without a Linux builder configured, `mvmctl build` does:
+`mvmctl build` does:
 
-1. Detects the gap — host has no Nix, or has Nix that can't build Linux derivations.
-2. Pulls a small, pinned Nix-bearing image — once, cached in `~/.cache/mvm/builder-image/`.
-3. Spawns a libkrun sandbox from the image with the user's flake source bind-mounted as `/work`, the host's `/nix/store` shared in if present, and a sane PATH.
-4. Runs `nix build .#default` inside the sandbox.
-5. Extracts the rootfs back to the host.
-6. Hands it to the runtime path (which uses libkrun's `RootfsSource::DiskImage` per the OCI non-goal — the *runtime* never pulls OCI).
+1. Stages the user's flake source and selected profile as a builder job.
+2. Boots or reuses the pinned Linux builder image.
+3. Mounts the staged source, job metadata, cache volumes, and artifact output directory into the builder boundary.
+4. Runs `nix build .#default` or the selected profile inside the builder VM.
+5. Extracts the kernel/rootfs artifacts back to the host cache.
+6. Hands the finished artifacts to the runtime path (which uses libkrun's `RootfsSource::DiskImage` per the OCI non-goal — the *runtime* never pulls OCI).
 
 **Why this is consistent with the OCI non-goal.** The non-goal banned OCI from the **runtime/boot path** — where user workloads run, where reproducibility, offline-by-default, and no-registry-trust matter. The **builder** lives in a different trust zone: it has to fetch caches, talk to the network, and run arbitrary `nix build` derivations. Builder VMs and runtime VMs are governed by different policies; using OCI for the builder doesn't compromise the runtime's invariants.
 
-**Cache reuse.** When the host has a Nix install, its `/nix/store` is shared into the builder sandbox. Builds populate the host store; subsequent builds reuse the same cached derivations. This is the same trick `nix-darwin`'s `linux-builder` uses — the difference is mvm doesn't require the user to have configured `nix-darwin`.
+**Cache reuse.** The builder VM keeps a warm Nix store/cache across builds. Host-side Nix may still be useful for direct developer commands, but mvm image construction goes through the builder VM so the behavior is consistent across macOS, Linux, and WSL2.
 
-**Detection and fallback.** If the host already has a working Linux builder (`nix-darwin`'s `linux-builder`, or a remote `nix-daemon` URL), mvm detects it and uses it instead — the libkrun-bootstrapped path is the *zero-config default*, not a forced override. Detection probes whether host Nix can realize a Linux derivation; success → host builds; failure → libkrun bootstrap.
-
-**This replaces every previous reference to "configure `nix-darwin`'s `linux-builder`" in the docs.** Users with an existing builder keep using it; everyone else gets the libkrun-bootstrapped path with no host-side configuration.
+**This replaces every previous reference to "configure `nix-darwin`'s `linux-builder`" as a prerequisite for mvm builds.** Users can still configure one for their own direct Nix workflows; `mvmctl build` does not require it.
 
 ## Non-goal: OCI / container images
 

--- a/public/src/content/docs/getting-started/installation.md
+++ b/public/src/content/docs/getting-started/installation.md
@@ -53,7 +53,7 @@ mvmctl automatically detects your platform at startup and selects the best VM ba
 | **Linux without `/dev/kvm`** | Docker | Tier 3 fallback when no microVM backend is available. |
 | **Docker available** | Docker | Tier 3 container fallback. Used only if no hypervisor backend works. |
 
-You don't need Nix on the host. On first build, mvm resolves a Linux builder microVM, runs `nix build` inside it, and extracts the rootfs back. Host-side Nix is not part of the managed `mvmctl` path.
+You don't need Nix on the host. On first build, mvm bootstraps or reuses a Linux builder VM, runs Nix evaluation and `nix build` inside it, and extracts the rootfs back. You run `mvmctl build` from the host; you do not need to enter a dev shell first. See [Builder VM](/guides/builder-vm/) for the full model.
 
 ### First-Time Setup
 

--- a/public/src/content/docs/guides/builder-vm.md
+++ b/public/src/content/docs/guides/builder-vm.md
@@ -1,0 +1,176 @@
+---
+title: "Builder VM"
+description: How mvm builds Linux microVM images from the host without requiring you to enter a dev shell or install host-side Nix.
+---
+
+The short version: **you run `mvmctl build` from the host, and mvm runs Nix inside the builder VM.** You do not need to enter an interactive dev shell to build a template or runtime image.
+
+The host process is the control plane. The builder VM is the Linux execution boundary for Nix evaluation, Nix builds, and image assembly. The runtime backend is separate: after the image is built, mvm boots the prebuilt kernel and rootfs with the selected microVM backend, such as Firecracker on Linux or Apple Virtualization on macOS.
+
+```text
+macOS or Linux host
+  |
+  | mvmctl build --flake .
+  v
+host-side mvmctl process
+  |
+  | stages flake, job metadata, and artifact directory
+  v
+builder VM
+  |
+  | runs nix eval / nix build on Linux
+  v
+host artifact cache
+  |
+  | mvmctl up --hypervisor apple-container
+  v
+runtime microVM
+```
+
+## What Runs Where
+
+| Work | Runs on | Why |
+|---|---|---|
+| CLI parsing, config loading, cache lookup | Host | Fast local control-plane work. |
+| Nix flake evaluation | Builder VM | The target is a Linux image, and the build environment must be Linux. |
+| `nix build` | Builder VM | Keeps host Nix optional and avoids macOS/Linux platform mismatch. |
+| Rootfs and kernel artifact extraction | Builder VM, then host cache | The builder produces artifacts; the host stores and reuses them. |
+| Runtime boot | Runtime backend | Uses an already-built image. This is Firecracker, Apple Virtualization, libkrun, or another backend. |
+| Runtime guest agent traffic | Runtime microVM | Uses the runtime VM's guest communication path, normally vsock where supported. |
+
+This separation is deliberate. A build can take seconds or minutes because it may fetch and compile Nix closures. A runtime boot benchmark should normally measure only the already-built image booting, not the build phase.
+
+## You Do Not Need a Dev Shell to Build
+
+The normal build command is:
+
+```bash
+mvmctl build --flake .
+```
+
+That command should be run from your project directory on the host. `mvmctl` takes care of starting or reaching the builder VM, staging the flake, running the build, and copying the result back.
+
+Use an interactive shell only when you want to debug the builder environment:
+
+```bash
+mvmctl dev shell
+```
+
+Examples of things a dev shell is useful for:
+
+- inspecting the Linux build environment;
+- manually running `nix build` to debug a flake error;
+- checking disk usage in the builder VM's Nix store;
+- reproducing an issue that only appears inside the Linux build boundary.
+
+Examples of things that should not require a dev shell:
+
+- `mvmctl build --flake .`;
+- `mvmctl run`;
+- `mvmctl up --flake .`;
+- building a registered template;
+- booting a prebuilt runtime image.
+
+## Build Then Boot
+
+For an explicit two-step flow:
+
+```bash
+# 1. Build the runtime image.
+mvmctl build --flake .
+
+# 2. Boot the already-built image.
+mvmctl up --flake . --hypervisor apple-container
+```
+
+On macOS, `--hypervisor apple-container` selects the Apple Virtualization runtime backend when available. The builder VM remains a build-time implementation detail. It is not the same VM as your workload VM.
+
+For development convenience, `mvmctl run` combines the two phases:
+
+```bash
+mvmctl run
+```
+
+That is equivalent to "build if needed, then boot." It is convenient for daily use, but it is not the right measurement point if you are trying to isolate runtime boot latency.
+
+## Builder VM vs Runtime MicroVM
+
+The builder VM and runtime microVM have different jobs:
+
+| VM | Purpose | Lifetime | State |
+|---|---|---|---|
+| Builder VM | Runs Linux Nix builds and image assembly. | Reused or launched as needed by the build pipeline. | Has a warm Nix store/cache. |
+| Runtime microVM | Runs your workload from a finished image. | Created by `mvmctl up`, `run`, `exec`, or tests. | Uses the built rootfs/kernel artifacts. |
+
+Do not benchmark the builder VM when you want runtime boot time. The builder VM exists so that the host can ask for Linux builds without becoming a Linux build machine itself.
+
+## Communication Model
+
+From the user's perspective, the interface is the host command:
+
+```bash
+mvmctl build --flake .
+```
+
+Internally, mvm stages the build request into the builder boundary: source path, selected profile, target system, output directory, and job metadata. The builder runs the Linux-side build and returns structured artifact metadata to the host.
+
+The exact transport is backend-specific. Implementations may use mounted job directories, virtio-fs, a control socket, vsock, or a small supervisor process. That detail should not leak into the user workflow. The contract is:
+
+1. the host starts the request;
+2. the builder VM performs Linux-only work;
+3. the host receives a kernel/rootfs artifact set;
+4. runtime commands boot those artifacts.
+
+## Nix on the Host
+
+Host-side Nix is not required for normal mvm use.
+
+On macOS, host Nix also does not remove the need for a Linux build boundary: the guest image is a Linux artifact. A macOS `nix` install can be useful for editor tooling, formatting, or unrelated projects, but `mvmctl build` should treat the builder VM as the authoritative place where Nix evaluation and builds happen.
+
+On Linux, the host may already be capable of Linux Nix builds, but mvm still keeps the same conceptual boundary: `mvmctl build` is the user-facing command, and the builder path owns image construction and cache policy. This keeps the CLI behavior consistent across platforms.
+
+## Caching
+
+The builder VM keeps build state warm so repeated builds avoid re-fetching the world:
+
+- Nix store paths are cached inside the builder environment.
+- Built runtime artifacts are cached on the host.
+- Unchanged flakes and lock files should reuse previous work.
+
+The first build is allowed to be slower because it may bootstrap the builder image and populate the Nix store. Later builds should be dominated by changed inputs.
+
+## Benchmarking Runtime Boot
+
+When measuring whether a prebuilt runtime image boots under a budget such as 200 ms, separate the phases:
+
+```text
+Build benchmark:
+  host mvmctl build -> builder VM -> artifacts
+
+Runtime boot benchmark:
+  existing artifacts -> runtime backend -> guest ready signal
+```
+
+The runtime boot benchmark should start after the kernel and rootfs already exist. It should not include:
+
+- builder VM startup;
+- Nix evaluation;
+- dependency download;
+- rootfs assembly;
+- artifact copy from the builder.
+
+For Apple Virtualization runtime tests, point the benchmark config at the built kernel and rootfs and use the Apple backend. The builder VM is only involved if the benchmark setup step chooses to rebuild the image first.
+
+## Failure Modes
+
+If `mvmctl build` fails, check the phase named in the error:
+
+| Symptom | Likely phase | What to inspect |
+|---|---|---|
+| Builder image missing or invalid | Builder bootstrap | `mvmctl doctor`, cache directory, builder image manifest. |
+| Flake attribute not found | Nix evaluation | `flake.nix`, selected `--profile`, `packages.<system>.<profile>`. |
+| Package fetch or hash mismatch | Nix build | The failing derivation output and fixed-output hash. |
+| Artifact metadata missing | Artifact extraction | Builder result JSON, kernel/rootfs output paths. |
+| Runtime boot timeout | Runtime backend | Backend logs, kernel command line, guest init, guest agent readiness. |
+
+The important debugging rule is to keep build failures and boot failures separate. A Nix failure is not a runtime boot regression, and a runtime timeout is not usually a builder VM problem if the image already exists.

--- a/public/src/content/docs/guides/building-microvm-images.md
+++ b/public/src/content/docs/guides/building-microvm-images.md
@@ -51,13 +51,22 @@ mvmctl build              # reads mvm.toml; builds the named flake target
 mvmctl run                # builds (if needed) + boots
 ```
 
-`mvmctl` selects the backend automatically (Firecracker on Linux+KVM, libkrun on macOS / Linux without KVM). Override with `--hypervisor libkrun` if you want to force the cross-platform path.
+`mvmctl build` is a host command. You run it from macOS or Linux, and mvm sends the Linux-only Nix work into the builder VM. You do not need to enter `mvmctl dev shell` first. The shell is for debugging the build environment manually, not a prerequisite for normal builds.
+
+`mvmctl` selects the runtime backend automatically when you boot the finished image. Use `--hypervisor` on runtime commands when you want to force a specific runtime backend:
+
+```sh
+mvmctl up --flake . --hypervisor apple-container
+mvmctl up --flake . --hypervisor firecracker
+```
 
 If you want to drive `nix build` directly without `mvmctl` in the loop:
 
 ```sh
 nix build .#default
 ```
+
+That direct Nix command is only for users who intentionally manage their own Nix environment. It bypasses mvm's builder VM orchestration and is not required for the normal workflow. See [Builder VM](/guides/builder-vm/) for the detailed build boundary.
 
 ## What `mkGuest` accepts
 
@@ -184,10 +193,10 @@ nix flake check --no-build
 
 ## Cross-platform notes
 
-mvm bootstraps a Linux builder microVM on first build (libkrun-backed; see [ADR-013 §"Linux builder via libkrun"](/contributing/adr/013-libkrun-pivot/)) and runs `nix build` inside it. You don't need host-side Nix.
+mvm runs Nix builds inside the project builder VM and copies the finished kernel/rootfs artifacts back to the host cache. You don't need host-side Nix, and you don't need to enter a dev shell before building.
 
-- **Linux**: the builder microVM runs on Firecracker against `/dev/kvm`. Firecracker is also the default runtime backend. If you've opted into host-side Nix and it can build Linux derivations, mvm uses it directly and skips the builder VM.
-- **macOS**: the builder microVM runs on libkrun via Hypervisor.framework. The resulting microVM is then booted on the same backend. If you already have [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary) or a remote `nix-daemon` configured, mvm detects and uses it instead.
+- **Linux**: the builder VM provides the Linux build boundary and cache policy. Firecracker is the default runtime backend when `/dev/kvm` is available.
+- **macOS**: the host `mvmctl build` command orchestrates a Linux builder VM. The resulting runtime image can then boot with Apple Virtualization (`--hypervisor apple-container`) or another available macOS runtime backend.
 - **Windows**: Tauri-only (the `mvm-studio` desktop app packages a WSL2-backed builder + runtime). See [ADR-031](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/031-cross-platform-strategy.md).
 
 ## Rootless workloads

--- a/public/src/content/docs/guides/dev-image.md
+++ b/public/src/content/docs/guides/dev-image.md
@@ -131,10 +131,10 @@ The build path is the same as any mvm image:
 
 ```sh
 # From your project directory:
-nix build .#dev
+mvmctl build --flake . --profile dev
 ```
 
-Output is a derivation with `passthru.mvm.{accessible, sealed, expectedBootMs}`. Check it:
+If you intentionally manage your own Nix environment, you can run `nix build .#dev` directly. The normal mvm path is `mvmctl build`, which runs Nix inside the builder VM. Output is a derivation with `passthru.mvm.{accessible, sealed, expectedBootMs}`. Check it from a Nix-enabled debug environment:
 
 ```sh
 nix eval .#dev.passthru.mvm
@@ -145,9 +145,9 @@ nix eval .#dev.passthru.mvm
 
 ### Cross-platform build notes
 
-mvm bootstraps a Linux builder microVM (libkrun-backed) on first build and runs `nix build` inside it. You don't need Nix on your host. See [ADR-013 §"Linux builder via libkrun"](/contributing/adr/013-libkrun-pivot/).
+mvm runs Nix builds inside the project builder VM and copies the finished artifacts back to the host cache. You don't need Nix on your host, and you don't need to enter a dev shell before building. See [Builder VM](/guides/builder-vm/).
 
-- **Linux** (native host with `/dev/kvm`): the builder VM owns image construction; Firecracker is the default runtime backend.
+- **Linux** (with `/dev/kvm`): the builder VM owns image construction; Firecracker is the default runtime backend.
 - **macOS Apple Silicon**: the host `mvmctl build` command orchestrates the builder VM. The resulting dev image can then boot on the selected macOS runtime backend.
 - **Windows / WSL2**: future work. WSL2 nested KVM and a Hyper-V managed Linux builder are not supported local paths today.
 

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -3,7 +3,9 @@ title: Writing Nix Flakes
 description: Create custom Nix flakes that build microVM images for mvm.
 ---
 
-mvmctl uses Nix flakes to produce reproducible microVM images. Each build runs `nix build` inside the Linux build environment (a libkrun-backed builder VM on macOS, the host shell on Linux with `/dev/kvm`), producing a kernel and rootfs. The same rootfs works on all backends (Firecracker, Apple Container, libkrun).
+mvmctl uses Nix flakes to produce reproducible microVM images. You run `mvmctl build` from the host, and mvm runs Nix evaluation and `nix build` inside the Linux builder VM. The result is a kernel and rootfs that can boot on any supported runtime backend, including Firecracker, Apple Virtualization, and libkrun.
+
+You do not need to enter a dev shell to build a flake. The dev shell is only for manually debugging the Linux build environment. See [Builder VM](/guides/builder-vm/) for the full host-vs-builder model.
 
 ## Minimal Flake
 
@@ -258,11 +260,11 @@ All three helpers return the same shape: `{ package, service, healthCheck }`. Th
 
 When you run `mvmctl build --flake .`:
 
-1. The flake is copied into the Linux build environment (builder VM on macOS, native on Linux with `/dev/kvm`)
-2. `nix build` runs inside that environment
-3. The resulting closure is packed into the rootfs
-4. Kernel and rootfs artifacts are cached
-5. Subsequent builds with unchanged `flake.lock` reuse the cache
+1. The host CLI reads config and stages the selected flake/profile as a builder job.
+2. The builder VM runs Nix evaluation and `nix build` in Linux.
+3. The resulting closure is packed into the rootfs.
+4. Kernel and rootfs artifacts are copied back to the host cache.
+5. Runtime commands boot those already-built artifacts on the selected backend.
 
 The same rootfs works on all backends (Firecracker, Apple Container, microvm.nix, Docker).
 

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -3,9 +3,9 @@ title: Troubleshooting
 description: Common issues and their solutions.
 ---
 
-## Dev VM Issues
+## Builder VM and Dev Shell Issues
 
-The dev VM is the Linux environment mvmctl runs Nix builds in. On macOS Apple Silicon it uses Apple Container or libkrun via `Hypervisor.framework`; on Linux with `/dev/kvm` the host shell *is* the dev environment and no VM hop exists. macOS Intel, native Windows, and WSL2 are not supported local dev hosts today.
+The builder VM is the Linux environment mvmctl uses for Nix evaluation and image builds. You normally do not enter it yourself: `mvmctl build --flake .` is a host command that stages work for the builder VM and copies artifacts back to the host cache. `mvmctl dev shell` is only for manual debugging. See [Builder VM](/guides/builder-vm/) for the full model.
 
 ### "Dev VM is not running"
 
@@ -69,12 +69,12 @@ mvmctl up --manifest <template> --name <name>
 ### Nix build fails
 
 ```bash
-# Test the flake locally first
+# Re-run the normal host-orchestrated build.
+mvmctl build --flake .
+
+# If you need an interactive Linux debug environment:
 mvmctl dev shell
 nix build .#default
-
-# Check for errors in the flake
-nix flake check
 ```
 
 ### "Cache miss" rebuilds
@@ -105,11 +105,12 @@ error: No space left on device
 
 **Fix**:
 ```bash
-# Run garbage collection
-nix-collect-garbage -d
-
 # Check Nix store size (mvmctl doctor warns if >20 GiB)
 mvmctl doctor
+
+# For manual cleanup inside a debug shell:
+mvmctl dev shell
+nix-collect-garbage -d
 ```
 
 ### Hash mismatch (fixed-output derivation)

--- a/public/src/content/docs/install/linux.md
+++ b/public/src/content/docs/install/linux.md
@@ -18,7 +18,7 @@ You'll need:
   If `/dev/kvm` exists but is `root`-only, add yourself to the `kvm` group: `sudo usermod -aG kvm "$USER"` (re-login required).
 - **Rust 1.85+** if you build `mvmctl` from source.
 
-You **do not need Nix on your host**. mvm bootstraps a small Linux builder microVM on first build, runs `nix build` inside it, and extracts the resulting rootfs back to your host. See [ADR-013 §"Linux builder via libkrun"](/contributing/adr/013-libkrun-pivot/) for the design.
+You **do not need Nix on your host**. You run `mvmctl build` from the host, and mvm runs Nix evaluation and `nix build` through the project builder VM before extracting the resulting rootfs back to your host. See [Builder VM](/guides/builder-vm/) for the design.
 
 ## Install mvmctl
 
@@ -81,7 +81,7 @@ See [Building MicroVM Images](/guides/building-microvm-images) for the user-faci
 
 ## Optional: host-side Nix for power users
 
-mvm doesn't need Nix on the host — the builder microVM handles managed `nix build` invocations. You may still want host-side Nix if you're:
+mvm doesn't need Nix on the host — the builder VM handles mvm image builds. You may still want host-side Nix if you're:
 
 - contributing to mvm itself and want a shared `/nix/store` between your editor's build commands and mvm's,
 - already running a `nix-daemon` for other projects.
@@ -98,7 +98,7 @@ The upstream NixOS installer also works:
 sh <(curl -L https://nixos.org/nix/install) --daemon
 ```
 
-Host-side Nix is for your own commands; `mvmctl build` uses the builder VM path.
+Installing host-side Nix does not change the normal `mvmctl build` contract: the CLI remains the host control plane, and the builder VM remains the image build boundary.
 
 ## Distro-specific notes
 

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -48,11 +48,13 @@ cargo install mvmctl
 
 ## Linux Builds On macOS
 
-macOS Nix can't build Linux derivations natively. mvm routes Linux builds through the project builder VM so the host does not need to build Linux artifacts directly.
+macOS Nix can't build Linux derivations natively, and most Mac users don't have Nix installed at all. mvm handles both cases **without requiring host-side configuration**: on `mvmctl build`, the host CLI stages the selected flake as a builder job, the Linux builder VM runs `nix build`, and mvm copies the resulting kernel/rootfs artifacts back to the host cache. See [Builder VM](/guides/builder-vm/) for the full control-plane flow.
 
-### Optional: Host-Side Nix For Contributors
+The builder VM is separate from the runtime VM. After the build completes, `mvmctl up --hypervisor apple-container` boots the already-built runtime image with Apple Virtualization. The build phase and boot phase can be benchmarked separately.
 
-Most users skip this section. You may want host-side Nix if you're contributing to mvm itself, want a shared `/nix/store` for your editor's build commands, or already run `nix-darwin` for unrelated reasons. This is not part of the `mvmctl` runtime path.
+### Optional: host-side Nix for power users
+
+Most users skip this section. You may want host-side Nix if you're contributing to mvm itself, want Nix for editor tooling, or already run `nix-darwin` for unrelated reasons. Host-side Nix is not required by `mvmctl build`; the builder VM remains the Linux build boundary for mvm images.
 
 [Determinate Nix](https://determinate.systems/posts/determinate-nix-installer) is the easiest path:
 
@@ -60,7 +62,7 @@ Most users skip this section. You may want host-side Nix if you're contributing 
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
 ```
 
-If you configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary), use it for your own host-side commands; mvm's managed build path continues to run inside the project builder VM.
+If you configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary), it can be useful for direct `nix build` commands that you run yourself. It is not required for `mvmctl build`.
 
 ## Verify
 
@@ -78,13 +80,13 @@ mvmctl init
 mvmctl run
 ```
 
-`mvmctl init` scaffolds the project. On first `mvmctl run`, mvm bootstraps the builder microVM if needed, runs `nix build` inside it, and boots the resulting rootfs.
+`mvmctl init` scaffolds the project. On first `mvmctl run`, mvm bootstraps the builder VM if needed, runs `nix build` inside it, and boots the resulting rootfs with the selected macOS runtime backend. Expected runtime cold boot is measured after the image is already built; the first build may also pay a one-time builder-image fetch.
 
 ## Troubleshooting
 
 **"Hypervisor.framework: entitlement missing"** — re-codesign the binary with the entitlement: `codesign --entitlements resources/mvmctl.entitlements -f -s - ~/.local/bin/mvmctl`. The release binary ships pre-signed; this only matters if you've stripped entitlements or built from source without the build script's signing step.
 
-**`nix build` fails with "a 'x86_64-linux' with features … is required"** — the macOS host is trying to build Linux derivations directly. Use the project builder VM path, or configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary) for editor-side workflows.
+**`nix build` fails with "a 'x86_64-linux' with features … is required"** — that is a direct host-side Nix command failing because macOS cannot build Linux derivations by itself. Use `mvmctl build --flake .` so the Linux build runs inside the builder VM. If you intentionally want direct `nix build` on macOS, configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary).
 
 **`mvmctl run` boots but `mvmctl console` fails to attach** — the `console` subcommand is only enabled for *accessible* images. If your `entrypoint.command = [ ... ]`, the build is *sealed* and console attach is rejected. Switch to `entrypoint.shell = "/bin/sh"` or pass `dev = true` in your `mkGuest` call. See [Building MicroVM Images](/guides/building-microvm-images).
 

--- a/public/src/content/docs/install/windows.md
+++ b/public/src/content/docs/install/windows.md
@@ -38,7 +38,7 @@ sh <(curl -L https://nixos.org/nix/install) --daemon
 . /etc/profile.d/nix.sh
 ```
 
-When `mvmctl build` detects a working host-side Nix that can build Linux derivations, it uses it directly and skips the builder microVM.
+Installing host-side Nix is optional. The normal `mvmctl build` path still treats the CLI as the host control plane and the builder VM as the image build boundary. See [Builder VM](/guides/builder-vm/).
 
 ## Alternative: Tier 3 Docker fallback
 

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -21,7 +21,7 @@ macOS:          mvmctl up  -->  libkrun microVM (Hypervisor.framework)
 Docker:         mvmctl up  -->  Docker container (Tier 3 fallback)
 ```
 
-All backends consume the same Nix-built ext4 rootfs. Override auto-detection with `--hypervisor`:
+All backends consume the same Nix-built ext4 rootfs. The rootfs is built through the builder VM first, then booted by the selected runtime backend. Override runtime auto-detection with `--hypervisor`:
 
 ```bash
 mvmctl up --flake . --hypervisor apple-container
@@ -101,8 +101,8 @@ Where Linux commands run. Defined in `mvm-core`:
 - `run_capture()` -- run and capture both stdout and stderr
 
 Implementations:
-- **`BuilderVmEnv`** -- delegates commands into the libkrun/libkrun builder VM (macOS hosts)
-- **`NativeEnv`** -- runs commands directly (Linux with `/dev/kvm`)
+- **`BuilderVmEnv`** -- delegates Linux-only build work into the project builder VM
+- **`NativeEnv`** -- runs Linux commands directly where the host itself is the Linux execution boundary
 
 ### ShellEnvironment
 
@@ -136,7 +136,7 @@ Extends `ShellEnvironment` for fleet orchestration:
 
 ## How It Works
 
-At startup, mvmctl detects the platform and selects the appropriate backend:
+At startup, mvmctl detects the platform and selects the appropriate runtime backend:
 
 1. **Native Linux with `/dev/kvm`** -- uses `FirecrackerBackend` for runtime VM lifecycle
 2. **macOS 26+ Apple Silicon** -- uses `AppleContainerBackend` for dev/runtime VM lifecycle; Nix builds run inside the libkrun-backed builder VM
@@ -154,12 +154,14 @@ Host (macOS Apple Silicon / native Linux KVM)
 
 ## Build Pipeline
 
-`mvmctl build` and `mvmctl template build` invoke `nix build` inside the Linux environment, producing:
+`mvmctl build` and `mvmctl template build` are host commands that stage a build job for the builder VM. The builder VM invokes `nix build` inside Linux, producing:
 
 - **vmlinux** -- Firecracker-compatible kernel
 - **rootfs.ext4** or **rootfs.squashfs** -- guest root filesystem
 
 No initrd is needed -- the kernel boots directly into a busybox init script on the rootfs.
+
+The builder VM is not the runtime VM. Runtime commands such as `mvmctl up`, `mvmctl run`, and boot benchmarks consume the finished artifacts from the host cache. See [Builder VM](/guides/builder-vm/) for the detailed control-plane flow.
 
 ## Platform Support
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -375,20 +375,18 @@ output (see [Building MicroVM Images](/guides/building-microvm-images)).
 
 Build resolution order on first use:
 
-1. **Builder microVM (default).** mvm bootstraps a small Linux builder
-   microVM (libkrun-backed, see
-   [ADR-013 §"Linux builder via libkrun"](/contributing/adr/013-libkrun-pivot/)),
-   runs `nix build` inside it, and extracts the rootfs. No host-side
-   Nix required.
-2. **Host-side Nix (auto-detected).** If the host already has a working
-   Nix that can build Linux derivations (Linux Nix, or `nix-darwin`'s
-   `linux-builder`, or a remote `nix-daemon` URL), mvm uses it directly
-   and skips the builder microVM.
-3. **Prebuilt artifacts (offline).** If neither is available — for
-   example, a fully-offline host without the builder image cached — mvm
-   downloads the prebuilt `default-microvm` artifacts from the GitHub
-   release matching the `mvmctl` version, hash-verified per the
-   `*-checksums-sha256.txt` manifest (security claim 6).
+1. **Builder VM.** mvm bootstraps or reuses the project Linux builder VM,
+   runs Nix evaluation and `nix build` inside it, and extracts the rootfs.
+   No host-side Nix is required, and you do not need to enter
+   `mvmctl dev shell` first.
+2. **Prebuilt artifacts (offline).** If the host is fully offline and the
+   builder image is not available, mvm can use the prebuilt
+   `default-microvm` artifacts from the GitHub release matching the
+   `mvmctl` version, hash-verified per the `*-checksums-sha256.txt`
+   manifest (security claim 6).
+
+See [Builder VM](/guides/builder-vm/) for the host-orchestrated build
+flow and the distinction between build time and runtime boot time.
 
 ## Cache
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -46,6 +46,8 @@ Recent maintenance:
 - [x] Clarified the local platform policy after the cleanup: supported builder/runtime hosts are macOS Apple Silicon and native Linux with `/dev/kvm`; macOS Intel and native Windows are unsupported, while WSL2 nested KVM and a Hyper-V managed Linux builder remain future backend work.
 - [x] Added ADR-048 and Plan 74 to turn the Microsandbox comparison into claim-gated `mvm` runtime work: docs hygiene, OCI ingest, programmable networking, secret placeholders, SDK-owned lifecycle, measured cold-starts, and filesystem backend contracts.
 - [ ] Plan 74 W0 (claims hygiene and docs guardrails) in flight — new public Sandbox parity status page (`security/sandbox-parity-status.md`), `cargo xtask check-doc-claims` lint covering `<100ms` / `any OCI image` / `secrets cannot leak` / variants, `mvmforge` cleanup in `guides/exec.md` and `reference/cli-commands.md`, gap-analysis updated for current `crates/mvm-sdk` layout and mvmd ADR-0020 handoff, and a new `specs/plans/74-w1-w6-attack-plan.md` sequencing sidecar that defers risk discussion to plan 74's `## Risks` section (R1-R12).
+- [x] Added intent-bound admission profiles to signed `ExecutionPlan` v4, binding intent, seccomp tier, policy refs, secret-release posture, and audit taxonomy without adding new sandbox execution capability.
+- [x] Documented the host-orchestrated builder VM flow across the website docs, clarifying that `mvmctl build` runs from the host while Nix evaluation/builds execute inside the builder VM and runtime boot benchmarks consume already-built artifacts.
 
 ## In-flight workstreams
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -48,6 +48,7 @@ Recent maintenance:
 - [ ] Plan 74 W0 (claims hygiene and docs guardrails) in flight — new public Sandbox parity status page (`security/sandbox-parity-status.md`), `cargo xtask check-doc-claims` lint covering `<100ms` / `any OCI image` / `secrets cannot leak` / variants, `mvmforge` cleanup in `guides/exec.md` and `reference/cli-commands.md`, gap-analysis updated for current `crates/mvm-sdk` layout and mvmd ADR-0020 handoff, and a new `specs/plans/74-w1-w6-attack-plan.md` sequencing sidecar that defers risk discussion to plan 74's `## Risks` section (R1-R12).
 - [x] Added intent-bound admission profiles to signed `ExecutionPlan` v4, binding intent, seccomp tier, policy refs, secret-release posture, and audit taxonomy without adding new sandbox execution capability.
 - [x] Documented the host-orchestrated builder VM flow across the website docs, clarifying that `mvmctl build` runs from the host while Nix evaluation/builds execute inside the builder VM and runtime boot benchmarks consume already-built artifacts.
+- [x] Aligned `dev_build` with the builder VM invariant by removing the host-Nix dispatch probe from the normal path; Nix builds now route through the libkrun builder VM when builder-VM support is compiled in.
 
 ## In-flight workstreams
 


### PR DESCRIPTION
## Summary

Updates the website docs to describe the host-orchestrated builder VM
flow that mvm uses today: `mvmctl build` runs on the host while Nix
evaluation and `nix build` execute inside the Linux builder VM, with
artifacts copied back to the host cache.

This is a docs-only PR — the underlying code already landed via the
Plan 72 W2–W5 stack and Plan 74 W1 OCI pipeline. The original
`feat/docs-builder-vm-flow` branch had a companion code commit
("Route dev builds through builder VM") whose substance is now upstream;
the remaining artifact of that commit is a 3-line gitignore + SPRINT.md
chore (commit 2 in this PR).

## Changes

**Commit 1 — Document builder VM build flow** (rebased onto current main)
- New `guides/builder-vm.md` (+176 lines)
- Refreshed `install/macos.md`, `install/linux.md`, `getting-started/installation.md`, `guides/building-microvm-images.md`, `guides/dev-image.md`, `guides/nix-flakes.md`, `guides/troubleshooting.md`, `reference/architecture.md`, `reference/cli-commands.md`
- ADR-013 (`013-libkrun-pivot.md`) wording: drops the host-Nix detection-and-fallback language to match the current "host Nix never used by mvmctl" invariant in CLAUDE.md
- SPRINT.md history entries

**Commit 2 — chore: ignore .worktrees + graphify-out scratch dirs**
- `.gitignore` adds `.worktrees/` and `graphify-out/`
- SPRINT.md history entry

## Resolution notes

This branch was rebased over ~30 commits that landed during today's
session. The original "Route dev builds through builder VM" code
commit was reduced to a chore because every feature-flag rename,
`dev_build.rs` rewrite, and `apple_container.rs` dispatch change it
introduced has already shipped on main under newer names
(`backends-builder-vm-libkrun` instead of `builder-vm`,
`builder_env_has_nix` runtime probe instead of `#[cfg(...)]`).

## Test plan

- [x] No code changes; docs render with `pnpm dev` in `public/`
- [ ] Spot-check the rendered `guides/builder-vm.md` page
- [ ] Verify cross-links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)