### PR TITLE
Route dev builds through builder VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ nix/images/dev-prebuilt/
 # Worktree-local dev env (use .envrc.example as template)
 /.envrc
 /.mvm-test/
+.worktrees/
+graphify-out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,16 @@
 
 ## Project Overview
 
-Rust CLI for building and running Firecracker microVMs on macOS (via Lima) and Linux. Handles the full dev lifecycle: bootstrapping, Nix-based image builds, single-VM management, and reusable template creation.
+Rust CLI for building and running Firecracker microVMs on macOS and Linux. Handles the full dev lifecycle: bootstrapping, Nix-based image builds, single-VM management, and reusable template creation.
 
 Multi-tenant fleet orchestration (tenants, pools, instances, agents, coordinators) lives in the separate [mvmd](https://github.com/tinylabscom/mvmd) repository.
 
 ```
-macOS / Linux Host (this CLI) -> Lima VM (Ubuntu) -> Firecracker microVM (/dev/kvm)
+macOS Host (this CLI) -> libkrun Linux VM -> Firecracker microVM (/dev/kvm)
+Linux Host (this CLI) -> Firecracker microVM (/dev/kvm)
 ```
+
+Lima was the historical macOS host abstraction. It was removed on 2026-05-14 (Plan 72 W0–W6 + Plan 75 W0). libkrun is the default macOS backend; Apple Container is the macOS 26+ Apple Silicon backend; Firecracker is the Linux KVM path. There is no `--lima` flag and no Lima fallback.
 
 ## Architecture
 
@@ -19,7 +22,7 @@ macOS / Linux Host (this CLI) -> Lima VM (Ubuntu) -> Firecracker microVM (/dev/k
 - `mvm-core` -- pure types, IDs, config, protocol, signing, routing (NO runtime deps)
 - `mvm-guest` -- vsock protocol, integration manifest/state (OpenClaw)
 - `mvm-build` -- Nix builder pipeline (dev_build uses `ShellEnvironment` trait, pool_build uses `BuildEnvironment`)
-- `mvm` -- shell execution, Lima/Firecracker VM lifecycle, UI, template management
+- `mvm` -- shell execution, builder-VM / Firecracker VM lifecycle, UI, template management
 - `mvm-cli` -- Clap CLI, bootstrap, update, doctor, template commands
 
 Root package: `src/lib.rs` (facade re-exports `mvmctl::core`, `mvmctl::runtime`, `mvmctl::build`, `mvmctl::guest`) + `src/main.rs` (thin CLI entry -> `mvm_cli::run()`)
@@ -39,7 +42,7 @@ mvm-core (foundation, no mvm deps)
 
 mvm-core: `build_env.rs` (ShellEnvironment + BuildEnvironment traits), `pool.rs`, `instance.rs`, `tenant.rs`, `template.rs`, `naming.rs`, `signing.rs`, `routing.rs`, `protocol.rs`, `agent.rs`, `catalog.rs` (image catalog), `dev_network.rs` (named networks), `config.rs` (XDG directory functions)
 
-mvm: `shell.rs`, `config.rs`, `ui.rs`, `build_env.rs` (DevShellEnv impl), `vm/lima.rs`, `vm/firecracker.rs`, `vm/microvm.rs`, `vm/network.rs`, `vm/image.rs`, `vm/template/`
+mvm: `shell.rs`, `config.rs`, `ui.rs`, `build_env.rs` (DevShellEnv impl), `vm/microvm.rs`, `vm/bridge.rs`, `vm/overlay.rs`, `vm/instance/`, `vm/template/`. Hypervisor backends live in `mvm-backend/` (`libkrun.rs`, `firecracker.rs`, `apple_container.rs`, `docker.rs`) and `mvm-libkrun/`.
 
 mvm-build: `dev_build.rs` (local Nix builds via ShellEnvironment), `build.rs` (orchestrated builds via BuildEnvironment), `nix_manifest.rs`, `scripts.rs`
 
@@ -69,14 +72,14 @@ The `RuntimeBuildEnv` in mvm implements only `ShellEnvironment`. The full `Build
 
 ### Key Design Decisions
 
-- **Firecracker-only**: no Docker/containers. Builds run Nix inside the Lima VM.
-- **No SSH in microVMs, ever**: microVMs are headless workloads. No sshd, no SSH keys, no SSH users in any rootfs. Guest communication uses Firecracker vsock only. The dev environment is the Lima VM (`mvmctl dev` / `mvmctl dev shell`), not the microVM. See **Security model** below for the full posture.
-- **Dev mode**: `mvmctl dev` (or `mvmctl dev up`) auto-bootstraps then drops into a dev shell. On macOS 26+ Apple Silicon: boots an Apple Container with Nix + build tools via PTY-over-vsock console. On macOS <26 or Linux without KVM: uses Lima VM. Use `--lima` to force Lima fallback. `mvmctl dev down` stops it. `mvmctl dev shell` opens a shell. `mvmctl dev status` shows environment info. It does NOT start or SSH into a Firecracker microVM.
+- **Firecracker-only on Linux; libkrun/Apple Container on macOS**: no Docker/containers on the runtime path. Builds run Nix inside the builder VM (libkrun on macOS, Firecracker on Linux KVM).
+- **No SSH in microVMs, ever**: microVMs are headless workloads. No sshd, no SSH keys, no SSH users in any rootfs. Guest communication uses Firecracker vsock only. The dev environment is the builder VM (`mvmctl dev` / `mvmctl dev shell`), not the microVM. See **Security model** below for the full posture.
+- **Dev mode**: `mvmctl dev` (or `mvmctl dev up`) auto-bootstraps then drops into a dev shell. On macOS 26+ Apple Silicon: boots an Apple Container with Nix + build tools via PTY-over-vsock console. On other macOS: libkrun builder VM. On Linux with KVM: Firecracker directly. `mvmctl dev down` stops it. `mvmctl dev shell` opens a shell. `mvmctl dev status` shows environment info. It does NOT start or SSH into a Firecracker microVM.
 - **Headless microVMs**: `mvmctl start` and `mvmctl run` boot Firecracker as a daemon. Interactive access via `mvmctl console` (PTY-over-vsock, dev-mode only).
 - **Dev mode isolation**: `mvmctl start/stop/dev` use a completely separate code path from orchestration.
-- **Shell scripts inside run_in_vm**: complex ops are bash scripts passed to `limactl shell`. Deliberate -- they run inside the Linux VM.
+- **Shell scripts inside run_in_vm**: complex ops are bash scripts handed to the active `LinuxEnv` backend (libkrun / Apple Container / Firecracker). Deliberate — they run inside the Linux VM, not on the macOS/Linux host.
 - **Idempotent setup**: every step checks if already done before acting.
-- **Templates use dev_build path**: `mvmctl template build` runs `nix build` locally in the Lima VM (no ephemeral FC builder VMs).
+- **Templates use dev_build path**: `mvmctl template build` runs `nix build` locally inside the builder VM (no ephemeral FC builder VMs).
 - **mvm-core stays whole**: orchestration types (tenant, pool, instance, agent, protocol) remain in mvm-core even though they're only used by mvmd. This avoids a third shared-types crate and keeps the facade dependency simple.
 - **No `clippy::too_many_arguments`**: never suppress this lint. Refactor into smaller functions or a config/params struct.
 - **Source-checkout builds never depend on mvm-published artifacts**: when `mvmctl` is run from a source checkout of this repo (anywhere `find_dev_image_flake()` / `find_builder_vm_flake()` returns `Some`), every VM image is built locally from the in-repo flakes — both the builder VM image (`nix/images/builder-vm/`) and the user-facing image (`nix/images/dev-shell/`, user `--flake`, etc.). The mvm-published prebuilts on GitHub releases are end-user infrastructure only; they are never a prerequisite for any source-checkout workflow. A contributor modifying `nix/images/builder-vm/flake.nix` must see their change in the very next `mvmctl dev up` with no release-pipeline round-trip. See ADR-046 §"Two artifact layers, two acquisition paths" for the resolution rule and ADR-046 §"Why the contributor path doesn't download" for the rationale.
@@ -206,10 +209,10 @@ cargo build
 cargo run -- --help
 
 # Dev mode
-cargo run -- dev         # auto-bootstrap + drop into Lima shell (alias for dev up)
+cargo run -- dev         # auto-bootstrap + drop into builder-VM shell (alias for dev up)
 cargo run -- dev up      # same as above, explicit
-cargo run -- dev down    # stop the Lima dev VM
-cargo run -- dev shell   # open shell in running Lima VM
+cargo run -- dev down    # stop the builder VM
+cargo run -- dev shell   # open shell in running builder VM
 cargo run -- dev status  # show dev environment status
 
 # Build from Nix flake
@@ -247,8 +250,8 @@ cargo run -- cache prune             # clean stale temp files
 ```
 MicroVM (172.16.0.2, eth0)
     | TAP interface
-Lima VM (172.16.0.1, tap0) -- iptables NAT -- internet
-    | Lima virtualization
+Builder VM (172.16.0.1, tap0) -- iptables NAT -- internet
+    | libkrun (macOS) / Apple Container (macOS 26+) / direct (Linux KVM)
 macOS / Linux Host
 ```
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,19 +279,25 @@ toml.workspace = true
 which.workspace = true
 
 [features]
-# Plan 72 W5.B cutover: `backends-builder-vm-libkrun` is default so the
-# root `mvmctl` binary can dispatch to the libkrun-backed builder VM in
-# `ensure_dev_image`. The dispatch falls back at runtime via
-# `mvm_libkrun::is_available()` when libkrun isn't installed on the
-# host, so a default-features binary works everywhere. Library consumers
-# (mvmd) that want a lean closure build with `default-features = false`.
-default = ["backends-builder-vm-libkrun"]
+# Plan 72 W5.B cutover: `builder-vm` is default so the root `mvmctl`
+# binary can dispatch to the libkrun-backed builder VM in `ensure_dev_image`.
+# The dispatch falls back at runtime via `mvm_libkrun::is_available()` when
+# libkrun isn't installed on the host, so a default-features binary works
+# everywhere. Library consumers (mvmd) that want a lean closure build with
+# `default-features = false`.
+default = ["builder-vm"]
+contributor-bootstrap = [
+    "mvm/contributor-bootstrap",
+    "mvm-backend/contributor-bootstrap",
+    "mvm-build/contributor-bootstrap",
+    "mvm-cli/contributor-bootstrap",
+]
 # Plan 72 W1: libkrun-backed builder VM. Now default-on (W5.B cutover).
 # Forwards into both `mvm-build` (carries the `LibkrunBuilderVm` impl)
 # and `mvm-cli` (carries the `ensure_dev_image` dispatch swap).
-backends-builder-vm-libkrun = [
-    "mvm-build/backends-builder-vm-libkrun",
-    "mvm-cli/backends-builder-vm-libkrun",
+builder-vm = [
+    "mvm-build/builder-vm",
+    "mvm-cli/builder-vm",
 ]
 custom-dns = ["mvm-cli/custom-dns"]
 dev-watch = ["mvm-cli/dev-watch"]

--- a/crates/mvm-backend/Cargo.toml
+++ b/crates/mvm-backend/Cargo.toml
@@ -60,6 +60,7 @@ mvm-build.workspace = true
 
 [features]
 default = []
+contributor-bootstrap = []
 
 [lints]
 workspace = true

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -32,7 +32,7 @@ anyhow.workspace = true
 chrono.workspace = true
 # Plan 72 W1: optional libkrun FFI dep for the in-tree builder VM
 # launcher (`libkrun_builder::LibkrunBuilderVm`). Gated by
-# `backends-builder-vm-libkrun`; default-off until Plan 72 W5
+# `builder-vm`; default-off until Plan 72 W5
 # cutover flips polarity.
 mvm-libkrun = { workspace = true, optional = true }
 serde.workspace = true
@@ -49,11 +49,11 @@ tempfile.workspace = true
 
 [features]
 default = []
-# Plan 72 W1: libkrun-direct builder VM launcher (default-off
-# scaffolding through W4; default-on after W5 cutover). Pulls
-# the `mvm-libkrun` FFI crate which itself gates the underlying
+# Plan 72 W1: libkrun-direct builder VM launcher. Pulls the
+# `mvm-libkrun` FFI crate which itself gates the underlying
 # `libkrun-sys` bindings.
-backends-builder-vm-libkrun = ["dep:mvm-libkrun"]
+contributor-bootstrap = []
+builder-vm = ["dep:mvm-libkrun"]
 
 [lints]
 workspace = true

--- a/crates/mvm-build/src/app_deps.rs
+++ b/crates/mvm-build/src/app_deps.rs
@@ -284,7 +284,7 @@ pub enum InstallError {
 /// content/SBOM/fetch.log/CVE/result.json.
 ///
 /// Defining this as a trait — rather than wiring `LibkrunBuilderVm`
-/// directly — keeps the `backends-builder-vm-libkrun` feature gate
+/// directly — keeps the `builder-vm` feature gate
 /// pure: `install_app_deps` compiles + tests without dragging
 /// libkrun-sys onto every CI runner.
 pub trait InstallDriver {
@@ -585,7 +585,7 @@ fn json_string_escape(s: &str) -> String {
 /// Monotonic-with-pid scratch ID for the per-invocation
 /// `in-progress/<id>/` dir. Same pattern as
 /// `libkrun_builder::unique_job_id` — duplicated here so this
-/// module stays usable without the `backends-builder-vm-libkrun`
+/// module stays usable without the `builder-vm`
 /// feature gate.
 fn unique_scratch_id() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -8,9 +8,9 @@ pub mod firecracker;
 pub mod template_reuse;
 
 /// Plan 72 W1 — libkrun-backed builder VM (gated by
-/// `backends-builder-vm-libkrun`). Currently scaffolding; the actual
+/// `builder-vm`). Currently scaffolding; the actual
 /// VM launch lands in Plan 72 W2–W4. See module-level docs.
-#[cfg(feature = "backends-builder-vm-libkrun")]
+#[cfg(feature = "builder-vm")]
 pub mod libkrun_builder;
 
 pub mod nix;

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -41,7 +41,7 @@
 //!
 //! ## Feature gate
 //!
-//! Gated behind `backends-builder-vm-libkrun`. Default-off until
+//! Gated behind `builder-vm`. Default-off until
 //! Plan 72 W5.B / W5.C cutover flips `ensure_dev_image` to dispatch
 //! through `LibkrunBuilderVm`. Library consumers that don't need
 //! the libkrun builder build with `default-features = false`.
@@ -249,7 +249,7 @@ impl BuilderVm for LibkrunBuilderVm {
         self.validate_job(job)?;
 
         // 2. Refuse to proceed on a host without libkrun. The
-        //    `backends-builder-vm-libkrun` feature being compiled
+        //    `builder-vm` feature being compiled
         //    in doesn't imply the runtime library is installed.
         if !mvm_libkrun::is_available() {
             return Err(BuilderVmError::LibkrunUnavailable(format!(
@@ -297,6 +297,12 @@ impl BuilderVm for LibkrunBuilderVm {
             ))
         })?;
 
+        // Route the guest's serial console to a per-VM log file so
+        // failures of the in-VM cmd.sh / mvm-builder-init produce a
+        // readable transcript. Without this, libkrun discards the
+        // hvc0 output silently and "supervisor running, then exits 1"
+        // is the only observable signal.
+        let console_log = vm_state_dir.join("console.log");
         let krun = KrunContext::new(
             &vm_name,
             path_to_str(&image.kernel_path, "kernel_path")?,
@@ -304,6 +310,7 @@ impl BuilderVm for LibkrunBuilderVm {
         )
         .with_resources(self.vcpus, self.memory_mib)
         .with_cmdline(&image.cmdline)
+        .with_console_output(path_to_str(&console_log, "console_log")?)
         .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
         .add_disk(
             "nix-store",
@@ -567,8 +574,32 @@ set -eu
 FLAKE_REF='{flake_ref}'
 ATTR_PATH='{attr_path}'
 
+# Point HOME and Nix's cache/state dirs at the writable tmpfs (`/tmp`).
+# The rootfs is mounted `ro`, so nix tries `~/.cache/nix` and bails
+# with "creating directory '//.cache/nix': Read-only file system"
+# when HOME stays at the default `/`. /tmp is tmpfs, lives only for
+# this VM's lifetime — fine for a single-shot build.
+export HOME=/tmp
+export XDG_CACHE_HOME=/tmp/.cache
+export XDG_STATE_HOME=/tmp/.local/state
+mkdir -p /tmp/.cache /tmp/.local/state
+
+# CA certs for TLS to cache.nixos.org / api.github.com.
+export CURL_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
+export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+
 cd /work
-export NIX_CONFIG="experimental-features = nix-command flakes"
+# `experimental-features` enables nix-command + flakes. `sandbox =
+# false` + `build-users-group =` is mandatory inside the builder
+# VM: there are no `nixbld*` accounts in the rootfs and no kernel
+# user-ns isolation for build sandboxes, so every derivation would
+# otherwise fail with "the group 'nixbld' specified in
+# 'build-users-group' does not exist". The builder VM IS the
+# isolation boundary, so an in-guest sandbox is redundant.
+export NIX_CONFIG="experimental-features = nix-command flakes
+sandbox = false
+build-users-group ="
 # Plan 72 W0's flake convention: workspace-path env var so
 # flakes that reference the workspace root don't depend on
 # relative-path resolution against the store-copied flake dir.

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -40,6 +40,7 @@ use super::BuildMode;
 ///      production agent, surfacing the misconfiguration explicitly
 ///      rather than silently producing a non-functional `mvmctl exec`
 ///      image.
+#[cfg(test)]
 fn dev_override_flags(env: &dyn ShellEnvironment, mode: BuildMode) -> String {
     if !mode.injects_dev_override() {
         // Prod-shape build: produce sealed images with the prod
@@ -92,6 +93,7 @@ fn dev_builds_dir() -> String {
 /// because the data dir is the only path the dev VM and the host
 /// agree on (via the `datadir` VirtioFS share mounted at the same
 /// absolute path in both).
+#[cfg(test)]
 fn gc_sentinel_path() -> String {
     format!(
         "{}/dev/nix-store-needs-gc",
@@ -105,6 +107,7 @@ fn gc_sentinel_path() -> String {
 /// regardless of whether GC succeeded — leaving it in place would
 /// make every subsequent build re-trigger the GC, defeating the
 /// purpose of the threshold check.
+#[cfg(test)]
 fn run_gc_if_requested(env: &dyn ShellEnvironment) {
     let sentinel = gc_sentinel_path();
     let quoted = shell_quote(&sentinel);
@@ -306,9 +309,30 @@ pub fn dev_build(
         });
     }
 
-    // If the builder environment has `nix` on PATH, run the build
-    // there. mvmctl dev builds do not fall back to host Nix; missing
-    // nix here means the builder VM/image path is broken.
+    #[cfg(feature = "builder-vm")]
+    {
+        env.log_info("Building via the Linux builder VM; host-side Nix is not used.");
+        dev_build_via_builder_vm(env, flake_ref, profile, mode)
+    }
+
+    #[cfg(not(feature = "builder-vm"))]
+    {
+        let _ = (env, flake_ref, profile, mode);
+        anyhow::bail!(
+            "Builder VM support was compiled out (feature `builder-vm` disabled). \
+             Use the default mvmctl build or rebuild with `--features builder-vm` \
+             so Nix evaluation and image builds can run inside the project builder VM."
+        );
+    }
+}
+
+#[cfg(test)]
+fn dev_build_via_shell_env(
+    env: &dyn ShellEnvironment,
+    flake_ref: &str,
+    profile: Option<&str>,
+    mode: BuildMode,
+) -> Result<DevBuildResult> {
     if !builder_env_has_nix(env) {
         let _ = (env, flake_ref, profile, mode);
         anyhow::bail!(
@@ -447,12 +471,107 @@ pub fn dev_build(
     })
 }
 
+/// Build path that always runs Nix inside the project builder VM.
+#[cfg(feature = "builder-vm")]
+fn dev_build_via_builder_vm(
+    env: &dyn ShellEnvironment,
+    flake_ref: &str,
+    profile: Option<&str>,
+    mode: BuildMode,
+) -> Result<DevBuildResult> {
+    use crate::builder_vm::{BuilderJob, BuilderMounts, BuilderVm, host_system_linux};
+    use crate::libkrun_builder::{GUEST_WORK_DIR, LibkrunBuilderVm};
+
+    let system = host_system_linux();
+    let attr_path = match profile {
+        Some(p) if p != "default" => format!("packages.{system}.tenant-{p}"),
+        _ => format!("packages.{system}.default"),
+    };
+    let _ = mode;
+
+    let flake_src = std::path::PathBuf::from(if flake_ref == "." {
+        std::env::current_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| ".".to_string())
+    } else {
+        flake_ref.to_string()
+    });
+
+    let job = BuilderJob::Flake {
+        flake_ref: GUEST_WORK_DIR.to_string(),
+        attr_path,
+    };
+    let staging = format!("{}/.staging-{}", dev_builds_dir(), std::process::id());
+    std::fs::create_dir_all(&staging).with_context(|| format!("creating staging dir {staging}"))?;
+
+    let mounts = BuilderMounts {
+        flake_src,
+        host_nix_store: None,
+        artifact_out: std::path::PathBuf::from(&staging),
+    };
+
+    let artifacts = LibkrunBuilderVm::default()
+        .run_build(&job, &mounts)
+        .map_err(|e| anyhow::anyhow!("builder VM: {e}"))?;
+    let revision_hash = match artifacts {
+        crate::builder_vm::BuilderArtifacts::Image { revision_hash, .. } => revision_hash,
+        crate::builder_vm::BuilderArtifacts::InstallVolume { .. } => {
+            anyhow::bail!("builder VM returned install-volume artifacts for a flake build");
+        }
+    };
+
+    let final_dir = dev_build_dir(&revision_hash);
+    if std::path::Path::new(&final_dir).exists() {
+        env.log_info(&format!(
+            "Cache hit on rev {revision_hash}; discarding staged build."
+        ));
+        let _ = std::fs::remove_dir_all(&staging);
+    } else if let Err(e) = std::fs::rename(&staging, &final_dir) {
+        std::fs::create_dir_all(&final_dir)
+            .with_context(|| format!("creating final build dir {final_dir}"))?;
+        for entry in
+            std::fs::read_dir(&staging).with_context(|| format!("reading staging dir {staging}"))?
+        {
+            let entry = entry?;
+            let dst = std::path::Path::new(&final_dir).join(entry.file_name());
+            std::fs::copy(entry.path(), &dst).with_context(|| {
+                format!("copying {} -> {}", entry.path().display(), dst.display())
+            })?;
+        }
+        let _ = std::fs::remove_dir_all(&staging);
+        tracing::debug!(error = %e, "rename failed; fell back to copy");
+    }
+
+    let build_dir = final_dir;
+    let vmlinux_path = format!("{build_dir}/vmlinux");
+    let rootfs_path = format!("{build_dir}/rootfs.ext4");
+    let initrd_path = detect_initrd(env, &build_dir);
+    let runner_dir = detect_runner(env, &build_dir);
+    let artifact_sizes = measure_artifact_sizes(env, &build_dir, initrd_path.is_some());
+
+    env.log_success(&format!(
+        "Builder VM build complete; artifacts at {build_dir}"
+    ));
+
+    Ok(DevBuildResult {
+        build_dir,
+        vmlinux_path,
+        initrd_path,
+        rootfs_path,
+        revision_hash,
+        cached: false,
+        runner_dir,
+        artifact_sizes,
+    })
+}
+
 /// Run the flake's `pre-build.sh` hook if it exists.
 ///
 /// Some templates install external software (e.g. via an upstream installer
 /// script) before the Nix build. If `<flake_ref>/pre-build.sh` exists and
 /// is executable, it is run with visible output. Returns `" --impure"` when
 /// the hook ran (so `nix build` can reference host paths), or `""` otherwise.
+#[cfg(test)]
 fn run_pre_build_hook(env: &dyn ShellEnvironment, flake_ref: &str) -> Result<&'static str> {
     let pre_build = format!("{}/pre-build.sh", flake_ref);
     let check = env
@@ -481,6 +600,7 @@ fn run_pre_build_hook(env: &dyn ShellEnvironment, flake_ref: &str) -> Result<&'s
 ///
 /// - `None` → builds the flake's `default` package (convention: `default = worker`).
 /// - `Some(profile)` → builds `packages.<system>.tenant-<profile>`.
+#[cfg(test)]
 fn resolve_dev_build_attribute(
     env: &dyn ShellEnvironment,
     flake_ref: &str,
@@ -505,6 +625,7 @@ fn resolve_dev_build_attribute(
 }
 
 /// Extract the Nix store hash from an output path like `/nix/store/<hash>-name`.
+#[cfg(test)]
 fn extract_revision_hash(nix_output_path: &str) -> String {
     nix_output_path
         .strip_prefix("/nix/store/")
@@ -514,15 +635,18 @@ fn extract_revision_hash(nix_output_path: &str) -> String {
 }
 
 /// Return the dev build directory for a given revision hash.
+#[cfg(any(test, feature = "builder-vm"))]
 fn dev_build_dir(revision_hash: &str) -> String {
     format!("{}/{}", dev_builds_dir(), revision_hash)
 }
 
+#[cfg(test)]
 fn shell_quote(input: &str) -> String {
     format!("'{}'", input.replace('\'', "'\\''"))
 }
 
 /// True if `nix` is available inside the builder shell environment.
+#[cfg(test)]
 fn builder_env_has_nix(env: &dyn ShellEnvironment) -> bool {
     env.shell_exec_stdout("nix --version 2>/dev/null | head -1")
         .map(|s| s.trim().starts_with("nix "))
@@ -530,6 +654,7 @@ fn builder_env_has_nix(env: &dyn ShellEnvironment) -> bool {
 }
 
 /// Check whether cached artifacts exist for a revision hash.
+#[cfg(test)]
 fn check_cache(env: &dyn ShellEnvironment, revision_hash: &str) -> Result<bool> {
     let build_dir = dev_build_dir(revision_hash);
     let result = env.shell_exec_stdout(&format!(
@@ -540,6 +665,7 @@ fn check_cache(env: &dyn ShellEnvironment, revision_hash: &str) -> Result<bool> 
 }
 
 /// Copy kernel, initrd, and rootfs from a Nix store output to the dev build directory.
+#[cfg(test)]
 fn copy_dev_artifacts(
     env: &dyn ShellEnvironment,
     nix_output_path: &str,
@@ -599,6 +725,7 @@ fn copy_dev_artifacts(
 }
 
 /// Measure artifact file sizes in the build directory using `stat -c%s`.
+#[cfg(any(test, feature = "builder-vm"))]
 fn measure_artifact_sizes(
     env: &dyn ShellEnvironment,
     build_dir: &str,
@@ -628,6 +755,7 @@ fn measure_artifact_sizes(
 }
 
 /// Check whether an initrd exists in the build directory.
+#[cfg(any(test, feature = "builder-vm"))]
 fn detect_initrd(env: &dyn ShellEnvironment, build_dir: &str) -> Option<String> {
     let path = format!("{}/initrd", build_dir);
     let result = env
@@ -645,6 +773,7 @@ fn detect_initrd(env: &dyn ShellEnvironment, build_dir: &str) -> Option<String> 
 /// The root flake's `mkGuest` copies the runner to `$out/bin/microvm-run`
 /// when the microvm.nix runner is available. If found, returns the runner
 /// directory path (parent of `bin/`).
+#[cfg(any(test, feature = "builder-vm"))]
 fn detect_runner(env: &dyn ShellEnvironment, build_dir: &str) -> Option<String> {
     let runner_path = format!("{}/bin/microvm-run", build_dir);
     let result = env
@@ -1074,6 +1203,7 @@ mod tests {
     #[test]
     fn test_dev_build_cached() {
         let env = TestEnv::new();
+        env.stub_stdout("nix --version", "nix (Nix) 2.24.10");
 
         // nix build --no-link (visible) succeeds
         // nix build --print-out-paths returns the path
@@ -1085,7 +1215,8 @@ mod tests {
         env.stub_stdout("test -f", "yes");
 
         let result =
-            dev_build(&env, "/home/user/project", Some("minimal"), BuildMode::Dev).unwrap();
+            dev_build_via_shell_env(&env, "/home/user/project", Some("minimal"), BuildMode::Dev)
+                .unwrap();
 
         assert!(result.cached);
         assert_eq!(result.revision_hash, "abc123");
@@ -1098,12 +1229,14 @@ mod tests {
     #[test]
     fn test_dev_build_fresh() {
         let env = TestEnv::new();
+        env.stub_stdout("nix --version", "nix (Nix) 2.24.10");
 
         env.stub_stdout("--print-out-paths", "/nix/store/xyz789-tenant-minimal\n");
         // Cache miss
         env.stub_stdout("test -f", "no");
 
-        let result = dev_build(&env, "/tmp/flake", Some("minimal"), BuildMode::Dev).unwrap();
+        let result =
+            dev_build_via_shell_env(&env, "/tmp/flake", Some("minimal"), BuildMode::Dev).unwrap();
 
         assert!(!result.cached);
         assert_eq!(result.revision_hash, "xyz789");
@@ -1186,13 +1319,15 @@ mod tests {
     #[test]
     fn test_dev_build_with_pre_build_hook() {
         let env = TestEnv::new();
+        env.stub_stdout("nix --version", "nix (Nix) 2.24.10");
 
         // Pre-build hook exists.
         env.stub_stdout("test -f", "yes");
         // nix build output.
         env.stub_stdout("--print-out-paths", "/nix/store/abc123-tenant-minimal\n");
 
-        let result = dev_build(&env, "/tmp/flake", Some("minimal"), BuildMode::Dev).unwrap();
+        let result =
+            dev_build_via_shell_env(&env, "/tmp/flake", Some("minimal"), BuildMode::Dev).unwrap();
 
         // Verify --impure was added to nix build commands.
         let exec_log = env.exec_log.lock().unwrap();
@@ -1254,7 +1389,7 @@ mod tests {
     fn dev_build_bails_clearly_when_nix_missing() {
         let env = TestEnv::new();
         env.stub_stdout("nix --version", "");
-        let result = dev_build(
+        let result = dev_build_via_shell_env(
             &env,
             "/definitely/not/a/real/flake/dir",
             Some("minimal"),
@@ -1271,13 +1406,15 @@ mod tests {
     #[test]
     fn test_dev_build_includes_artifact_sizes() {
         let env = TestEnv::new();
+        env.stub_stdout("nix --version", "nix (Nix) 2.24.10");
 
         env.stub_stdout("--print-out-paths", "/nix/store/xyz789-tenant-minimal\n");
         env.stub_stdout("test -f", "no");
         // stat calls return sizes
         env.stub_stdout("stat -c%s", "99999");
 
-        let result = dev_build(&env, "/tmp/flake", Some("minimal"), BuildMode::Dev).unwrap();
+        let result =
+            dev_build_via_shell_env(&env, "/tmp/flake", Some("minimal"), BuildMode::Dev).unwrap();
         // Sizes should be populated (exact value depends on stub matching)
         assert!(result.artifact_sizes.vmlinux_bytes > 0 || result.artifact_sizes.rootfs_bytes > 0);
     }

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -304,13 +304,15 @@ mod linux {
     }
 
     fn setup_filesystems() -> Result<(), String> {
-        // Standard init filesystems. `MS_NOSUID | MS_NODEV` on
-        // /tmp matches the kernel default for tmpfs; the others
-        // use stock flags.
-        mount_fs("proc", "/proc", "proc")?;
-        mount_fs("sysfs", "/sys", "sysfs")?;
-        mount_fs("devtmpfs", "/dev", "devtmpfs")?;
-        mount_fs("tmpfs", "/tmp", "tmpfs")?;
+        // Standard init filesystems. libkrun's kernel mounts
+        // devtmpfs (and sometimes /proc /sys) before handing off to
+        // init, so EBUSY here means "already mounted by an earlier
+        // stage" — that's success for our purposes. Anything else
+        // is fatal.
+        mount_fs_idempotent("proc", "/proc", "proc")?;
+        mount_fs_idempotent("sysfs", "/sys", "sysfs")?;
+        mount_fs_idempotent("devtmpfs", "/dev", "devtmpfs")?;
+        mount_fs_idempotent("tmpfs", "/tmp", "tmpfs")?;
 
         std::fs::create_dir_all(NIX_STORE_MOUNT)
             .map_err(|e| format!("create {NIX_STORE_MOUNT}: {e}"))?;
@@ -320,8 +322,71 @@ mod linux {
         }
         mount_fs(NIX_STORE_DEV, NIX_STORE_MOUNT, "ext4")?;
 
+        // Seed the persistent `/nix-store` from the rootfs's baked-in
+        // `/nix/store` on first boot. A plain `MS_BIND` shadows the
+        // mount target — without seeding, bind-mounting an empty disk
+        // over `/nix` hides the Nix daemon binary the rootfs ships at
+        // `/nix/store/<hash>-nix/bin/nix`, so cmd.sh's `nix build`
+        // fails with exit 127 (command not found). Subsequent boots
+        // see a non-empty store and skip the copy, so the seed cost
+        // is paid once per builder-VM image generation.
+        let needs_seed = match std::fs::read_dir(NIX_STORE_MOUNT) {
+            Ok(entries) => {
+                let mut any_non_lf = false;
+                for entry in entries {
+                    if let Ok(entry) = entry
+                        && entry.file_name() != "lost+found"
+                    {
+                        any_non_lf = true;
+                        break;
+                    }
+                }
+                !any_non_lf
+            }
+            Err(_) => true,
+        };
+        if needs_seed {
+            eprintln!("mvm-builder-init: seeding {NIX_STORE_MOUNT} from {NIX_TARGET} (first boot)");
+            let status = Command::new("/bin/cp")
+                .args([
+                    "-aR",
+                    &format!("{NIX_TARGET}/."),
+                    &format!("{NIX_STORE_MOUNT}/"),
+                ])
+                .status()
+                .map_err(|e| format!("spawn cp: {e}"))?;
+            if !status.success() {
+                return Err(format!(
+                    "seeding {NIX_STORE_MOUNT} from {NIX_TARGET}: cp exit {:?}",
+                    status.code()
+                ));
+            }
+        }
+
         std::fs::create_dir_all(NIX_TARGET).map_err(|e| format!("create {NIX_TARGET}: {e}"))?;
         bind_mount(NIX_STORE_MOUNT, NIX_TARGET)?;
+
+        // Load FUSE + virtio-fs kernel modules before mounting the
+        // host-exported shares. Stock nixpkgs kernel ships these as
+        // `=m` (loadable modules); without modprobe, `mount -t
+        // virtiofs` bails with ENODEV. `mkGuest` (PR #215) stages
+        // `/lib/modules/<kver>/` into the rootfs precisely so we can
+        // load them at boot. Failure is non-fatal — the subsequent
+        // mount attempts will fail visibly if a module is genuinely
+        // missing rather than just not-yet-loaded.
+        for module in &["fuse", "virtiofs"] {
+            let status = Command::new("/bin/busybox")
+                .args(["modprobe", module])
+                .status();
+            match status {
+                Ok(s) if s.success() => {}
+                Ok(s) => eprintln!(
+                    "mvm-builder-init: modprobe {module} exited {} (continuing)",
+                    s.code().unwrap_or(-1)
+                ),
+                Err(e) => eprintln!("mvm-builder-init: spawn modprobe {module}: {e} (continuing)"),
+            }
+        }
 
         // virtio-fs shares declared by `LibkrunBuilderVm` (Plan 72
         // W4). Each entry is `(tag, target)` — the kernel routes
@@ -420,6 +485,24 @@ mod linux {
             None::<&str>,
         )
         .map_err(|e| format!("mount {source} -> {target} ({fstype}): {e}"))
+    }
+
+    /// `mount_fs` that treats EBUSY as success. libkrun's kernel
+    /// pre-mounts some of `/proc`, `/sys`, `/dev` depending on
+    /// cmdline + initramfs config; without this tolerance,
+    /// mvm-builder-init bails on its first such call instead of
+    /// reaching the user's cmd.sh.
+    fn mount_fs_idempotent(source: &str, target: &str, fstype: &str) -> Result<(), String> {
+        match mount_fs(source, target, fstype) {
+            Ok(()) => Ok(()),
+            Err(e) if e.contains("EBUSY") => {
+                eprintln!(
+                    "mvm-builder-init: {target} ({fstype}) already mounted (EBUSY) — continuing"
+                );
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
     }
 
     fn bind_mount(source: &str, target: &str) -> Result<(), String> {

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -63,15 +63,19 @@ predicates.workspace = true
 rand.workspace = true
 
 [features]
-# Plan 72 W5.B cutover: `backends-builder-vm-libkrun` is now default so
-# `mvmctl dev up` prefers the libkrun-backed builder VM (64 GiB
-# persistent /nix store) over libkrun (4 GiB overlay too small for
-# the dev-shell rustc closure). Library consumers that don't want the
-# libkrun FFI in their closure build with `default-features = false`.
-# Runtime gating via `mvm_libkrun::is_available()` still falls back
-# cleanly when libkrun isn't installed on the host.
-default = ["backends-builder-vm-libkrun"]
-backends-builder-vm-libkrun = ["mvm-build/backends-builder-vm-libkrun"]
+# Plan 72 W5.B cutover: `builder-vm` is now default so `mvmctl dev up`
+# prefers the libkrun-backed builder VM with a persistent /nix store.
+# Library consumers that don't want the libkrun FFI in their closure build
+# with `default-features = false`. Runtime gating via
+# `mvm_libkrun::is_available()` still falls back cleanly when libkrun isn't
+# installed on the host.
+default = ["builder-vm"]
+contributor-bootstrap = [
+    "mvm/contributor-bootstrap",
+    "mvm-build/contributor-bootstrap",
+    "mvm-backend/contributor-bootstrap",
+]
+builder-vm = ["mvm-build/builder-vm"]
 custom-dns = ["mvm-supervisor/custom-dns"]
 dev-watch = ["dep:notify", "dep:notify-debouncer-mini"]
 manifest-verify = [

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -543,11 +543,9 @@ fn plist_env_string_value(plist: &str, key: &str) -> Option<String> {
 /// virtio-fs `/out` mount lands on the read-only Nix store path
 /// and Apple Container fails with EACCES.
 ///
-/// `allow(dead_code)`: only reachable under the libkrun-dispatch
-/// branch of `ensure_dev_image`, which itself is gated on
-/// `backends-builder-vm-libkrun`. Default-features-off builds
-/// don't reach this helper.
-#[allow(dead_code)]
+/// Only reachable under the libkrun-dispatch branch of `ensure_dev_image`,
+/// which itself is gated on `builder-vm`.
+#[cfg(feature = "builder-vm")]
 fn prepare_dev_image_out_dir(out_dir: &str) -> Result<()> {
     if let Some(parent) = std::path::Path::new(out_dir).parent() {
         std::fs::create_dir_all(parent)
@@ -604,8 +602,8 @@ pub(super) fn ensure_dev_image() -> Result<(String, String)> {
     // since the typical failure mode (libkrun runtime mismatch, builder-
     // vm image cache missing) is a config error that hiding behind the
     // prebuilt would mask.
-    // Gate the dispatch itself on `backends-builder-vm-libkrun`.
-    #[cfg(feature = "backends-builder-vm-libkrun")]
+    // Gate the dispatch itself on `builder-vm`.
+    #[cfg(feature = "builder-vm")]
     if let Some(flake_dir) = &find_dev_image_flake().ok()
         && find_builder_vm_flake().is_ok()
     {
@@ -1700,7 +1698,7 @@ fn download_file(url: &str, dest: &str) -> Result<()> {
 /// "double-prefix attribute" `nix build` failure inside the
 /// sandbox. The bail signals `ensure_dev_image` to take the
 /// published-prebuilt download path (W5.1 — hash-verified).
-#[cfg(feature = "backends-builder-vm-libkrun")]
+#[cfg(feature = "builder-vm")]
 fn find_dev_image_flake() -> Result<String> {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let workspace_root = std::path::Path::new(manifest_dir)
@@ -1778,7 +1776,7 @@ fn find_builder_vm_flake() -> Result<String> {
 ///
 /// `allow(dead_code)`: same justification as
 /// [`find_builder_vm_flake`] — only called when
-/// `backends-builder-vm-libkrun` is on.
+/// `builder-vm` is on.
 #[allow(dead_code)]
 fn bootstrap_builder_vm_image() -> Result<()> {
     let arch = if cfg!(target_arch = "aarch64") {
@@ -1924,8 +1922,8 @@ fn builder_vm_artifact_names(arch: &str) -> BuilderVmArtifactNames {
 ///   - confirmed `find_builder_vm_flake().is_ok()` (Layer 1 source is
 ///     present in the workspace),
 ///   - run [`prepare_dev_image_out_dir`] on `out_dir`.
-// Gated only on `backends-builder-vm-libkrun`.
-#[cfg(feature = "backends-builder-vm-libkrun")]
+// Gated only on `builder-vm`.
+#[cfg(feature = "builder-vm")]
 fn build_image_via_libkrun(out_dir: &str) -> Result<(String, String)> {
     use mvm_build::builder_vm::{BuilderJob, BuilderMounts, BuilderVm, host_system_linux};
     use mvm_build::libkrun_builder::LibkrunBuilderVm;

--- a/crates/mvm/Cargo.toml
+++ b/crates/mvm/Cargo.toml
@@ -43,6 +43,10 @@ libc.workspace = true
 
 [features]
 default = []
+contributor-bootstrap = [
+    "mvm-build/contributor-bootstrap",
+    "mvm-backend/contributor-bootstrap",
+]
 manifest-verify = ["mvm-security/manifest-verify"]
 template-registry-s3 = ["dep:opendal"]
 

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -148,13 +148,18 @@
         # Plan 73 Followup B.2 — app-deps install pipeline.
         uv
         pnpm
-        # `cyclonedx-py` ships under `python3Packages` in
-        # nixpkgs (the upstream package name; `pkgs.cyclonedx-py`
-        # is the entry point binary). Pulls a Python interpreter
-        # closure but the same one `pip-audit` needs, so the
-        # marginal cost is minor.
-        python3Packages.cyclonedx-bom
-        python3Packages.pip-audit
+        # NOTE (Plan 72 W5.D unblock): `python3Packages.cyclonedx-bom`
+        # and `python3Packages.pip-audit` are referenced here but not
+        # present in nixpkgs-25.11 under those exact attribute names;
+        # the Stage 0 nix eval bails with "attribute 'cyclonedx-bom'
+        # missing". Commented out until the right attribute name (or
+        # a newer nixpkgs pin that has them) lands. Plan 73's
+        # deps-volume audit pipeline still works at runtime via the
+        # `mvm-egress-proxy` allowlist; the SBOM/CVE tools were a
+        # nice-to-have inside the builder VM, not a load-bearing
+        # blocker for `mvmctl dev up`.
+        # python3Packages.cyclonedx-bom
+        # python3Packages.pip-audit
       ];
 
       # Build `mvm-builder-init` (Plan 72 W3) for the target system.

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -350,19 +350,51 @@ let
   # builder can reach it without duplicating the agent derivation.
   verityInitBinary = "${guestAgentPkg}/bin/mvm-verity-init";
 
-  # extraFiles — { "absolute/path" = { content; mode?; }; }
+  # extraFiles — three accepted spec shapes per target path:
+  #
+  #   { "absolute/path" = { content = "..."; mode? = "0644"; }; }
+  #     → write text content via `pkgs.writeText`. Default mode 0644.
+  #
+  #   { "absolute/path" = { source = "/nix/store/.../bin/foo"; mode? = "0755"; }; }
+  #     → copy an existing file (typically a built binary) from the
+  #       given store path. Default mode 0755 (executables dominate).
+  #
+  #   { "absolute/path" = "/nix/store/.../bin/foo"; }
+  #     → shorthand for `{ source = <that string>; }`.
+  #
+  # Binary-source variants exist so Plan 72's builder-vm flake can
+  # install `mvm-builder-init` at `/sbin/mvm-builder-init` without
+  # inlining its bytes as a string (`writeText` is text-only).
   extraFilePopulation = lib.concatMapStringsSep "\n"
     (path:
       let
-        spec = extraFiles.${path};
-        mode = spec.mode or "0644";
-        target = "$out${path}";
+        rawSpec = extraFiles.${path};
+        spec =
+          if builtins.isString rawSpec then { source = rawSpec; }
+          else rawSpec;
+        hasContent = spec ? content;
+        hasSource = spec ? source;
+        mode =
+          if spec ? mode then spec.mode
+          else if hasSource then "0755"
+          else "0644";
+        src =
+          if hasContent then
+            pkgs.writeText "extra-${builtins.hashString "sha256" path}" spec.content
+          else if hasSource then
+            spec.source
+          else
+            throw "mkGuest: extraFiles[${path}] must set either `content` (text) or `source` (file path)";
       in
+      # Path arrives from Nix-interpolated keys (no shell escaping
+      # needed); inline via `"$out${path}"` rather than via
+      # `lib.escapeShellArg` so the shell expands `$out` instead of
+      # treating it as a literal in single quotes.
       ''
-        mkdir -p "$(dirname ${lib.escapeShellArg target})"
+        mkdir -p "$out$(dirname ${lib.escapeShellArg path})"
         ${pkgs.coreutils}/bin/install -m ${mode} \
-          ${pkgs.writeText "extra-${builtins.hashString "sha256" path}" spec.content} \
-          ${lib.escapeShellArg target}
+          ${src} \
+          "$out${path}"
       ''
     )
     (lib.attrNames extraFiles);
@@ -380,8 +412,11 @@ let
     set -e
     mkdir -p "$out"
 
-    # Standard FHS dirs the kernel + init expect.
-    mkdir -p "$out"/{bin,sbin,etc,proc,sys,dev,tmp,run,var,root,home,nix/store,etc/mvm}
+    # Standard FHS dirs the kernel + init expect. `/nix-store`,
+    # `/job`, `/out`, `/work` are mount points the libkrun builder
+    # VM (Plan 72 W3) needs pre-created — rootfs boots `ro` so
+    # `mvm-builder-init` can't `mkdir` them at runtime.
+    mkdir -p "$out"/{bin,sbin,etc,proc,sys,dev,tmp,run,var,root,home,nix/store,nix-store,etc/mvm,job,out,work}
     chmod 1777 "$out/tmp"
     chmod 0755 "$out/run"
 
@@ -458,6 +493,22 @@ let
     fi
     chmod 0644 "$out/etc/group"
 
+    # Default /etc/resolv.conf and CA cert bundle — needed for any
+    # guest that talks to the network over TLS (most Nix flake
+    # fetches reach cache.nixos.org / api.github.com). Cloudflare +
+    # Google as the canonical no-infra-of-my-own DNS defaults; the
+    # cert bundle is the standard Mozilla one from `pkgs.cacert`.
+    cat > "$out/etc/resolv.conf" <<EOF
+    nameserver 1.1.1.1
+    nameserver 8.8.8.8
+    EOF
+    chmod 0644 "$out/etc/resolv.conf"
+
+    mkdir -p "$out/etc/ssl/certs"
+    cp ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt "$out/etc/ssl/certs/ca-bundle.crt"
+    ln -sf /etc/ssl/certs/ca-bundle.crt "$out/etc/ssl/certs/ca-certificates.crt"
+    chmod 0644 "$out/etc/ssl/certs/ca-bundle.crt"
+
     # mvm-guest-agent — installed under /usr/local/bin so /init can
     # exec it. Mode 0555 so the agent can't rewrite itself; ownership
     # is the build-time user (Nix sandbox has no root) — Phase 6 W2.2
@@ -515,17 +566,25 @@ let
     # Extra user-supplied files.
     ${extraFilePopulation}
 
-    # Closure of additional packages — copy each into /usr/local/bin
-    # by symlink so they're on PATH alongside the busybox applets.
+    # Closure of additional packages — symlink each binary into
+    # `/usr/local/bin` AND `/sbin` so the standard system-binary
+    # paths (`/sbin/mkfs.ext4`, `/sbin/udhcpc`, etc.) resolve.
+    # `mvm-builder-init` uses those paths verbatim and would
+    # ENOENT-fail without them (e.g. e2fsprogs ships mkfs.ext4 in
+    # the package's sbin subdir, not bin).
     mkdir -p "$out/usr/local/bin"
     ${lib.concatMapStringsSep "\n"
       (pkg: ''
-        if [ -d "${pkg}/bin" ]; then
-          for bin in "${pkg}"/bin/*; do
-            [ -e "$bin" ] || continue
-            ln -sf "$bin" "$out/usr/local/bin/$(basename "$bin")"
-          done
-        fi
+        for srcdir in bin sbin; do
+          if [ -d "${pkg}/$srcdir" ]; then
+            for binpath in "${pkg}/$srcdir"/*; do
+              [ -e "$binpath" ] || continue
+              name=$(basename "$binpath")
+              ln -sf "$binpath" "$out/usr/local/bin/$name"
+              ln -sf "$binpath" "$out/sbin/$name"
+            done
+          fi
+        done
       '')
       packages}
   '';

--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -90,6 +90,7 @@ export default defineConfig({
             { label: "Writing Nix Flakes", slug: "guides/nix-flakes" },
             { label: "From Workload IR to MicroVM Image", slug: "guides/ir-to-image" },
             { label: "Building MicroVM Images", slug: "guides/building-microvm-images" },
+            { label: "Builder VM", slug: "guides/builder-vm" },
             { label: "Sandboxed Exec", slug: "guides/exec" },
             { label: "Config & Secrets", slug: "guides/config-secrets" },
             { label: "Manifests", slug: "guides/manifests" },

--- a/public/src/content/docs/contributing/adr/013-libkrun-pivot.md
+++ b/public/src/content/docs/contributing/adr/013-libkrun-pivot.md
@@ -11,19 +11,15 @@ Proposed. Implementation tracked in [Plan 60](https://github.com/tinylabscom/mvm
 
 `mvmctl` runs on a stock host. **Nix is not a prerequisite.** On first build, mvm bootstraps a small Linux builder microVM (libkrun-backed), runs `nix build` inside it, and extracts the resulting rootfs to the host. The runtime path stays Nix-free; the builder path keeps Nix inside the sandbox where it belongs.
 
-Host-side Nix is an opt-in power-user path:
+Host-side Nix is optional and only affects commands users run themselves:
 
-- contributors hacking on mvm itself who want a shared `/nix/store`,
-- users with [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary) already configured (mvm detects and uses it),
-- users with a remote `nix-daemon` URL.
+- contributors hacking on mvm itself may want Nix for editor tooling or direct `nix build` debugging;
+- users with [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary) can use it for direct Nix commands;
+- users with a remote `nix-daemon` URL can use it outside mvm's normal build path.
 
 The full design is in [§"Linux builder via libkrun (no Lima)"](#linux-builder-via-libkrun-no-lima) below.
 
-> **Current status (2026-05-08):** the bootstrap is in flight on the
-> `feat/micro` branch as part of W6.x. Until it lands, contributors
-> building rootfs images still need host-side Nix (or `nix-darwin`'s
-> `linux-builder` on macOS). The docs describe the target user-facing
-> shape; the in-flight gap is a footnote, not the headline.
+The user-facing contract is documented in [Builder VM](/guides/builder-vm/): `mvmctl build` is a host command, while Nix evaluation and image construction happen inside the builder VM.
 
 ## Context
 
@@ -50,7 +46,6 @@ Three coupled choices:
 3. macOS Container         → AppleContainerBackend (legacy; scheduled for removal)
 4. raw libkrun             → LibkrunBackend (legacy; scheduled for removal)
 5. Docker                  → DockerBackend (Tier 3 fallback; banner emitted)
-6. Firecracker via Lima    → legacy macOS fallback
 ```
 
 `mvmctl run --hypervisor libkrun <flake>` always selects libkrun explicitly regardless of the host's KVM status.
@@ -59,22 +54,20 @@ Three coupled choices:
 
 macOS hosts can't `nix build` Linux derivations natively. The previous iteration solved that with a Lima VM as the Linux builder; this iteration drops Lima entirely. The replacement: **bootstrap a Linux builder inside libkrun itself**.
 
-On a host without a Linux builder configured, `mvmctl build` does:
+`mvmctl build` does:
 
-1. Detects the gap — host has no Nix, or has Nix that can't build Linux derivations.
-2. Pulls a small, pinned Nix-bearing image — once, cached in `~/.cache/mvm/builder-image/`.
-3. Spawns a libkrun sandbox from the image with the user's flake source bind-mounted as `/work`, the host's `/nix/store` shared in if present, and a sane PATH.
-4. Runs `nix build .#default` inside the sandbox.
-5. Extracts the rootfs back to the host.
-6. Hands it to the runtime path (which uses libkrun's `RootfsSource::DiskImage` per the OCI non-goal — the *runtime* never pulls OCI).
+1. Stages the user's flake source and selected profile as a builder job.
+2. Boots or reuses the pinned Linux builder image.
+3. Mounts the staged source, job metadata, cache volumes, and artifact output directory into the builder boundary.
+4. Runs `nix build .#default` or the selected profile inside the builder VM.
+5. Extracts the kernel/rootfs artifacts back to the host cache.
+6. Hands the finished artifacts to the runtime path (which uses libkrun's `RootfsSource::DiskImage` per the OCI non-goal — the *runtime* never pulls OCI).
 
 **Why this is consistent with the OCI non-goal.** The non-goal banned OCI from the **runtime/boot path** — where user workloads run, where reproducibility, offline-by-default, and no-registry-trust matter. The **builder** lives in a different trust zone: it has to fetch caches, talk to the network, and run arbitrary `nix build` derivations. Builder VMs and runtime VMs are governed by different policies; using OCI for the builder doesn't compromise the runtime's invariants.
 
-**Cache reuse.** When the host has a Nix install, its `/nix/store` is shared into the builder sandbox. Builds populate the host store; subsequent builds reuse the same cached derivations. This is the same trick `nix-darwin`'s `linux-builder` uses — the difference is mvm doesn't require the user to have configured `nix-darwin`.
+**Cache reuse.** The builder VM keeps a warm Nix store/cache across builds. Host-side Nix may still be useful for direct developer commands, but mvm image construction goes through the builder VM so the behavior is consistent across macOS, Linux, and WSL2.
 
-**Detection and fallback.** If the host already has a working Linux builder (`nix-darwin`'s `linux-builder`, or a remote `nix-daemon` URL), mvm detects it and uses it instead — the libkrun-bootstrapped path is the *zero-config default*, not a forced override. Detection probes whether host Nix can realize a Linux derivation; success → host builds; failure → libkrun bootstrap.
-
-**This replaces every previous reference to "configure `nix-darwin`'s `linux-builder`" in the docs.** Users with an existing builder keep using it; everyone else gets the libkrun-bootstrapped path with no host-side configuration.
+**This replaces every previous reference to "configure `nix-darwin`'s `linux-builder`" as a prerequisite for mvm builds.** Users can still configure one for their own direct Nix workflows; `mvmctl build` does not require it.
 
 ## Non-goal: OCI / container images
 

--- a/public/src/content/docs/getting-started/installation.md
+++ b/public/src/content/docs/getting-started/installation.md
@@ -53,7 +53,7 @@ mvmctl automatically detects your platform at startup and selects the best VM ba
 | **Linux without `/dev/kvm`** | Docker | Tier 3 fallback when no microVM backend is available. |
 | **Docker available** | Docker | Tier 3 container fallback. Used only if no hypervisor backend works. |
 
-You don't need Nix on the host. On first build, mvm resolves a Linux builder microVM, runs `nix build` inside it, and extracts the rootfs back. Host-side Nix is not part of the managed `mvmctl` path.
+You don't need Nix on the host. On first build, mvm bootstraps or reuses a Linux builder VM, runs Nix evaluation and `nix build` inside it, and extracts the rootfs back. You run `mvmctl build` from the host; you do not need to enter a dev shell first. See [Builder VM](/guides/builder-vm/) for the full model.
 
 ### First-Time Setup
 

--- a/public/src/content/docs/guides/builder-vm.md
+++ b/public/src/content/docs/guides/builder-vm.md
@@ -1,0 +1,176 @@
+---
+title: "Builder VM"
+description: How mvm builds Linux microVM images from the host without requiring you to enter a dev shell or install host-side Nix.
+---
+
+The short version: **you run `mvmctl build` from the host, and mvm runs Nix inside the builder VM.** You do not need to enter an interactive dev shell to build a template or runtime image.
+
+The host process is the control plane. The builder VM is the Linux execution boundary for Nix evaluation, Nix builds, and image assembly. The runtime backend is separate: after the image is built, mvm boots the prebuilt kernel and rootfs with the selected microVM backend, such as Firecracker on Linux or Apple Virtualization on macOS.
+
+```text
+macOS or Linux host
+  |
+  | mvmctl build --flake .
+  v
+host-side mvmctl process
+  |
+  | stages flake, job metadata, and artifact directory
+  v
+builder VM
+  |
+  | runs nix eval / nix build on Linux
+  v
+host artifact cache
+  |
+  | mvmctl up --hypervisor apple-container
+  v
+runtime microVM
+```
+
+## What Runs Where
+
+| Work | Runs on | Why |
+|---|---|---|
+| CLI parsing, config loading, cache lookup | Host | Fast local control-plane work. |
+| Nix flake evaluation | Builder VM | The target is a Linux image, and the build environment must be Linux. |
+| `nix build` | Builder VM | Keeps host Nix optional and avoids macOS/Linux platform mismatch. |
+| Rootfs and kernel artifact extraction | Builder VM, then host cache | The builder produces artifacts; the host stores and reuses them. |
+| Runtime boot | Runtime backend | Uses an already-built image. This is Firecracker, Apple Virtualization, libkrun, or another backend. |
+| Runtime guest agent traffic | Runtime microVM | Uses the runtime VM's guest communication path, normally vsock where supported. |
+
+This separation is deliberate. A build can take seconds or minutes because it may fetch and compile Nix closures. A runtime boot benchmark should normally measure only the already-built image booting, not the build phase.
+
+## You Do Not Need a Dev Shell to Build
+
+The normal build command is:
+
+```bash
+mvmctl build --flake .
+```
+
+That command should be run from your project directory on the host. `mvmctl` takes care of starting or reaching the builder VM, staging the flake, running the build, and copying the result back.
+
+Use an interactive shell only when you want to debug the builder environment:
+
+```bash
+mvmctl dev shell
+```
+
+Examples of things a dev shell is useful for:
+
+- inspecting the Linux build environment;
+- manually running `nix build` to debug a flake error;
+- checking disk usage in the builder VM's Nix store;
+- reproducing an issue that only appears inside the Linux build boundary.
+
+Examples of things that should not require a dev shell:
+
+- `mvmctl build --flake .`;
+- `mvmctl run`;
+- `mvmctl up --flake .`;
+- building a registered template;
+- booting a prebuilt runtime image.
+
+## Build Then Boot
+
+For an explicit two-step flow:
+
+```bash
+# 1. Build the runtime image.
+mvmctl build --flake .
+
+# 2. Boot the already-built image.
+mvmctl up --flake . --hypervisor apple-container
+```
+
+On macOS, `--hypervisor apple-container` selects the Apple Virtualization runtime backend when available. The builder VM remains a build-time implementation detail. It is not the same VM as your workload VM.
+
+For development convenience, `mvmctl run` combines the two phases:
+
+```bash
+mvmctl run
+```
+
+That is equivalent to "build if needed, then boot." It is convenient for daily use, but it is not the right measurement point if you are trying to isolate runtime boot latency.
+
+## Builder VM vs Runtime MicroVM
+
+The builder VM and runtime microVM have different jobs:
+
+| VM | Purpose | Lifetime | State |
+|---|---|---|---|
+| Builder VM | Runs Linux Nix builds and image assembly. | Reused or launched as needed by the build pipeline. | Has a warm Nix store/cache. |
+| Runtime microVM | Runs your workload from a finished image. | Created by `mvmctl up`, `run`, `exec`, or tests. | Uses the built rootfs/kernel artifacts. |
+
+Do not benchmark the builder VM when you want runtime boot time. The builder VM exists so that the host can ask for Linux builds without becoming a Linux build machine itself.
+
+## Communication Model
+
+From the user's perspective, the interface is the host command:
+
+```bash
+mvmctl build --flake .
+```
+
+Internally, mvm stages the build request into the builder boundary: source path, selected profile, target system, output directory, and job metadata. The builder runs the Linux-side build and returns structured artifact metadata to the host.
+
+The exact transport is backend-specific. Implementations may use mounted job directories, virtio-fs, a control socket, vsock, or a small supervisor process. That detail should not leak into the user workflow. The contract is:
+
+1. the host starts the request;
+2. the builder VM performs Linux-only work;
+3. the host receives a kernel/rootfs artifact set;
+4. runtime commands boot those artifacts.
+
+## Nix on the Host
+
+Host-side Nix is not required for normal mvm use.
+
+On macOS, host Nix also does not remove the need for a Linux build boundary: the guest image is a Linux artifact. A macOS `nix` install can be useful for editor tooling, formatting, or unrelated projects, but `mvmctl build` should treat the builder VM as the authoritative place where Nix evaluation and builds happen.
+
+On Linux, the host may already be capable of Linux Nix builds, but mvm still keeps the same conceptual boundary: `mvmctl build` is the user-facing command, and the builder path owns image construction and cache policy. This keeps the CLI behavior consistent across platforms.
+
+## Caching
+
+The builder VM keeps build state warm so repeated builds avoid re-fetching the world:
+
+- Nix store paths are cached inside the builder environment.
+- Built runtime artifacts are cached on the host.
+- Unchanged flakes and lock files should reuse previous work.
+
+The first build is allowed to be slower because it may bootstrap the builder image and populate the Nix store. Later builds should be dominated by changed inputs.
+
+## Benchmarking Runtime Boot
+
+When measuring whether a prebuilt runtime image boots under a budget such as 200 ms, separate the phases:
+
+```text
+Build benchmark:
+  host mvmctl build -> builder VM -> artifacts
+
+Runtime boot benchmark:
+  existing artifacts -> runtime backend -> guest ready signal
+```
+
+The runtime boot benchmark should start after the kernel and rootfs already exist. It should not include:
+
+- builder VM startup;
+- Nix evaluation;
+- dependency download;
+- rootfs assembly;
+- artifact copy from the builder.
+
+For Apple Virtualization runtime tests, point the benchmark config at the built kernel and rootfs and use the Apple backend. The builder VM is only involved if the benchmark setup step chooses to rebuild the image first.
+
+## Failure Modes
+
+If `mvmctl build` fails, check the phase named in the error:
+
+| Symptom | Likely phase | What to inspect |
+|---|---|---|
+| Builder image missing or invalid | Builder bootstrap | `mvmctl doctor`, cache directory, builder image manifest. |
+| Flake attribute not found | Nix evaluation | `flake.nix`, selected `--profile`, `packages.<system>.<profile>`. |
+| Package fetch or hash mismatch | Nix build | The failing derivation output and fixed-output hash. |
+| Artifact metadata missing | Artifact extraction | Builder result JSON, kernel/rootfs output paths. |
+| Runtime boot timeout | Runtime backend | Backend logs, kernel command line, guest init, guest agent readiness. |
+
+The important debugging rule is to keep build failures and boot failures separate. A Nix failure is not a runtime boot regression, and a runtime timeout is not usually a builder VM problem if the image already exists.

--- a/public/src/content/docs/guides/building-microvm-images.md
+++ b/public/src/content/docs/guides/building-microvm-images.md
@@ -51,13 +51,22 @@ mvmctl build              # reads mvm.toml; builds the named flake target
 mvmctl run                # builds (if needed) + boots
 ```
 
-`mvmctl` selects the backend automatically (Firecracker on Linux+KVM, libkrun on macOS / Linux without KVM). Override with `--hypervisor libkrun` if you want to force the cross-platform path.
+`mvmctl build` is a host command. You run it from macOS or Linux, and mvm sends the Linux-only Nix work into the builder VM. You do not need to enter `mvmctl dev shell` first. The shell is for debugging the build environment manually, not a prerequisite for normal builds.
+
+`mvmctl` selects the runtime backend automatically when you boot the finished image. Use `--hypervisor` on runtime commands when you want to force a specific runtime backend:
+
+```sh
+mvmctl up --flake . --hypervisor apple-container
+mvmctl up --flake . --hypervisor firecracker
+```
 
 If you want to drive `nix build` directly without `mvmctl` in the loop:
 
 ```sh
 nix build .#default
 ```
+
+That direct Nix command is only for users who intentionally manage their own Nix environment. It bypasses mvm's builder VM orchestration and is not required for the normal workflow. See [Builder VM](/guides/builder-vm/) for the detailed build boundary.
 
 ## What `mkGuest` accepts
 
@@ -184,10 +193,10 @@ nix flake check --no-build
 
 ## Cross-platform notes
 
-mvm bootstraps a Linux builder microVM on first build (libkrun-backed; see [ADR-013 §"Linux builder via libkrun"](/contributing/adr/013-libkrun-pivot/)) and runs `nix build` inside it. You don't need host-side Nix.
+mvm runs Nix builds inside the project builder VM and copies the finished kernel/rootfs artifacts back to the host cache. You don't need host-side Nix, and you don't need to enter a dev shell before building.
 
-- **Linux**: the builder microVM runs on Firecracker against `/dev/kvm`. Firecracker is also the default runtime backend. If you've opted into host-side Nix and it can build Linux derivations, mvm uses it directly and skips the builder VM.
-- **macOS**: the builder microVM runs on libkrun via Hypervisor.framework. The resulting microVM is then booted on the same backend. If you already have [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary) or a remote `nix-daemon` configured, mvm detects and uses it instead.
+- **Linux**: the builder VM provides the Linux build boundary and cache policy. Firecracker is the default runtime backend when `/dev/kvm` is available.
+- **macOS**: the host `mvmctl build` command orchestrates a Linux builder VM. The resulting runtime image can then boot with Apple Virtualization (`--hypervisor apple-container`) or another available macOS runtime backend.
 - **Windows**: Tauri-only (the `mvm-studio` desktop app packages a WSL2-backed builder + runtime). See [ADR-031](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/031-cross-platform-strategy.md).
 
 ## Rootless workloads

--- a/public/src/content/docs/guides/dev-image.md
+++ b/public/src/content/docs/guides/dev-image.md
@@ -131,10 +131,10 @@ The build path is the same as any mvm image:
 
 ```sh
 # From your project directory:
-nix build .#dev
+mvmctl build --flake . --profile dev
 ```
 
-Output is a derivation with `passthru.mvm.{accessible, sealed, expectedBootMs}`. Check it:
+If you intentionally manage your own Nix environment, you can run `nix build .#dev` directly. The normal mvm path is `mvmctl build`, which runs Nix inside the builder VM. Output is a derivation with `passthru.mvm.{accessible, sealed, expectedBootMs}`. Check it from a Nix-enabled debug environment:
 
 ```sh
 nix eval .#dev.passthru.mvm
@@ -145,9 +145,9 @@ nix eval .#dev.passthru.mvm
 
 ### Cross-platform build notes
 
-mvm bootstraps a Linux builder microVM (libkrun-backed) on first build and runs `nix build` inside it. You don't need Nix on your host. See [ADR-013 §"Linux builder via libkrun"](/contributing/adr/013-libkrun-pivot/).
+mvm runs Nix builds inside the project builder VM and copies the finished artifacts back to the host cache. You don't need Nix on your host, and you don't need to enter a dev shell before building. See [Builder VM](/guides/builder-vm/).
 
-- **Linux** (native host with `/dev/kvm`): the builder VM owns image construction; Firecracker is the default runtime backend.
+- **Linux** (with `/dev/kvm`): the builder VM owns image construction; Firecracker is the default runtime backend.
 - **macOS Apple Silicon**: the host `mvmctl build` command orchestrates the builder VM. The resulting dev image can then boot on the selected macOS runtime backend.
 - **Windows / WSL2**: future work. WSL2 nested KVM and a Hyper-V managed Linux builder are not supported local paths today.
 

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -3,7 +3,9 @@ title: Writing Nix Flakes
 description: Create custom Nix flakes that build microVM images for mvm.
 ---
 
-mvmctl uses Nix flakes to produce reproducible microVM images. Each build runs `nix build` inside the Linux build environment (a libkrun-backed builder VM on macOS, the host shell on Linux with `/dev/kvm`), producing a kernel and rootfs. The same rootfs works on all backends (Firecracker, Apple Container, libkrun).
+mvmctl uses Nix flakes to produce reproducible microVM images. You run `mvmctl build` from the host, and mvm runs Nix evaluation and `nix build` inside the Linux builder VM. The result is a kernel and rootfs that can boot on any supported runtime backend, including Firecracker, Apple Virtualization, and libkrun.
+
+You do not need to enter a dev shell to build a flake. The dev shell is only for manually debugging the Linux build environment. See [Builder VM](/guides/builder-vm/) for the full host-vs-builder model.
 
 ## Minimal Flake
 
@@ -258,11 +260,11 @@ All three helpers return the same shape: `{ package, service, healthCheck }`. Th
 
 When you run `mvmctl build --flake .`:
 
-1. The flake is copied into the Linux build environment (builder VM on macOS, native on Linux with `/dev/kvm`)
-2. `nix build` runs inside that environment
-3. The resulting closure is packed into the rootfs
-4. Kernel and rootfs artifacts are cached
-5. Subsequent builds with unchanged `flake.lock` reuse the cache
+1. The host CLI reads config and stages the selected flake/profile as a builder job.
+2. The builder VM runs Nix evaluation and `nix build` in Linux.
+3. The resulting closure is packed into the rootfs.
+4. Kernel and rootfs artifacts are copied back to the host cache.
+5. Runtime commands boot those already-built artifacts on the selected backend.
 
 The same rootfs works on all backends (Firecracker, Apple Container, microvm.nix, Docker).
 

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -3,9 +3,9 @@ title: Troubleshooting
 description: Common issues and their solutions.
 ---
 
-## Dev VM Issues
+## Builder VM and Dev Shell Issues
 
-The dev VM is the Linux environment mvmctl runs Nix builds in. On macOS Apple Silicon it uses Apple Container or libkrun via `Hypervisor.framework`; on Linux with `/dev/kvm` the host shell *is* the dev environment and no VM hop exists. macOS Intel, native Windows, and WSL2 are not supported local dev hosts today.
+The builder VM is the Linux environment mvmctl uses for Nix evaluation and image builds. You normally do not enter it yourself: `mvmctl build --flake .` is a host command that stages work for the builder VM and copies artifacts back to the host cache. `mvmctl dev shell` is only for manual debugging. See [Builder VM](/guides/builder-vm/) for the full model.
 
 ### "Dev VM is not running"
 
@@ -69,12 +69,12 @@ mvmctl up --manifest <template> --name <name>
 ### Nix build fails
 
 ```bash
-# Test the flake locally first
+# Re-run the normal host-orchestrated build.
+mvmctl build --flake .
+
+# If you need an interactive Linux debug environment:
 mvmctl dev shell
 nix build .#default
-
-# Check for errors in the flake
-nix flake check
 ```
 
 ### "Cache miss" rebuilds
@@ -105,11 +105,12 @@ error: No space left on device
 
 **Fix**:
 ```bash
-# Run garbage collection
-nix-collect-garbage -d
-
 # Check Nix store size (mvmctl doctor warns if >20 GiB)
 mvmctl doctor
+
+# For manual cleanup inside a debug shell:
+mvmctl dev shell
+nix-collect-garbage -d
 ```
 
 ### Hash mismatch (fixed-output derivation)

--- a/public/src/content/docs/install/linux.md
+++ b/public/src/content/docs/install/linux.md
@@ -18,7 +18,7 @@ You'll need:
   If `/dev/kvm` exists but is `root`-only, add yourself to the `kvm` group: `sudo usermod -aG kvm "$USER"` (re-login required).
 - **Rust 1.85+** if you build `mvmctl` from source.
 
-You **do not need Nix on your host**. mvm bootstraps a small Linux builder microVM on first build, runs `nix build` inside it, and extracts the resulting rootfs back to your host. See [ADR-013 §"Linux builder via libkrun"](/contributing/adr/013-libkrun-pivot/) for the design.
+You **do not need Nix on your host**. You run `mvmctl build` from the host, and mvm runs Nix evaluation and `nix build` through the project builder VM before extracting the resulting rootfs back to your host. See [Builder VM](/guides/builder-vm/) for the design.
 
 ## Install mvmctl
 
@@ -81,7 +81,7 @@ See [Building MicroVM Images](/guides/building-microvm-images) for the user-faci
 
 ## Optional: host-side Nix for power users
 
-mvm doesn't need Nix on the host — the builder microVM handles managed `nix build` invocations. You may still want host-side Nix if you're:
+mvm doesn't need Nix on the host — the builder VM handles mvm image builds. You may still want host-side Nix if you're:
 
 - contributing to mvm itself and want a shared `/nix/store` between your editor's build commands and mvm's,
 - already running a `nix-daemon` for other projects.
@@ -98,7 +98,7 @@ The upstream NixOS installer also works:
 sh <(curl -L https://nixos.org/nix/install) --daemon
 ```
 
-Host-side Nix is for your own commands; `mvmctl build` uses the builder VM path.
+Installing host-side Nix does not change the normal `mvmctl build` contract: the CLI remains the host control plane, and the builder VM remains the image build boundary.
 
 ## Distro-specific notes
 

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -48,11 +48,13 @@ cargo install mvmctl
 
 ## Linux Builds On macOS
 
-macOS Nix can't build Linux derivations natively. mvm routes Linux builds through the project builder VM so the host does not need to build Linux artifacts directly.
+macOS Nix can't build Linux derivations natively, and most Mac users don't have Nix installed at all. mvm handles both cases **without requiring host-side configuration**: on `mvmctl build`, the host CLI stages the selected flake as a builder job, the Linux builder VM runs `nix build`, and mvm copies the resulting kernel/rootfs artifacts back to the host cache. See [Builder VM](/guides/builder-vm/) for the full control-plane flow.
 
-### Optional: Host-Side Nix For Contributors
+The builder VM is separate from the runtime VM. After the build completes, `mvmctl up --hypervisor apple-container` boots the already-built runtime image with Apple Virtualization. The build phase and boot phase can be benchmarked separately.
 
-Most users skip this section. You may want host-side Nix if you're contributing to mvm itself, want a shared `/nix/store` for your editor's build commands, or already run `nix-darwin` for unrelated reasons. This is not part of the `mvmctl` runtime path.
+### Optional: host-side Nix for power users
+
+Most users skip this section. You may want host-side Nix if you're contributing to mvm itself, want Nix for editor tooling, or already run `nix-darwin` for unrelated reasons. Host-side Nix is not required by `mvmctl build`; the builder VM remains the Linux build boundary for mvm images.
 
 [Determinate Nix](https://determinate.systems/posts/determinate-nix-installer) is the easiest path:
 
@@ -60,7 +62,7 @@ Most users skip this section. You may want host-side Nix if you're contributing 
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
 ```
 
-If you configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary), use it for your own host-side commands; mvm's managed build path continues to run inside the project builder VM.
+If you configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary), it can be useful for direct `nix build` commands that you run yourself. It is not required for `mvmctl build`.
 
 ## Verify
 
@@ -78,13 +80,13 @@ mvmctl init
 mvmctl run
 ```
 
-`mvmctl init` scaffolds the project. On first `mvmctl run`, mvm bootstraps the builder microVM if needed, runs `nix build` inside it, and boots the resulting rootfs.
+`mvmctl init` scaffolds the project. On first `mvmctl run`, mvm bootstraps the builder VM if needed, runs `nix build` inside it, and boots the resulting rootfs with the selected macOS runtime backend. Expected runtime cold boot is measured after the image is already built; the first build may also pay a one-time builder-image fetch.
 
 ## Troubleshooting
 
 **"Hypervisor.framework: entitlement missing"** — re-codesign the binary with the entitlement: `codesign --entitlements resources/mvmctl.entitlements -f -s - ~/.local/bin/mvmctl`. The release binary ships pre-signed; this only matters if you've stripped entitlements or built from source without the build script's signing step.
 
-**`nix build` fails with "a 'x86_64-linux' with features … is required"** — the macOS host is trying to build Linux derivations directly. Use the project builder VM path, or configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary) for editor-side workflows.
+**`nix build` fails with "a 'x86_64-linux' with features … is required"** — that is a direct host-side Nix command failing because macOS cannot build Linux derivations by itself. Use `mvmctl build --flake .` so the Linux build runs inside the builder VM. If you intentionally want direct `nix build` on macOS, configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary).
 
 **`mvmctl run` boots but `mvmctl console` fails to attach** — the `console` subcommand is only enabled for *accessible* images. If your `entrypoint.command = [ ... ]`, the build is *sealed* and console attach is rejected. Switch to `entrypoint.shell = "/bin/sh"` or pass `dev = true` in your `mkGuest` call. See [Building MicroVM Images](/guides/building-microvm-images).
 

--- a/public/src/content/docs/install/windows.md
+++ b/public/src/content/docs/install/windows.md
@@ -38,7 +38,7 @@ sh <(curl -L https://nixos.org/nix/install) --daemon
 . /etc/profile.d/nix.sh
 ```
 
-When `mvmctl build` detects a working host-side Nix that can build Linux derivations, it uses it directly and skips the builder microVM.
+Installing host-side Nix is optional. The normal `mvmctl build` path still treats the CLI as the host control plane and the builder VM as the image build boundary. See [Builder VM](/guides/builder-vm/).
 
 ## Alternative: Tier 3 Docker fallback
 

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -21,7 +21,7 @@ macOS:          mvmctl up  -->  libkrun microVM (Hypervisor.framework)
 Docker:         mvmctl up  -->  Docker container (Tier 3 fallback)
 ```
 
-All backends consume the same Nix-built ext4 rootfs. Override auto-detection with `--hypervisor`:
+All backends consume the same Nix-built ext4 rootfs. The rootfs is built through the builder VM first, then booted by the selected runtime backend. Override runtime auto-detection with `--hypervisor`:
 
 ```bash
 mvmctl up --flake . --hypervisor apple-container
@@ -101,8 +101,8 @@ Where Linux commands run. Defined in `mvm-core`:
 - `run_capture()` -- run and capture both stdout and stderr
 
 Implementations:
-- **`BuilderVmEnv`** -- delegates commands into the libkrun/libkrun builder VM (macOS hosts)
-- **`NativeEnv`** -- runs commands directly (Linux with `/dev/kvm`)
+- **`BuilderVmEnv`** -- delegates Linux-only build work into the project builder VM
+- **`NativeEnv`** -- runs Linux commands directly where the host itself is the Linux execution boundary
 
 ### ShellEnvironment
 
@@ -136,7 +136,7 @@ Extends `ShellEnvironment` for fleet orchestration:
 
 ## How It Works
 
-At startup, mvmctl detects the platform and selects the appropriate backend:
+At startup, mvmctl detects the platform and selects the appropriate runtime backend:
 
 1. **Native Linux with `/dev/kvm`** -- uses `FirecrackerBackend` for runtime VM lifecycle
 2. **macOS 26+ Apple Silicon** -- uses `AppleContainerBackend` for dev/runtime VM lifecycle; Nix builds run inside the libkrun-backed builder VM
@@ -154,12 +154,14 @@ Host (macOS Apple Silicon / native Linux KVM)
 
 ## Build Pipeline
 
-`mvmctl build` and `mvmctl template build` invoke `nix build` inside the Linux environment, producing:
+`mvmctl build` and `mvmctl template build` are host commands that stage a build job for the builder VM. The builder VM invokes `nix build` inside Linux, producing:
 
 - **vmlinux** -- Firecracker-compatible kernel
 - **rootfs.ext4** or **rootfs.squashfs** -- guest root filesystem
 
 No initrd is needed -- the kernel boots directly into a busybox init script on the rootfs.
+
+The builder VM is not the runtime VM. Runtime commands such as `mvmctl up`, `mvmctl run`, and boot benchmarks consume the finished artifacts from the host cache. See [Builder VM](/guides/builder-vm/) for the detailed control-plane flow.
 
 ## Platform Support
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -375,20 +375,18 @@ output (see [Building MicroVM Images](/guides/building-microvm-images)).
 
 Build resolution order on first use:
 
-1. **Builder microVM (default).** mvm bootstraps a small Linux builder
-   microVM (libkrun-backed, see
-   [ADR-013 §"Linux builder via libkrun"](/contributing/adr/013-libkrun-pivot/)),
-   runs `nix build` inside it, and extracts the rootfs. No host-side
-   Nix required.
-2. **Host-side Nix (auto-detected).** If the host already has a working
-   Nix that can build Linux derivations (Linux Nix, or `nix-darwin`'s
-   `linux-builder`, or a remote `nix-daemon` URL), mvm uses it directly
-   and skips the builder microVM.
-3. **Prebuilt artifacts (offline).** If neither is available — for
-   example, a fully-offline host without the builder image cached — mvm
-   downloads the prebuilt `default-microvm` artifacts from the GitHub
-   release matching the `mvmctl` version, hash-verified per the
-   `*-checksums-sha256.txt` manifest (security claim 6).
+1. **Builder VM.** mvm bootstraps or reuses the project Linux builder VM,
+   runs Nix evaluation and `nix build` inside it, and extracts the rootfs.
+   No host-side Nix is required, and you do not need to enter
+   `mvmctl dev shell` first.
+2. **Prebuilt artifacts (offline).** If the host is fully offline and the
+   builder image is not available, mvm can use the prebuilt
+   `default-microvm` artifacts from the GitHub release matching the
+   `mvmctl` version, hash-verified per the `*-checksums-sha256.txt`
+   manifest (security claim 6).
+
+See [Builder VM](/guides/builder-vm/) for the host-orchestrated build
+flow and the distinction between build time and runtime boot time.
 
 ## Cache
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -46,6 +46,8 @@ Recent maintenance:
 - [x] Clarified the local platform policy after the cleanup: supported builder/runtime hosts are macOS Apple Silicon and native Linux with `/dev/kvm`; macOS Intel and native Windows are unsupported, while WSL2 nested KVM and a Hyper-V managed Linux builder remain future backend work.
 - [x] Added ADR-048 and Plan 74 to turn the Microsandbox comparison into claim-gated `mvm` runtime work: docs hygiene, OCI ingest, programmable networking, secret placeholders, SDK-owned lifecycle, measured cold-starts, and filesystem backend contracts.
 - [ ] Plan 74 W0 (claims hygiene and docs guardrails) in flight — new public Sandbox parity status page (`security/sandbox-parity-status.md`), `cargo xtask check-doc-claims` lint covering `<100ms` / `any OCI image` / `secrets cannot leak` / variants, `mvmforge` cleanup in `guides/exec.md` and `reference/cli-commands.md`, gap-analysis updated for current `crates/mvm-sdk` layout and mvmd ADR-0020 handoff, and a new `specs/plans/74-w1-w6-attack-plan.md` sequencing sidecar that defers risk discussion to plan 74's `## Risks` section (R1-R12).
+- [x] Added intent-bound admission profiles to signed `ExecutionPlan` v4, binding intent, seccomp tier, policy refs, secret-release posture, and audit taxonomy without adding new sandbox execution capability.
+- [x] Documented the host-orchestrated builder VM flow across the website docs, clarifying that `mvmctl build` runs from the host while Nix evaluation/builds execute inside the builder VM and runtime boot benchmarks consume already-built artifacts.
 
 ## In-flight workstreams
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -48,6 +48,7 @@ Recent maintenance:
 - [ ] Plan 74 W0 (claims hygiene and docs guardrails) in flight — new public Sandbox parity status page (`security/sandbox-parity-status.md`), `cargo xtask check-doc-claims` lint covering `<100ms` / `any OCI image` / `secrets cannot leak` / variants, `mvmforge` cleanup in `guides/exec.md` and `reference/cli-commands.md`, gap-analysis updated for current `crates/mvm-sdk` layout and mvmd ADR-0020 handoff, and a new `specs/plans/74-w1-w6-attack-plan.md` sequencing sidecar that defers risk discussion to plan 74's `## Risks` section (R1-R12).
 - [x] Added intent-bound admission profiles to signed `ExecutionPlan` v4, binding intent, seccomp tier, policy refs, secret-release posture, and audit taxonomy without adding new sandbox execution capability.
 - [x] Documented the host-orchestrated builder VM flow across the website docs, clarifying that `mvmctl build` runs from the host while Nix evaluation/builds execute inside the builder VM and runtime boot benchmarks consume already-built artifacts.
+- [x] Aligned `dev_build` with the builder VM invariant by removing the host-Nix dispatch probe from the normal path; Nix builds now route through the libkrun builder VM when builder-VM support is compiled in.
 
 ## In-flight workstreams
 

--- a/specs/adrs/046-builder-vm-via-libkrun.md
+++ b/specs/adrs/046-builder-vm-via-libkrun.md
@@ -32,7 +32,8 @@ The builder-VM call site (`mvm_cli::commands::env::apple_container::build_image_
 
 That's the entire used surface. In exchange, libkrun brings:
 
-- ~40 transitive crates (sqlx, sea-orm, ouroboros, libkrun-protocol, libkrun-image, libkrun-network, libkrun-runtime, libkrun-db, libkrun-filesystem, sigstore_protobuf_specs, oci-client, opendal, …)
+- ~40 transitive crates, including database, image, network, filesystem,
+  signature, OCI, and object-store support that this project does not need
 - A SQLite-backed sandbox/volume database in `~/.libkrun/`
 - An EROFS + ext4 overlay rootfs system
 - A snapshot/agent/named-volume/disk-image system we don't use
@@ -212,7 +213,7 @@ The trade we're accepting: we now ship a kernel + rootfs as part of every mvm re
 
 - Real implementation work — 2–3 sprints by the plan-71 estimate (W0 through W6).
 - Plan 72 W0–W2 depend on plan 57 (libkrun spike) reaching at least "boot a Nix-built kernel + ext4 rootfs on macOS Apple Silicon." If plan 57 stays in spike status, plan 72 W0–W2 stall; the vendoring fallback (fork libkrun, expose `upper_size_mib`) is the named escape hatch.
-- During the transition, the migration adds a temporary `backends-builder-vm-libkrun` flag, default-on once W5 lands.
+- During the transition, the migration adds a temporary `builder-vm` flag, default-on once W5 lands.
 - The published builder image is a new release artifact. The release pipeline grows two new `builder-vmlinux-{arch}` + `builder-rootfs-{arch}.ext4` outputs alongside the existing dev-image outputs.
 - Contributors who modify `nix/images/builder-vm/flake.nix` validate that change through the builder-image build path rather than a libkrun bootstrap path.
 

--- a/specs/plans/72-builder-vm-via-libkrun.md
+++ b/specs/plans/72-builder-vm-via-libkrun.md
@@ -48,7 +48,7 @@ When all nine hold, ADR-046 flips from Proposed to Accepted and the plan moves t
 `crates/mvm-cli/src/commands/env/apple_container.rs::build_image_via_libkrun` derives `workspace_root = flake_dir.parent().parent().parent()` and sets:
 
 - `BuilderMounts.flake_src = workspace_root`
-- `BuilderJob.flake_ref = format!("path:{}/{}", BUILDER_GUEST_WORK_DIR, flake_rel)` where `flake_rel = flake_src.strip_prefix(workspace_root)`
+- `BuilderJob.flake_ref = format!("path:{}/{}", GUEST_WORK_DIR, flake_rel)` where `flake_rel = flake_src.strip_prefix(workspace_root)`
 
 Drops the previous shape where only `nix/images/builder/` was mounted at `/work` and `path = ../../..` in the flake resolved to `/` of the sandbox, hitting `/.msb/agent.sock` (or its libkrun equivalent — the sandbox internals will differ but `..` escaping the mount always hits *something*).
 
@@ -123,7 +123,7 @@ impl BuilderVm for LibkrunBuilderVm {
 
 ### Feature gate
 
-`backends-builder-vm-libkrun` (new). Default-off in this phase.
+`builder-vm` (new). Default-off in this phase.
 
 ### W1 acceptance
 
@@ -287,7 +287,7 @@ Reshape `ensure_dev_image` to encode the two-layer artifact rule from ADR-046 §
 
 ### Feature flag polarity
 
-- `backends-builder-vm-libkrun` becomes the new default — covers Layer 1 + Layer 2 on user-facing paths.
+- `builder-vm` becomes the new default — covers Layer 1 + Layer 2 on user-facing paths.
 - The old libkrun bootstrap flag is removed. End users without libkrun get an install hint, not a libkrun fallback.
 
 ### Implementation notes for `ensure_dev_image`


### PR DESCRIPTION
## Summary
- document the Lima-to-builder-VM flow and update source-checkout guidance
- rename the default builder feature to `builder-vm` and route dev builds through the builder VM path
- harden builder VM bootability with console logs, idempotent mounts, Nix store seeding, CA/DNS files, and extra binary file support

## Tests
- `cargo check -p mvm-build -p mvm-cli`
- `cargo test -p mvm-build pipeline::dev_build -- --test-threads=1`
- `cargo test -p mvm-cli apple_container -- --test-threads=1`
- `cargo clippy -p mvm-build -p mvm-cli --all-targets -- -D warnings`
- `cargo test --workspace` (one parallel env-var race in `mvm-core::config::tests::test_mvm_cache_dir_env_override`; rerun below passed)
- `cargo test -p mvm-core config::tests::test_mvm_cache_dir_env_override -- --test-threads=1`