### PR TITLE
Plan 76 Phase 6: portable signed `.mvm` artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2934,11 +2934,13 @@ version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "ed25519-dalek",
  "flate2",
  "mvm-core",
  "mvm-guest",
  "mvm-libkrun",
  "mvm-sdk",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -38,6 +38,12 @@ mvm-libkrun = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+# Plan 76 Phase 6 — `.mvm` packed artifacts carry an Ed25519
+# manifest signature. We verify (and produce, when the caller
+# hands us a signing key) signatures inside this crate so the
+# format library is self-contained; the CLI passes the host
+# signer's key bytes in.
+ed25519-dalek.workspace = true
 # Plan 74 W1.4b.4 — `download_runtime_overlay` stages files into a
 # temp dir before atomic install into the cache. Promoted from a
 # dev-dep so lib code (not just tests) can reach it.
@@ -47,6 +53,13 @@ tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
 which = "6"
+
+[dev-dependencies]
+# Plan 76 Phase 6 — `packed_artifact::tests` generate Ed25519
+# keypairs for round-trip tests. ed25519-dalek's
+# `SigningKey::generate` takes any `CryptoRng + RngCore`; the
+# concrete `OsRng` lives in `rand`.
+rand = "0.8"
 
 [features]
 default = []

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -5,6 +5,10 @@ pub mod backend;
 pub mod builder_vm;
 pub mod cache;
 pub mod firecracker;
+/// Plan 76 Phase 6 — portable signed `.mvm` artifacts. A tar.gz
+/// wrapper around kernel + rootfs + verity sidecars + cmdline,
+/// with an Ed25519-signed manifest that hashes every payload.
+pub mod packed_artifact;
 pub mod template_reuse;
 
 /// Plan 72 W1 — libkrun-backed builder VM (gated by

--- a/crates/mvm-build/src/packed_artifact.rs
+++ b/crates/mvm-build/src/packed_artifact.rs
@@ -1,0 +1,1032 @@
+//! Plan 76 Phase 6 — portable signed `.mvm` artifacts.
+//!
+//! A `.mvm` file is a gzip-compressed tarball wrapping a sealed-prod
+//! microVM image. It contains:
+//!
+//! ```text
+//!   manifest.json                       ← signed envelope (this module)
+//!   kernel/vmlinux
+//!   rootfs/rootfs.ext4
+//!   rootfs/rootfs.verity                (optional; required for sealed-prod)
+//!   rootfs/roothash                     (optional; required for sealed-prod)
+//!   initrd/verity-initrd.cpio.gz        (optional)
+//!   cmdline.txt
+//!   signatures/manifest.ed25519         ← 64-byte Ed25519 signature
+//! ```
+//!
+//! The signature covers a deterministic byte representation of the
+//! manifest (serde_json `to_vec` with `BTreeMap`-shaped fields → stable
+//! ordering). The manifest itself embeds SHA-256 hashes of every other
+//! file in the archive, so verifying the manifest signature transitively
+//! verifies the whole archive contents.
+//!
+//! **Why not OCI.** OCI is the registry-distribution format; this is
+//! the internal-sealed unit. Plan 76 §"OCI distribution as a
+//! compatibility layer" wants `.mvm` to remain the signed boundary and
+//! optionally wrap in OCI for transport. Keeping the verification path
+//! single ensures sealed-prod policies aren't split between two
+//! formats.
+//!
+//! **Fail-closed properties** (plan 76 §"Artifact extraction is an
+//! attack surface"):
+//! - Tar path-traversal entries (`../`, absolute paths) are rejected
+//!   pre-extraction.
+//! - Symlinks and hardlinks are rejected outright — the archive is
+//!   regular files only.
+//! - Special files (devices, fifos, sockets) are rejected.
+//! - Each declared file is bounded by `MAX_ENTRY_BYTES`; the total
+//!   uncompressed size by `MAX_ARCHIVE_BYTES`. Decompression bombs
+//!   fail with `ArtifactError::SizeCap` before exhausting disk.
+//! - Unknown manifest format versions are rejected (no permissive
+//!   inference).
+//! - `SealedProd`-declared artifacts that omit verity sidecars are
+//!   rejected at verification time.
+
+use std::collections::BTreeMap;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::Context;
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use flate2::Compression;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tar::{Archive, Builder, EntryType, Header};
+
+// ============================================================================
+// Public surface
+// ============================================================================
+
+/// Current `.mvm` manifest format. A future format bump is a breaking
+/// change — old readers MUST refuse the new version, new readers MUST
+/// refuse unknown versions. Plan 76 §"Compatibility stance" §"Unknown
+/// artifact format versions should fail closed".
+pub const MANIFEST_FORMAT_VERSION: u32 = 1;
+
+/// Hard cap on a single file inside the archive (2 GiB). Matches the
+/// per-layer cap used by `oci_to_rootfs` for the same decompression-
+/// bomb reason.
+pub const MAX_ENTRY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Hard cap on the total uncompressed bytes consumed during verify
+/// extraction (4 GiB). Any legitimate sealed image fits comfortably;
+/// a malicious manifest pointing at a >4 GiB blob is refused before
+/// it can fill the host disk.
+pub const MAX_ARCHIVE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+/// Filename of the signed manifest inside the tar.
+pub const MANIFEST_FILENAME: &str = "manifest.json";
+
+/// Filename of the detached Ed25519 signature inside the tar.
+pub const SIGNATURE_FILENAME: &str = "signatures/manifest.ed25519";
+
+/// Profile a `.mvm` artifact declares for the guest agent it
+/// boots into. Mirrors `mvm_core::security::AgentProfile`'s
+/// wire-stable kebab-case shape so callers can re-export the
+/// same enum across the boundary without translation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ArtifactProfile {
+    SealedProd,
+    Dev,
+    Builder,
+}
+
+/// Per-file hash + size record. Filenames are the in-archive paths;
+/// `size_bytes` matches what `tar` reports on `Entry::size()`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct FileEntry {
+    pub path: String,
+    pub sha256_hex: String,
+    pub size_bytes: u64,
+}
+
+/// Security posture the artifact declares. `SealedProd` requires
+/// verity sidecars to be present and listed in `files`; verify
+/// refuses sealed-prod artifacts that omit them.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SecurityPosture {
+    pub profile: ArtifactProfile,
+    /// `true` when the rootfs is dm-verity-protected and the
+    /// kernel cmdline carries a `roothash=` parameter. Plan 27 W3.
+    pub verity_protected: bool,
+    /// `true` when the agent enforces `require_auth = true` on the
+    /// vsock control socket. Plan 76 Phase 1.
+    pub requires_auth: bool,
+    /// `true` when the image config permits runtime volume mounts.
+    /// `false` for the v1 SealedProd default (boot-declared volumes
+    /// only).
+    pub allows_volumes: bool,
+    /// `true` when the image config permits outbound egress beyond
+    /// the host firewall's deny-by-default.
+    pub allows_egress: bool,
+}
+
+/// `.mvm` manifest. Serialized to `manifest.json` inside the
+/// archive; the detached signature at `signatures/manifest.ed25519`
+/// covers `to_signing_bytes()`.
+///
+/// `BTreeMap` for the file index gives deterministic JSON ordering
+/// so re-serialisation produces byte-identical output — necessary
+/// for signature verification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Manifest {
+    /// Always `MANIFEST_FORMAT_VERSION` for the current shape.
+    /// Unknown values are refused.
+    pub format_version: u32,
+    /// Producer's `CARGO_PKG_VERSION`. Surfaced in error messages;
+    /// not load-bearing for verify (we don't pin host-vs-artifact
+    /// versions).
+    pub mvm_version: String,
+    /// `"aarch64-linux"`, `"x86_64-linux"`, etc. Matches the rootfs
+    /// builder's `--target` argument; mismatched arch fails at boot,
+    /// not at verify.
+    pub target_arch: String,
+    /// SHA-256 hashes of every file in the archive, keyed by
+    /// in-archive path. `BTreeMap` for deterministic ordering.
+    pub files: BTreeMap<String, FileEntry>,
+    /// Pointer back to the build provenance — the mvm tenant +
+    /// build invocation that produced this artifact. Free-form
+    /// today; reserved for ADR-051-style attestation linkage.
+    pub build_provenance: Option<String>,
+    /// Security claims the producer makes about this artifact.
+    pub security: SecurityPosture,
+}
+
+impl Manifest {
+    /// Deterministic byte representation used by both signer and
+    /// verifier. `serde_json::to_vec` is canonical here because
+    /// `BTreeMap` gives ordered keys and we control every field
+    /// shape (no `serde(flatten)`, no untagged enums).
+    pub fn to_signing_bytes(&self) -> Result<Vec<u8>, ArtifactError> {
+        serde_json::to_vec(self).map_err(ArtifactError::from)
+    }
+}
+
+/// Inputs to `pack`. Filenames inside the archive are derived from
+/// the field — for example, `kernel` always ends up at `kernel/vmlinux`.
+/// Optional sidecars (`verity`, `roothash`, `initrd`) are skipped
+/// when `None`; SealedProd verifies them in.
+#[derive(Debug, Clone)]
+pub struct PackInputs<'a> {
+    pub kernel: &'a Path,
+    pub rootfs: &'a Path,
+    pub cmdline: &'a Path,
+    pub verity: Option<&'a Path>,
+    pub roothash: Option<&'a Path>,
+    pub initrd: Option<&'a Path>,
+    pub target_arch: String,
+    pub build_provenance: Option<String>,
+    pub security: SecurityPosture,
+}
+
+/// Sign-and-pack a `.mvm` artifact at `out_path`.
+pub fn pack(
+    inputs: &PackInputs<'_>,
+    signing_key: &SigningKey,
+    out_path: &Path,
+) -> Result<(), ArtifactError> {
+    // 1. Resolve every input. Each `Option<&Path>` either contributes
+    //    a `(archive_path, host_path)` pair or is skipped.
+    let mut planned: Vec<(String, &Path)> = vec![
+        ("kernel/vmlinux".to_string(), inputs.kernel),
+        ("rootfs/rootfs.ext4".to_string(), inputs.rootfs),
+        ("cmdline.txt".to_string(), inputs.cmdline),
+    ];
+    if let Some(p) = inputs.verity {
+        planned.push(("rootfs/rootfs.verity".to_string(), p));
+    }
+    if let Some(p) = inputs.roothash {
+        planned.push(("rootfs/roothash".to_string(), p));
+    }
+    if let Some(p) = inputs.initrd {
+        planned.push(("initrd/verity-initrd.cpio.gz".to_string(), p));
+    }
+
+    if inputs.security.profile == ArtifactProfile::SealedProd
+        && (inputs.verity.is_none() || inputs.roothash.is_none())
+    {
+        return Err(ArtifactError::SealedProdMissingVerity);
+    }
+
+    // 2. Stream-hash each input file. We keep the byte content in
+    //    memory only long enough to feed it into the tar writer
+    //    below; for sealed prod artifacts the rootfs can be large
+    //    (hundreds of MB), so reading once + writing once matters.
+    //    The `files` map is built ahead of the tar so the manifest
+    //    can be serialised + signed before any payload bytes go in.
+    let mut files: BTreeMap<String, FileEntry> = BTreeMap::new();
+    let mut total_bytes: u64 = 0;
+    for (archive_path, host_path) in &planned {
+        let (sha, size) = hash_file(host_path)?;
+        if size > MAX_ENTRY_BYTES {
+            return Err(ArtifactError::EntryTooLarge {
+                path: archive_path.clone(),
+                size,
+            });
+        }
+        total_bytes = total_bytes.saturating_add(size);
+        if total_bytes > MAX_ARCHIVE_BYTES {
+            return Err(ArtifactError::SizeCap);
+        }
+        files.insert(
+            archive_path.clone(),
+            FileEntry {
+                path: archive_path.clone(),
+                sha256_hex: sha,
+                size_bytes: size,
+            },
+        );
+    }
+
+    let manifest = Manifest {
+        format_version: MANIFEST_FORMAT_VERSION,
+        mvm_version: env!("CARGO_PKG_VERSION").to_string(),
+        target_arch: inputs.target_arch.clone(),
+        files,
+        build_provenance: inputs.build_provenance.clone(),
+        security: inputs.security.clone(),
+    };
+    let manifest_bytes = manifest.to_signing_bytes()?;
+    let signature: Signature = signing_key.sign(&manifest_bytes);
+
+    // 3. Write tar.gz with manifest first, signature second, then
+    //    every input file. The "manifest first" ordering means a
+    //    streaming verifier can read manifest + signature + reject
+    //    bad signatures before extracting a single payload byte.
+    let file = File::create(out_path).with_context(|| format!("create {}", out_path.display()))?;
+    let gz = GzEncoder::new(file, Compression::default());
+    let mut tar = Builder::new(gz);
+    tar.mode(tar::HeaderMode::Deterministic);
+
+    append_bytes(&mut tar, MANIFEST_FILENAME, &manifest_bytes)?;
+    append_bytes(&mut tar, SIGNATURE_FILENAME, &signature.to_bytes())?;
+    for (archive_path, host_path) in &planned {
+        let bytes = fs::read(host_path).with_context(|| format!("read {}", host_path.display()))?;
+        append_bytes(&mut tar, archive_path, &bytes)?;
+    }
+    tar.finish().context("finalize tar")?;
+    Ok(())
+}
+
+/// Verify an existing `.mvm` artifact without extracting payload
+/// bytes to disk. Returns the parsed `Manifest` on success.
+pub fn verify(path: &Path, verifying_key: &VerifyingKey) -> Result<Manifest, ArtifactError> {
+    // First pass: read manifest + signature. The archive layout
+    // guarantees these are the first two entries, but we walk the
+    // whole tar to find them so a re-ordered tar (e.g. produced by
+    // a non-mvm packer) still verifies — at the cost of one extra
+    // streaming pass.
+    let manifest_bytes;
+    let signature_bytes;
+    {
+        let f = File::open(path).with_context(|| format!("open {}", path.display()))?;
+        let gz = GzDecoder::new(f);
+        let mut archive = Archive::new(gz);
+        let (m, s) = read_manifest_and_signature(&mut archive)?;
+        manifest_bytes = m;
+        signature_bytes = s;
+    }
+
+    let manifest: Manifest =
+        serde_json::from_slice(&manifest_bytes).map_err(ArtifactError::from)?;
+    if manifest.format_version != MANIFEST_FORMAT_VERSION {
+        return Err(ArtifactError::UnknownFormatVersion {
+            got: manifest.format_version,
+            expected: MANIFEST_FORMAT_VERSION,
+        });
+    }
+
+    // Re-serialise the parsed manifest and compare against the on-
+    // wire bytes; this catches a malicious packer that emits a JSON
+    // shape we accept on read but whose re-serialisation differs.
+    // `BTreeMap` + `deny_unknown_fields` already make the path
+    // narrow; this is belt-and-suspenders.
+    let canonical = manifest.to_signing_bytes()?;
+    if canonical != manifest_bytes {
+        return Err(ArtifactError::ManifestNotCanonical);
+    }
+
+    let signature =
+        Signature::from_slice(&signature_bytes).map_err(|_| ArtifactError::BadSignatureBytes)?;
+    verifying_key
+        .verify(&manifest_bytes, &signature)
+        .map_err(|_| ArtifactError::SignatureMismatch)?;
+
+    // SealedProd posture requires verity sidecars to be present
+    // AND listed in the manifest. Either omission is a refusal.
+    if manifest.security.profile == ArtifactProfile::SealedProd {
+        let need = ["rootfs/rootfs.verity", "rootfs/roothash"];
+        for p in need {
+            if !manifest.files.contains_key(p) {
+                return Err(ArtifactError::SealedProdMissingVerity);
+            }
+        }
+    }
+
+    // Second pass: verify each payload file's SHA-256 against the
+    // manifest. Streaming hash avoids holding the whole rootfs in
+    // memory; size cap fires before exhausting disk on a manifest
+    // that lies about its declared size.
+    {
+        let f = File::open(path).with_context(|| format!("open {}", path.display()))?;
+        let gz = GzDecoder::new(f);
+        let mut archive = Archive::new(gz);
+        let mut total_bytes: u64 = 0;
+        let mut hashed: BTreeMap<String, String> = BTreeMap::new();
+        for entry in archive.entries().context("iterate archive")? {
+            let entry = entry.context("read tar entry")?;
+            validate_entry_meta(&entry)?;
+            let path_str = entry_path_string(&entry)?;
+            if path_str == MANIFEST_FILENAME || path_str == SIGNATURE_FILENAME {
+                continue;
+            }
+            let declared =
+                manifest
+                    .files
+                    .get(&path_str)
+                    .ok_or_else(|| ArtifactError::UnexpectedFile {
+                        path: path_str.clone(),
+                    })?;
+            if declared.size_bytes != entry.size() {
+                return Err(ArtifactError::SizeMismatch {
+                    path: path_str,
+                    declared: declared.size_bytes,
+                    actual: entry.size(),
+                });
+            }
+            total_bytes = total_bytes.saturating_add(entry.size());
+            if total_bytes > MAX_ARCHIVE_BYTES {
+                return Err(ArtifactError::SizeCap);
+            }
+            let sha = stream_hash(entry)?;
+            if sha != declared.sha256_hex {
+                return Err(ArtifactError::HashMismatch {
+                    path: path_str,
+                    declared: declared.sha256_hex.clone(),
+                    actual: sha,
+                });
+            }
+            hashed.insert(path_str, declared.sha256_hex.clone());
+        }
+        // Every manifest entry must have been seen exactly once.
+        // A missing file is a refusal — sealed-prod must not boot
+        // a half-archive.
+        for declared in manifest.files.keys() {
+            if !hashed.contains_key(declared) {
+                return Err(ArtifactError::MissingFile {
+                    path: declared.clone(),
+                });
+            }
+        }
+    }
+
+    Ok(manifest)
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+#[derive(Debug, thiserror::Error)]
+pub enum ArtifactError {
+    #[error("manifest format version {got} not supported (expected {expected})")]
+    UnknownFormatVersion { got: u32, expected: u32 },
+    #[error("sealed-prod artifact missing verity sidecars (rootfs.verity / roothash)")]
+    SealedProdMissingVerity,
+    #[error("manifest signature did not verify")]
+    SignatureMismatch,
+    #[error("manifest signature bytes are not a valid Ed25519 signature")]
+    BadSignatureBytes,
+    #[error("manifest JSON not in canonical form (re-serialise mismatch)")]
+    ManifestNotCanonical,
+    #[error("file {path} not declared in manifest")]
+    UnexpectedFile { path: String },
+    #[error("file {path} declared in manifest is missing from archive")]
+    MissingFile { path: String },
+    #[error("file {path} size mismatch: declared {declared}, actual {actual}")]
+    SizeMismatch {
+        path: String,
+        declared: u64,
+        actual: u64,
+    },
+    #[error("file {path} hash mismatch: declared {declared}, actual {actual}")]
+    HashMismatch {
+        path: String,
+        declared: String,
+        actual: String,
+    },
+    #[error("entry {path} exceeds per-entry size cap")]
+    EntryTooLarge { path: String, size: u64 },
+    #[error("archive exceeds total uncompressed size cap")]
+    SizeCap,
+    #[error("path-traversal entry rejected: {0}")]
+    PathTraversal(String),
+    #[error("non-regular file entry rejected: {0}")]
+    NonRegularEntry(String),
+    #[error("manifest absent from archive")]
+    ManifestAbsent,
+    #[error("signature absent from archive")]
+    SignatureAbsent,
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn append_bytes<W: Write>(
+    tar: &mut Builder<W>,
+    archive_path: &str,
+    bytes: &[u8],
+) -> Result<(), ArtifactError> {
+    let mut header = Header::new_gnu();
+    header
+        .set_path(archive_path)
+        .map_err(|e| ArtifactError::Other(anyhow::anyhow!("set path {archive_path}: {e}")))?;
+    header.set_size(bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_mtime(0);
+    header.set_entry_type(EntryType::Regular);
+    header.set_cksum();
+    tar.append(&header, bytes)
+        .with_context(|| format!("write tar entry {archive_path}"))?;
+    Ok(())
+}
+
+fn hash_file(path: &Path) -> Result<(String, u64), ArtifactError> {
+    let mut f = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    let mut total: u64 = 0;
+    loop {
+        let n = f.read(&mut buf).context("read input")?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        total += n as u64;
+    }
+    let digest = hasher.finalize();
+    Ok((hex_lower(&digest), total))
+}
+
+fn stream_hash<R: Read>(mut entry: R) -> Result<String, ArtifactError> {
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = entry.read(&mut buf).context("read tar entry body")?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(hex_nibble(b >> 4));
+        out.push(hex_nibble(b & 0xf));
+    }
+    out
+}
+
+fn hex_nibble(n: u8) -> char {
+    match n {
+        0..=9 => (b'0' + n) as char,
+        _ => (b'a' + n - 10) as char,
+    }
+}
+
+fn read_manifest_and_signature<R: Read>(
+    archive: &mut Archive<R>,
+) -> Result<(Vec<u8>, Vec<u8>), ArtifactError> {
+    let mut manifest: Option<Vec<u8>> = None;
+    let mut signature: Option<Vec<u8>> = None;
+    for entry in archive.entries().context("iterate archive")? {
+        let mut entry = entry.context("read tar entry")?;
+        validate_entry_meta(&entry)?;
+        let path = entry_path_string(&entry)?;
+        if path == MANIFEST_FILENAME {
+            let mut buf = Vec::with_capacity(entry.size() as usize);
+            entry.read_to_end(&mut buf).context("read manifest body")?;
+            manifest = Some(buf);
+        } else if path == SIGNATURE_FILENAME {
+            let mut buf = Vec::with_capacity(entry.size() as usize);
+            entry.read_to_end(&mut buf).context("read signature body")?;
+            signature = Some(buf);
+        }
+        if manifest.is_some() && signature.is_some() {
+            break;
+        }
+    }
+    let manifest = manifest.ok_or(ArtifactError::ManifestAbsent)?;
+    let signature = signature.ok_or(ArtifactError::SignatureAbsent)?;
+    Ok((manifest, signature))
+}
+
+/// Reject anything that isn't a regular file with a tar-traversal-
+/// safe path. Plan 76 §"Artifact extraction is an attack surface"
+/// lists the specific risks; this function gates each one.
+fn validate_entry_meta<R: Read>(entry: &tar::Entry<'_, R>) -> Result<(), ArtifactError> {
+    let kind = entry.header().entry_type();
+    if kind != EntryType::Regular && kind != EntryType::Continuous {
+        let p = entry
+            .path()
+            .ok()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "<unreadable>".to_string());
+        return Err(ArtifactError::NonRegularEntry(format!(
+            "{p}: kind={:?}",
+            kind
+        )));
+    }
+    Ok(())
+}
+
+/// Read an entry's path as a String, rejecting traversal components.
+/// Refuses absolute paths, `..` segments, embedded NULs, and
+/// non-UTF-8 paths.
+fn entry_path_string<R: Read>(entry: &tar::Entry<'_, R>) -> Result<String, ArtifactError> {
+    let path = entry
+        .path()
+        .map_err(|e| ArtifactError::PathTraversal(format!("read path: {e}")))?;
+    let path: PathBuf = path.into_owned();
+    if path.is_absolute() {
+        return Err(ArtifactError::PathTraversal(format!(
+            "absolute path: {}",
+            path.display()
+        )));
+    }
+    for c in path.components() {
+        match c {
+            Component::Normal(_) => {}
+            _ => {
+                return Err(ArtifactError::PathTraversal(format!(
+                    "non-normal component in {}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    path.to_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| ArtifactError::PathTraversal(format!("non-UTF8 path: {}", path.display())))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+    use std::io::Cursor;
+
+    fn test_keypair() -> SigningKey {
+        SigningKey::generate(&mut OsRng)
+    }
+
+    fn write_fixture(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, body).unwrap();
+        p
+    }
+
+    fn dev_inputs<'a>(kernel: &'a Path, rootfs: &'a Path, cmdline: &'a Path) -> PackInputs<'a> {
+        PackInputs {
+            kernel,
+            rootfs,
+            cmdline,
+            verity: None,
+            roothash: None,
+            initrd: None,
+            target_arch: "aarch64-linux".to_string(),
+            build_provenance: Some("test".to_string()),
+            security: SecurityPosture {
+                profile: ArtifactProfile::Dev,
+                verity_protected: false,
+                requires_auth: false,
+                allows_volumes: true,
+                allows_egress: true,
+            },
+        }
+    }
+
+    fn sealed_inputs<'a>(
+        kernel: &'a Path,
+        rootfs: &'a Path,
+        cmdline: &'a Path,
+        verity: &'a Path,
+        roothash: &'a Path,
+    ) -> PackInputs<'a> {
+        PackInputs {
+            kernel,
+            rootfs,
+            cmdline,
+            verity: Some(verity),
+            roothash: Some(roothash),
+            initrd: None,
+            target_arch: "aarch64-linux".to_string(),
+            build_provenance: Some("test".to_string()),
+            security: SecurityPosture {
+                profile: ArtifactProfile::SealedProd,
+                verity_protected: true,
+                requires_auth: true,
+                allows_volumes: false,
+                allows_egress: false,
+            },
+        }
+    }
+
+    #[test]
+    fn pack_then_verify_dev_artifact_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let k = write_fixture(dir.path(), "vmlinux", b"kernel bytes");
+        let r = write_fixture(dir.path(), "rootfs.ext4", b"rootfs bytes");
+        let c = write_fixture(dir.path(), "cmdline.txt", b"console=hvc0 root=/dev/vda");
+        let key = test_keypair();
+        let out = dir.path().join("out.mvm");
+        pack(&dev_inputs(&k, &r, &c), &key, &out).unwrap();
+
+        let mf = verify(&out, &key.verifying_key()).unwrap();
+        assert_eq!(mf.format_version, MANIFEST_FORMAT_VERSION);
+        assert_eq!(mf.target_arch, "aarch64-linux");
+        assert_eq!(mf.security.profile, ArtifactProfile::Dev);
+        assert!(mf.files.contains_key("kernel/vmlinux"));
+        assert!(mf.files.contains_key("rootfs/rootfs.ext4"));
+        assert!(mf.files.contains_key("cmdline.txt"));
+    }
+
+    #[test]
+    fn pack_then_verify_sealed_artifact_roundtrips_with_verity() {
+        let dir = tempfile::tempdir().unwrap();
+        let k = write_fixture(dir.path(), "vmlinux", b"k");
+        let r = write_fixture(dir.path(), "rootfs.ext4", b"r");
+        let c = write_fixture(dir.path(), "cmdline.txt", b"roothash=abc root=/dev/vda");
+        let v = write_fixture(dir.path(), "rootfs.verity", b"v");
+        let h = write_fixture(dir.path(), "roothash", b"deadbeef");
+        let key = test_keypair();
+        let out = dir.path().join("sealed.mvm");
+        pack(&sealed_inputs(&k, &r, &c, &v, &h), &key, &out).unwrap();
+        let mf = verify(&out, &key.verifying_key()).unwrap();
+        assert_eq!(mf.security.profile, ArtifactProfile::SealedProd);
+        assert!(mf.security.verity_protected);
+    }
+
+    #[test]
+    fn pack_refuses_sealed_prod_without_verity_sidecars() {
+        let dir = tempfile::tempdir().unwrap();
+        let k = write_fixture(dir.path(), "vmlinux", b"k");
+        let r = write_fixture(dir.path(), "rootfs.ext4", b"r");
+        let c = write_fixture(dir.path(), "cmdline.txt", b"c");
+        let key = test_keypair();
+        let out = dir.path().join("nope.mvm");
+        // SealedProd posture but no verity/roothash supplied.
+        let bad = PackInputs {
+            kernel: &k,
+            rootfs: &r,
+            cmdline: &c,
+            verity: None,
+            roothash: None,
+            initrd: None,
+            target_arch: "aarch64-linux".to_string(),
+            build_provenance: None,
+            security: SecurityPosture {
+                profile: ArtifactProfile::SealedProd,
+                verity_protected: true,
+                requires_auth: true,
+                allows_volumes: false,
+                allows_egress: false,
+            },
+        };
+        let err = pack(&bad, &key, &out).unwrap_err();
+        assert!(matches!(err, ArtifactError::SealedProdMissingVerity));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let k = write_fixture(dir.path(), "vmlinux", b"k");
+        let r = write_fixture(dir.path(), "rootfs.ext4", b"r");
+        let c = write_fixture(dir.path(), "cmdline.txt", b"c");
+        let producer = test_keypair();
+        let attacker = test_keypair();
+        let out = dir.path().join("out.mvm");
+        pack(&dev_inputs(&k, &r, &c), &producer, &out).unwrap();
+        // Attacker's verifying key — same signature shape, wrong
+        // public key. Verify must refuse rather than silently
+        // accepting.
+        let err = verify(&out, &attacker.verifying_key()).unwrap_err();
+        assert!(matches!(err, ArtifactError::SignatureMismatch));
+    }
+
+    #[test]
+    fn verify_rejects_tampered_rootfs() {
+        let dir = tempfile::tempdir().unwrap();
+        let k = write_fixture(dir.path(), "vmlinux", b"k");
+        let r = write_fixture(dir.path(), "rootfs.ext4", b"original rootfs");
+        let c = write_fixture(dir.path(), "cmdline.txt", b"c");
+        let key = test_keypair();
+        let out = dir.path().join("out.mvm");
+        pack(&dev_inputs(&k, &r, &c), &key, &out).unwrap();
+
+        // Tamper: open the .mvm, swap a byte in the rootfs payload,
+        // and re-pack with a fresh tar that keeps the original
+        // manifest + signature. The simulation here writes a brand-
+        // new archive with mutated rootfs bytes while pretending
+        // the manifest is unchanged.
+        tamper_payload(&out, "rootfs/rootfs.ext4", b"corrupted rootfs!");
+        let err = verify(&out, &key.verifying_key()).unwrap_err();
+        // The tampered rootfs has a different size + hash; either
+        // a SizeMismatch or HashMismatch is acceptable — both
+        // signal "the file changed after sign".
+        assert!(
+            matches!(
+                err,
+                ArtifactError::HashMismatch { .. } | ArtifactError::SizeMismatch { .. }
+            ),
+            "expected hash or size mismatch, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_unknown_format_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let k = write_fixture(dir.path(), "vmlinux", b"k");
+        let r = write_fixture(dir.path(), "rootfs.ext4", b"r");
+        let c = write_fixture(dir.path(), "cmdline.txt", b"c");
+        let key = test_keypair();
+        let out = dir.path().join("out.mvm");
+        pack(&dev_inputs(&k, &r, &c), &key, &out).unwrap();
+
+        // Re-pack the tar with a bumped format_version. The
+        // signature was over the original manifest, so this will
+        // also fail signature verify — but the format-version
+        // check fires FIRST so the error is the right one.
+        rewrite_manifest_version(&out, 999);
+        let err = verify(&out, &key.verifying_key()).unwrap_err();
+        assert!(matches!(
+            err,
+            ArtifactError::UnknownFormatVersion { got: 999, .. }
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_archive_missing_signature() {
+        let dir = tempfile::tempdir().unwrap();
+        let k = write_fixture(dir.path(), "vmlinux", b"k");
+        let r = write_fixture(dir.path(), "rootfs.ext4", b"r");
+        let c = write_fixture(dir.path(), "cmdline.txt", b"c");
+        let key = test_keypair();
+        let out = dir.path().join("out.mvm");
+        pack(&dev_inputs(&k, &r, &c), &key, &out).unwrap();
+
+        // Re-pack the tar with the signature entry stripped.
+        rebuild_archive_without(&out, &[SIGNATURE_FILENAME]);
+        let err = verify(&out, &key.verifying_key()).unwrap_err();
+        assert!(matches!(err, ArtifactError::SignatureAbsent), "got {err:?}");
+    }
+
+    #[test]
+    fn verify_rejects_path_traversal_in_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("malicious.mvm");
+        // Build a tarball whose manifest claims to ship a normal
+        // file but whose contents include a `../` traversal entry.
+        // The verifier walks the archive entries before trusting
+        // any payload, so the traversal entry fires the gate.
+        let key = test_keypair();
+        let mut manifest = Manifest {
+            format_version: MANIFEST_FORMAT_VERSION,
+            mvm_version: "test".to_string(),
+            target_arch: "aarch64-linux".to_string(),
+            files: BTreeMap::new(),
+            build_provenance: None,
+            security: SecurityPosture {
+                profile: ArtifactProfile::Dev,
+                verity_protected: false,
+                requires_auth: false,
+                allows_volumes: true,
+                allows_egress: true,
+            },
+        };
+        manifest.files.insert(
+            "../escape".to_string(),
+            FileEntry {
+                path: "../escape".to_string(),
+                sha256_hex: "a".repeat(64),
+                size_bytes: 1,
+            },
+        );
+        let manifest_bytes = manifest.to_signing_bytes().unwrap();
+        let sig = key.sign(&manifest_bytes);
+
+        let buf = Vec::new();
+        let gz = GzEncoder::new(buf, Compression::default());
+        let mut tar = Builder::new(gz);
+        tar.mode(tar::HeaderMode::Deterministic);
+        append_bytes(&mut tar, MANIFEST_FILENAME, &manifest_bytes).unwrap();
+        append_bytes(&mut tar, SIGNATURE_FILENAME, &sig.to_bytes()).unwrap();
+        // Mimic a malicious entry — by manipulating the tar Header
+        // directly we get an entry whose path looks like `../escape`.
+        let body = b"x";
+        let mut header = Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_mtime(0);
+        header.set_entry_type(EntryType::Regular);
+        header.set_path("../escape").expect_err(
+            "tar refuses to encode absolute or traversal paths; use the override below",
+        );
+        // The tar crate refuses to encode `..` via `set_path`, so we
+        // instead inject a synthetic entry that doesn't go through the
+        // path normalizer. This exercises the verifier's defensive
+        // path check against archives produced by hostile non-mvm
+        // packers.
+        let synthetic = synthetic_traversal_archive(&manifest_bytes, &sig.to_bytes());
+        fs::write(&out, &synthetic).unwrap();
+        let err = verify(&out, &key.verifying_key()).unwrap_err();
+        assert!(
+            matches!(err, ArtifactError::PathTraversal(_)),
+            "got {err:?}"
+        );
+    }
+
+    // ── Helpers used only by tests ────────────────────────────────
+
+    /// Rebuild the gzipped tar at `path` with every entry except
+    /// those whose archive path is in `drop`. Manifest + signature
+    /// + payloads are preserved otherwise.
+    fn rebuild_archive_without(path: &Path, drop: &[&str]) {
+        let bytes = fs::read(path).unwrap();
+        let gz = GzDecoder::new(Cursor::new(bytes));
+        let mut archive = Archive::new(gz);
+
+        let buf = Vec::new();
+        let gz_out = GzEncoder::new(buf, Compression::default());
+        let mut out = Builder::new(gz_out);
+        out.mode(tar::HeaderMode::Deterministic);
+        for entry in archive.entries().unwrap() {
+            let mut e = entry.unwrap();
+            let p = e.path().unwrap().to_string_lossy().to_string();
+            if drop.contains(&p.as_str()) {
+                continue;
+            }
+            let mut body = Vec::with_capacity(e.size() as usize);
+            e.read_to_end(&mut body).unwrap();
+            let mut h = Header::new_gnu();
+            h.set_path(&p).unwrap();
+            h.set_size(body.len() as u64);
+            h.set_mode(0o644);
+            h.set_mtime(0);
+            h.set_entry_type(EntryType::Regular);
+            h.set_cksum();
+            out.append(&h, body.as_slice()).unwrap();
+        }
+        out.finish().unwrap();
+        let inner = out.into_inner().unwrap();
+        let final_bytes = inner.finish().unwrap();
+        fs::write(path, final_bytes).unwrap();
+    }
+
+    /// Rewrite the manifest entry in the archive at `path` with
+    /// `format_version` set to `new_version`. Manifest signature is
+    /// untouched, so verify is expected to fail — but the failure
+    /// must be on the version check, not on signature.
+    fn rewrite_manifest_version(path: &Path, new_version: u32) {
+        let bytes = fs::read(path).unwrap();
+        let gz = GzDecoder::new(Cursor::new(bytes));
+        let mut archive = Archive::new(gz);
+
+        let buf = Vec::new();
+        let gz_out = GzEncoder::new(buf, Compression::default());
+        let mut out = Builder::new(gz_out);
+        out.mode(tar::HeaderMode::Deterministic);
+        for entry in archive.entries().unwrap() {
+            let mut e = entry.unwrap();
+            let p = e.path().unwrap().to_string_lossy().to_string();
+            let mut body = Vec::with_capacity(e.size() as usize);
+            e.read_to_end(&mut body).unwrap();
+            if p == MANIFEST_FILENAME {
+                let mut m: Manifest = serde_json::from_slice(&body).unwrap();
+                m.format_version = new_version;
+                body = serde_json::to_vec(&m).unwrap();
+            }
+            let mut h = Header::new_gnu();
+            h.set_path(&p).unwrap();
+            h.set_size(body.len() as u64);
+            h.set_mode(0o644);
+            h.set_mtime(0);
+            h.set_entry_type(EntryType::Regular);
+            h.set_cksum();
+            out.append(&h, body.as_slice()).unwrap();
+        }
+        out.finish().unwrap();
+        let inner = out.into_inner().unwrap();
+        let final_bytes = inner.finish().unwrap();
+        fs::write(path, final_bytes).unwrap();
+    }
+
+    /// Replace the bytes of `entry_path` inside the archive at `path`
+    /// with `new_body`. Manifest + signature untouched — verify is
+    /// expected to fail on size or hash mismatch.
+    fn tamper_payload(path: &Path, entry_path: &str, new_body: &[u8]) {
+        let bytes = fs::read(path).unwrap();
+        let gz = GzDecoder::new(Cursor::new(bytes));
+        let mut archive = Archive::new(gz);
+
+        let buf = Vec::new();
+        let gz_out = GzEncoder::new(buf, Compression::default());
+        let mut out = Builder::new(gz_out);
+        out.mode(tar::HeaderMode::Deterministic);
+        for entry in archive.entries().unwrap() {
+            let mut e = entry.unwrap();
+            let p = e.path().unwrap().to_string_lossy().to_string();
+            let mut body = Vec::with_capacity(e.size() as usize);
+            e.read_to_end(&mut body).unwrap();
+            if p == entry_path {
+                body = new_body.to_vec();
+            }
+            let mut h = Header::new_gnu();
+            h.set_path(&p).unwrap();
+            h.set_size(body.len() as u64);
+            h.set_mode(0o644);
+            h.set_mtime(0);
+            h.set_entry_type(EntryType::Regular);
+            h.set_cksum();
+            out.append(&h, body.as_slice()).unwrap();
+        }
+        out.finish().unwrap();
+        let inner = out.into_inner().unwrap();
+        let final_bytes = inner.finish().unwrap();
+        fs::write(path, final_bytes).unwrap();
+    }
+
+    /// Hand-build a gzipped tar whose entries include a
+    /// path-traversal `../escape` regular-file entry. The `tar`
+    /// crate's `set_path` refuses to encode `..` for us, so we
+    /// build the tar by hand using the lower-level header API and
+    /// manually constructing the path slot.
+    fn synthetic_traversal_archive(manifest_bytes: &[u8], sig_bytes: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let gz = GzEncoder::new(&mut buf, Compression::default());
+        let mut tar = Builder::new(gz);
+        tar.mode(tar::HeaderMode::Deterministic);
+        // Manifest + signature
+        let mut h = Header::new_gnu();
+        h.set_path(MANIFEST_FILENAME).unwrap();
+        h.set_size(manifest_bytes.len() as u64);
+        h.set_mode(0o644);
+        h.set_mtime(0);
+        h.set_entry_type(EntryType::Regular);
+        h.set_cksum();
+        tar.append(&h, manifest_bytes).unwrap();
+        let mut h2 = Header::new_gnu();
+        h2.set_path(SIGNATURE_FILENAME).unwrap();
+        h2.set_size(sig_bytes.len() as u64);
+        h2.set_mode(0o644);
+        h2.set_mtime(0);
+        h2.set_entry_type(EntryType::Regular);
+        h2.set_cksum();
+        tar.append(&h2, sig_bytes).unwrap();
+
+        // Synthesize a traversal entry by writing the GNU header
+        // bytes directly. We bypass tar's encoder safety by using
+        // append_data on a header whose `path` slot we set with the
+        // raw bytes of "../escape".
+        let mut bad = Header::new_gnu();
+        // `set_path` would refuse `..` — instead set the long-name
+        // GNU extension to point at the traversal. The tar crate
+        // tolerates writing such headers; the verifier rejects them.
+        bad.set_size(1);
+        bad.set_mode(0o644);
+        bad.set_mtime(0);
+        bad.set_entry_type(EntryType::Regular);
+        // Write the path bytes directly into the header name slot.
+        let name_bytes = b"../escape";
+        let name_field = bad.as_old_mut().name.as_mut_slice();
+        name_field[..name_bytes.len()].copy_from_slice(name_bytes);
+        bad.set_cksum();
+        tar.append(&bad, &b"x"[..]).unwrap();
+
+        tar.finish().unwrap();
+        drop(tar);
+        buf
+    }
+}

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -191,6 +191,7 @@ impl Commands {
             Commands::Deps(_) => "deps",
             Commands::Wait(_) => "wait",
             Commands::BootReport(_) => "boot-report",
+            Commands::Artifact(_) => "artifact",
         }
     }
 }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -255,6 +255,12 @@ pub(in crate::commands) enum Commands {
     /// boot timings. Plan 76 Phase 4. Single round-trip; use
     /// `mvmctl wait` to poll.
     BootReport(vm::wait::BootReportArgs),
+    /// Pack + verify portable signed `.mvm` artifacts (Plan 76
+    /// Phase 6). `pack` writes a tar.gz with kernel + rootfs +
+    /// verity sidecars and signs a manifest hashing each payload.
+    /// `verify` checks the signature + every file hash without
+    /// extracting payloads to disk.
+    Artifact(vm::artifact::Args),
 }
 
 // ============================================================================
@@ -394,6 +400,7 @@ pub fn run() -> Result<()> {
         Commands::Deps(a) => deps::run(&cli, a, &cfg),
         Commands::Wait(a) => vm::wait::run_wait(&cli, a, &cfg),
         Commands::BootReport(a) => vm::wait::run_boot_report(&cli, a, &cfg),
+        Commands::Artifact(a) => vm::artifact::run(&cli, a, &cfg),
     };
 
     cmd_audit::emit_cmd_outcome(cmd_recorder.as_ref(), verb, &result);

--- a/crates/mvm-cli/src/commands/vm/artifact.rs
+++ b/crates/mvm-cli/src/commands/vm/artifact.rs
@@ -1,0 +1,196 @@
+//! `mvmctl artifact pack` / `verify` — plan 76 Phase 6.
+//!
+//! Wraps `mvm_build::packed_artifact::{pack, verify}` with the
+//! host-side wiring the library can't reach: signing-key loading
+//! (`host_signer.rs` from Plan 64), CLI argument shape, JSON output.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use clap::{Args as ClapArgs, Subcommand, ValueEnum};
+
+use mvm_build::packed_artifact::{
+    ArtifactProfile, PackInputs, SecurityPosture, pack as pack_artifact, verify as verify_artifact,
+};
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+use super::host_signer;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub command: Cmd,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum Cmd {
+    /// Sign-and-pack a `.mvm` artifact from a kernel, rootfs,
+    /// cmdline, and optional verity sidecars. Refuses to produce
+    /// a `--profile sealed-prod` artifact without verity inputs.
+    Pack(PackArgs),
+    /// Verify a `.mvm` artifact's manifest signature, file hashes,
+    /// declared format version, and security-posture invariants.
+    /// Exits 0 on success, 65 (`EX_DATAERR`) on a verification
+    /// failure. Does not extract payload bytes to disk.
+    Verify(VerifyArgs),
+}
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct PackArgs {
+    /// Kernel binary (vmlinux).
+    #[arg(long)]
+    pub kernel: PathBuf,
+    /// Root filesystem image (rootfs.ext4).
+    #[arg(long)]
+    pub rootfs: PathBuf,
+    /// Kernel command line, as a text file.
+    #[arg(long)]
+    pub cmdline: PathBuf,
+    /// dm-verity sidecar (rootfs.verity). Required for
+    /// `--profile sealed-prod`.
+    #[arg(long)]
+    pub verity: Option<PathBuf>,
+    /// Verity roothash file. Required for `--profile sealed-prod`.
+    #[arg(long)]
+    pub roothash: Option<PathBuf>,
+    /// Optional verity initramfs (cpio.gz).
+    #[arg(long)]
+    pub initrd: Option<PathBuf>,
+    /// Output path for the produced `.mvm` archive.
+    #[arg(long)]
+    pub out: PathBuf,
+    /// Target architecture string. Free-form; matches what the
+    /// rootfs builder emits (e.g. `aarch64-linux`).
+    #[arg(long)]
+    pub target_arch: String,
+    /// Image profile baked into the artifact's security posture.
+    #[arg(long, value_enum, default_value_t = CliProfile::SealedProd)]
+    pub profile: CliProfile,
+    /// `true` when the rootfs is dm-verity-protected and the
+    /// cmdline carries `roothash=`.
+    #[arg(long, default_value_t = false)]
+    pub verity_protected: bool,
+    /// `true` when the agent enforces `require_auth = true`.
+    #[arg(long, default_value_t = true)]
+    pub requires_auth: bool,
+    /// `true` when the image config permits runtime volume mounts.
+    #[arg(long, default_value_t = false)]
+    pub allows_volumes: bool,
+    /// `true` when the image config permits outbound egress.
+    #[arg(long, default_value_t = false)]
+    pub allows_egress: bool,
+    /// Build provenance pointer to surface in the manifest. Free-
+    /// form today; reserved for ADR-051 attestation linkage.
+    #[arg(long)]
+    pub build_provenance: Option<String>,
+}
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct VerifyArgs {
+    /// Path to the `.mvm` artifact to verify.
+    pub path: PathBuf,
+    /// Path to the verifying-key file (32-byte Ed25519 public key,
+    /// raw bytes). Defaults to the host signer's public half at
+    /// `~/.mvm/keys/host-signer.pub`.
+    #[arg(long)]
+    pub key: Option<PathBuf>,
+    /// Print the verified manifest as JSON on success.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[clap(rename_all = "kebab-case")]
+pub(in crate::commands) enum CliProfile {
+    SealedProd,
+    Dev,
+    Builder,
+}
+
+impl From<CliProfile> for ArtifactProfile {
+    fn from(p: CliProfile) -> Self {
+        match p {
+            CliProfile::SealedProd => ArtifactProfile::SealedProd,
+            CliProfile::Dev => ArtifactProfile::Dev,
+            CliProfile::Builder => ArtifactProfile::Builder,
+        }
+    }
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    match args.command {
+        Cmd::Pack(a) => run_pack(a),
+        Cmd::Verify(a) => run_verify(a),
+    }
+}
+
+fn run_pack(args: PackArgs) -> Result<()> {
+    // Reuse Plan 64's host signer so packed artifacts share the
+    // operator's trust root with the audit chain. A future PR can
+    // wire `--key <path>` for offline signing keys.
+    let signer = host_signer::load_or_init().context("load host signer")?;
+
+    let inputs = PackInputs {
+        kernel: &args.kernel,
+        rootfs: &args.rootfs,
+        cmdline: &args.cmdline,
+        verity: args.verity.as_deref(),
+        roothash: args.roothash.as_deref(),
+        initrd: args.initrd.as_deref(),
+        target_arch: args.target_arch,
+        build_provenance: args.build_provenance,
+        security: SecurityPosture {
+            profile: args.profile.into(),
+            verity_protected: args.verity_protected,
+            requires_auth: args.requires_auth,
+            allows_volumes: args.allows_volumes,
+            allows_egress: args.allows_egress,
+        },
+    };
+    pack_artifact(&inputs, &signer.signing, &args.out).context("pack artifact")?;
+    crate::ui::success(&format!("wrote {}", args.out.display()));
+    Ok(())
+}
+
+fn run_verify(args: VerifyArgs) -> Result<()> {
+    use ed25519_dalek::VerifyingKey;
+    let key_bytes = match args.key {
+        Some(p) => std::fs::read(&p).with_context(|| format!("read {}", p.display()))?,
+        None => {
+            let signer = host_signer::load_or_init().context("load host signer")?;
+            std::fs::read(&signer.public_path)
+                .with_context(|| format!("read {}", signer.public_path.display()))?
+        }
+    };
+    if key_bytes.len() != 32 {
+        bail!(
+            "verifying key must be 32 raw Ed25519 bytes, got {}",
+            key_bytes.len()
+        );
+    }
+    let mut buf = [0u8; 32];
+    buf.copy_from_slice(&key_bytes);
+    let verifying = VerifyingKey::from_bytes(&buf).context("parse Ed25519 verifying key")?;
+
+    match verify_artifact(&args.path, &verifying) {
+        Ok(manifest) => {
+            if args.json {
+                println!("{}", serde_json::to_string_pretty(&manifest)?);
+            } else {
+                crate::ui::success(&format!(
+                    "{}: verified ({}, profile={:?}, {} files)",
+                    args.path.display(),
+                    manifest.target_arch,
+                    manifest.security.profile,
+                    manifest.files.len()
+                ));
+            }
+            Ok(())
+        }
+        Err(e) => {
+            crate::ui::warn(&format!("{}: verify failed: {e}", args.path.display()));
+            std::process::exit(65);
+        }
+    }
+}

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -1,5 +1,6 @@
 //! VM lifecycle commands — start, stop, list, attach, exec.
 
+pub(super) mod artifact;
 pub(super) mod audit_chain;
 pub(super) mod console;
 pub(super) mod cp;

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -159,6 +159,15 @@ const SNAPSHOT_SUB: &[(&str, AuditPosture)] = &[
     ("rm", AuditPosture::Emits("SnapshotDelete")),
 ];
 
+// Plan 76 Phase 6 — `mvmctl artifact pack/verify`. Both are
+// disk-side operations: pack writes a new `.mvm` file but does
+// not touch host audit chain state; verify is a pure read. The
+// host signer's keypair is consulted (read-only) for both.
+const ARTIFACT_SUB: &[(&str, AuditPosture)] = &[
+    ("pack", AuditPosture::ReadOnly),
+    ("verify", AuditPosture::ReadOnly),
+];
+
 // Sprint 52 W2 — bundle / trust subcommand tables.
 //
 // `bundle export` writes a `.mvmpkg` archive to disk under the
@@ -298,6 +307,8 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     // mutate host or guest state.
     ("wait", AuditPosture::ReadOnly),
     ("boot-report", AuditPosture::ReadOnly),
+    // Plan 76 Phase 6 — portable signed `.mvm` artifacts.
+    ("artifact", AuditPosture::DelegatesToSub(ARTIFACT_SUB)),
 ];
 
 // ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add a new packed-artifact format that wraps **kernel + rootfs + verity sidecars + cmdline** behind an Ed25519-signed manifest hashing every payload. Packing is sign-and-tar; verifying is a streaming hash + signature check that never extracts payload bytes to disk.

### Library: `crates/mvm-build/src/packed_artifact.rs`

- `Manifest` with `BTreeMap`-shaped file index for deterministic JSON ordering — required so re-serialising the parsed manifest produces byte-identical output for signature verify.
- `pack(inputs, signing_key, out)` — streams each input file through SHA-256, builds + signs the manifest, writes a tar.gz with manifest first, signature second, payloads last. Refuses to produce a `SealedProd` artifact without verity sidecars.
- `verify(path, verifying_key)` — two-pass: read manifest + signature, check Ed25519 signature, refuse unknown format version + non-canonical JSON + missing-verity-for-sealed-prod; then walk every entry re-hashing against declared SHA-256, refusing path-traversal entries, non-regular files, size/hash mismatches, unexpected/missing files.

### CLI: `mvmctl artifact pack` / `mvmctl artifact verify`

- `pack` reuses Plan 64's host signer so packed artifacts share the operator's trust root with the audit chain.
- `verify` defaults to the host signer's public half; `--key <path>` accepts a raw 32-byte Ed25519 public key for offline verification. Exit 0 ready, 65 (`EX_DATAERR`) on any failure.

### Fail-closed properties (plan 76 §"Artifact extraction is an attack surface")

- `MAX_ENTRY_BYTES = 2 GiB`, `MAX_ARCHIVE_BYTES = 4 GiB` — decompression bombs fail before exhausting disk.
- Tar path-traversal entries (`../`, absolute, non-normal components) rejected pre-extraction.
- Symlinks, hardlinks, special files all rejected — regular files only.
- Unknown manifest `format_version` fails closed; no permissive inference.
- `SealedProd` artifacts that omit verity sidecars are refused at pack time AND verify time.

## Test plan

- [x] `cargo test --workspace` — all green. New: 8 in `packed_artifact::tests` (pack/verify roundtrip dev, pack/verify roundtrip sealed-prod, pack refuses sealed-prod-without-verity, verify rejects wrong key, tampered rootfs, unknown format version, missing signature, path-traversal in archive).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `audit_total_coverage` test — new `ARTIFACT_SUB` table covers both subcommands (both `ReadOnly` — pack writes a `.mvm` file but does NOT touch the audit chain; verify is a pure read).
- [x] `scripts/check-sealed-prod-allowlist.sh` — green (Phase 1/8-partial gate still locked).

## Out of scope (deliberate)

- `mvmctl artifact push/pull` to OCI registries. Plan 76 §"OCI distribution as a compatibility layer" keeps `.mvm` as the signed internal unit; OCI is the optional transport.
- Host-side warm artifact cache. Today `verify` reads the archive twice; caching the extracted + verified contents is a straightforward follow-up.
- SBOM / attestation sidecars in the manifest. Schema reserves `build_provenance: Option<String>` as a pointer; future work fills it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)