### PR TITLE
Plan 76 Phase 5: builder VM init parallelism + boot-timings.json

### DIFF
--- a/crates/mvm-builder-init/src/boot_timings.rs
+++ b/crates/mvm-builder-init/src/boot_timings.rs
@@ -1,0 +1,244 @@
+//! Per-phase cold-path timings for the builder VM. Plan 76 Phase 5.
+//!
+//! The builder VM init pipeline has obvious points where time is
+//! spent (pseudofs mount, /dev/vdb format-or-mount, /nix-store seed,
+//! virtio-fs share mount, network up, job execution). When a user
+//! sees `mvmctl build` take longer than expected, the right question
+//! is "which phase ate the wall clock?" — and the right answer is a
+//! per-phase millisecond breakdown written next to `/job/result` so
+//! the host can surface it through `mvmctl boot-report` (Phase 4)
+//! without parsing console logs.
+//!
+//! **Wire shape.** JSON object, hand-rolled with the same JSON
+//! escaper used for `/job/result` so we don't pull `serde_json` into
+//! the builder-init crate's size budget (Plan 72 W3 caps the
+//! static-linked init at 1.5 MiB). Every field is `u64` ms-since-
+//! init-start or `null` for "phase didn't run this boot" (e.g.
+//! `nix_seeded_ms` on a second-boot reuse).
+//!
+//! **Anchor.** `init_start_ms` is always `0`. All other timings are
+//! `Instant::now().duration_since(boot_at).as_millis()` against the
+//! `BootTimings::new()` call's anchor. That anchor sits as close to
+//! `linux::run`'s entry as we can get; the few milliseconds spent
+//! pre-anchor are constant across boots and uninteresting.
+//!
+//! **Module shape.** Cross-platform so `cargo test` on macOS hosts
+//! exercises the JSON writer without paying for a Linux cross-
+//! compile. The Linux-only `linux` module in `main.rs` is the only
+//! caller; macOS / non-Linux builds compile this module but never
+//! call into it. `#[allow(dead_code)]` at the `mod` site in `main.rs`
+//! handles the workspace-ergonomics dead-code warning the same way
+//! `install` and `proxy` are handled.
+
+use std::time::Instant;
+
+/// Per-phase cold-path timings, in ms since `init_start_ms`.
+///
+/// `None` means "this phase didn't run on this boot" — for example,
+/// `nix_seeded_ms` stays `None` on the second + subsequent boots
+/// because the persistent store is already populated.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct BootTimings {
+    /// Anchor — always `Some(0)` once stamped. Cheaper to keep the
+    /// `Option` shape than to special-case the first field.
+    pub init_start_ms: Option<u64>,
+    /// `/proc`, `/sys`, `/dev`, `/tmp` mounted.
+    pub pseudofs_ready_ms: Option<u64>,
+    /// `/dev/vdb` formatted (only stamped on the first boot of a
+    /// fresh image) and mounted at `/nix-store`.
+    pub nix_device_ready_ms: Option<u64>,
+    /// `/nix-store` seeded from the rootfs's `/nix/store`.
+    /// `None` on second-boot reuse where the seed was skipped.
+    pub nix_seeded_ms: Option<u64>,
+    /// `/nix-store` bind-mounted over `/nix`.
+    pub nix_mounted_ms: Option<u64>,
+    /// `fuse` + `virtiofs` kernel modules loaded.
+    pub modules_ready_ms: Option<u64>,
+    /// All virtio-fs shares (`job`, `out`, `work`) mounted.
+    pub virtiofs_ready_ms: Option<u64>,
+    /// Network up (DHCP successful). `None` on offline builds.
+    pub network_ready_ms: Option<u64>,
+    /// User's `cmd.sh` / install pipeline started executing.
+    pub job_start_ms: Option<u64>,
+    /// User's `cmd.sh` / install pipeline returned.
+    pub job_end_ms: Option<u64>,
+    /// `reboot(RB_POWER_OFF)` about to be invoked. The host sees
+    /// the shutdown-eventfd shortly after.
+    pub poweroff_start_ms: Option<u64>,
+}
+
+impl BootTimings {
+    /// Stamp `init_start_ms = 0` against `anchor`. Subsequent
+    /// `mark_*` calls measure ms since `anchor`.
+    pub fn new(anchor: Instant) -> (Self, Instant) {
+        let t = Self {
+            init_start_ms: Some(0),
+            ..Self::default()
+        };
+        // Return both the struct and the anchor so callers don't
+        // have to thread `Instant` separately.
+        (t, anchor)
+    }
+
+    /// Convert an `Instant` to "ms since `anchor`", saturating on
+    /// the absurd. The builder VM's lifetime is bounded by the
+    /// host's `mvmctl build --timeout` and the job's own deadline
+    /// — neither ever approaches `u64::MAX` ms — but we saturate
+    /// rather than panic to keep init crash-safe.
+    pub fn ms_since(anchor: Instant) -> u64 {
+        u64::try_from(anchor.elapsed().as_millis()).unwrap_or(u64::MAX)
+    }
+
+    /// Render the struct as a single-line JSON object using the
+    /// same escape discipline as `/job/result`. Hand-rolled to
+    /// avoid pulling `serde_json` into the size budget.
+    pub fn to_json(&self) -> String {
+        let mut out = String::with_capacity(256);
+        out.push('{');
+        Self::push_field(&mut out, "init_start_ms", self.init_start_ms, true);
+        Self::push_field(&mut out, "pseudofs_ready_ms", self.pseudofs_ready_ms, false);
+        Self::push_field(
+            &mut out,
+            "nix_device_ready_ms",
+            self.nix_device_ready_ms,
+            false,
+        );
+        Self::push_field(&mut out, "nix_seeded_ms", self.nix_seeded_ms, false);
+        Self::push_field(&mut out, "nix_mounted_ms", self.nix_mounted_ms, false);
+        Self::push_field(&mut out, "modules_ready_ms", self.modules_ready_ms, false);
+        Self::push_field(&mut out, "virtiofs_ready_ms", self.virtiofs_ready_ms, false);
+        Self::push_field(&mut out, "network_ready_ms", self.network_ready_ms, false);
+        Self::push_field(&mut out, "job_start_ms", self.job_start_ms, false);
+        Self::push_field(&mut out, "job_end_ms", self.job_end_ms, false);
+        Self::push_field(&mut out, "poweroff_start_ms", self.poweroff_start_ms, false);
+        out.push('}');
+        out
+    }
+
+    fn push_field(out: &mut String, name: &str, value: Option<u64>, first: bool) {
+        if !first {
+            out.push(',');
+        }
+        out.push('"');
+        out.push_str(name);
+        out.push_str("\":");
+        match value {
+            Some(v) => out.push_str(&v.to_string()),
+            None => out.push_str("null"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_all_none_except_no_anchor() {
+        let t = BootTimings::default();
+        assert!(t.init_start_ms.is_none());
+        assert!(t.pseudofs_ready_ms.is_none());
+        assert!(t.job_start_ms.is_none());
+        assert!(t.poweroff_start_ms.is_none());
+    }
+
+    #[test]
+    fn new_anchors_init_start_at_zero() {
+        let (t, _anchor) = BootTimings::new(Instant::now());
+        assert_eq!(t.init_start_ms, Some(0));
+        assert!(t.pseudofs_ready_ms.is_none());
+    }
+
+    #[test]
+    fn ms_since_returns_monotonic_elapsed() {
+        let anchor = Instant::now();
+        std::thread::sleep(std::time::Duration::from_millis(3));
+        let elapsed = BootTimings::ms_since(anchor);
+        // Allow some slack — CI runners are noisy — but make sure
+        // the elapsed time is at least 1 ms (rules out a frozen
+        // clock or anchor mishandling).
+        assert!(elapsed >= 1, "expected >= 1 ms, got {elapsed}");
+    }
+
+    #[test]
+    fn to_json_emits_all_fields_in_stable_order() {
+        let t = BootTimings {
+            init_start_ms: Some(0),
+            pseudofs_ready_ms: Some(12),
+            nix_device_ready_ms: Some(18),
+            nix_seeded_ms: None,
+            nix_mounted_ms: Some(220),
+            modules_ready_ms: Some(35),
+            virtiofs_ready_ms: Some(48),
+            network_ready_ms: Some(250),
+            job_start_ms: Some(260),
+            job_end_ms: Some(8400),
+            poweroff_start_ms: Some(8410),
+        };
+        let json = t.to_json();
+        // Field order is the wire contract for downstream parsers
+        // that key off ordering (e.g. shell scripts using `jq -c`
+        // and pipe ordering for visual diff).
+        assert_eq!(
+            json,
+            "{\"init_start_ms\":0,\
+             \"pseudofs_ready_ms\":12,\
+             \"nix_device_ready_ms\":18,\
+             \"nix_seeded_ms\":null,\
+             \"nix_mounted_ms\":220,\
+             \"modules_ready_ms\":35,\
+             \"virtiofs_ready_ms\":48,\
+             \"network_ready_ms\":250,\
+             \"job_start_ms\":260,\
+             \"job_end_ms\":8400,\
+             \"poweroff_start_ms\":8410}"
+        );
+    }
+
+    #[test]
+    fn to_json_emits_null_for_missing_phases() {
+        // Cold-tier second boot: no seed, no network (offline).
+        let t = BootTimings {
+            init_start_ms: Some(0),
+            pseudofs_ready_ms: Some(7),
+            nix_device_ready_ms: Some(11),
+            nix_seeded_ms: None,
+            nix_mounted_ms: Some(15),
+            modules_ready_ms: Some(22),
+            virtiofs_ready_ms: Some(30),
+            network_ready_ms: None,
+            job_start_ms: Some(40),
+            job_end_ms: Some(120),
+            poweroff_start_ms: Some(125),
+        };
+        let json = t.to_json();
+        assert!(json.contains("\"nix_seeded_ms\":null"), "got {json}");
+        assert!(json.contains("\"network_ready_ms\":null"), "got {json}");
+    }
+
+    #[test]
+    fn to_json_round_trip_through_serde_json_value_parses_cleanly() {
+        // Belt + suspenders: hand-rolled JSON must still parse as
+        // valid JSON via a real parser. Test-only dev-dep on
+        // serde_json (already transitive through the workspace);
+        // no impact on the builder-init binary's size.
+        let t = BootTimings {
+            init_start_ms: Some(0),
+            pseudofs_ready_ms: Some(12),
+            nix_device_ready_ms: Some(18),
+            nix_seeded_ms: None,
+            nix_mounted_ms: Some(220),
+            modules_ready_ms: Some(35),
+            virtiofs_ready_ms: Some(48),
+            network_ready_ms: Some(250),
+            job_start_ms: Some(260),
+            job_end_ms: Some(8400),
+            poweroff_start_ms: Some(8410),
+        };
+        let json = t.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parses as JSON");
+        assert_eq!(parsed["init_start_ms"], 0);
+        assert_eq!(parsed["nix_seeded_ms"], serde_json::Value::Null);
+        assert_eq!(parsed["network_ready_ms"], 250);
+    }
+}

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -69,6 +69,8 @@ use std::process::ExitCode;
 // would flag them otherwise. Real dead code would still surface as
 // red because the tests would lose coverage.
 #[allow(dead_code)]
+mod boot_timings;
+#[allow(dead_code)]
 mod install;
 #[allow(dead_code)]
 mod install_spec;
@@ -98,6 +100,10 @@ fn main() -> ExitCode {
 mod linux {
     use std::path::Path;
     use std::process::{Command, ExitCode};
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+
+    use crate::boot_timings::BootTimings;
 
     /// Persistent Nix-store device — virtio-blk attached as
     /// `/dev/vdb` by `LibkrunBuilderVm` (Plan 72 W4 will wire
@@ -155,19 +161,87 @@ mod linux {
     pub fn run() -> ExitCode {
         eprintln!("mvm-builder-init: pid 1 starting");
 
-        if let Err(e) = setup_filesystems() {
-            eprintln!("mvm-builder-init: setup_filesystems failed: {e}");
-            write_result(2, &format!("setup_filesystems failed: {e}"));
+        // Plan 76 Phase 5: anchor the boot-timings clock as close
+        // to init entry as we can. The few ms of `eprintln!` +
+        // module dispatch above this point are constant across
+        // boots and uninteresting.
+        let anchor = Instant::now();
+        let (timings, _) = BootTimings::new(anchor);
+        let timings = Arc::new(Mutex::new(timings));
+
+        // Pseudofs mounts must complete before anything else —
+        // every subsequent phase needs /proc, /sys, /dev to be
+        // readable.
+        if let Err(e) = mount_pseudofs() {
+            eprintln!("mvm-builder-init: mount_pseudofs failed: {e}");
+            write_result(2, &format!("mount_pseudofs failed: {e}"));
+            stamp(&timings, |t| {
+                t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
+            });
+            write_boot_timings(&timings);
+            return power_off();
+        }
+        stamp(&timings, |t| {
+            t.pseudofs_ready_ms = Some(BootTimings::ms_since(anchor))
+        });
+
+        // Plan 76 Phase 5: three independent setup tracks fan out
+        // after pseudofs. They share no state with each other
+        // until join.
+        //
+        //   Track A (this thread): /dev/vdb format → mount → seed
+        //     → bind over /nix. Serial; each step depends on the
+        //     previous. Long pole on first-boot (the seed copy).
+        //   Track B: modprobe fuse + virtiofs → mount virtio-fs
+        //     shares. Independent of /nix work — the kernel
+        //     modules and the persistent-store ext4 don't share
+        //     resources.
+        //   Track C: udhcpc network setup. Independent of both.
+        //     Non-fatal: offline builds against the seed store
+        //     still work.
+        //
+        // Threads write into the same `Mutex<BootTimings>`;
+        // contention is a non-issue (a handful of writes per
+        // boot, none on the hot path).
+        let track_b = {
+            let timings = Arc::clone(&timings);
+            std::thread::spawn(move || setup_modules_and_virtiofs(&timings, anchor))
+        };
+        let track_c = {
+            let timings = Arc::clone(&timings);
+            std::thread::spawn(move || {
+                if let Err(e) = setup_network() {
+                    eprintln!("mvm-builder-init: setup_network warning (non-fatal): {e}");
+                    // Leave network_ready_ms = None — the JSON
+                    // signals "offline build" downstream.
+                    return;
+                }
+                stamp(&timings, |t| {
+                    t.network_ready_ms = Some(BootTimings::ms_since(anchor))
+                });
+            })
+        };
+
+        // Track A on the main thread.
+        if let Err(e) = setup_nix_store(&timings, anchor) {
+            eprintln!("mvm-builder-init: setup_nix_store failed: {e}");
+            // Drain the other tracks so their threads don't get
+            // orphaned across the reboot syscall.
+            let _ = track_b.join();
+            let _ = track_c.join();
+            write_result(2, &format!("setup_nix_store failed: {e}"));
+            stamp(&timings, |t| {
+                t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
+            });
+            write_boot_timings(&timings);
             return power_off();
         }
 
-        // Network failure is non-fatal — offline builds against
-        // the seed store still work for some derivations. The
-        // host-side supervisor logs the warning via the libkrun
-        // console.
-        if let Err(e) = setup_network() {
-            eprintln!("mvm-builder-init: setup_network warning (non-fatal): {e}");
-        }
+        // Wait for the fan-out tracks before dispatching the job.
+        // Failures on B/C are already logged inside the closures;
+        // we don't abort the build for them.
+        let _ = track_b.join();
+        let _ = track_c.join();
 
         // Plan 73 Followup B.2 dispatch: install jobs hand the init
         // binary a structured spec rather than a shell script. We
@@ -176,19 +250,74 @@ mod linux {
         let install_spec_path = format!("{JOB_DIR}/{INSTALL_SPEC_FILENAME}");
         if Path::new(&install_spec_path).exists() {
             eprintln!("mvm-builder-init: install spec detected, routing through install pipeline");
+            stamp(&timings, |t| {
+                t.job_start_ms = Some(BootTimings::ms_since(anchor))
+            });
             run_install_job(&install_spec_path);
+            stamp(&timings, |t| {
+                t.job_end_ms = Some(BootTimings::ms_since(anchor))
+            });
+            stamp(&timings, |t| {
+                t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
+            });
+            write_boot_timings(&timings);
             return power_off();
         }
 
         let cmd_path = format!("{JOB_DIR}/cmd.sh");
         if !Path::new(&cmd_path).exists() {
             write_result(2, &format!("missing {cmd_path}"));
+            stamp(&timings, |t| {
+                t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
+            });
+            write_boot_timings(&timings);
             return power_off();
         }
 
+        stamp(&timings, |t| {
+            t.job_start_ms = Some(BootTimings::ms_since(anchor))
+        });
         let (code, tail) = run_job(&cmd_path);
+        stamp(&timings, |t| {
+            t.job_end_ms = Some(BootTimings::ms_since(anchor))
+        });
         write_result(code, &tail);
+        stamp(&timings, |t| {
+            t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
+        });
+        write_boot_timings(&timings);
         power_off()
+    }
+
+    /// Convenience for `timings.lock().map(|mut t| f(&mut *t))`. A
+    /// poisoned mutex (a peer thread panicked mid-stamp) becomes a
+    /// no-op rather than escalating — these timings are
+    /// observability, never gating.
+    fn stamp<F: FnOnce(&mut BootTimings)>(timings: &Arc<Mutex<BootTimings>>, f: F) {
+        if let Ok(mut t) = timings.lock() {
+            f(&mut t);
+        }
+    }
+
+    /// Write the current `BootTimings` snapshot to
+    /// `/job/boot-timings.json` and mirror a one-line summary to
+    /// stderr. Best-effort: if `/job` is not mounted (virtio-fs
+    /// failed) the write fails silently; the stderr line still
+    /// reaches the host-side console capture.
+    fn write_boot_timings(timings: &Arc<Mutex<BootTimings>>) {
+        let snapshot = match timings.lock() {
+            Ok(t) => t.clone(),
+            Err(_) => {
+                eprintln!("mvm-builder-init: boot-timings mutex poisoned; skipping JSON write");
+                return;
+            }
+        };
+        let json = snapshot.to_json();
+        eprintln!("mvm-builder-init: boot-timings={json}");
+        let path = format!("{JOB_DIR}/boot-timings.json");
+        if let Err(e) = std::fs::write(&path, format!("{json}\n")) {
+            eprintln!("mvm-builder-init: failed to write {path}: {e}");
+        }
     }
 
     /// Drive the install pipeline against `/job/install_spec.json`.
@@ -303,7 +432,11 @@ mod linux {
         }
     }
 
-    fn setup_filesystems() -> Result<(), String> {
+    /// Plan 76 Phase 5: the first phase, on the critical path for
+    /// every other init step. /proc, /sys, /dev, /tmp must be
+    /// available before module loading, device probing, or virtio-fs
+    /// mounting; nothing else fans out concurrently with this.
+    fn mount_pseudofs() -> Result<(), String> {
         // Standard init filesystems. libkrun's kernel mounts
         // devtmpfs (and sometimes /proc /sys) before handing off to
         // init, so EBUSY here means "already mounted by an earlier
@@ -313,7 +446,14 @@ mod linux {
         mount_fs_idempotent("sysfs", "/sys", "sysfs")?;
         mount_fs_idempotent("devtmpfs", "/dev", "devtmpfs")?;
         mount_fs_idempotent("tmpfs", "/tmp", "tmpfs")?;
+        Ok(())
+    }
 
+    /// Plan 76 Phase 5: serial chain that gates job execution.
+    /// /dev/vdb format (first boot only) → mount → seed (first
+    /// boot only) → bind-mount over /nix. Each step depends on the
+    /// previous, so this stays single-threaded inside.
+    fn setup_nix_store(timings: &Arc<Mutex<BootTimings>>, anchor: Instant) -> Result<(), String> {
         std::fs::create_dir_all(NIX_STORE_MOUNT)
             .map_err(|e| format!("create {NIX_STORE_MOUNT}: {e}"))?;
         if !is_ext4_formatted(NIX_STORE_DEV)? {
@@ -321,6 +461,9 @@ mod linux {
             format_ext4(NIX_STORE_DEV)?;
         }
         mount_fs(NIX_STORE_DEV, NIX_STORE_MOUNT, "ext4")?;
+        stamp(timings, |t| {
+            t.nix_device_ready_ms = Some(BootTimings::ms_since(anchor))
+        });
 
         // Seed the persistent `/nix-store` from the rootfs's baked-in
         // `/nix/store` on first boot. A plain `MS_BIND` shadows the
@@ -361,11 +504,25 @@ mod linux {
                     status.code()
                 ));
             }
+            stamp(timings, |t| {
+                t.nix_seeded_ms = Some(BootTimings::ms_since(anchor))
+            });
         }
 
         std::fs::create_dir_all(NIX_TARGET).map_err(|e| format!("create {NIX_TARGET}: {e}"))?;
         bind_mount(NIX_STORE_MOUNT, NIX_TARGET)?;
+        stamp(timings, |t| {
+            t.nix_mounted_ms = Some(BootTimings::ms_since(anchor))
+        });
 
+        Ok(())
+    }
+
+    /// Plan 76 Phase 5: independent track that runs concurrently
+    /// with `setup_nix_store`. Loads the `fuse` + `virtiofs`
+    /// kernel modules (themselves fanned out across two threads),
+    /// then mounts the three virtio-fs shares.
+    fn setup_modules_and_virtiofs(timings: &Arc<Mutex<BootTimings>>, anchor: Instant) {
         // Load FUSE + virtio-fs kernel modules before mounting the
         // host-exported shares. Stock nixpkgs kernel ships these as
         // `=m` (loadable modules); without modprobe, `mount -t
@@ -374,19 +531,18 @@ mod linux {
         // load them at boot. Failure is non-fatal — the subsequent
         // mount attempts will fail visibly if a module is genuinely
         // missing rather than just not-yet-loaded.
-        for module in &["fuse", "virtiofs"] {
-            let status = Command::new("/bin/busybox")
-                .args(["modprobe", module])
-                .status();
-            match status {
-                Ok(s) if s.success() => {}
-                Ok(s) => eprintln!(
-                    "mvm-builder-init: modprobe {module} exited {} (continuing)",
-                    s.code().unwrap_or(-1)
-                ),
-                Err(e) => eprintln!("mvm-builder-init: spawn modprobe {module}: {e} (continuing)"),
-            }
-        }
+        //
+        // Plan 76 Phase 5: the two modprobes fan out across a pair
+        // of threads. modprobe is mostly I/O-bound (open + read the
+        // module file, run the insmod ioctl); running them
+        // concurrently halves the wall-clock cost on slower disks.
+        let fuse = std::thread::spawn(|| run_modprobe("fuse"));
+        let virtiofs = std::thread::spawn(|| run_modprobe("virtiofs"));
+        let _ = fuse.join();
+        let _ = virtiofs.join();
+        stamp(timings, |t| {
+            t.modules_ready_ms = Some(BootTimings::ms_since(anchor))
+        });
 
         // virtio-fs shares declared by `LibkrunBuilderVm` (Plan 72
         // W4). Each entry is `(tag, target)` — the kernel routes
@@ -402,8 +558,23 @@ mod linux {
                 eprintln!("mvm-builder-init: virtio-fs '{tag}' -> {target} failed: {e}");
             }
         }
+        stamp(timings, |t| {
+            t.virtiofs_ready_ms = Some(BootTimings::ms_since(anchor))
+        });
+    }
 
-        Ok(())
+    fn run_modprobe(module: &str) {
+        let status = Command::new("/bin/busybox")
+            .args(["modprobe", module])
+            .status();
+        match status {
+            Ok(s) if s.success() => {}
+            Ok(s) => eprintln!(
+                "mvm-builder-init: modprobe {module} exited {} (continuing)",
+                s.code().unwrap_or(-1)
+            ),
+            Err(e) => eprintln!("mvm-builder-init: spawn modprobe {module}: {e} (continuing)"),
+        }
     }
 
     fn setup_network() -> Result<(), String> {


### PR DESCRIPTION
## Summary

Apply the Phase 2 / 3 cold-path discipline to the libkrun builder VM's PID-1 init. Three independent setup tracks fan out after pseudofs mounts, and `BootTimings` writes a structured `/job/boot-timings.json` (plus stderr mirror) so the host can surface per-phase latency through `mvmctl boot-report` without parsing console logs.

New parallel structure inside `linux::run`:

```
mount_pseudofs (main thread; gating)
├── Track A (main):    /dev/vdb format → mount → seed → bind over /nix  (serial chain)
├── Track B (thread):  modprobe fuse + modprobe virtiofs (parallel pair) → mount virtio-fs shares
└── Track C (thread):  udhcpc network setup (non-fatal)
                         join B + C
                         dispatch /job/install_spec.json or /job/cmd.sh
                         write /job/result + /job/boot-timings.json
                         reboot(RB_POWER_OFF)
```

## Wire shape

```json
{
  "init_start_ms": 0,
  "pseudofs_ready_ms": 12,
  "nix_device_ready_ms": 18,
  "nix_seeded_ms": null,
  "nix_mounted_ms": 220,
  "modules_ready_ms": 35,
  "virtiofs_ready_ms": 48,
  "network_ready_ms": 250,
  "job_start_ms": 260,
  "job_end_ms": 8400,
  "poweroff_start_ms": 8410
}
```

Every field is `u64` ms-since-`init_start_ms` or `null` (phase didn't run — e.g. `nix_seeded_ms` on second-boot reuse, `network_ready_ms` on offline builds). Field **order** is the wire contract for `jq -c` consumers and visual diff. Hand-rolled JSON serializer (same discipline as `/job/result`) — the builder-init binary's size budget is ≤ 1.5 MiB (Plan 72 W3), so `serde_json` stays out of production builds. `serde_json` is already a dev-dep; a round-trip test parses the hand-rolled output to catch drift.

## Test plan

- [x] `cargo test -p mvm-builder-init` — 36 / 36 green (was 31; +5 new `boot_timings` tests covering default, new-anchor, ms-since elapsed, JSON field-order stability, null-for-missing-phases, round-trip-through-serde_json).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `scripts/check-sealed-prod-allowlist.sh` — green (Phase 1/8-partial gate still locked).
- [ ] **Live libkrun builder smoke** (Plan 72 W5) — gated by `MVM_LIVE_*` env vars; not run here. Once that lane lights up it'll produce `/job/boot-timings.json` artifacts the host can diff against expected budgets.

## Out of scope (deliberate, named in the commit)

- Linux-only helper scheduling tests with a mocked command runner. The existing helpers reach for raw `Command::new` + `nix::mount` syscalls; mocking those would need a substantial refactor for marginal coverage gain. Structural unit tests on `BootTimings` + the live libkrun smoke cover the runtime behaviour.
- Host-side display of `boot-timings.json` through `mvmctl boot-report`. Phase 4 surfaces the *guest* ReadinessReport timings; the builder VM is a separate (and shorter-lived) artifact. A follow-up can plumb `boot-timings.json` into `mvmctl build`'s post-build summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)