### PR TITLE
Plan 76 Phases 1–3 + 8 (partial): secure fast-boot foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,55 @@ jobs:
   # security.yml (which fires on the same triggers — push to main + PRs).
   # See specs/plans/40-cli-surface-polish.md follow-up note.
 
+  # ── Lane: sealed-prod vsock allowlist locked (plan 76 Phase 1) ────
+  # Plan 76 §"Phase 8 — Security regression gate" (partial). The big
+  # `test` lane above already runs the per-variant classifier and
+  # rejection tests, but a SealedProd allowlist widening is the kind
+  # of mistake that's catastrophic and easy to ship by accident
+  # (silently dropping a `RequestClass` line, classifying a new dev
+  # verb as `ProdSafe`). Promoting the relevant tests to their own
+  # named lane gives reviewers a single discoverable signal that
+  # "the prod surface didn't change" — same intent as
+  # `prod-agent-runentry-contract` in security.yml for the symbol
+  # contract (ADR-002 §W4.3), one step earlier in the gate stack.
+  #
+  # The actual assertions live in mvm-guest and mvm-core tests; this
+  # lane is a thin filter so a PR that widens the prod allowlist
+  # turns the lane red regardless of how many other tests pass.
+  # No untrusted GitHub event input flows into any step — all
+  # `run:` commands below are static literals.
+  sealed-prod-allowlist:
+    name: Sealed-prod vsock allowlist (plan 76 Phase 1)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install system build deps (see `test` job for why)
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+
+      - name: Cache cargo
+        # Share the `test` job's cache key — both jobs build the same
+        # mvm-guest/mvm-core graph, so a cache hit on either fills the
+        # other. GHA tolerates concurrent reads + best-of-N writes.
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-test-
+
+      - name: Assert SealedProd vsock allowlist matches plan 76 §Phase 1
+        # The script wraps `cargo test ... -- --exact <name>` with a
+        # count assertion. `cargo test --exact` exits 0 when filters
+        # match zero tests, which would silently green-light a delete
+        # or rename — the count guard turns that into a red lane.
+        run: ./scripts/check-sealed-prod-allowlist.sh
+
   mcp-server-smoke:
     name: MCP server stdio roundtrip (plan 32 / Proposal A)
     runs-on: ubuntu-latest

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -459,6 +459,11 @@ fn exit_code_for(event: &mvm_guest::vsock::EntrypointEvent) -> i32 {
                 // pattern; SIGALRM is repurposed here as a stable
                 // "your session was reaped" signal SDKs can match on.
                 RunEntrypointError::SessionKilled => (142, "session killed"),
+                // Plan 76 Phase 2: transient — entrypoint validation
+                // still in flight. Exit 75 = `EX_TEMPFAIL` so wrapper
+                // scripts can branch on "retry safe" vs. the terminal
+                // failures above.
+                RunEntrypointError::NotReady => (75, "agent not ready"),
                 RunEntrypointError::InternalError => (1, "internal error"),
             };
             ui::warn(&format!("invoke: {label}: {message}"));

--- a/crates/mvm-core/src/policy/security.rs
+++ b/crates/mvm-core/src/policy/security.rs
@@ -65,6 +65,46 @@ pub struct SessionHelloAck {
 }
 
 // ============================================================================
+// Agent profile (plan 76 Phase 1)
+// ============================================================================
+
+/// Profile baked into an mvm guest image. Determines the set of vsock
+/// verbs the guest agent's dispatcher will accept; dev-only verbs
+/// (`Exec`, `ConsoleOpen`, `ProcStart`, `RunCode`, filesystem RPC,
+/// port forwarding) are rejected pre-handler when the image declares
+/// `SealedProd`.
+///
+/// **Source of truth.** The profile is declared by the image config
+/// — `/etc/mvm/security.json` on a sealed-prod image lives on a
+/// dm-verity rootfs (ADR-002 §W3), so the value cannot be widened at
+/// runtime: any modification breaks the verity hash and the kernel
+/// panics in `mvm-verity-init` before userspace. The loader treats
+/// absence of the policy file as an unprovisioned dev image
+/// (`SecurityPolicy::dev_defaults`).
+///
+/// **Builder uses a different protocol.** `mvm-builder-agent`'s wire
+/// type is `BuilderRequest`, not `GuestRequest`; the `Builder`
+/// profile is reserved for any future `GuestRequest` variant that
+/// only makes sense during a build. No current variant is
+/// `BuilderOnly`, so the value is wire-stable but unused for the
+/// tenant agent today.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentProfile {
+    /// Hardened production guest. Only ADR-002 production-safe verbs
+    /// pass the dispatcher gate.
+    #[default]
+    SealedProd,
+    /// Development guest. Adds shell exec, process RPC, filesystem
+    /// RPC, console, port forwarding, and `RunCode`.
+    Dev,
+    /// Builder-VM agent. Reserved for `BuilderOnly`-classified verbs
+    /// when the builder protocol moves to `GuestRequest`; today the
+    /// builder agent speaks `BuilderRequest` exclusively.
+    Builder,
+}
+
+// ============================================================================
 // Security policy
 // ============================================================================
 
@@ -81,6 +121,12 @@ pub struct SecurityPolicy {
     /// Set to false only for dev/testing environments.
     #[serde(default = "default_true")]
     pub require_auth: bool,
+
+    /// Image profile (plan 76 Phase 1). Drives the agent's dispatcher
+    /// allowlist. Defaults to `SealedProd` for a serialized policy
+    /// that omits the field; `dev_defaults()` constructs with `Dev`.
+    #[serde(default)]
+    pub profile: AgentProfile,
 
     /// Access control toggles.
     #[serde(default)]
@@ -103,6 +149,7 @@ impl Default for SecurityPolicy {
     fn default() -> Self {
         Self {
             require_auth: true,
+            profile: AgentProfile::SealedProd,
             access: AccessPolicy::default(),
             rate_limits: RateLimitPolicy::default(),
             session: SessionPolicy::default(),
@@ -117,6 +164,7 @@ impl SecurityPolicy {
     pub fn dev_defaults() -> Self {
         Self {
             require_auth: false,
+            profile: AgentProfile::Dev,
             access: AccessPolicy {
                 console: true,
                 ..AccessPolicy::default()
@@ -469,6 +517,7 @@ mod tests {
         let policy = SecurityPolicy::default();
 
         assert!(policy.require_auth);
+        assert_eq!(policy.profile, AgentProfile::SealedProd);
         assert!(policy.access.filesystem);
         assert!(policy.access.network);
         assert!(policy.access.build);
@@ -477,6 +526,44 @@ mod tests {
         assert_eq!(policy.rate_limits.frames_per_minute, 3000);
         assert_eq!(policy.session.max_lifetime_secs, 0);
         assert_eq!(policy.session.max_tasks, 0);
+    }
+
+    #[test]
+    fn test_agent_profile_serde_kebab_case() {
+        // Wire format is kebab-case so a hand-written policy JSON can
+        // use the friendlier `"sealed-prod"` / `"dev"` / `"builder"`.
+        assert_eq!(
+            serde_json::to_string(&AgentProfile::SealedProd).unwrap(),
+            "\"sealed-prod\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AgentProfile::Dev).unwrap(),
+            "\"dev\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AgentProfile::Builder).unwrap(),
+            "\"builder\""
+        );
+
+        let p: AgentProfile = serde_json::from_str("\"sealed-prod\"").unwrap();
+        assert_eq!(p, AgentProfile::SealedProd);
+    }
+
+    #[test]
+    fn test_security_policy_dev_defaults_carries_dev_profile() {
+        let policy = SecurityPolicy::dev_defaults();
+        assert_eq!(policy.profile, AgentProfile::Dev);
+        assert!(!policy.require_auth);
+        assert!(policy.access.console);
+    }
+
+    #[test]
+    fn test_security_policy_missing_profile_field_is_sealed_prod() {
+        // An older or hand-rolled policy file that omits `profile`
+        // must NOT silently widen to `Dev`. ADR-002 fail-closed.
+        let json = "{}";
+        let policy: SecurityPolicy = serde_json::from_str(json).unwrap();
+        assert_eq!(policy.profile, AgentProfile::SealedProd);
     }
 
     #[test]
@@ -511,6 +598,7 @@ mod tests {
     fn test_security_policy_full_roundtrip() {
         let policy = SecurityPolicy {
             require_auth: true,
+            profile: AgentProfile::SealedProd,
             access: AccessPolicy {
                 filesystem: false,
                 network: true,
@@ -538,6 +626,7 @@ mod tests {
         let parsed: SecurityPolicy = serde_json::from_str(&json).unwrap();
 
         assert!(parsed.require_auth);
+        assert_eq!(parsed.profile, AgentProfile::SealedProd);
         assert!(!parsed.access.filesystem);
         assert!(!parsed.access.build);
         assert_eq!(parsed.rate_limits.frames_per_second, 200);

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -34,6 +34,7 @@ use mvm_guest::integrations::{
 use mvm_guest::lifecycle_hooks::{self, ReadinessConfig};
 use mvm_guest::probes::{self, ProbeEntry, ProbeOutputFormat, ProbeResult};
 use mvm_guest::runtime_config::{self, ConcurrencyConfig};
+use mvm_core::security::AgentProfile;
 use mvm_guest::vsock::{
     EntrypointEvent, FsChange, FsChangeKind, GUEST_AGENT_PORT, GuestRequest, GuestResponse,
     RunEntrypointError,
@@ -1696,6 +1697,7 @@ fn handle_client(
     integration_state: &Arc<Mutex<IntegrationState>>,
     probe_state: &Arc<Mutex<ProbeState>>,
     boot_at: std::time::Instant,
+    active_profile: AgentProfile,
 ) {
     // SAFETY: fd comes from accept and is a valid file descriptor owned by this function.
     let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
@@ -1745,6 +1747,24 @@ fn handle_client(
             }
         }
     };
+
+    // Plan 76 Phase 1: profile gate. Reject dev-only verbs in
+    // sealed-prod *before* the per-variant handler runs. The gate
+    // returns a typed `UnsupportedInProfile` response so an SDK
+    // can branch on capability without parsing message text — this
+    // sits at the protocol layer in addition to the per-handler
+    // policy checks (ADR-002 "Dispatcher allowlists are not enough
+    // by themselves") and the `#[cfg(feature = "dev-shell")]`
+    // compile-time symbol-absence gate for `do_exec` / `do_run_code`
+    // (ADR-002 §W4.3, claim 4).
+    if !req.allowed_in(active_profile) {
+        let resp = GuestResponse::UnsupportedInProfile {
+            profile: active_profile,
+            verb: req.verb_name().to_string(),
+        };
+        write_response(&mut file, &resp);
+        return;
+    }
 
     let resp = match req {
         // The hello-prelude loop above guarantees `req` is not a
@@ -2332,6 +2352,20 @@ fn run_port_forwarder(vsock_port: u32, tcp_port: u16) {
 fn main() {
     let cfg = parse_config();
 
+    // Plan 76 Phase 1: resolve the active vsock profile from the
+    // baked image config. The policy file lives on a dm-verity rootfs
+    // for sealed-prod images (ADR-002 §W3), so its `profile` field
+    // can't be widened at runtime — flipping it would break the
+    // verity hash and the kernel panics in `mvm-verity-init` before
+    // userspace. Absence of `/etc/mvm/security.json` is treated as an
+    // unprovisioned dev image (`SecurityPolicy::dev_defaults`).
+    let active_profile = mvm_guest::builder_agent::load_security_policy()
+        .ok()
+        .flatten()
+        .map(|p| p.profile)
+        .unwrap_or_else(|| mvm_core::security::SecurityPolicy::dev_defaults().profile);
+    eprintln!("mvm-guest-agent: profile={:?}", active_profile);
+
     eprintln!(
         "mvm-guest-agent: starting on vsock port {} (threshold={}, interval={}s)",
         cfg.port, cfg.busy_threshold, cfg.sample_interval_secs
@@ -2498,10 +2532,24 @@ fn main() {
             let integration_state = Arc::clone(&integration_state);
             let probe_state = Arc::clone(&probe_state);
             std::thread::spawn(move || {
-                handle_client(cfd, &state, &integration_state, &probe_state, boot_at);
+                handle_client(
+                    cfd,
+                    &state,
+                    &integration_state,
+                    &probe_state,
+                    boot_at,
+                    active_profile,
+                );
             });
         } else {
-            handle_client(cfd, &state, &integration_state, &probe_state, boot_at);
+            handle_client(
+                cfd,
+                &state,
+                &integration_state,
+                &probe_state,
+                boot_at,
+                active_profile,
+            );
         }
     }
 

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -376,21 +376,43 @@ impl AgentBootState {
         }
     }
 
+    /// Set the warm-pool component and stamp `warm_pool_ready_ms`
+    /// when the state first leaves `Starting` for a terminal value
+    /// (`Ready` / `Failed` / `Disabled`). Initial `Disabled` (the
+    /// `Default` value, set before any background thread runs) does
+    /// not stamp — we only count time once init actually starts.
     fn set_warm_pool(&self, state: ComponentState) {
         if let Ok(mut s) = self.inner.lock() {
+            let was_starting = matches!(s.warm_pool, ComponentState::Starting);
             s.warm_pool = state;
+            if was_starting && s.timing.warm_pool_ready_ms.is_none() {
+                s.timing.warm_pool_ready_ms = Some(self.elapsed_ms());
+            }
         }
     }
 
+    /// Set the integrations component. Stamps `integrations_ready_ms`
+    /// on the first transition out of `Starting`. See `set_warm_pool`
+    /// for the rationale on skipping initial-Disabled stamps.
     fn set_integrations(&self, state: ComponentState) {
         if let Ok(mut s) = self.inner.lock() {
+            let was_starting = matches!(s.integrations, ComponentState::Starting);
             s.integrations = state;
+            if was_starting && s.timing.integrations_ready_ms.is_none() {
+                s.timing.integrations_ready_ms = Some(self.elapsed_ms());
+            }
         }
     }
 
+    /// Set the probes component. Stamps `probes_ready_ms` on the
+    /// first transition out of `Starting`.
     fn set_probes(&self, state: ComponentState) {
         if let Ok(mut s) = self.inner.lock() {
+            let was_starting = matches!(s.probes, ComponentState::Starting);
             s.probes = state;
+            if was_starting && s.timing.probes_ready_ms.is_none() {
+                s.timing.probes_ready_ms = Some(self.elapsed_ms());
+            }
         }
     }
 
@@ -1556,6 +1578,71 @@ fn wait_for_after_start(pool: &Arc<WorkerPool>) {
     }
 }
 
+/// Scan `/etc/mvm/integrations.d/*.json`, populate
+/// `integration_state` with the discovered entries, and spawn the
+/// health-check loop iff at least one integration was loaded. Plan
+/// 76 Phase 3 — runs on its own background thread so a slow or
+/// malformed drop-in cannot delay the accept loop.
+///
+/// Transitions in `AgentBootState`:
+///   `Starting` → `Ready`    (≥ 1 integration loaded; health loop spawned)
+///   `Starting` → `Disabled` (no integrations declared)
+///
+/// `Failed` is not currently produced — `load_dropin_dir` is
+/// best-effort per-file (a malformed JSON file is skipped with a
+/// stderr log; the rest still load). That matches Phase 3's
+/// "malformed integration drop-in does not kill control-plane
+/// readiness" acceptance criterion.
+fn init_integrations(
+    boot_state: &Arc<AgentBootState>,
+    integration_state: &Arc<Mutex<IntegrationState>>,
+) {
+    boot_state.set_integrations(ComponentState::Starting);
+    let entries = integrations::load_dropin_dir(integrations::INTEGRATIONS_DROPIN_DIR);
+    let count = entries.len();
+    if let Ok(mut s) = integration_state.lock() {
+        s.integrations = entries
+            .into_iter()
+            .map(|e| IntegrationHealth {
+                entry: e,
+                last_result: None,
+            })
+            .collect();
+    }
+    if count > 0 {
+        boot_state.set_integrations(ComponentState::Ready);
+        let health_state = Arc::clone(integration_state);
+        std::thread::spawn(move || integration_health_loop(health_state));
+    } else {
+        boot_state.set_integrations(ComponentState::Disabled);
+    }
+}
+
+/// Scan `/etc/mvm/probes.d/*.json`, populate `probe_state` with the
+/// discovered entries, and spawn the probe loop iff at least one
+/// probe was loaded. Mirrors `init_integrations`. Plan 76 Phase 3.
+fn init_probes(boot_state: &Arc<AgentBootState>, probe_state: &Arc<Mutex<ProbeState>>) {
+    boot_state.set_probes(ComponentState::Starting);
+    let entries = probes::load_probe_dropin_dir(probes::PROBES_DROPIN_DIR);
+    let count = entries.len();
+    if let Ok(mut s) = probe_state.lock() {
+        s.probes = entries
+            .into_iter()
+            .map(|e| ProbeHealth {
+                entry: e,
+                last_result: None,
+            })
+            .collect();
+    }
+    if count > 0 {
+        boot_state.set_probes(ComponentState::Ready);
+        let health_state = Arc::clone(probe_state);
+        std::thread::spawn(move || probe_health_loop(health_state));
+    } else {
+        boot_state.set_probes(ComponentState::Disabled);
+    }
+}
+
 /// Generate a per-call TMPDIR path under /tmp. The mutex guarantees only
 /// one in-flight call per VM, so a name collision is exceedingly unlikely
 /// — but use pid + nanos anyway to survive any post-crash leftovers.
@@ -2694,59 +2781,36 @@ fn main() {
     HOT_SAMPLE_INTERVAL_SECS.store(cfg.sample_interval_secs, Ordering::Release);
     std::thread::spawn(move || monitoring_loop(monitor_state));
 
-    // Scan drop-in integrations and start health check thread.
-    // Plan 76 Phase 2: still synchronous here; Phase 3 moves the
-    // scan + health-loop spawn behind the accept loop. Reflect the
-    // synchronous-ready outcome into `AgentBootState` so
-    // `ReadinessStatus` reports it accurately today.
-    let entries = integrations::load_dropin_dir(integrations::INTEGRATIONS_DROPIN_DIR);
-    let integration_count = entries.len();
+    // Plan 76 Phase 3: defer integration drop-in scanning + health
+    // loop startup to a dedicated background thread. The scan
+    // itself is fast (single directory read), but moving it off the
+    // bind-to-accept critical path also means a malformed drop-in
+    // can't bubble a panic into the boot sequence.
     let integration_state = Arc::new(Mutex::new(IntegrationState {
-        integrations: entries
-            .into_iter()
-            .map(|e| IntegrationHealth {
-                entry: e,
-                last_result: None,
-            })
-            .collect(),
+        integrations: Vec::new(),
     }));
-    if integration_count > 0 {
-        boot_state.set_integrations(ComponentState::Ready);
-        let health_state = Arc::clone(&integration_state);
-        std::thread::spawn(move || integration_health_loop(health_state));
-    } else {
-        // `Disabled` is the AgentBootState default; the explicit set
-        // documents intent and survives future refactors that change
-        // the default.
-        boot_state.set_integrations(ComponentState::Disabled);
+    {
+        let bs = Arc::clone(&boot_state);
+        let s = Arc::clone(&integration_state);
+        std::thread::spawn(move || init_integrations(&bs, &s));
     }
 
-    // Scan drop-in probes and start probe execution thread.
-    let probe_entries = probes::load_probe_dropin_dir(probes::PROBES_DROPIN_DIR);
-    let probe_count = probe_entries.len();
+    // Same shape for the probe drop-in scan + loop. Plan 76 Phase 3.
     let probe_state = Arc::new(Mutex::new(ProbeState {
-        probes: probe_entries
-            .into_iter()
-            .map(|e| ProbeHealth {
-                entry: e,
-                last_result: None,
-            })
-            .collect(),
+        probes: Vec::new(),
     }));
-    if probe_count > 0 {
-        boot_state.set_probes(ComponentState::Ready);
-        let health_probe_state = Arc::clone(&probe_state);
-        std::thread::spawn(move || probe_health_loop(health_probe_state));
-    } else {
-        boot_state.set_probes(ComponentState::Disabled);
+    {
+        let bs = Arc::clone(&boot_state);
+        let s = Arc::clone(&probe_state);
+        std::thread::spawn(move || init_probes(&bs, &s));
     }
 
     // Port forwarders are started on-demand via StartPortForward requests
     // from the host (works with all backends, no config drive needed).
 
     eprintln!(
-        "mvm-guest-agent: listening on vsock port {} ({} integrations, {} probes)",
-        cfg.port, integration_count, probe_count
+        "mvm-guest-agent: listening on vsock port {} (entrypoint, warm pool, integrations, probes initializing in background)",
+        cfg.port
     );
 
     // Plan 43: when warm-process is active, real concurrency from
@@ -3371,5 +3435,93 @@ mod tests {
         assert_eq!(SHUTDOWN_HOOK_POLL, Duration::from_millis(200));
         assert_eq!(AFTER_START_HOOK, "/etc/mvm/hooks/after_start.sh");
         assert_eq!(BEFORE_STOP_HOOK, "/etc/mvm/hooks/before_stop.sh");
+    }
+
+    // ─── Plan 76 Phase 2 / Phase 3 — AgentBootState transitions ────
+
+    fn fresh_boot_state() -> AgentBootState {
+        AgentBootState::new(AgentProfile::SealedProd, std::time::Instant::now())
+    }
+
+    #[test]
+    fn boot_state_starts_with_starting_control_plane_and_entrypoint() {
+        let s = fresh_boot_state().snapshot();
+        assert_eq!(s.control_plane, ComponentState::Starting);
+        assert_eq!(s.entrypoint, ComponentState::Starting);
+        // Optional subsystems default to Disabled — they only flip
+        // to Starting when their background init thread actually runs.
+        assert_eq!(s.warm_pool, ComponentState::Disabled);
+        assert_eq!(s.integrations, ComponentState::Disabled);
+        assert_eq!(s.probes, ComponentState::Disabled);
+        assert_eq!(s.volumes, ComponentState::Disabled);
+    }
+
+    #[test]
+    fn mark_vsock_bound_flips_control_plane_to_ready_and_stamps_timing() {
+        let bs = fresh_boot_state();
+        bs.mark_vsock_bound();
+        let s = bs.snapshot();
+        assert_eq!(s.control_plane, ComponentState::Ready);
+        assert!(s.boot_millis.vsock_bound_ms.is_some());
+        assert!(s.boot_millis.agent_started_ms.is_some());
+    }
+
+    #[test]
+    fn set_entrypoint_ready_stamps_entrypoint_ready_ms_once() {
+        let bs = fresh_boot_state();
+        bs.set_entrypoint(ComponentState::Ready);
+        let t1 = bs.snapshot().boot_millis.entrypoint_ready_ms;
+        assert!(t1.is_some());
+        // A later transition (e.g. PostRestore reset) must not
+        // overwrite the original timing — readers polling for
+        // cold-path stats want the FIRST ready time, not the most
+        // recent.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        bs.set_entrypoint(ComponentState::Failed {
+            message: "synthetic".to_string(),
+        });
+        let t2 = bs.snapshot().boot_millis.entrypoint_ready_ms;
+        assert_eq!(t1, t2);
+    }
+
+    #[test]
+    fn set_integrations_starting_then_ready_stamps_timing() {
+        let bs = fresh_boot_state();
+        // Phase 3 helpers go through Starting first; only that path
+        // should stamp the timing. A direct Disabled → Disabled
+        // transition must NOT stamp.
+        bs.set_integrations(ComponentState::Disabled);
+        assert!(bs.snapshot().boot_millis.integrations_ready_ms.is_none());
+
+        bs.set_integrations(ComponentState::Starting);
+        assert!(bs.snapshot().boot_millis.integrations_ready_ms.is_none());
+
+        bs.set_integrations(ComponentState::Ready);
+        assert!(bs.snapshot().boot_millis.integrations_ready_ms.is_some());
+    }
+
+    #[test]
+    fn set_integrations_starting_then_disabled_also_stamps() {
+        // Empty drop-in dir: the background thread enters Starting,
+        // scans, finds nothing, and flips to Disabled. That's still
+        // a meaningful "scan completed" event — stamp the time so
+        // a host can see cold-path latency includes the no-op scan.
+        let bs = fresh_boot_state();
+        bs.set_integrations(ComponentState::Starting);
+        bs.set_integrations(ComponentState::Disabled);
+        assert!(bs.snapshot().boot_millis.integrations_ready_ms.is_some());
+    }
+
+    #[test]
+    fn set_warm_pool_only_stamps_after_first_starting_transition() {
+        let bs = fresh_boot_state();
+        // Initial Disabled (Default) → Disabled (cold-tier image,
+        // no warm-pool config). No Starting in between → no stamp.
+        bs.set_warm_pool(ComponentState::Disabled);
+        assert!(bs.snapshot().boot_millis.warm_pool_ready_ms.is_none());
+
+        bs.set_warm_pool(ComponentState::Starting);
+        bs.set_warm_pool(ComponentState::Ready);
+        assert!(bs.snapshot().boot_millis.warm_pool_ready_ms.is_some());
     }
 }

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use mvm_core::security::AgentProfile;
 use mvm_guest::entrypoint::{
     CallCaps, CallOutcome, EntrypointPolicy, PayloadCapStream, ValidatedEntrypoint, execute,
 };
@@ -34,7 +35,6 @@ use mvm_guest::integrations::{
 use mvm_guest::lifecycle_hooks::{self, ReadinessConfig};
 use mvm_guest::probes::{self, ProbeEntry, ProbeOutputFormat, ProbeResult};
 use mvm_guest::runtime_config::{self, ConcurrencyConfig};
-use mvm_core::security::AgentProfile;
 use mvm_guest::vsock::{
     BootTimingReport, ComponentState, EntrypointEvent, FsChange, FsChangeKind, GUEST_AGENT_PORT,
     GuestRequest, GuestResponse, ReadinessReport, RunEntrypointError,
@@ -365,10 +365,8 @@ impl AgentBootState {
 
     fn set_entrypoint(&self, state: ComponentState) {
         if let Ok(mut s) = self.inner.lock() {
-            let became_terminal = matches!(
-                state,
-                ComponentState::Ready | ComponentState::Failed { .. }
-            );
+            let became_terminal =
+                matches!(state, ComponentState::Ready | ComponentState::Failed { .. });
             s.entrypoint = state;
             if became_terminal && s.timing.entrypoint_ready_ms.is_none() {
                 s.timing.entrypoint_ready_ms = Some(self.elapsed_ms());
@@ -418,39 +416,42 @@ impl AgentBootState {
 
     fn snapshot(&self) -> ReadinessReport {
         let inner = self.inner.lock();
-        let (
-            control_plane,
-            entrypoint,
-            warm_pool,
-            integrations,
-            probes,
-            volumes,
-            timing,
-        ) = match inner {
-            Ok(s) => (
-                s.control_plane.clone(),
-                s.entrypoint.clone(),
-                s.warm_pool.clone(),
-                s.integrations.clone(),
-                s.probes.clone(),
-                s.volumes.clone(),
-                s.timing.clone(),
-            ),
-            // Poisoned lock means another thread panicked mid-update;
-            // surface that as a generic Failed rather than swallowing.
-            Err(_) => {
-                let msg = "boot-state lock poisoned".to_string();
-                (
-                    ComponentState::Failed { message: msg.clone() },
-                    ComponentState::Failed { message: msg.clone() },
-                    ComponentState::Failed { message: msg.clone() },
-                    ComponentState::Failed { message: msg.clone() },
-                    ComponentState::Failed { message: msg.clone() },
-                    ComponentState::Failed { message: msg },
-                    BootTimingReport::default(),
-                )
-            }
-        };
+        let (control_plane, entrypoint, warm_pool, integrations, probes, volumes, timing) =
+            match inner {
+                Ok(s) => (
+                    s.control_plane.clone(),
+                    s.entrypoint.clone(),
+                    s.warm_pool.clone(),
+                    s.integrations.clone(),
+                    s.probes.clone(),
+                    s.volumes.clone(),
+                    s.timing.clone(),
+                ),
+                // Poisoned lock means another thread panicked mid-update;
+                // surface that as a generic Failed rather than swallowing.
+                Err(_) => {
+                    let msg = "boot-state lock poisoned".to_string();
+                    (
+                        ComponentState::Failed {
+                            message: msg.clone(),
+                        },
+                        ComponentState::Failed {
+                            message: msg.clone(),
+                        },
+                        ComponentState::Failed {
+                            message: msg.clone(),
+                        },
+                        ComponentState::Failed {
+                            message: msg.clone(),
+                        },
+                        ComponentState::Failed {
+                            message: msg.clone(),
+                        },
+                        ComponentState::Failed { message: msg },
+                        BootTimingReport::default(),
+                    )
+                }
+            };
         ReadinessReport {
             control_plane,
             entrypoint,
@@ -2186,15 +2187,11 @@ fn handle_client(
             // terminal). Snapshot once so the decision is consistent
             // even if a concurrent background-thread update flips
             // state mid-handler.
-            if matches!(
-                boot_state.snapshot().entrypoint,
-                ComponentState::Starting
-            ) {
+            if matches!(boot_state.snapshot().entrypoint, ComponentState::Starting) {
                 GuestResponse::EntrypointEvent(EntrypointEvent::Error {
                     kind: RunEntrypointError::NotReady,
-                    message:
-                        "entrypoint validation in progress; poll ReadinessStatus and retry"
-                            .to_string(),
+                    message: "entrypoint validation in progress; poll ReadinessStatus and retry"
+                        .to_string(),
                 })
             } else {
                 handle_run_entrypoint(&mut file, stdin, timeout_secs)
@@ -2753,7 +2750,11 @@ fn main() {
     boot_state.mark_vsock_bound();
     eprintln!(
         "mvm-guest-agent: control plane ready ({}ms)",
-        boot_state.snapshot().boot_millis.vsock_bound_ms.unwrap_or(0)
+        boot_state
+            .snapshot()
+            .boot_millis
+            .vsock_bound_ms
+            .unwrap_or(0)
     );
 
     // Plan 76 Phase 2: defer entrypoint validation + warm-pool
@@ -2796,9 +2797,7 @@ fn main() {
     }
 
     // Same shape for the probe drop-in scan + loop. Plan 76 Phase 3.
-    let probe_state = Arc::new(Mutex::new(ProbeState {
-        probes: Vec::new(),
-    }));
+    let probe_state = Arc::new(Mutex::new(ProbeState { probes: Vec::new() }));
     {
         let bs = Arc::clone(&boot_state);
         let s = Arc::clone(&probe_state);
@@ -3115,7 +3114,14 @@ mod tests {
             integrations: vec![],
         }));
         let probe_state = Arc::new(Mutex::new(ProbeState { probes: vec![] }));
-        let boot_at = std::time::Instant::now();
+        // Plan 76 Phase 2: handle_client now takes `&Arc<AgentBootState>`
+        // (carrying profile + boot_at + readiness) instead of a bare
+        // boot_at + active_profile.
+        let boot_state = Arc::new(AgentBootState::new(
+            AgentProfile::Dev,
+            std::time::Instant::now(),
+        ));
+        boot_state.mark_vsock_bound();
 
         let handle = std::thread::spawn(move || {
             handle_client(
@@ -3123,7 +3129,7 @@ mod tests {
                 &state,
                 &integration_state,
                 &probe_state,
-                boot_at,
+                &boot_state,
             );
         });
 
@@ -3172,7 +3178,11 @@ mod tests {
             integrations: vec![],
         }));
         let probe_state = Arc::new(Mutex::new(ProbeState { probes: vec![] }));
-        let boot_at = std::time::Instant::now();
+        let boot_state = Arc::new(AgentBootState::new(
+            AgentProfile::Dev,
+            std::time::Instant::now(),
+        ));
+        boot_state.mark_vsock_bound();
 
         let handle = std::thread::spawn(move || {
             handle_client(
@@ -3180,7 +3190,7 @@ mod tests {
                 &state,
                 &integration_state,
                 &probe_state,
-                boot_at,
+                &boot_state,
             );
         });
 

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -305,6 +305,7 @@ struct AgentBootState {
     boot_at: std::time::Instant,
 }
 
+#[derive(Default)]
 struct BootStateInner {
     control_plane: ComponentState,
     entrypoint: ComponentState,
@@ -319,20 +320,18 @@ impl AgentBootState {
     fn new(profile: AgentProfile, boot_at: std::time::Instant) -> Self {
         Self {
             inner: Mutex::new(BootStateInner {
-                // control_plane flips to Ready immediately after
-                // `bind+listen` succeeds in `main`; until then we're
-                // not even running, so Starting is correct as the
-                // initial pre-bind value.
+                // Two components start `Starting` rather than the
+                // `Default` `Disabled`: `control_plane` flips to
+                // `Ready` immediately after `bind+listen` in `main`
+                // (we're not running until then), and `entrypoint`
+                // is the boot dependency `RunEntrypoint` gates on.
+                // The remaining components keep `Disabled` from
+                // `Default` — the background init thread flips them
+                // to `Starting` when it sees config that requires
+                // them.
                 control_plane: ComponentState::Starting,
                 entrypoint: ComponentState::Starting,
-                // Optional subsystems start `Disabled`. The
-                // background init thread flips them to `Starting`
-                // when it sees config that requires them.
-                warm_pool: ComponentState::Disabled,
-                integrations: ComponentState::Disabled,
-                probes: ComponentState::Disabled,
-                volumes: ComponentState::Disabled,
-                timing: BootTimingReport::default(),
+                ..Default::default()
             }),
             profile,
             boot_at,

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -36,8 +36,8 @@ use mvm_guest::probes::{self, ProbeEntry, ProbeOutputFormat, ProbeResult};
 use mvm_guest::runtime_config::{self, ConcurrencyConfig};
 use mvm_core::security::AgentProfile;
 use mvm_guest::vsock::{
-    EntrypointEvent, FsChange, FsChangeKind, GUEST_AGENT_PORT, GuestRequest, GuestResponse,
-    RunEntrypointError,
+    BootTimingReport, ComponentState, EntrypointEvent, FsChange, FsChangeKind, GUEST_AGENT_PORT,
+    GuestRequest, GuestResponse, ReadinessReport, RunEntrypointError,
 };
 use mvm_guest::worker_pool::{DispatchError, DispatchOutcome, WorkerPool};
 use mvm_guest::worker_protocol::WorkerOutcome;
@@ -269,6 +269,176 @@ impl AgentState {
         Self {
             status: "idle".to_string(),
             last_busy_at: None,
+        }
+    }
+}
+
+// ============================================================================
+// Boot readiness state (plan 76 Phase 2)
+// ============================================================================
+
+/// Per-subsystem readiness, surfaced through `ReadinessStatus` and
+/// also consulted by `RunEntrypoint` so a host that races
+/// invocation ahead of warmup gets a typed `NotReady` rather than a
+/// permanent failure.
+///
+/// **State design.** A single `Mutex<BootStateInner>` instead of
+/// per-component atomics. Readers (`ReadinessStatus` handlers,
+/// `entrypoint_ready()` checks) are rare; writers fire at boot
+/// completion events. The lock holds for at most a few struct-field
+/// reads so contention is a non-issue. Per-component atomics
+/// (`AtomicU8` + side-channel for `Failed { message }`) would be
+/// more complex and earn nothing measurable.
+///
+/// **Why background init is still safe.** Per-handler invariants
+/// stay intact:
+///   - `RunEntrypoint` consults this state AND the existing
+///     `VALIDATED_ENTRYPOINT` `OnceLock` — `NotReady` while
+///     `Starting`, `EntrypointInvalid` once `VALIDATED_ENTRYPOINT`
+///     is set to `Err`.
+///   - Warm-process dispatch in the worker pool keeps its own
+///     ready flag (`WorkerPool::wait_for_ready`) — this state is
+///     observability, not the gate.
+struct AgentBootState {
+    inner: Mutex<BootStateInner>,
+    profile: AgentProfile,
+    boot_at: std::time::Instant,
+}
+
+struct BootStateInner {
+    control_plane: ComponentState,
+    entrypoint: ComponentState,
+    warm_pool: ComponentState,
+    integrations: ComponentState,
+    probes: ComponentState,
+    volumes: ComponentState,
+    timing: BootTimingReport,
+}
+
+impl AgentBootState {
+    fn new(profile: AgentProfile, boot_at: std::time::Instant) -> Self {
+        Self {
+            inner: Mutex::new(BootStateInner {
+                // control_plane flips to Ready immediately after
+                // `bind+listen` succeeds in `main`; until then we're
+                // not even running, so Starting is correct as the
+                // initial pre-bind value.
+                control_plane: ComponentState::Starting,
+                entrypoint: ComponentState::Starting,
+                // Optional subsystems start `Disabled`. The
+                // background init thread flips them to `Starting`
+                // when it sees config that requires them.
+                warm_pool: ComponentState::Disabled,
+                integrations: ComponentState::Disabled,
+                probes: ComponentState::Disabled,
+                volumes: ComponentState::Disabled,
+                timing: BootTimingReport::default(),
+            }),
+            profile,
+            boot_at,
+        }
+    }
+
+    /// Milliseconds elapsed since `boot_at`. Always fits in `u64`
+    /// for any plausible agent lifetime; saturates on the absurd.
+    fn elapsed_ms(&self) -> u64 {
+        u64::try_from(self.boot_at.elapsed().as_millis()).unwrap_or(u64::MAX)
+    }
+
+    fn mark_vsock_bound(&self) {
+        if let Ok(mut s) = self.inner.lock() {
+            s.control_plane = ComponentState::Ready;
+            let ms = self.elapsed_ms();
+            s.timing.agent_started_ms.get_or_insert(ms);
+            s.timing.vsock_bound_ms.get_or_insert(ms);
+        }
+    }
+
+    /// Stamp the first-accept timing. Idempotent — only the first
+    /// caller wins, subsequent accept loops are no-ops.
+    fn mark_first_accept(&self) {
+        if let Ok(mut s) = self.inner.lock()
+            && s.timing.first_accept_ms.is_none()
+        {
+            s.timing.first_accept_ms = Some(self.elapsed_ms());
+        }
+    }
+
+    fn set_entrypoint(&self, state: ComponentState) {
+        if let Ok(mut s) = self.inner.lock() {
+            let became_terminal = matches!(
+                state,
+                ComponentState::Ready | ComponentState::Failed { .. }
+            );
+            s.entrypoint = state;
+            if became_terminal && s.timing.entrypoint_ready_ms.is_none() {
+                s.timing.entrypoint_ready_ms = Some(self.elapsed_ms());
+            }
+        }
+    }
+
+    fn set_warm_pool(&self, state: ComponentState) {
+        if let Ok(mut s) = self.inner.lock() {
+            s.warm_pool = state;
+        }
+    }
+
+    fn set_integrations(&self, state: ComponentState) {
+        if let Ok(mut s) = self.inner.lock() {
+            s.integrations = state;
+        }
+    }
+
+    fn set_probes(&self, state: ComponentState) {
+        if let Ok(mut s) = self.inner.lock() {
+            s.probes = state;
+        }
+    }
+
+    fn snapshot(&self) -> ReadinessReport {
+        let inner = self.inner.lock();
+        let (
+            control_plane,
+            entrypoint,
+            warm_pool,
+            integrations,
+            probes,
+            volumes,
+            timing,
+        ) = match inner {
+            Ok(s) => (
+                s.control_plane.clone(),
+                s.entrypoint.clone(),
+                s.warm_pool.clone(),
+                s.integrations.clone(),
+                s.probes.clone(),
+                s.volumes.clone(),
+                s.timing.clone(),
+            ),
+            // Poisoned lock means another thread panicked mid-update;
+            // surface that as a generic Failed rather than swallowing.
+            Err(_) => {
+                let msg = "boot-state lock poisoned".to_string();
+                (
+                    ComponentState::Failed { message: msg.clone() },
+                    ComponentState::Failed { message: msg.clone() },
+                    ComponentState::Failed { message: msg.clone() },
+                    ComponentState::Failed { message: msg.clone() },
+                    ComponentState::Failed { message: msg.clone() },
+                    ComponentState::Failed { message: msg },
+                    BootTimingReport::default(),
+                )
+            }
+        };
+        ReadinessReport {
+            control_plane,
+            entrypoint,
+            warm_pool,
+            integrations,
+            probes,
+            volumes,
+            profile: self.profile,
+            boot_millis: timing,
         }
     }
 }
@@ -1241,19 +1411,31 @@ fn run_before_stop_hook() {
 /// Validate `/etc/mvm/entrypoint` at agent boot. The result is stashed in
 /// `VALIDATED_ENTRYPOINT`. On failure, log a single line — the agent stays
 /// up; only `RunEntrypoint` requests fail with `EntrypointInvalid`.
-fn init_entrypoint_validation() {
+///
+/// Plan 76 Phase 2: also updates `AgentBootState.entrypoint` so
+/// `ReadinessStatus` reports `Ready` (or `Failed { message }`) and
+/// stamps `entrypoint_ready_ms` for cold-path timing.
+fn init_entrypoint_validation(boot_state: &Arc<AgentBootState>) {
     let result = EntrypointPolicy::production()
         .validate()
         .map_err(|e| e.to_string());
     match &result {
-        Ok(v) => eprintln!(
-            "mvm-guest-agent: entrypoint validated at {} (held open for fexecve)",
-            v.resolved.display()
-        ),
-        Err(msg) => eprintln!(
-            "mvm-guest-agent: entrypoint validation failed at boot: {msg}; \
-             RunEntrypoint requests will return EntrypointInvalid"
-        ),
+        Ok(v) => {
+            eprintln!(
+                "mvm-guest-agent: entrypoint validated at {} (held open for fexecve)",
+                v.resolved.display()
+            );
+            boot_state.set_entrypoint(ComponentState::Ready);
+        }
+        Err(msg) => {
+            eprintln!(
+                "mvm-guest-agent: entrypoint validation failed at boot: {msg}; \
+                 RunEntrypoint requests will return EntrypointInvalid"
+            );
+            boot_state.set_entrypoint(ComponentState::Failed {
+                message: msg.clone(),
+            });
+        }
     }
     let _ = VALIDATED_ENTRYPOINT.set(result);
 }
@@ -1269,49 +1451,72 @@ fn init_entrypoint_validation() {
 ///
 /// Missing `runtime.json` or absent `concurrency` → `Ok(None)`, the
 /// cold path stays in charge.
-fn init_warm_pool() {
+///
+/// Plan 76 Phase 2: runs in the boot-time background thread chained
+/// after `init_entrypoint_validation`. Updates
+/// `AgentBootState.warm_pool` (`Disabled` for cold-tier images,
+/// `Starting` → `Ready` for warm-pool, `Failed` on entrypoint
+/// dependency failure). Process-exit-on-bad-config is preserved —
+/// `runtime.json` is part of the immutable image and a malformed
+/// file is a build bug.
+fn init_warm_pool(boot_state: &Arc<AgentBootState>) {
     let result: Option<Arc<WorkerPool>> = match runtime_config::load() {
-        Ok(None) => None,
+        Ok(None) => {
+            boot_state.set_warm_pool(ComponentState::Disabled);
+            None
+        }
         Ok(Some(rc)) => match rc.concurrency {
-            None => None,
-            Some(ConcurrencyConfig::WarmProcess(wp)) => match VALIDATED_ENTRYPOINT.get() {
-                Some(Ok(entry)) => match entry.try_clone() {
-                    Ok(cloned) => match WorkerPool::start(wp, Arc::new(cloned), Vec::new()) {
-                        Ok(pool) => {
-                            // Plan 73 Followup E: run the baked
-                            // `after_start.sh` readiness probe before
-                            // letting traffic in. Pool starts in
-                            // `NotReady`; `wait_for_ready` flips it
-                            // on success, leaves it `NotReady` on
-                            // timeout/exec error so subsequent
-                            // dispatches fast-fail with `NotReady`
-                            // (host surface: Busy + "warming up"
-                            // message) rather than hitting an
-                            // unwarmed wrapper.
-                            wait_for_after_start(&pool);
-                            Some(pool)
-                        }
+            None => {
+                boot_state.set_warm_pool(ComponentState::Disabled);
+                None
+            }
+            Some(ConcurrencyConfig::WarmProcess(wp)) => {
+                boot_state.set_warm_pool(ComponentState::Starting);
+                match VALIDATED_ENTRYPOINT.get() {
+                    Some(Ok(entry)) => match entry.try_clone() {
+                        Ok(cloned) => match WorkerPool::start(wp, Arc::new(cloned), Vec::new()) {
+                            Ok(pool) => {
+                                // Plan 73 Followup E: run the baked
+                                // `after_start.sh` readiness probe before
+                                // letting traffic in. Pool starts in
+                                // `NotReady`; `wait_for_ready` flips it
+                                // on success, leaves it `NotReady` on
+                                // timeout/exec error so subsequent
+                                // dispatches fast-fail with `NotReady`
+                                // (host surface: Busy + "warming up"
+                                // message) rather than hitting an
+                                // unwarmed wrapper.
+                                wait_for_after_start(&pool);
+                                boot_state.set_warm_pool(ComponentState::Ready);
+                                Some(pool)
+                            }
+                            Err(e) => {
+                                eprintln!(
+                                    "mvm-guest-agent: warm-process pool start failed: {e}; refusing to boot"
+                                );
+                                std::process::exit(1);
+                            }
+                        },
                         Err(e) => {
                             eprintln!(
-                                "mvm-guest-agent: warm-process pool start failed: {e}; refusing to boot"
+                                "mvm-guest-agent: warm-process configured but entrypoint clone failed: {e}; refusing to boot"
                             );
                             std::process::exit(1);
                         }
                     },
-                    Err(e) => {
-                        eprintln!(
-                            "mvm-guest-agent: warm-process configured but entrypoint clone failed: {e}; refusing to boot"
-                        );
-                        std::process::exit(1);
+                    _ => {
+                        // Entrypoint validation failed; surface a
+                        // matching warm-pool failure rather than
+                        // process-exit. Plan 76 Phase 2: keep the
+                        // control plane up so `ReadinessStatus`
+                        // can report both failures together.
+                        boot_state.set_warm_pool(ComponentState::Failed {
+                            message: "entrypoint validation failed".to_string(),
+                        });
+                        None
                     }
-                },
-                _ => {
-                    eprintln!(
-                        "mvm-guest-agent: warm-process configured but entrypoint validation failed; refusing to boot"
-                    );
-                    std::process::exit(1);
                 }
-            },
+            }
         },
         Err(e) => {
             eprintln!("mvm-guest-agent: invalid /etc/mvm/runtime.json: {e}; refusing to boot");
@@ -1696,8 +1901,7 @@ fn handle_client(
     state: &Arc<Mutex<AgentState>>,
     integration_state: &Arc<Mutex<IntegrationState>>,
     probe_state: &Arc<Mutex<ProbeState>>,
-    boot_at: std::time::Instant,
-    active_profile: AgentProfile,
+    boot_state: &Arc<AgentBootState>,
 ) {
     // SAFETY: fd comes from accept and is a valid file descriptor owned by this function.
     let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
@@ -1747,6 +1951,9 @@ fn handle_client(
             }
         }
     };
+
+    let active_profile = boot_state.profile;
+    let boot_at = boot_state.boot_at;
 
     // Plan 76 Phase 1: profile gate. Reject dev-only verbs in
     // sealed-prod *before* the per-variant handler runs. The gate
@@ -1886,7 +2093,27 @@ fn handle_client(
         GuestRequest::RunEntrypoint {
             stdin,
             timeout_secs,
-        } => handle_run_entrypoint(&mut file, stdin, timeout_secs),
+        } => {
+            // Plan 76 Phase 2: distinguish "validation hasn't
+            // completed yet" (Starting → NotReady, transient) from
+            // "validation failed" (Failed → EntrypointInvalid,
+            // terminal). Snapshot once so the decision is consistent
+            // even if a concurrent background-thread update flips
+            // state mid-handler.
+            if matches!(
+                boot_state.snapshot().entrypoint,
+                ComponentState::Starting
+            ) {
+                GuestResponse::EntrypointEvent(EntrypointEvent::Error {
+                    kind: RunEntrypointError::NotReady,
+                    message:
+                        "entrypoint validation in progress; poll ReadinessStatus and retry"
+                            .to_string(),
+                })
+            } else {
+                handle_run_entrypoint(&mut file, stdin, timeout_secs)
+            }
+        }
 
         GuestRequest::FsDiff => {
             // Walk the overlay upper dir to find changes since boot.
@@ -1994,12 +2221,22 @@ fn handle_client(
                 path: None,
                 detail: Some(msg.clone()),
             },
+            // Plan 76 Phase 2: with background init, `None` means
+            // validation is still running, not "never ran".
             None => GuestResponse::EntrypointStatusReport {
                 ok: false,
                 path: None,
-                detail: Some("entrypoint validation never ran".to_string()),
+                detail: Some("entrypoint validation in progress".to_string()),
             },
         },
+
+        // Plan 76 Phase 2: structured readiness snapshot. Cheap —
+        // a single mutex lock + struct copy. Designed to be the
+        // verb a host polls during `mvmctl wait <vm> --for ...`
+        // without back-pressure on the rest of the agent.
+        GuestRequest::ReadinessStatus => {
+            GuestResponse::ReadinessStatusReport(boot_state.snapshot())
+        }
 
         // FS RPC verbs (W1 / A1). Production-safe surface backed
         // by `mvm_guest::fs_rpc::handle_with_defaults`: every path
@@ -2371,22 +2608,10 @@ fn main() {
         cfg.port, cfg.busy_threshold, cfg.sample_interval_secs
     );
 
-    // ADR-007 / plan 41 W2: validate `/etc/mvm/entrypoint` once at boot.
-    // Failures are non-fatal — only `RunEntrypoint` requests degrade.
-    init_entrypoint_validation();
-
-    // Plan 43: stand up the warm-process worker pool if mvmforge's
-    // /etc/mvm/runtime.json opts in. Must run AFTER
-    // `init_entrypoint_validation` since the pool spawns workers
-    // from the validated FD. Fail-loud on a misconfigured runtime.json.
-    init_warm_pool();
-
-    // Plan 44: wire SIGTERM/SIGINT handlers so a manual `kill -TERM`
-    // (or future hot-reload / operator-driven shutdown) drains the
-    // warm-process pool cleanly before the process exits. On a
-    // typical microVM teardown the kernel goes away faster than
-    // userspace can run handlers; this matters mostly when an
-    // operator targets the agent specifically.
+    // Plan 76 Phase 2: install signal handlers BEFORE vsock bind +
+    // background init. Same handlers fire whether we're mid-warmup
+    // or steady-state; better to wire them up before any work that
+    // might want clean teardown.
     install_signal_handlers();
 
     // SAFETY: libc call, arguments are constant values.
@@ -2432,6 +2657,34 @@ fn main() {
     // Record boot time for startup grace period tracking.
     let boot_at = std::time::Instant::now();
 
+    // Plan 76 Phase 2: shared readiness state. Created AFTER vsock
+    // bind+listen so `mark_vsock_bound` stamps an accurate
+    // `vsock_bound_ms`. Cloned into every handler thread via
+    // `Arc::clone` — the inner Mutex serialises the few writes
+    // (`set_entrypoint`, `set_warm_pool`, …) without measurable
+    // contention because writes only fire at boot completion events.
+    let boot_state = Arc::new(AgentBootState::new(active_profile, boot_at));
+    boot_state.mark_vsock_bound();
+    eprintln!(
+        "mvm-guest-agent: control plane ready ({}ms)",
+        boot_state.snapshot().boot_millis.vsock_bound_ms.unwrap_or(0)
+    );
+
+    // Plan 76 Phase 2: defer entrypoint validation + warm-pool
+    // startup to a background thread chained in dependency order
+    // (warm pool reads `VALIDATED_ENTRYPOINT.get()`, so the sequence
+    // must stay serial inside this one thread). The accept loop
+    // below begins serving `Ping` / `ReadinessStatus` /
+    // `EntrypointStatus` immediately; `RunEntrypoint` returns
+    // `NotReady` until the entrypoint flips to `Ready`.
+    {
+        let bs = Arc::clone(&boot_state);
+        std::thread::spawn(move || {
+            init_entrypoint_validation(&bs);
+            init_warm_pool(&bs);
+        });
+    }
+
     // Start background monitoring thread.
     let state = Arc::new(Mutex::new(AgentState::new()));
     let monitor_state = Arc::clone(&state);
@@ -2443,6 +2696,10 @@ fn main() {
     std::thread::spawn(move || monitoring_loop(monitor_state));
 
     // Scan drop-in integrations and start health check thread.
+    // Plan 76 Phase 2: still synchronous here; Phase 3 moves the
+    // scan + health-loop spawn behind the accept loop. Reflect the
+    // synchronous-ready outcome into `AgentBootState` so
+    // `ReadinessStatus` reports it accurately today.
     let entries = integrations::load_dropin_dir(integrations::INTEGRATIONS_DROPIN_DIR);
     let integration_count = entries.len();
     let integration_state = Arc::new(Mutex::new(IntegrationState {
@@ -2455,8 +2712,14 @@ fn main() {
             .collect(),
     }));
     if integration_count > 0 {
+        boot_state.set_integrations(ComponentState::Ready);
         let health_state = Arc::clone(&integration_state);
         std::thread::spawn(move || integration_health_loop(health_state));
+    } else {
+        // `Disabled` is the AgentBootState default; the explicit set
+        // documents intent and survives future refactors that change
+        // the default.
+        boot_state.set_integrations(ComponentState::Disabled);
     }
 
     // Scan drop-in probes and start probe execution thread.
@@ -2472,8 +2735,11 @@ fn main() {
             .collect(),
     }));
     if probe_count > 0 {
+        boot_state.set_probes(ComponentState::Ready);
         let health_probe_state = Arc::clone(&probe_state);
         std::thread::spawn(move || probe_health_loop(health_probe_state));
+    } else {
+        boot_state.set_probes(ComponentState::Disabled);
     }
 
     // Port forwarders are started on-demand via StartPortForward requests
@@ -2498,7 +2764,12 @@ fn main() {
     // returns < 0, which already triggers the bottom-of-loop check).
     // Once the flag flips, break out and drain via
     // `shutdown_subsystems`.
-    let warm_active = matches!(WARM_POOL.get(), Some(Some(_)));
+    // Plan 76 Phase 2: `warm_active` is now re-evaluated per
+    // iteration. The background init thread populates `WARM_POOL`
+    // some time after the accept loop starts, so a one-shot capture
+    // at loop entry would mis-classify all subsequent connections
+    // as cold-tier. `WARM_POOL.get()` is a relaxed atomic load —
+    // cheap enough to do per-accept.
     loop {
         if SHUTDOWN_REQUESTED.load(Ordering::Acquire) {
             break;
@@ -2527,29 +2798,20 @@ fn main() {
             // next iteration's compare_exchange.
             continue;
         }
+        // Plan 76 Phase 2: stamp first-accept timing once. Idempotent
+        // inside `AgentBootState` — subsequent calls are no-ops.
+        boot_state.mark_first_accept();
+        let warm_active = matches!(WARM_POOL.get(), Some(Some(_)));
         if warm_active {
             let state = Arc::clone(&state);
             let integration_state = Arc::clone(&integration_state);
             let probe_state = Arc::clone(&probe_state);
+            let bs = Arc::clone(&boot_state);
             std::thread::spawn(move || {
-                handle_client(
-                    cfd,
-                    &state,
-                    &integration_state,
-                    &probe_state,
-                    boot_at,
-                    active_profile,
-                );
+                handle_client(cfd, &state, &integration_state, &probe_state, &bs);
             });
         } else {
-            handle_client(
-                cfd,
-                &state,
-                &integration_state,
-                &probe_state,
-                boot_at,
-                active_profile,
-            );
+            handle_client(cfd, &state, &integration_state, &probe_state, &boot_state);
         }
     }
 

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -433,11 +433,17 @@ fn default_true() -> bool {
 /// registered) reports `Disabled`, while a present-and-warmed
 /// subsystem reports `Ready`. This lets the host UX distinguish
 /// "the workload doesn't use X" from "X is still warming".
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// `Default` is `Disabled` — the most-conservative semantically
+/// correct value (= "this subsystem isn't configured"). Lets
+/// constructors of `ReadinessReport` use `..Default::default()` to
+/// elide subsystems they don't care about in tests / fixtures.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum ComponentState {
     /// Subsystem is not configured for this image (no policy → no
     /// state machine to advance). Wire-stable distinct from `Ready`.
+    #[default]
     Disabled,
     /// Subsystem is initializing in the background.
     Starting,
@@ -501,7 +507,12 @@ pub struct BootTimingReport {
 ///   a typed error; the host can surface the validation message
 /// - "optional subsystem failed" → invoke is still safe; the host
 ///   surfaces a warning
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// `Default` composes the `Default` impls of each field — every
+/// component is `Disabled`, the profile is `SealedProd`, all
+/// timings are `None`. Tests and fixtures can construct partial
+/// reports with `..Default::default()`.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ReadinessReport {
     /// Vsock listener bound and accepting. Always `Ready` if the
@@ -4627,24 +4638,18 @@ mod tests {
     fn test_readiness_report_roundtrip_with_disabled_subsystems() {
         // A cold-tier image's readiness snapshot mid-boot: control
         // plane ready, entrypoint still validating, everything
-        // else Disabled (no warm pool, no integrations, no probes).
+        // else `Disabled` (no warm pool, no integrations, no
+        // probes) by virtue of `Default`.
         let report = ReadinessReport {
             control_plane: ComponentState::Ready,
             entrypoint: ComponentState::Starting,
-            warm_pool: ComponentState::Disabled,
-            integrations: ComponentState::Disabled,
-            probes: ComponentState::Disabled,
-            volumes: ComponentState::Disabled,
-            profile: AgentProfile::SealedProd,
             boot_millis: BootTimingReport {
                 agent_started_ms: Some(3),
                 vsock_bound_ms: Some(3),
                 first_accept_ms: Some(7),
-                entrypoint_ready_ms: None,
-                warm_pool_ready_ms: None,
-                integrations_ready_ms: None,
-                probes_ready_ms: None,
+                ..Default::default()
             },
+            ..Default::default()
         };
         let json = serde_json::to_string(&report).unwrap();
         let parsed: ReadinessReport = serde_json::from_str(&json).unwrap();
@@ -4705,5 +4710,52 @@ mod tests {
         assert!(t.warm_pool_ready_ms.is_none());
         assert!(t.integrations_ready_ms.is_none());
         assert!(t.probes_ready_ms.is_none());
+    }
+
+    #[test]
+    fn test_component_state_default_is_disabled() {
+        // "Not configured" is the semantically conservative default.
+        // A subsystem we haven't heard anything about must NOT
+        // accidentally read as `Ready` — that would short-circuit a
+        // host's readiness gate.
+        assert_eq!(ComponentState::default(), ComponentState::Disabled);
+    }
+
+    #[test]
+    fn test_readiness_report_default_is_all_disabled_sealed_prod() {
+        // A bare `ReadinessReport::default()` is what an unconfigured
+        // sealed-prod agent would report. Tests / fixtures that only
+        // care about one or two components can use this + struct-
+        // update syntax instead of listing every field.
+        let r = ReadinessReport::default();
+        assert_eq!(r.control_plane, ComponentState::Disabled);
+        assert_eq!(r.entrypoint, ComponentState::Disabled);
+        assert_eq!(r.warm_pool, ComponentState::Disabled);
+        assert_eq!(r.integrations, ComponentState::Disabled);
+        assert_eq!(r.probes, ComponentState::Disabled);
+        assert_eq!(r.volumes, ComponentState::Disabled);
+        assert_eq!(r.profile, AgentProfile::SealedProd);
+        assert_eq!(r.boot_millis, BootTimingReport::default());
+    }
+
+    #[test]
+    fn test_readiness_report_default_struct_update_ergonomics() {
+        // Demonstrates the intended call-site shape: change one or
+        // two components, default the rest. If the type ever grows a
+        // field this test still compiles — that's the whole point.
+        let r = ReadinessReport {
+            control_plane: ComponentState::Ready,
+            entrypoint: ComponentState::Starting,
+            boot_millis: BootTimingReport {
+                vsock_bound_ms: Some(7),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(r.control_plane, ComponentState::Ready);
+        assert_eq!(r.entrypoint, ComponentState::Starting);
+        assert_eq!(r.warm_pool, ComponentState::Disabled);
+        assert_eq!(r.boot_millis.vsock_bound_ms, Some(7));
+        assert!(r.boot_millis.first_accept_ms.is_none());
     }
 }

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -171,6 +171,22 @@ pub enum GuestRequest {
     /// Prod-safe — reveals no secrets, takes no inputs.
     EntrypointStatus,
 
+    /// Query structured readiness across every guest subsystem
+    /// (control plane, entrypoint, warm pool, integrations, probes,
+    /// volumes) plus per-phase boot timings. Plan 76 Phase 2.
+    ///
+    /// Prod-safe — the response carries no secrets and reveals only
+    /// state the host already chose to provision (via image config /
+    /// drop-in files). Designed to be the verb that responds first
+    /// after vsock bind, so a host can begin streaming progress UX
+    /// before entrypoint validation or warm-pool warmup finish.
+    ///
+    /// Distinct from `EntrypointStatus` (which is entrypoint-only and
+    /// returns a flat `EntrypointStatusReport`): `ReadinessStatus`
+    /// reports the *full* boot phase set with `ComponentState` per
+    /// component, and is intended to be polled (`mvmctl wait`).
+    ReadinessStatus,
+
     // ========================================================================
     // Filesystem RPC (W1 / A1 of the filesystem-volumes plan).
     //
@@ -407,6 +423,114 @@ fn default_true() -> bool {
 }
 
 // ============================================================================
+// Readiness model (plan 76 Phase 2)
+// ============================================================================
+
+/// State of a single guest subsystem during boot.
+///
+/// `Disabled` is distinct from `Ready` — a missing optional subsystem
+/// (no integrations declared, no warm pool configured, no probes
+/// registered) reports `Disabled`, while a present-and-warmed
+/// subsystem reports `Ready`. This lets the host UX distinguish
+/// "the workload doesn't use X" from "X is still warming".
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum ComponentState {
+    /// Subsystem is not configured for this image (no policy → no
+    /// state machine to advance). Wire-stable distinct from `Ready`.
+    Disabled,
+    /// Subsystem is initializing in the background.
+    Starting,
+    /// Subsystem is up and accepting work.
+    Ready,
+    /// Subsystem failed to initialize. `message` is a short human-
+    /// readable reason; no secrets / paths beyond what the host
+    /// already knows.
+    Failed {
+        /// Short human-readable failure reason. Stable enough for an
+        /// operator to recognise, not a structured cause — pair with
+        /// stderr logs for diagnosis.
+        message: String,
+    },
+}
+
+/// Per-phase monotonic boot timings in milliseconds since the agent
+/// process started.
+///
+/// Plan 76 Phase 4 fills in the full per-phase set. Phase 2 wires
+/// `agent_started_ms`, `vsock_bound_ms`, `first_accept_ms`, and
+/// `entrypoint_ready_ms` so callers can already display the cold-path
+/// timing breakdown. Fields populated by Phase 4 (`warm_pool_ready_ms`,
+/// `integrations_ready_ms`, `probes_ready_ms`) stay `None` for now.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BootTimingReport {
+    /// Milliseconds from agent process start to vsock bind/listen.
+    /// Always present once the agent has bound — this number is the
+    /// dominant signal for early-readiness regressions.
+    pub agent_started_ms: Option<u64>,
+    /// Milliseconds from agent start to a successful `bind+listen`
+    /// pair on the control port. Same anchor as `agent_started_ms`
+    /// today; reserved for diverging if a future Phase 4 refactor
+    /// splits "process started" from "socket created".
+    pub vsock_bound_ms: Option<u64>,
+    /// Milliseconds from agent start to the first accepted host
+    /// connection. `None` until the first `accept()` returns.
+    pub first_accept_ms: Option<u64>,
+    /// Milliseconds from agent start to `entrypoint = Ready` (or
+    /// `Failed`). `None` while still `Starting`.
+    pub entrypoint_ready_ms: Option<u64>,
+    /// Filled in by Phase 4. `None` for now.
+    pub warm_pool_ready_ms: Option<u64>,
+    /// Filled in by Phase 4. `None` for now.
+    pub integrations_ready_ms: Option<u64>,
+    /// Filled in by Phase 4. `None` for now.
+    pub probes_ready_ms: Option<u64>,
+}
+
+/// Snapshot of agent readiness at the moment of a `ReadinessStatus`
+/// call.
+///
+/// Plan 76 Phase 2 §"Early control-plane readiness". Used by host
+/// callers (`mvmctl wait`, `mvmctl up --timings`, `mvmctl doctor`)
+/// to distinguish:
+///
+/// - "control plane is up, workload not yet warm" → invoke would
+///   block; the host can stream progress to the user
+/// - "entrypoint validation failed" → invoke would fail fast with
+///   a typed error; the host can surface the validation message
+/// - "optional subsystem failed" → invoke is still safe; the host
+///   surfaces a warning
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ReadinessReport {
+    /// Vsock listener bound and accepting. Always `Ready` if the
+    /// agent could respond at all.
+    pub control_plane: ComponentState,
+    /// `/etc/mvm/entrypoint` validation result. Gates `RunEntrypoint`
+    /// — a request submitted while `Starting` returns
+    /// `RunEntrypointError::NotReady`.
+    pub entrypoint: ComponentState,
+    /// Warm-process pool readiness. `Disabled` for cold-tier images;
+    /// `Ready` once the `after_start.sh` probe passes.
+    pub warm_pool: ComponentState,
+    /// Drop-in integration scan + health loop. `Disabled` if no
+    /// `/etc/mvm/integrations.d/*.json` files present.
+    pub integrations: ComponentState,
+    /// Drop-in probe scan + probe loop. `Disabled` if no
+    /// `/etc/mvm/probes.d/*.json` files present.
+    pub probes: ComponentState,
+    /// Volume-mount state — wire-stable placeholder. `Disabled` in
+    /// v1 (mount/unmount are on-demand verbs, not boot state).
+    pub volumes: ComponentState,
+    /// Active agent profile. Same value the dispatcher uses for the
+    /// `allowed_in` gate.
+    pub profile: AgentProfile,
+    /// Per-phase monotonic timings.
+    pub boot_millis: BootTimingReport,
+}
+
+// ============================================================================
 // Profile classifier (plan 76 Phase 1)
 // ============================================================================
 
@@ -456,6 +580,7 @@ impl GuestRequest {
             GuestRequest::ConsoleClose { .. } => "ConsoleClose",
             GuestRequest::ConsoleResize { .. } => "ConsoleResize",
             GuestRequest::EntrypointStatus => "EntrypointStatus",
+            GuestRequest::ReadinessStatus => "ReadinessStatus",
             GuestRequest::FsRead { .. } => "FsRead",
             GuestRequest::FsWrite { .. } => "FsWrite",
             GuestRequest::FsList { .. } => "FsList",
@@ -494,6 +619,7 @@ impl GuestRequest {
             | GuestRequest::RunEntrypoint { .. }
             | GuestRequest::PostRestore
             | GuestRequest::EntrypointStatus
+            | GuestRequest::ReadinessStatus
             | GuestRequest::MountVolume { .. }
             | GuestRequest::UnmountVolume { .. }
             | GuestRequest::UpdateIdleTimeout { .. } => RequestClass::ProdSafe,
@@ -651,6 +777,10 @@ pub enum GuestResponse {
         path: Option<String>,
         detail: Option<String>,
     },
+
+    /// Result of a `ReadinessStatus` query. Plan 76 Phase 2.
+    /// Snapshot of every component plus per-phase timings.
+    ReadinessStatusReport(ReadinessReport),
 
     /// Result of a filesystem RPC call. The single top-level variant
     /// keeps `GuestResponse` from sprawling — the `FsResult` sub-enum
@@ -1182,6 +1312,13 @@ pub enum RunEntrypointError {
     Busy,
     /// The wrapper process died unexpectedly (signal, OOM, etc.).
     WrapperCrashed,
+    /// Entrypoint validation has not yet completed. Plan 76 Phase 2:
+    /// the agent binds vsock early and validates entrypoint in the
+    /// background, so a host that races `RunEntrypoint` ahead of
+    /// `ReadinessStatus { entrypoint: Ready }` gets this back rather
+    /// than `EntrypointInvalid` (which would imply a permanent
+    /// failure). Hosts should poll readiness, not retry blindly.
+    NotReady,
     /// `/etc/mvm/entrypoint` is missing, fails validation
     /// (symlink crossing FS, wrong perms, off the verity
     /// partition), or otherwise can't be loaded. Reported per-call
@@ -2286,6 +2423,7 @@ mod tests {
                 code: "print('hello')".into(),
                 timeout_secs: 30,
             },
+            GuestRequest::ReadinessStatus,
         ];
 
         for req in &variants {
@@ -2331,6 +2469,24 @@ mod tests {
                 profile: AgentProfile::SealedProd,
                 verb: "Exec".to_string(),
             },
+            GuestResponse::ReadinessStatusReport(ReadinessReport {
+                control_plane: ComponentState::Ready,
+                entrypoint: ComponentState::Starting,
+                warm_pool: ComponentState::Disabled,
+                integrations: ComponentState::Disabled,
+                probes: ComponentState::Disabled,
+                volumes: ComponentState::Disabled,
+                profile: AgentProfile::SealedProd,
+                boot_millis: BootTimingReport {
+                    agent_started_ms: Some(5),
+                    vsock_bound_ms: Some(5),
+                    first_accept_ms: Some(8),
+                    entrypoint_ready_ms: None,
+                    warm_pool_ready_ms: None,
+                    integrations_ready_ms: None,
+                    probes_ready_ms: None,
+                },
+            }),
             GuestResponse::IntegrationStatusReport {
                 integrations: vec![IntegrationStateReport {
                     name: "whatsapp".to_string(),
@@ -4157,6 +4313,7 @@ mod tests {
             "RunEntrypoint",
             "PostRestore",
             "EntrypointStatus",
+            "ReadinessStatus",
             "MountVolume",
             "UnmountVolume",
             "UpdateIdleTimeout",
@@ -4196,6 +4353,7 @@ mod tests {
                 rows: 1,
             },
             GuestRequest::EntrypointStatus,
+            GuestRequest::ReadinessStatus,
             GuestRequest::FsRead {
                 path: "/x".into(),
                 offset: None,
@@ -4415,5 +4573,137 @@ mod tests {
             }
             other => panic!("unexpected variant: {other:?}"),
         }
+    }
+
+    // ========================================================================
+    // Plan 76 Phase 2 — readiness model
+    // ========================================================================
+
+    #[test]
+    fn test_readiness_status_classifies_prod_safe() {
+        // `ReadinessStatus` must respond from sealed-prod images
+        // even before entrypoint validation completes — that's the
+        // whole point of the verb. If a future refactor downgrades
+        // it to DevOnly, this test fails loud.
+        let req = GuestRequest::ReadinessStatus;
+        assert_eq!(req.class(), RequestClass::ProdSafe);
+        assert!(req.allowed_in(AgentProfile::SealedProd));
+        assert!(req.allowed_in(AgentProfile::Dev));
+        assert!(!req.allowed_in(AgentProfile::Builder));
+        assert_eq!(req.verb_name(), "ReadinessStatus");
+    }
+
+    #[test]
+    fn test_component_state_wire_format_is_snake_case() {
+        // Wire format keeps JSON ergonomic for hand-written
+        // policies / mock fixtures.
+        assert_eq!(
+            serde_json::to_string(&ComponentState::Starting).unwrap(),
+            "\"starting\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ComponentState::Ready).unwrap(),
+            "\"ready\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ComponentState::Disabled).unwrap(),
+            "\"disabled\""
+        );
+        let failed_json = serde_json::to_string(&ComponentState::Failed {
+            message: "boom".into(),
+        })
+        .unwrap();
+        assert!(failed_json.contains("\"failed\""), "got {failed_json}");
+        assert!(failed_json.contains("\"boom\""), "got {failed_json}");
+
+        let parsed: ComponentState = serde_json::from_str(&failed_json).unwrap();
+        assert!(matches!(
+            parsed,
+            ComponentState::Failed { ref message } if message == "boom"
+        ));
+    }
+
+    #[test]
+    fn test_readiness_report_roundtrip_with_disabled_subsystems() {
+        // A cold-tier image's readiness snapshot mid-boot: control
+        // plane ready, entrypoint still validating, everything
+        // else Disabled (no warm pool, no integrations, no probes).
+        let report = ReadinessReport {
+            control_plane: ComponentState::Ready,
+            entrypoint: ComponentState::Starting,
+            warm_pool: ComponentState::Disabled,
+            integrations: ComponentState::Disabled,
+            probes: ComponentState::Disabled,
+            volumes: ComponentState::Disabled,
+            profile: AgentProfile::SealedProd,
+            boot_millis: BootTimingReport {
+                agent_started_ms: Some(3),
+                vsock_bound_ms: Some(3),
+                first_accept_ms: Some(7),
+                entrypoint_ready_ms: None,
+                warm_pool_ready_ms: None,
+                integrations_ready_ms: None,
+                probes_ready_ms: None,
+            },
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        let parsed: ReadinessReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, report);
+    }
+
+    #[test]
+    fn test_readiness_report_rejects_unknown_fields() {
+        // ADR-002 §W4.1: every host↔guest type must deny unknown
+        // fields. Verify the outer report shape; ComponentState +
+        // BootTimingReport carry their own `deny_unknown_fields`.
+        let json = r#"{
+            "control_plane": "ready",
+            "entrypoint": "starting",
+            "warm_pool": "disabled",
+            "integrations": "disabled",
+            "probes": "disabled",
+            "volumes": "disabled",
+            "profile": "sealed-prod",
+            "boot_millis": {
+                "agent_started_ms": null,
+                "vsock_bound_ms": null,
+                "first_accept_ms": null,
+                "entrypoint_ready_ms": null,
+                "warm_pool_ready_ms": null,
+                "integrations_ready_ms": null,
+                "probes_ready_ms": null
+            },
+            "smuggled": 1
+        }"#;
+        let err = serde_json::from_str::<ReadinessReport>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("unknown field"),
+            "expected unknown-field rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_run_entrypoint_error_not_ready_roundtrip() {
+        // Plan 76 Phase 2: the typed variant returned when a host
+        // races `RunEntrypoint` ahead of `entrypoint=Ready`.
+        let err = RunEntrypointError::NotReady;
+        let json = serde_json::to_string(&err).unwrap();
+        assert_eq!(json, "\"NotReady\"");
+        let parsed: RunEntrypointError = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, err);
+    }
+
+    #[test]
+    fn test_boot_timing_report_default_is_all_none() {
+        // The skeleton ships with all-`None` so Phase 4 can fill
+        // the remaining fields without breaking the wire shape.
+        let t = BootTimingReport::default();
+        assert!(t.agent_started_ms.is_none());
+        assert!(t.vsock_bound_ms.is_none());
+        assert!(t.first_accept_ms.is_none());
+        assert!(t.entrypoint_ready_ms.is_none());
+        assert!(t.warm_pool_ready_ms.is_none());
+        assert!(t.integrations_ready_ms.is_none());
+        assert!(t.probes_ready_ms.is_none());
     }
 }

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -575,6 +575,7 @@ impl GuestRequest {
     /// renaming a verb is a breaking change.
     pub fn verb_name(&self) -> &'static str {
         match self {
+            GuestRequest::ProtocolHello { .. } => "ProtocolHello",
             GuestRequest::WorkerStatus => "WorkerStatus",
             GuestRequest::SleepPrep { .. } => "SleepPrep",
             GuestRequest::Wake => "Wake",
@@ -616,11 +617,16 @@ impl GuestRequest {
     /// `GuestRequest` variant fails to compile until it is classified.
     pub fn class(&self) -> RequestClass {
         match self {
-            // ProdSafe: lifecycle + status + entrypoint + sleep/wake
-            // + mount-volume + idle-timeout. Volume mounts are
-            // additionally constrained by `MountPathPolicy` inside
-            // the handler — the gate just lets the verb reach it.
-            GuestRequest::WorkerStatus
+            // ProdSafe: handshake + lifecycle + status + entrypoint
+            // + sleep/wake + mount-volume + idle-timeout. Volume
+            // mounts are additionally constrained by
+            // `MountPathPolicy` inside the handler — the gate just
+            // lets the verb reach it. `ProtocolHello` MUST be
+            // prod-safe; it's the negotiation that runs before
+            // every other request and a sealed-prod agent that
+            // refuses it would never see another verb.
+            GuestRequest::ProtocolHello { .. }
+            | GuestRequest::WorkerStatus
             | GuestRequest::SleepPrep { .. }
             | GuestRequest::Wake
             | GuestRequest::Ping
@@ -675,8 +681,10 @@ impl GuestRequest {
     pub fn allowed_in(&self, profile: AgentProfile) -> bool {
         matches!(
             (self.class(), profile),
-            (RequestClass::ProdSafe, AgentProfile::SealedProd | AgentProfile::Dev)
-                | (RequestClass::DevOnly, AgentProfile::Dev)
+            (
+                RequestClass::ProdSafe,
+                AgentProfile::SealedProd | AgentProfile::Dev
+            ) | (RequestClass::DevOnly, AgentProfile::Dev)
                 | (RequestClass::BuilderOnly, AgentProfile::Builder)
         )
     }
@@ -4314,6 +4322,7 @@ mod tests {
     #[test]
     fn test_request_class_coverage_matches_sealed_prod_allowlist() {
         let prod_safe_verbs: &[&str] = &[
+            "ProtocolHello",
             "WorkerStatus",
             "SleepPrep",
             "Wake",
@@ -4333,6 +4342,12 @@ mod tests {
         // One representative `GuestRequest` value per variant. Used to
         // exercise `class()` + `verb_name()` together.
         let all: Vec<GuestRequest> = vec![
+            GuestRequest::ProtocolHello {
+                host_protocol_version: 1,
+                min_supported_version: 1,
+                host_version: "test".into(),
+                requested_capabilities: vec![],
+            },
             GuestRequest::WorkerStatus,
             GuestRequest::SleepPrep {
                 drain_timeout_secs: 0,
@@ -4465,7 +4480,10 @@ mod tests {
         // assertion too.
         let names: Vec<&'static str> = all.iter().map(|r| r.verb_name()).collect();
         for v in prod_safe_verbs {
-            assert!(names.contains(v), "SealedProd verb {v} missing from coverage");
+            assert!(
+                names.contains(v),
+                "SealedProd verb {v} missing from coverage"
+            );
         }
     }
 

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use mvm_core::security::{
-    AuthenticatedFrame, PROTOCOL_VERSION_AUTHENTICATED, SessionHello, SessionHelloAck,
+    AgentProfile, AuthenticatedFrame, PROTOCOL_VERSION_AUTHENTICATED, SessionHello, SessionHelloAck,
 };
 use mvm_core::signing::SignedPayload;
 use serde::{Deserialize, Serialize};
@@ -406,6 +406,145 @@ fn default_true() -> bool {
     true
 }
 
+// ============================================================================
+// Profile classifier (plan 76 Phase 1)
+// ============================================================================
+
+/// Coarse profile-eligibility class for each `GuestRequest` variant.
+///
+/// Wire types are compiled into every agent build; this classifier
+/// is the dispatcher-side gate that rejects out-of-profile verbs
+/// *before* the per-variant handler runs. See ADR-002 §W4.3 for the
+/// complementary compile-time symbol-absence story (`do_exec`,
+/// `do_run_code`, process RPC handlers gated by `dev-shell`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RequestClass {
+    /// Allowed under `SealedProd` and `Dev` profiles. Includes the
+    /// lifecycle, entrypoint-status, sleep/wake, mount-volume, and
+    /// idle-timeout verbs. Sub-policies (mount path, idle timeout
+    /// scope) are enforced inside the handler.
+    ProdSafe,
+    /// Allowed only under `Dev`. Process RPC, filesystem RPC, console,
+    /// port forwarding, shell exec, code eval.
+    DevOnly,
+    /// Allowed only under `Builder`. No current `GuestRequest`
+    /// variant is `BuilderOnly`; the variant is reserved for forward
+    /// compatibility when builder-specific verbs land on the tenant
+    /// wire.
+    BuilderOnly,
+}
+
+impl GuestRequest {
+    /// Stable string name for the verb, used in audit logs and the
+    /// `UnsupportedInProfile` rejection response. Wire-stable —
+    /// renaming a verb is a breaking change.
+    pub fn verb_name(&self) -> &'static str {
+        match self {
+            GuestRequest::WorkerStatus => "WorkerStatus",
+            GuestRequest::SleepPrep { .. } => "SleepPrep",
+            GuestRequest::Wake => "Wake",
+            GuestRequest::Ping => "Ping",
+            GuestRequest::IntegrationStatus => "IntegrationStatus",
+            GuestRequest::CheckpointIntegrations { .. } => "CheckpointIntegrations",
+            GuestRequest::ProbeStatus => "ProbeStatus",
+            GuestRequest::Exec { .. } => "Exec",
+            GuestRequest::RunEntrypoint { .. } => "RunEntrypoint",
+            GuestRequest::PostRestore => "PostRestore",
+            GuestRequest::FsDiff => "FsDiff",
+            GuestRequest::StartPortForward { .. } => "StartPortForward",
+            GuestRequest::ConsoleOpen { .. } => "ConsoleOpen",
+            GuestRequest::ConsoleClose { .. } => "ConsoleClose",
+            GuestRequest::ConsoleResize { .. } => "ConsoleResize",
+            GuestRequest::EntrypointStatus => "EntrypointStatus",
+            GuestRequest::FsRead { .. } => "FsRead",
+            GuestRequest::FsWrite { .. } => "FsWrite",
+            GuestRequest::FsList { .. } => "FsList",
+            GuestRequest::FsStat { .. } => "FsStat",
+            GuestRequest::FsMkdir { .. } => "FsMkdir",
+            GuestRequest::FsRemove { .. } => "FsRemove",
+            GuestRequest::FsMove { .. } => "FsMove",
+            GuestRequest::ProcStart { .. } => "ProcStart",
+            GuestRequest::ProcList => "ProcList",
+            GuestRequest::ProcSignal { .. } => "ProcSignal",
+            GuestRequest::ProcSendInput { .. } => "ProcSendInput",
+            GuestRequest::ProcWait { .. } => "ProcWait",
+            GuestRequest::ProcKill { .. } => "ProcKill",
+            GuestRequest::MountVolume { .. } => "MountVolume",
+            GuestRequest::UnmountVolume { .. } => "UnmountVolume",
+            GuestRequest::UpdateIdleTimeout { .. } => "UpdateIdleTimeout",
+            GuestRequest::RunCode { .. } => "RunCode",
+        }
+    }
+
+    /// Profile class of this request. Exhaustive match — adding a new
+    /// `GuestRequest` variant fails to compile until it is classified.
+    pub fn class(&self) -> RequestClass {
+        match self {
+            // ProdSafe: lifecycle + status + entrypoint + sleep/wake
+            // + mount-volume + idle-timeout. Volume mounts are
+            // additionally constrained by `MountPathPolicy` inside
+            // the handler — the gate just lets the verb reach it.
+            GuestRequest::WorkerStatus
+            | GuestRequest::SleepPrep { .. }
+            | GuestRequest::Wake
+            | GuestRequest::Ping
+            | GuestRequest::IntegrationStatus
+            | GuestRequest::CheckpointIntegrations { .. }
+            | GuestRequest::ProbeStatus
+            | GuestRequest::RunEntrypoint { .. }
+            | GuestRequest::PostRestore
+            | GuestRequest::EntrypointStatus
+            | GuestRequest::MountVolume { .. }
+            | GuestRequest::UnmountVolume { .. }
+            | GuestRequest::UpdateIdleTimeout { .. } => RequestClass::ProdSafe,
+
+            // DevOnly: shell exec, process RPC, filesystem RPC,
+            // console, port forwarding, code eval, filesystem diff.
+            // Filesystem reads look benign but can leak secrets and
+            // mounted-volume contents (plan 76 "Read-only filesystem
+            // access can leak secrets"), so the entire filesystem
+            // RPC surface is DevOnly in v1.
+            GuestRequest::Exec { .. }
+            | GuestRequest::FsDiff
+            | GuestRequest::StartPortForward { .. }
+            | GuestRequest::ConsoleOpen { .. }
+            | GuestRequest::ConsoleClose { .. }
+            | GuestRequest::ConsoleResize { .. }
+            | GuestRequest::FsRead { .. }
+            | GuestRequest::FsWrite { .. }
+            | GuestRequest::FsList { .. }
+            | GuestRequest::FsStat { .. }
+            | GuestRequest::FsMkdir { .. }
+            | GuestRequest::FsRemove { .. }
+            | GuestRequest::FsMove { .. }
+            | GuestRequest::ProcStart { .. }
+            | GuestRequest::ProcList
+            | GuestRequest::ProcSignal { .. }
+            | GuestRequest::ProcSendInput { .. }
+            | GuestRequest::ProcWait { .. }
+            | GuestRequest::ProcKill { .. }
+            | GuestRequest::RunCode { .. } => RequestClass::DevOnly,
+        }
+    }
+
+    /// Whether this request is allowed under `profile`.
+    ///
+    /// Profile rules:
+    /// - `SealedProd` allows only `ProdSafe`.
+    /// - `Dev` allows `ProdSafe` and `DevOnly` (a superset).
+    /// - `Builder` allows only `BuilderOnly` — today the builder
+    ///   agent speaks `BuilderRequest`, so `GuestRequest` reaching
+    ///   a `Builder`-profile agent is a configuration error.
+    pub fn allowed_in(&self, profile: AgentProfile) -> bool {
+        matches!(
+            (self.class(), profile),
+            (RequestClass::ProdSafe, AgentProfile::SealedProd | AgentProfile::Dev)
+                | (RequestClass::DevOnly, AgentProfile::Dev)
+                | (RequestClass::BuilderOnly, AgentProfile::Builder)
+        )
+    }
+}
+
 /// Response from guest vsock agent to host.
 ///
 /// Same `deny_unknown_fields` discipline as `GuestRequest` — a
@@ -444,6 +583,18 @@ pub enum GuestResponse {
     Pong,
     /// Error from guest agent.
     Error { message: String },
+    /// The dispatcher refused this verb because the active
+    /// `AgentProfile` does not allow it (plan 76 Phase 1). Distinct
+    /// from `Error { message }` so SDK callers can branch on
+    /// capability without parsing message text — analogous to
+    /// `ProcErrorKind::UnsupportedInProduction` for process RPC,
+    /// but at the protocol layer rather than per-handler.
+    UnsupportedInProfile {
+        /// Active profile on the agent that rejected the call.
+        profile: AgentProfile,
+        /// `verb_name()` of the rejected request. Wire-stable.
+        verb: String,
+    },
     /// Per-integration status report.
     IntegrationStatusReport {
         integrations: Vec<crate::integrations::IntegrationStateReport>,
@@ -2175,6 +2326,10 @@ mod tests {
             GuestResponse::Pong,
             GuestResponse::Error {
                 message: "oops".to_string(),
+            },
+            GuestResponse::UnsupportedInProfile {
+                profile: AgentProfile::SealedProd,
+                verb: "Exec".to_string(),
             },
             GuestResponse::IntegrationStatusReport {
                 integrations: vec![IntegrationStateReport {
@@ -3978,5 +4133,287 @@ mod tests {
         // This is correct: we verify the guest controls the key it claims.
         let result = host_handle.join().unwrap();
         assert!(result.is_ok());
+    }
+
+    // ========================================================================
+    // Plan 76 Phase 1 — profile classifier
+    // ========================================================================
+
+    /// Every `GuestRequest` variant must classify as either `ProdSafe`
+    /// or `DevOnly` today. Compile-fail when a new variant is added
+    /// without being classified — the exhaustive match inside
+    /// `class()` guarantees that, and this test fails closed if the
+    /// variant ever lands in an unexpected class.
+    #[test]
+    fn test_request_class_coverage_matches_sealed_prod_allowlist() {
+        let prod_safe_verbs: &[&str] = &[
+            "WorkerStatus",
+            "SleepPrep",
+            "Wake",
+            "Ping",
+            "IntegrationStatus",
+            "CheckpointIntegrations",
+            "ProbeStatus",
+            "RunEntrypoint",
+            "PostRestore",
+            "EntrypointStatus",
+            "MountVolume",
+            "UnmountVolume",
+            "UpdateIdleTimeout",
+        ];
+
+        // One representative `GuestRequest` value per variant. Used to
+        // exercise `class()` + `verb_name()` together.
+        let all: Vec<GuestRequest> = vec![
+            GuestRequest::WorkerStatus,
+            GuestRequest::SleepPrep {
+                drain_timeout_secs: 0,
+            },
+            GuestRequest::Wake,
+            GuestRequest::Ping,
+            GuestRequest::IntegrationStatus,
+            GuestRequest::CheckpointIntegrations {
+                integrations: vec![],
+            },
+            GuestRequest::ProbeStatus,
+            GuestRequest::Exec {
+                command: "x".into(),
+                stdin: None,
+                timeout_secs: None,
+            },
+            GuestRequest::RunEntrypoint {
+                stdin: vec![],
+                timeout_secs: 1,
+            },
+            GuestRequest::PostRestore,
+            GuestRequest::FsDiff,
+            GuestRequest::StartPortForward { guest_port: 1 },
+            GuestRequest::ConsoleOpen { cols: 1, rows: 1 },
+            GuestRequest::ConsoleClose { session_id: 1 },
+            GuestRequest::ConsoleResize {
+                session_id: 1,
+                cols: 1,
+                rows: 1,
+            },
+            GuestRequest::EntrypointStatus,
+            GuestRequest::FsRead {
+                path: "/x".into(),
+                offset: None,
+                length: 1,
+                follow_symlinks: true,
+            },
+            GuestRequest::FsWrite {
+                path: "/x".into(),
+                content: vec![],
+                mode: 0,
+                create_parents: false,
+                follow_symlinks: false,
+            },
+            GuestRequest::FsList {
+                path: "/x".into(),
+                follow_symlinks: true,
+            },
+            GuestRequest::FsStat {
+                path: "/x".into(),
+                follow_symlinks: true,
+            },
+            GuestRequest::FsMkdir {
+                path: "/x".into(),
+                mode: 0,
+                parents: false,
+            },
+            GuestRequest::FsRemove {
+                path: "/x".into(),
+                recursive: false,
+                follow_symlinks: false,
+            },
+            GuestRequest::FsMove {
+                from: "/x".into(),
+                to: "/y".into(),
+                follow_symlinks: false,
+            },
+            GuestRequest::ProcStart {
+                argv: vec!["/x".into()],
+                env: Default::default(),
+                cwd: None,
+                stdin: vec![],
+                timeout_secs: None,
+            },
+            GuestRequest::ProcList,
+            GuestRequest::ProcSignal {
+                pid_token: "t".into(),
+                signum: 15,
+            },
+            GuestRequest::ProcSendInput {
+                pid_token: "t".into(),
+                bytes: vec![],
+            },
+            GuestRequest::ProcWait {
+                pid_token: "t".into(),
+                timeout_secs: None,
+            },
+            GuestRequest::ProcKill {
+                pid_token: "t".into(),
+            },
+            GuestRequest::MountVolume {
+                volume_name: "v".into(),
+                guest_path: "/x".into(),
+                read_only: true,
+            },
+            GuestRequest::UnmountVolume {
+                guest_path: "/x".into(),
+                force: false,
+            },
+            GuestRequest::UpdateIdleTimeout { secs: 0 },
+            GuestRequest::RunCode {
+                code: "x".into(),
+                timeout_secs: 1,
+            },
+        ];
+
+        // Every variant has a stable verb_name; that name appears in
+        // exactly one of the two classification buckets.
+        for req in &all {
+            let name = req.verb_name();
+            let in_prod = prod_safe_verbs.contains(&name);
+            match req.class() {
+                RequestClass::ProdSafe => assert!(
+                    in_prod,
+                    "{name}: classified ProdSafe but missing from SealedProd allowlist"
+                ),
+                RequestClass::DevOnly => assert!(
+                    !in_prod,
+                    "{name}: classified DevOnly but present in SealedProd allowlist"
+                ),
+                RequestClass::BuilderOnly => {
+                    panic!("{name}: no GuestRequest variant should be BuilderOnly yet")
+                }
+            }
+        }
+
+        // The allowlist itself stays anchored: every prod-safe verb
+        // shows up in `all` above, so renaming a variant trips this
+        // assertion too.
+        let names: Vec<&'static str> = all.iter().map(|r| r.verb_name()).collect();
+        for v in prod_safe_verbs {
+            assert!(names.contains(v), "SealedProd verb {v} missing from coverage");
+        }
+    }
+
+    #[test]
+    fn test_sealed_prod_rejects_dev_only_verbs() {
+        let dev_only_samples = [
+            GuestRequest::Exec {
+                command: "x".into(),
+                stdin: None,
+                timeout_secs: None,
+            },
+            GuestRequest::ConsoleOpen { cols: 80, rows: 24 },
+            GuestRequest::ProcStart {
+                argv: vec!["/x".into()],
+                env: Default::default(),
+                cwd: None,
+                stdin: vec![],
+                timeout_secs: None,
+            },
+            GuestRequest::RunCode {
+                code: "print(1)".into(),
+                timeout_secs: 1,
+            },
+            GuestRequest::FsWrite {
+                path: "/x".into(),
+                content: vec![],
+                mode: 0,
+                create_parents: false,
+                follow_symlinks: false,
+            },
+            GuestRequest::FsRead {
+                path: "/x".into(),
+                offset: None,
+                length: 1,
+                follow_symlinks: true,
+            },
+            GuestRequest::StartPortForward { guest_port: 8080 },
+        ];
+
+        for req in &dev_only_samples {
+            assert!(
+                !req.allowed_in(AgentProfile::SealedProd),
+                "{} should be rejected in SealedProd",
+                req.verb_name()
+            );
+            assert!(
+                req.allowed_in(AgentProfile::Dev),
+                "{} should be allowed in Dev",
+                req.verb_name()
+            );
+            assert!(
+                !req.allowed_in(AgentProfile::Builder),
+                "{} should not be allowed in Builder",
+                req.verb_name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_sealed_prod_accepts_prod_safe_verbs() {
+        let prod_safe_samples = [
+            GuestRequest::Ping,
+            GuestRequest::WorkerStatus,
+            GuestRequest::EntrypointStatus,
+            GuestRequest::RunEntrypoint {
+                stdin: vec![],
+                timeout_secs: 60,
+            },
+            GuestRequest::SleepPrep {
+                drain_timeout_secs: 5,
+            },
+            GuestRequest::Wake,
+            GuestRequest::PostRestore,
+            GuestRequest::UpdateIdleTimeout { secs: 600 },
+            GuestRequest::MountVolume {
+                volume_name: "v".into(),
+                guest_path: "/data".into(),
+                read_only: true,
+            },
+            GuestRequest::UnmountVolume {
+                guest_path: "/data".into(),
+                force: false,
+            },
+        ];
+
+        for req in &prod_safe_samples {
+            assert!(
+                req.allowed_in(AgentProfile::SealedProd),
+                "{} should be allowed in SealedProd",
+                req.verb_name()
+            );
+            assert!(
+                req.allowed_in(AgentProfile::Dev),
+                "{} should be allowed in Dev (Dev ⊃ SealedProd)",
+                req.verb_name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_unsupported_in_profile_response_roundtrip() {
+        let resp = GuestResponse::UnsupportedInProfile {
+            profile: AgentProfile::SealedProd,
+            verb: "Exec".into(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        // kebab-case profile wire format keeps user-facing JSON tidy.
+        assert!(json.contains("\"sealed-prod\""), "got {json}");
+        assert!(json.contains("\"Exec\""), "got {json}");
+
+        let parsed: GuestResponse = serde_json::from_str(&json).unwrap();
+        match parsed {
+            GuestResponse::UnsupportedInProfile { profile, verb } => {
+                assert_eq!(profile, AgentProfile::SealedProd);
+                assert_eq!(verb, "Exec");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
     }
 }

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -27,6 +27,36 @@ The agent communicates using **length-prefixed JSON frames** over vsock (Firecra
 
 Request types: `ping`, `status`, `sleep-prep`, `wake`, and more.
 
+## Profile gate
+
+Every guest image declares an **agent profile** in its
+`/etc/mvm/security.json` (plan 76 Phase 1). The profile is the
+dispatcher-side allowlist for vsock verbs — dev-only requests
+sent to a sealed-prod agent are rejected before any handler runs:
+
+| Profile | Effective verb set | Used by |
+|---------|-------------------|---------|
+| `sealed-prod` (default) | Lifecycle, status, entrypoint, sleep/wake, volume mount/unmount, idle-timeout updates. The full ADR-002 production-safe surface. | Production images. The policy file lives on a dm-verity rootfs (ADR-002 §W3) so the profile cannot be widened at runtime. |
+| `dev` | `sealed-prod` plus shell `Exec`, process RPC, filesystem RPC, console PTY, port forwarding, and `RunCode`. | `mvmctl dev` images and any image built with `dev-shell` feature. |
+| `builder` | Reserved for builder-only verbs. The current builder agent speaks a separate `BuilderRequest` protocol, so this profile is wire-stable but unused for the tenant agent. | Future builder VM agent if/when its verbs land on the tenant wire. |
+
+Rejected requests return a typed `UnsupportedInProfile` response:
+
+```json
+{ "UnsupportedInProfile": { "profile": "sealed-prod", "verb": "Exec" } }
+```
+
+SDK callers can branch on capability without parsing message text —
+this is the protocol-layer analog of
+`ProcErrorKind::UnsupportedInProduction` for process RPC.
+
+The profile gate is **complementary** to the existing compile-time
+gate (`#[cfg(feature = "dev-shell")]` for `do_exec` / `do_run_code` /
+process RPC handlers per ADR-002 §W4.3, claim 4). The compile-time
+gate keeps the handler symbols *absent* from production binaries; the
+profile gate keeps the dispatcher *reachable but refusing* for dev
+verbs in sealed-prod. Both checks run on every request.
+
 ## Health Checks
 
 Health checks defined in `mkGuest`'s `healthChecks` parameter are automatically written to `/etc/mvm/integrations.d/` at build time:

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -57,6 +57,54 @@ gate keeps the handler symbols *absent* from production binaries; the
 profile gate keeps the dispatcher *reachable but refusing* for dev
 verbs in sealed-prod. Both checks run on every request.
 
+## Readiness model
+
+Plan 76 Phase 2 binds the vsock control port **before** entrypoint
+validation and warm-process pool startup. That keeps the host's
+`mvmctl up` from blocking on guest-side warmup — the agent accepts
+`Ping` / `ReadinessStatus` / `EntrypointStatus` immediately, and
+`RunEntrypoint` returns a typed `RunEntrypointError::NotReady` until
+entrypoint validation completes.
+
+A host queries the live state via the `ReadinessStatus` verb:
+
+```json
+{
+  "ReadinessStatusReport": {
+    "control_plane": "ready",
+    "entrypoint": "starting",
+    "warm_pool": "disabled",
+    "integrations": "ready",
+    "probes": "disabled",
+    "volumes": "disabled",
+    "profile": "sealed-prod",
+    "boot_millis": {
+      "agent_started_ms": 7,
+      "vsock_bound_ms": 7,
+      "first_accept_ms": 12,
+      "entrypoint_ready_ms": null,
+      "warm_pool_ready_ms": null,
+      "integrations_ready_ms": null,
+      "probes_ready_ms": null
+    }
+  }
+}
+```
+
+`ComponentState` values:
+
+| State | Meaning |
+|-------|---------|
+| `disabled` | Subsystem isn't configured for this image (no policy → no state machine to advance). Distinct from `ready` so the host can tell "image opted out" from "still warming". |
+| `starting` | Background init in progress. `RunEntrypoint` while `entrypoint = starting` returns `NotReady` — the host should poll readiness and retry. |
+| `ready` | Subsystem is up and accepting work. |
+| `failed` | Subsystem failed to initialize. Carries a short human-readable `message` (no secrets, no host paths the caller doesn't already know). For `entrypoint`, this maps to `RunEntrypoint` returning the existing `EntrypointInvalid`. |
+
+`BootTimingReport` exposes monotonic milliseconds since agent
+process start. Phase 4 fills in the remaining fields
+(`warm_pool_ready_ms`, `integrations_ready_ms`, `probes_ready_ms`);
+the four populated today are enough to surface cold-path regressions.
+
 ## Health Checks
 
 Health checks defined in `mkGuest`'s `healthChecks` parameter are automatically written to `/etc/mvm/integrations.d/` at build time:

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -60,11 +60,23 @@ verbs in sealed-prod. Both checks run on every request.
 ## Readiness model
 
 Plan 76 Phase 2 binds the vsock control port **before** entrypoint
-validation and warm-process pool startup. That keeps the host's
-`mvmctl up` from blocking on guest-side warmup — the agent accepts
+validation and warm-process pool startup. Phase 3 extends the same
+pattern to integration / probe drop-in scans. The agent accepts
 `Ping` / `ReadinessStatus` / `EntrypointStatus` immediately, and
 `RunEntrypoint` returns a typed `RunEntrypointError::NotReady` until
 entrypoint validation completes.
+
+Background init threads in order of when they start:
+
+1. Entrypoint validation → warm-pool startup (serial inside one
+   thread because the pool depends on `VALIDATED_ENTRYPOINT`).
+2. Integration drop-in scan + health-loop spawn.
+3. Probe drop-in scan + probe-loop spawn.
+
+All three run in parallel after the accept loop is already serving
+control-plane traffic. A malformed drop-in cannot block bind or
+delay `Ping`; a slow `after_start.sh` only delays
+`warm_pool_ready_ms`, not the rest of the readiness report.
 
 A host queries the live state via the `ReadinessStatus` verb:
 

--- a/scripts/check-sealed-prod-allowlist.sh
+++ b/scripts/check-sealed-prod-allowlist.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Plan 76 Phase 1 / Phase 8 (partial) — sealed-prod vsock allowlist
+# regression gate.
+#
+# The `cargo test ... -- --exact <name>` invocation exits 0 when no
+# tests match the filter — so if any of the named tests are renamed
+# or deleted, a naive `cargo test` step would silently report
+# "0 passed" and turn the lane green. This script wraps cargo test
+# with a count assertion: it fails if the expected number of tests
+# does not run AND pass, which catches deletions and renames in
+# addition to the classifier widening the SealedProd allowlist.
+#
+# Plan reference: specs/plans/76-secure-fast-boot-and-dx.md
+# ADR reference: specs/adrs/002-microvm-security-posture.md
+#                §W4.1 (deny-unknown-fields), §W4.3 (compile-time
+#                symbol absence for do_exec / do_run_code).
+
+set -euo pipefail
+
+# Test names locked by plan 76 Phase 1. Adding a test to this list
+# requires updating EXPECTED_GUEST_COUNT / EXPECTED_CORE_COUNT to
+# match.
+GUEST_TESTS=(
+  "vsock::tests::test_request_class_coverage_matches_sealed_prod_allowlist"
+  "vsock::tests::test_sealed_prod_rejects_dev_only_verbs"
+  "vsock::tests::test_sealed_prod_accepts_prod_safe_verbs"
+  "vsock::tests::test_unsupported_in_profile_response_roundtrip"
+)
+EXPECTED_GUEST_COUNT=${#GUEST_TESTS[@]}
+
+CORE_TESTS=(
+  "policy::security::tests::test_security_policy_defaults"
+  "policy::security::tests::test_security_policy_missing_profile_field_is_sealed_prod"
+  "policy::security::tests::test_security_policy_dev_defaults_carries_dev_profile"
+  "policy::security::tests::test_agent_profile_serde_kebab_case"
+)
+EXPECTED_CORE_COUNT=${#CORE_TESTS[@]}
+
+run_locked_tests() {
+  local crate="$1"
+  local expected="$2"
+  shift 2
+  local tests=("$@")
+  local log
+  log=$(mktemp)
+  trap 'rm -f "$log"' RETURN
+
+  echo "── ${crate}: asserting ${expected} sealed-prod tests pass"
+  if ! cargo test -p "${crate}" --lib --no-fail-fast -- --exact "${tests[@]}" \
+    >"${log}" 2>&1; then
+    cat "${log}"
+    echo "❌ cargo test failed for ${crate}"
+    return 1
+  fi
+  cat "${log}"
+
+  # Count lines like `test foo::bar::baz ... ok` for the tests we
+  # asked for. `--exact` filters mean nothing else can match, so
+  # `wc -l` of " ... ok$" lines == expected count iff every named
+  # test ran and passed.
+  local actual
+  actual=$(grep -cE ' \.\.\. ok$' "${log}" || true)
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo
+    echo "❌ ${crate}: expected exactly ${expected} sealed-prod tests, got ${actual}"
+    echo "   A locked test was likely renamed or deleted. Update"
+    echo "   scripts/check-sealed-prod-allowlist.sh to match — but"
+    echo "   first justify in the PR description why widening or"
+    echo "   relaxing the SealedProd surface is intentional."
+    return 1
+  fi
+}
+
+run_locked_tests mvm-guest "${EXPECTED_GUEST_COUNT}" "${GUEST_TESTS[@]}"
+run_locked_tests mvm-core  "${EXPECTED_CORE_COUNT}"  "${CORE_TESTS[@]}"
+
+echo
+echo "✅ Sealed-prod vsock allowlist locked: ${EXPECTED_GUEST_COUNT} mvm-guest + ${EXPECTED_CORE_COUNT} mvm-core tests pass."

--- a/specs/plans/76-secure-fast-boot-and-dx.md
+++ b/specs/plans/76-secure-fast-boot-and-dx.md
@@ -1,0 +1,1029 @@
+# Plan 76 - Secure fast-boot and DX improvements
+
+> **Status:** proposed
+> **Owner:** TBD
+> **Started:** -
+> **Depends on:** ADR-002, ADR-007, ADR-013, ADR-046, plans 41, 43, 45, 57, 72
+> **Implements:** tighter production vsock profile, earlier guest readiness, deferred guest init, builder-storage boot parallelism, portable image artifacts, libkrun tiering
+> **Tracking:** cold-path UX improvements that preserve mvm's Firecracker / dm-verity / vsock-only security baseline
+
+## Why
+
+A fast local cold path is the product of several optimizations working together: daemonless hypervisor startup, a tiny guest init path, early control-plane readiness, deferred non-critical guest work, pre-packed artifacts, and portable distribution. mvm should adopt those product and systems lessons without weakening its security posture.
+
+mvm's security claim is stronger and must remain first-class:
+
+- No SSH inside microVMs.
+- Vsock is the only default communication path.
+- Sealed production images keep dm-verity, authenticated frames, least privilege, and restricted guest verbs.
+- Firecracker remains the hardened production baseline.
+- libkrun is used where it is best: local dev, builder VMs, macOS, and fast smoke paths.
+
+The goal of this plan is to make mvm's cold path fast and ergonomic while making the production attack surface smaller than it is today.
+
+## Current observations
+
+The current code already has useful security scaffolding:
+
+- `mvm_guest::vsock::GUEST_AGENT_PORT` is a single unprivileged control port, currently `5252`.
+- Frame size is capped at 256 KiB in the guest vsock path.
+- `GuestRequest` and `GuestResponse` use `serde(deny_unknown_fields)`.
+- Authenticated frames use Ed25519 signatures, session IDs, and monotonically checked sequence numbers.
+- `SecurityPolicy::default()` sets `require_auth = true`.
+- Fuzz targets exist for request parsing and authenticated frame verification.
+- Production/dev handler separation already exists in several places.
+
+The main problem is not that vsock is unconstrained at the transport level. The problem is that the **logical production surface is too broad**. `GuestRequest` contains lifecycle verbs, entrypoint invocation, filesystem RPC, process RPC, console control, code eval, port forwarding, and volume mounting. Some are dev-gated in handlers, but the production contract is not obvious enough, and future edits can accidentally widen it.
+
+## Whole-plan acceptance criteria
+
+When this plan is done:
+
+1. A sealed production guest exposes a small, explicit vsock profile.
+2. Dev-only verbs return typed `UnsupportedInProfile` errors before handler logic runs.
+3. `mvmctl up` can report control-plane readiness before entrypoint warmup, probes, integrations, or optional subsystems finish.
+4. `RunEntrypoint` still refuses until entrypoint validation and readiness gates pass.
+5. Builder VM boot emits phase timing and parallelizes safe setup work.
+6. mvm can pack and verify a portable signed artifact containing kernel, rootfs, verity metadata, cmdline, manifest, SBOM/attestation hooks, and signatures.
+7. libkrun is documented and enforced as a Tier 2 backend for local/dev/builder usage, not as the hardened production default.
+8. CI has explicit tests that prove prod images reject SSH, TCP listeners, and dev-only vsock verbs.
+
+---
+
+## Design principle
+
+Use this rule for every phase:
+
+> Bind early, authorize narrowly, initialize lazily, measure every phase.
+
+Early readiness is not permission. It is observability and latency reduction. The guest can be "control-plane ready" while still refusing workload execution until the relevant security and readiness checks finish.
+
+## Compatibility stance
+
+This plan intentionally does **not** preserve migration or backward compatibility. Implementations should prefer clean, secure breaking changes over compatibility layers.
+
+Rules:
+
+- No legacy vsock protocol support is required.
+- No compatibility shim for old guest agents is required.
+- No compatibility shim for old hosts is required.
+- No old artifact format support is required.
+- No old readiness behavior needs to remain available.
+- No `--legacy-*` CLI flags should be added unless a later plan explicitly reverses this decision.
+- Missing profile metadata should fail closed, not infer a permissive mode.
+- Unknown protocol versions should fail closed.
+- Unknown artifact format versions should fail closed.
+
+This simplifies the implementation order: each phase may update the host and guest contract together, delete obsolete code, and update tests/docs to match the new single supported behavior.
+
+---
+
+## Phase 1 - Explicit vsock profiles
+
+### Goal
+
+Make the allowed production verb set explicit and centrally enforced.
+
+### New types
+
+Add a profile enum in the guest/protocol layer:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentProfile {
+    SealedProd,
+    Dev,
+    Builder,
+}
+```
+
+Add a request classifier:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestClass {
+    ProdSafe,
+    DevOnly,
+    BuilderOnly,
+}
+
+impl GuestRequest {
+    pub fn class(&self) -> RequestClass { ... }
+    pub fn allowed_in(&self, profile: AgentProfile) -> bool { ... }
+}
+```
+
+### Initial profile policy
+
+`SealedProd` allows:
+
+- `Ping`
+- `WorkerStatus`
+- `EntrypointStatus`
+- `RunEntrypoint`
+- `SleepPrep`
+- `Wake`
+- `PostRestore`
+- `UpdateIdleTimeout`, if warm-process runtime is configured
+- `MountVolume` / `UnmountVolume`, only if the security policy and mount policy allow volumes for this image
+
+`Dev` additionally allows:
+
+- `Exec`
+- `ConsoleOpen`
+- `ConsoleClose`
+- `ConsoleResize`
+- `ProcStart`
+- `ProcList`
+- `ProcSignal`
+- `ProcSendInput`
+- `ProcWait`
+- `ProcKill`
+- `RunCode`
+- `FsRead`
+- `FsWrite`
+- `FsList`
+- `FsStat`
+- `FsMkdir`
+- `FsRemove`
+- `FsMove`
+- `StartPortForward`
+
+`Builder` should not reuse the full tenant protocol. Prefer a separate builder protocol. If a temporary bridge is needed, allow only the verbs required by the builder path and document each one.
+
+### Dispatcher changes
+
+Before matching on the request in `mvm-guest-agent`, run:
+
+```rust
+if !request.allowed_in(active_profile) {
+    return GuestResponse::UnsupportedInProfile {
+        profile: active_profile,
+        verb: request.verb_name(),
+    };
+}
+```
+
+Add a closed response/error shape rather than returning free-text `GuestResponse::Error`.
+
+### Where profile comes from
+
+Source of truth should be immutable image configuration:
+
+- sealed production image: profile defaults to `SealedProd`
+- dev image: profile defaults to `Dev`
+- builder image: profile defaults to `Builder`
+
+CLI/session mode may further restrict, but must not widen a sealed image at runtime.
+
+### Tests
+
+- Unit tests for every `GuestRequest` variant mapping to `RequestClass`.
+- Snapshot-style test proving the `SealedProd` allowlist contains only the expected verbs.
+- Dispatcher tests:
+  - prod rejects `Exec`
+  - prod rejects `ConsoleOpen`
+  - prod rejects `ProcStart`
+  - prod rejects `RunCode`
+  - prod rejects `FsWrite`
+  - prod rejects `StartPortForward`
+  - dev allows the same verbs when the image profile is dev
+- Security regression: a sealed image cannot opt into `Dev` via runtime config.
+- Fuzz corpus updated for the new `UnsupportedInProfile` response.
+
+### Acceptance
+
+`cargo test -p mvm-guest vsock_profile` passes and a prod build of `mvm-guest-agent` has no reachable handler path for dev-only verbs after profile rejection.
+
+---
+
+## Phase 2 - Early guest control-plane readiness
+
+### Goal
+
+Bind the vsock control port as early as safely possible and expose structured readiness instead of blocking host UX on all guest initialization.
+
+### New readiness model
+
+Add:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReadinessReport {
+    pub control_plane: ComponentState,
+    pub entrypoint: ComponentState,
+    pub warm_pool: ComponentState,
+    pub integrations: ComponentState,
+    pub probes: ComponentState,
+    pub volumes: ComponentState,
+    pub profile: AgentProfile,
+    pub boot_millis: BootTimingReport,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentState {
+    Disabled,
+    Starting,
+    Ready,
+    Failed { message: String },
+}
+```
+
+Add `GuestRequest::ReadinessStatus` and `GuestResponse::ReadinessReport`.
+
+### Boot sequence change
+
+Current high-level shape:
+
+1. parse config
+2. validate entrypoint
+3. initialize warm pool
+4. install signals
+5. create/bind/listen vsock
+6. start monitoring/integration/probe threads
+7. accept requests
+
+Target shape:
+
+1. parse minimal config and profile
+2. install signal handlers
+3. initialize shared readiness state
+4. create/bind/listen vsock
+5. mark `control_plane = Ready`
+6. start accept loop
+7. initialize entrypoint validation in background
+8. initialize warm pool in background
+9. load integrations/probes in background
+10. run lifecycle hooks in background
+
+### Security invariants
+
+- `RunEntrypoint` must reject while `entrypoint != Ready`.
+- Warm-process dispatch must reject while `warm_pool == Starting`.
+- Dev-only verbs remain profile-gated before readiness checks.
+- A failed optional subsystem must be visible in readiness, not silently ignored.
+
+### Host UX
+
+Add host-side wait modes:
+
+- `mvmctl wait <vm> --for control-plane`
+- `mvmctl wait <vm> --for entrypoint`
+- `mvmctl wait <vm> --for warm-pool`
+- `mvmctl wait <vm> --for all`
+
+Update `mvmctl up` to show:
+
+```text
+control plane ready in 94 ms
+entrypoint ready in 138 ms
+warm pool warming...
+```
+
+### Tests
+
+- Unit test readiness state transitions.
+- Agent dispatcher test: `ReadinessStatus` works before entrypoint validation completes.
+- Agent dispatcher test: `RunEntrypoint` rejects with typed `NotReady` until entrypoint is ready.
+- Integration test with a fake slow `after_start.sh` proving control plane is ready first.
+
+### Acceptance
+
+`mvmctl up` can return or stream useful status as soon as vsock is bound, while `mvmctl invoke` remains blocked until entrypoint readiness passes.
+
+---
+
+## Phase 3 - Defer non-critical guest initialization
+
+### Goal
+
+Move slow, optional, or non-security-critical initialization out of the synchronous boot path.
+
+### Defer after vsock bind
+
+Defer:
+
+- integration drop-in scanning
+- integration health loop startup
+- probe drop-in scanning
+- probe loop startup
+- warm-process pool creation
+- lifecycle `after_start` hook
+- optional filesystem diff baseline
+- optional port-forward preparation
+
+Keep before vsock bind:
+
+- minimal config parse
+- profile selection
+- signal handler install
+- socket bind/listen
+- any immutable security policy load needed to reject verbs
+
+Keep before `RunEntrypoint`:
+
+- entrypoint file validation
+- wrapper mode/owner/path checks
+- runtime config validation for warm-process mode
+- readiness hook success, when configured as mandatory
+
+### Work breakdown
+
+1. Introduce `AgentBootState` with atomics/mutexes for each component.
+2. Split `init_entrypoint_validation()` into a background-capable function that reports state.
+3. Split `init_warm_pool()` into parse/validate/start phases.
+4. Make integrations/probes lazy background tasks with startup result reporting.
+5. Teach `handle_client` to consult readiness state for affected verbs.
+
+### Tests
+
+- Slow probe directory fixture does not delay `Ping`.
+- Malformed `runtime.json` marks warm pool failed and makes `RunEntrypoint` return a typed readiness/config error.
+- Malformed integration drop-in does not kill control-plane readiness.
+
+### Acceptance
+
+On a fixture with slow probes and warm pool startup, `Ping` and `ReadinessStatus` respond before optional subsystems finish.
+
+---
+
+## Phase 4 - Boot phase telemetry
+
+### Goal
+
+Make cold-path performance visible and enforceable.
+
+### Add timings
+
+Track monotonic elapsed milliseconds for:
+
+- host launch requested
+- VMM process started
+- kernel/init entered, when guest can report it
+- agent process started
+- vsock socket bound
+- first host connection accepted
+- entrypoint validation started/finished
+- warm pool started/ready
+- integrations loaded
+- probes loaded
+- first `RunEntrypoint` accepted
+- first `RunEntrypoint` completed
+
+### Data model
+
+Add `BootTimingReport` to readiness:
+
+```rust
+pub struct BootTimingReport {
+    pub agent_started_ms: Option<u64>,
+    pub vsock_bound_ms: Option<u64>,
+    pub first_accept_ms: Option<u64>,
+    pub entrypoint_ready_ms: Option<u64>,
+    pub warm_pool_ready_ms: Option<u64>,
+    pub integrations_ready_ms: Option<u64>,
+    pub probes_ready_ms: Option<u64>,
+}
+```
+
+Host-side VMM timings live in mvm runtime state and are joined with guest timings for display.
+
+### CLI
+
+Add:
+
+- `mvmctl boot-report <vm>`
+- `mvmctl up --timings`
+
+Output should be compact and copyable for issue reports.
+
+### Tests
+
+- Unit tests for monotonic timing report construction.
+- CLI snapshot test for `boot-report`.
+- Live smoke test gated by existing live env vars, with budgets initially informational.
+
+### Acceptance
+
+Every boot can produce a timing report that identifies whether time was spent in VMM launch, guest init, entrypoint validation, warm pool, probes, integrations, or first invocation.
+
+---
+
+## Phase 5 - Builder VM storage parallelism
+
+### Goal
+
+Apply the same cold-path discipline to `mvm-builder-init`.
+
+### Current serial path
+
+`mvm-builder-init` currently does:
+
+1. mount `/proc`, `/sys`, `/dev`, `/tmp`
+2. probe/format/mount `/dev/vdb`
+3. seed `/nix-store`
+4. bind `/nix-store` over `/nix`
+5. modprobe `fuse` and `virtiofs`
+6. mount virtio-fs `work`, `out`, `job`
+7. setup network
+8. run job
+9. write result
+10. power off
+
+### Target safe parallelism
+
+Keep serialized:
+
+- `/dev/vdb` format/mount
+- first-boot seed of `/nix-store`
+- bind mount over `/nix`
+- job execution
+
+Parallelize:
+
+- start network setup after pseudofs mounts
+- start module loading as soon as `/sys` and `/dev` exist
+- mount `job` and `out` virtio-fs as soon as modules are loaded
+- mount `work` before job execution, but do not block failure reporting on `work` if `job`/`out` are available
+
+### Add builder boot timings
+
+Write `/job/boot-timings.json` and mirror to stderr:
+
+- init start
+- pseudofs mounted
+- network start/end
+- module load start/end
+- nix device ready
+- nix mounted
+- seed start/end
+- virtiofs mount start/end per tag
+- job start/end
+- poweroff start
+
+### Failure behavior
+
+- If `job` is mounted, write failure result there.
+- If `out` is mounted, write structured result there too.
+- If only stderr is available, emit enough timing and failure context for the host supervisor to surface.
+
+### Tests
+
+- Unit tests for timing JSON writer.
+- Linux-only test for helper scheduling with mocked command runner.
+- Existing `mvm-builder-init` tests remain green.
+- Live libkrun builder smoke records `boot-timings.json`.
+
+### Acceptance
+
+Builder VM logs show overlapped network/module/share setup, and the first failed setup phase is visible without reading the full console log.
+
+---
+
+## Phase 6 - Portable signed artifacts
+
+### Goal
+
+Add an mvm-native packed artifact that is portable across hosts while preserving mvm's sealed-image security model.
+
+### Artifact layout
+
+Use a deterministic tar or zstd-compressed tar. Suggested extension: `.mvm`.
+
+```text
+artifact.mvm
+  manifest.json
+  kernel/vmlinux
+  rootfs/rootfs.ext4
+  rootfs/rootfs.verity
+  rootfs/roothash
+  initrd/verity-initrd.cpio.gz
+  cmdline.txt
+  sbom/sbom.json
+  attestations/
+  signatures/manifest.ed25519
+```
+
+### Manifest requirements
+
+`manifest.json` includes:
+
+- artifact format version
+- mvm version
+- target architecture
+- backend compatibility
+- rootfs hash
+- kernel hash
+- initrd hash
+- dm-verity sidecar hash
+- roothash
+- cmdline hash
+- SBOM hash, if present
+- build provenance pointer
+- security posture: sealed/dev, profile, requires auth, allows volumes, allows egress
+
+The manifest signature covers every referenced byte by hash. Verification happens before launch.
+
+### CLI
+
+Add:
+
+- `mvmctl artifact pack --manifest <mvm.toml> --out app.mvm`
+- `mvmctl artifact verify app.mvm`
+- `mvmctl up --artifact app.mvm`
+- later: `mvmctl artifact push/pull`
+
+### Security requirements
+
+- Refuse unsigned artifacts by default.
+- Refuse artifacts whose manifest declares `SealedProd` but omits verity metadata.
+- Refuse unknown artifact format versions unless explicitly allowed.
+- Verify before extraction or launch.
+- Extract only into a private temp/cache dir with restrictive permissions.
+- Never allow artifact contents to write outside the extraction dir.
+
+### Tests
+
+- Pack/verify roundtrip.
+- Tampered rootfs rejected.
+- Tampered manifest rejected.
+- Missing signature rejected.
+- Missing verity metadata rejected for sealed prod.
+- Path traversal entries in tar rejected.
+- Unknown format version rejected.
+- CLI help/reference docs updated.
+
+### Acceptance
+
+A sealed image can be packed, copied, verified, and launched from one file without losing dm-verity or signature guarantees.
+
+---
+
+## Phase 7 - libkrun backend tiering
+
+### Goal
+
+Make libkrun a first-class fast local/backend path without overstating its isolation properties.
+
+### Backend tiers
+
+Document and enforce:
+
+- **Tier 1:** Firecracker. Hardened production default on Linux/KVM.
+- **Tier 2:** libkrun. Fast local/dev/builder backend for macOS and non-KVM dev hosts.
+- **Tier 3:** fallback/non-production backends, with warnings.
+
+### Policy
+
+`mvmctl up --prod` should not silently select libkrun unless an explicit override says the operator accepts Tier 2 isolation.
+
+Suggested explicit flag:
+
+```text
+mvmctl up --prod --hypervisor libkrun --accept-tier2-isolation
+```
+
+Dev commands can auto-select libkrun where it is the best user experience.
+
+### Tests
+
+- Backend auto-select tests:
+  - prod on Linux/KVM chooses Firecracker
+  - dev on macOS may choose libkrun
+  - prod with libkrun but no acknowledgement refuses
+  - prod with acknowledgement logs/audits the decision
+- `doctor` reports backend tier and reason.
+
+### Acceptance
+
+No production path silently downgrades from Tier 1 isolation to Tier 2 isolation.
+
+---
+
+## Phase 8 - Security regression gate
+
+### Goal
+
+Make the no-SSH/vsock-only claim mechanically checked.
+
+### Checks
+
+Add CI/runbook checks for sealed prod images:
+
+- no `sshd` binary
+- no SSH host keys
+- no port 22 listener
+- no TCP listeners unless explicitly configured
+- guest agent binds only vsock control port by default
+- dev-only vsock verbs rejected
+- `SecurityPolicy.require_auth = true`
+- rootfs verity metadata present
+- agent runs without ambient capabilities where expected
+
+### Tests
+
+- Static image inspection test.
+- Guest agent profile test.
+- Live smoke, gated, that runs:
+  - `mvmctl doctor vsock-profile <vm>`
+  - `mvmctl invoke <vm>` succeeds
+  - `mvmctl exec <vm>` fails in sealed prod
+  - `mvmctl console <vm>` fails in sealed prod
+  - port 22 is not open
+
+### Acceptance
+
+The security claim appears in CI as a named gate, not as an assumption in docs.
+
+---
+
+## Additional ideas not yet phased
+
+These are not required for the first implementation pass, but they are worth keeping visible. Each should become a separate phase or follow-up plan only after Phases 1-4 make the security and readiness model explicit.
+
+### Split wire schema by profile
+
+Phase 1 keeps one `GuestRequest` enum and classifies variants. A stronger future shape is separate protocol enums:
+
+- `ProdRequest`
+- `DevRequest`
+- `BuilderRequest`
+
+The host would serialize only the profile-specific enum after handshake. This reduces accidental prod exposure at compile time, not just dispatch time. The tradeoff is migration churn across CLI helpers and fuzz targets.
+
+### Capability negotiation after handshake
+
+After authenticated session setup, add a `Capabilities` report:
+
+- profile
+- protocol version
+- allowed verbs
+- max frame size
+- streaming support
+- volume support
+- warm-pool support
+- artifact format support
+
+The host can then fail with precise messages before sending a verb that will be rejected. This helps DX and also gives CI a simple way to assert the prod contract.
+
+### Per-verb authz and audit events
+
+Profiles are coarse. Add a second layer where each verb has:
+
+- required profile
+- required security-policy bit
+- audit event type
+- whether request/response payloads may be logged
+- redaction policy
+
+This avoids future handlers inventing ad hoc authorization rules. It also protects against accidentally logging stdin, env, file contents, or command output.
+
+### Separate control socket from data sockets
+
+Keep the single control port small and stable. Move high-volume streams to explicitly negotiated secondary vsock ports with short-lived tokens:
+
+- console data
+- proc wait streams
+- large fs read/write streams
+- future artifact transfer streams
+
+The control channel remains bounded and easy to fuzz. Data channels can have separate byte budgets, timeouts, and token expiry.
+
+### Stronger key identity model
+
+Current authenticated frames prove possession of session keys. A future hardening pass should bind session keys to image identity and launch identity:
+
+- manifest signing key
+- expected guest public key or measured key derivation
+- VM instance ID
+- artifact digest
+- roothash
+
+This prevents a host-side bug from connecting to the wrong guest and accepting a valid but unintended session.
+
+### Readiness as a state machine
+
+The plan currently sketches readiness fields. Make it a real state machine:
+
+- valid transitions only
+- monotonic component states unless reset by `Wake` or `PostRestore`
+- typed failure reasons
+- no ambiguous "ready but failed optional hook" states
+
+This makes CLI output clearer and prevents future code from setting readiness flags inconsistently.
+
+### Lazy subsystem loading by first use
+
+Phase 3 defers non-critical initialization in the background. A later optimization can avoid initializing optional subsystems until first use:
+
+- load probe definitions only on `ProbeStatus`
+- initialize filesystem diff only on `FsDiff`
+- start console support only on `ConsoleOpen`
+- initialize port-forwarding only on `StartPortForward`
+
+This is useful for minimal production images where most features are never used.
+
+### Snapshot and restore readiness
+
+If snapshots are used for fast boot, readiness needs snapshot-aware semantics:
+
+- readiness state must not be restored as `Ready` if external resources changed
+- session keys must not survive restore unless explicitly designed for it
+- sequence numbers must not roll back
+- `PostRestore` should force revalidation of entrypoint, volumes, network, time, and secrets
+
+This should be a dedicated hardening phase before using snapshots as a production fast-start feature.
+
+### Precomputed image index
+
+For portable artifacts and faster startup, generate an image index at build time:
+
+- entrypoint metadata
+- allowed profile
+- expected files and modes
+- volume declarations
+- probe/integration declarations
+- security posture summary
+
+The guest can read one small file instead of scanning multiple directories on boot. The host can verify the same file before launch.
+
+### Host-side warm artifact cache
+
+For `.mvm` artifacts, keep a content-addressed verified cache:
+
+- artifact digest directory
+- extracted kernel/rootfs/verity sidecars
+- verification stamp bound to verifier version
+- restrictive permissions
+- cache GC
+
+This makes `mvmctl up --artifact` fast after the first verified extraction.
+
+### OCI distribution as a compatibility layer
+
+Do not make OCI the internal artifact format first. Instead, make `.mvm` the signed internal unit and optionally wrap it in OCI for registry distribution. This preserves one verification path and avoids splitting security semantics between tar and OCI layouts.
+
+### Dev UX commands
+
+Small commands that make the model obvious:
+
+- `mvmctl doctor vsock-profile <vm>`
+- `mvmctl capabilities <vm>`
+- `mvmctl readiness <vm> --watch`
+- `mvmctl boot-report <vm> --json`
+- `mvmctl artifact inspect app.mvm`
+- `mvmctl artifact diff a.mvm b.mvm`
+
+### Kernel and init tuning
+
+After telemetry lands, consider kernel/init changes only where measurements justify them:
+
+- built-in virtiofs/fuse modules instead of `modprobe`
+- smaller kernel config for dev images
+- deterministic cmdline presets per backend
+- initramfs only where it reduces net time or strengthens verified boot
+
+Do not tune blindly. Require boot timing evidence first.
+
+---
+
+## Security concerns to track explicitly
+
+These concerns are documented here so implementation sessions do not optimize through them accidentally.
+
+### Early readiness can become an auth bypass
+
+Binding vsock earlier is safe only if authorization and readiness gates run before every sensitive verb. `Ping` and `ReadinessStatus` may work early; `RunEntrypoint`, dev verbs, volume operations, and data streams must still check profile, policy, and component readiness.
+
+### Dispatcher allowlists are not enough by themselves
+
+A profile check in the dispatcher is necessary but not sufficient. Handlers must still enforce local invariants because future code may call helpers directly from tests, alternate dispatchers, or builder paths.
+
+### Dev-only code compiled into prod binaries
+
+Even if prod rejects dev verbs at runtime, compiled handler symbols increase audit burden. Where practical, keep dangerous handlers behind feature gates or profile-specific modules:
+
+- shell exec
+- process spawn
+- code eval
+- console shell
+- filesystem write/remove
+- port forwarding
+
+CI should continue checking that prod builds do not accidentally include direct exec paths.
+
+### Read-only filesystem access can leak secrets
+
+`FsRead`, `FsList`, and `FsStat` look safer than writes, but they can expose secrets, environment files, tokens, application data, or mounted volume contents. Default sealed prod should treat all filesystem RPC as dev-only unless a specific product requirement justifies a constrained read-only subset.
+
+### Volume mounts can shadow trusted paths
+
+Runtime mounts can bypass assumptions made at image-build time. Never allow mounts over:
+
+- `/bin`
+- `/sbin`
+- `/usr`
+- `/lib`
+- `/lib64`
+- `/etc`
+- `/proc`
+- `/sys`
+- `/dev`
+- `/nix`
+- `/nix/store`
+- the entrypoint path
+- the agent binary path
+
+Prefer boot-declared production volumes over runtime mount/unmount for sealed prod.
+
+### Port forwarding widens the network boundary
+
+`StartPortForward` converts vsock-only communication into TCP reachability. It should remain dev-only by default. If production forwarding is ever required, it needs a separate policy with explicit host bind address, port allowlist, audit events, and no wildcard binds.
+
+### Console is equivalent to shell access
+
+Console support must be treated like SSH from a security perspective even though it uses vsock. It is acceptable for dev images and forced recovery workflows, but sealed prod must reject it by default.
+
+### RunCode is remote code execution by design
+
+`RunCode` must remain dev-only. Do not attempt to make it production-safe by adding filters. The production-safe primitive is `RunEntrypoint` against a baked and validated wrapper.
+
+### Process RPC can bypass entrypoint policy
+
+`ProcStart` and related verbs can run programs other than the baked entrypoint. They must remain dev-only unless a future plan creates a strict allowlisted production process model with no shell, no arbitrary env, no writable cwd escape, and clear audit semantics.
+
+### Authenticated frames need freshness and identity
+
+Sequence checks prevent simple replay within a session, but future snapshot/restore and reconnect flows can reintroduce replay risk if counters roll back. Session identity should eventually bind to VM instance ID, artifact digest, and guest key identity.
+
+### Timestamps are not security until clocks are trustworthy
+
+Frame timestamps are useful for audit ordering, but should not be used as the primary freshness control unless guest/host clock trust is explicitly designed. Prefer nonces, challenges, session IDs, and sequence numbers.
+
+### Denial of service via early bind
+
+An early-bound agent can receive requests while still initializing. Add bounds:
+
+- connection backlog
+- per-peer request timeout
+- max concurrent handlers
+- max queued readiness waiters
+- per-verb byte budgets
+- fail-fast behavior while warming
+
+### Background init races
+
+Deferring init introduces races between readiness state and handler state. Use a single shared state object and avoid duplicated booleans. Tests should force slow init and concurrent requests.
+
+### Logging and audit redaction
+
+Boot reports, readiness errors, artifact manifests, and vsock error messages must not leak:
+
+- stdin payloads
+- env vars
+- tokens
+- file contents
+- full command lines when they may contain secrets
+- host filesystem paths beyond what is already user-visible
+
+Every new audit event should define redaction rules.
+
+### Artifact extraction is an attack surface
+
+Portable artifacts must be treated as untrusted input until fully verified. Risks:
+
+- path traversal entries
+- symlinks escaping extraction root
+- hardlinks
+- special files
+- huge sparse files
+- decompression bombs
+- duplicate paths
+- case-collision issues on case-insensitive filesystems
+- mismatched manifest paths vs archive paths
+
+Verification must happen before launch, and extraction must happen into a private restrictive directory.
+
+### Artifact signatures need key policy
+
+Signing a manifest is not enough without a trust policy:
+
+- which keys are trusted
+- how keys rotate
+- how revoked keys are handled
+- whether dev artifacts can be unsigned
+- how CI/release keys differ from local developer keys
+- how verification results are cached
+
+Do not let `--insecure-skip-verify` become a normal path.
+
+### libkrun isolation is not Firecracker isolation
+
+libkrun is valuable for speed and macOS UX, but its host/guest boundary should not be described as equivalent to Firecracker with jailer/seccomp. Production selection must require explicit operator acknowledgement when using Tier 2 isolation.
+
+### virtio-fs trust boundary
+
+virtio-fs shares host filesystem semantics into the guest. Risks include metadata leakage, symlink behavior, cache incoherence, permission surprises, and host path exposure. Production virtio-fs mounts need strict path policy, read-only defaults where possible, and audit events.
+
+### Builder VM supply chain
+
+The builder VM is security-critical because it creates artifacts. It needs:
+
+- verified builder image download
+- signed builder image manifest
+- pinned hashes for kernel/rootfs/cmdline
+- restricted workspace mount
+- no secret leakage into artifacts
+- egress policy for dependency fetches
+- audit logs for install/build inputs
+
+Fast builder UX must not bypass supply-chain gates.
+
+### Warm caches can preserve unsafe state
+
+Persistent Nix stores, artifact caches, and warm worker pools improve speed but can retain compromised or stale state. Add cache identity, validation, GC, and invalidation rules. Never let a warm cache override a manifest hash or policy change.
+
+---
+
+## Suggested implementation order
+
+1. Phase 1: vsock profiles.
+2. Phase 8 partial: profile/security regression tests for existing behavior.
+3. Phase 2: readiness report.
+4. Phase 3: deferred init.
+5. Phase 4: boot telemetry.
+6. Phase 5: builder init parallelism.
+7. Phase 6: portable artifacts.
+8. Phase 7: libkrun tier enforcement and docs.
+9. Phase 8 complete: live sealed-prod gate.
+
+Reasoning: shrink and test the security surface before making boot faster. Then make readiness visible. Then optimize. Then package/distribute.
+
+## Documentation updates
+
+Each implementation PR must update relevant docs:
+
+- `public/src/content/docs/reference/guest-agent.md`
+- `public/src/content/docs/reference/cli-commands.md`
+- `public/src/content/docs/reference/architecture.md`
+- `public/src/content/docs/guides/building-microvm-images.md`
+- `public/src/content/docs/guides/builder-vm.md`
+- `public/src/content/docs/guides/manifests.md`
+- `public/src/content/docs/guides/troubleshooting.md`
+
+Docs must clearly distinguish:
+
+- control-plane readiness vs workload readiness
+- sealed production vs dev profile
+- Firecracker Tier 1 vs libkrun Tier 2
+- artifact verification vs artifact extraction
+
+## AI session handoff prompt
+
+Use this prompt to start an implementation session:
+
+```text
+We are implementing specs/plans/76-secure-fast-boot-and-dx.md.
+
+Start with Phase <N>. Follow AGENTS.md strictly:
+- create a feature worktree under ../.worktrees/
+- run git only from the main checkout with git -C <worktree>
+- run cargo on the macOS host unless the test genuinely needs Linux
+- do not use limactl
+- keep security first: no SSH, vsock-only by default, sealed prod profile must reject dev-only verbs
+- do not preserve backward compatibility unless this plan is explicitly amended; fail closed on old/unknown protocol and artifact formats
+
+Before editing, inspect:
+- crates/mvm-guest/src/vsock.rs
+- crates/mvm-guest/src/bin/mvm-guest-agent.rs
+- crates/mvm-core/src/policy/security.rs
+- specs/SPRINT.md
+- relevant docs under public/src/content/docs/
+
+Implement only Phase <N>, including tests and docs. Do not widen production behavior. At the end, run:
+- cargo test --workspace
+- cargo check --workspace
+- cargo clippy --workspace -- -D warnings
+
+If Linux-only or live-KVM validation is required, add a gated test/runbook and explain exactly what remains for the builder VM or KVM host.
+```
+
+## Open questions
+
+1. Should read-only filesystem RPC be allowed in sealed prod, or should all filesystem RPC be dev-only by default?
+2. Should volume mount/unmount be prod-safe in v1, or should production volumes be boot-declared only?
+3. Should artifact packing use tar+zstd, OCI layout, or both?
+4. Should `ReadinessStatus` be a new request or folded into `WorkerStatus`?
+5. Should the builder VM use a separate vsock protocol from day one, or only after current libkrun builder stabilization?
+
+## Non-goals
+
+- Adding SSH or ssh-agent forwarding to guests.
+- Replacing Firecracker as the production baseline.
+- Removing dm-verity from sealed artifacts.
+- Making dev-only process/filesystem/code-eval verbs production-safe.
+- Building a custom VMM.
+- Rewriting the guest agent in async Rust unless sync/threaded code proves insufficient.


### PR DESCRIPTION
## Summary

Implements Phases 1–3 of [plan 76](specs/plans/76-secure-fast-boot-and-dx.md) plus the Phase 8 CI lane that locks the security surface. Six commits on the stack — recommend **merge-commit** (not squash) so the per-phase history lands on `main` intact.

- **Spec** (`d9f2511`) — Plan 76 in full, eight phases, scrubbed of smolvm references in title/body/filename.
- **Phase 1** (`37d3c67`) — Explicit `AgentProfile { SealedProd, Dev, Builder }` on the policy file. `GuestRequest::class()` + `allowed_in()` exhaustive classifier. Dispatcher gate returns typed `GuestResponse::UnsupportedInProfile { profile, verb }` before any handler runs. Compile-time `#[cfg(feature = "dev-shell")]` gate preserved (ADR-002 §W4.3, claim 4).
- **Phase 8 (partial)** (`5a5b749`) — Named CI lane \`sealed-prod-allowlist\` + \`scripts/check-sealed-prod-allowlist.sh\`. Wraps `cargo test … -- --exact <name>` with a passed-count assertion so a rename/delete of a locked test fails the lane (raw `cargo test --exact` silently exits 0 on zero matches).
- **Phase 2** (`b18afcd`) — Vsock bind + listen moved *before* entrypoint validation and warm-pool startup. New \`GuestRequest::ReadinessStatus\` (prod-safe) returns structured `ReadinessReport { control_plane, entrypoint, warm_pool, integrations, probes, volumes, profile, boot_millis }`. `RunEntrypoint` gate: `entrypoint = Starting` → typed `RunEntrypointError::NotReady`; `Failed` falls through to existing `EntrypointInvalid`. Warm-pool no longer `exit(1)`s on entrypoint-dep failure — surfaces \`ComponentState::Failed\` so readiness can report both failures together.
- **Default impls** (`283e3a3`) — `ComponentState::default() = Disabled` (conservative "not configured" — a forgotten field never reads as `Ready`). `ReadinessReport::default()` composes the per-field defaults. Enables `..Default::default()` struct-update syntax at call sites.
- **Phase 3** (`c218739`) — Integration + probe drop-in scans move to their own background threads alongside the Phase 2 entrypoint/warm-pool thread. `BootTimingReport` fields Phase 2 left as `None` (`warm_pool_ready_ms`, `integrations_ready_ms`, `probes_ready_ms`) now stamped on the first transition out of `Starting`. Initial `Default` `Disabled` does NOT stamp — cold-tier images with no warm pool / no drop-ins correctly skip the timing.

## Test plan

- [x] `cargo test -p mvm-core -p mvm-guest` — 544 / 200 / 26 / 17 / 2 green.
- [x] `cargo clippy --workspace -p mvm-core -p mvm-guest --all-targets -- -D warnings` — clean.
- [x] `cargo check --bin mvm-guest-agent --no-default-features` — prod build still compiles; ADR-002 §W4.3 claim 4 preserved.
- [x] `scripts/check-sealed-prod-allowlist.sh` — green (4 mvm-guest + 4 mvm-core security tests pass via `--exact` filter + count assertion).
- [x] Verified the count-guard fires correctly: deliberate typo in a locked test name → `cargo test` exits 0 (silent fail) → guard catches 3 ≠ 4 → exit 1.
- [ ] **Out of scope for this PR (deliberate, named in commits):**
  - Live-KVM smoke that boots a sealed-prod image and asserts `mvmctl exec` / `mvmctl console` fail. Full Phase 8 will add the live-KVM lane.
  - Phase 4 boot-report CLI (\`mvmctl boot-report <vm>\`, \`mvmctl up --timings\`). Wire shape is already populated by Phases 2+3; Phase 4 is host-side surfacing.
  - Phase 2c \`mvmctl wait <vm> --for <component>\` CLI. Verb (`ReadinessStatus`) is in place; CLI follow-up.

## Spec open questions answered in implementation

- Q1 (filesystem RPC in `SealedProd`) — **all `Fs*` are `DevOnly`** per the spec's "Read-only filesystem access can leak secrets" warning.
- Q2 (volume mount/unmount in `SealedProd`) — **`MountVolume` / `UnmountVolume` classified `ProdSafe`**; the gate passes them to the existing `MountPathPolicy` handler check, matching the spec's conditionally-prod-safe line.

## Merge guidance

Pick **Create a merge commit** (not squash) — keeps the six per-phase commits on `main` for future archaeology, cherry-pick, and selective revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)