### PR TITLE
Plan 74 W2 — bake mvm-guest-netinit into runtime overlay

### DIFF
--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "mvm runtime overlay disk — verity-sealed ext4 carrying the guest agent + seccomp shim + runner, mounted at /mvm/runtime in every microVM (ADR-051)";
+  description = "mvm runtime overlay disk — verity-sealed ext4 carrying the guest agent + seccomp shim + netinit + runner, mounted at /mvm/runtime in every microVM (ADR-051)";
 
   # ── Why this flake exists ─────────────────────────────────────────
   #
@@ -7,12 +7,14 @@
   # a second virtio-blk device that every mvm microVM attaches at
   # boot — Nix-built rootfs and OCI-pulled rootfs alike. The
   # overlay carries the in-VM binaries mvm controls (the guest
-  # agent, the per-service seccomp shim, the verity-initrd PID 1
-  # binary, the function-workload runner) plus a placeholder for
-  # the per-language SDK runtime libraries that ADR-049's vsock
-  # substitution depends on (the libraries themselves land in
-  # plan 74 W4; this flake reserves the directory layout today so
-  # the boot path is stable).
+  # agent, the per-service seccomp shim, the function-workload
+  # runner, and — plan 74 W2 — `mvm-guest-netinit` which installs
+  # kernel blackhole routes for `MANDATORY_DENY_RANGES` so OCI-
+  # imported workloads get Layer 1 network defense too) plus a
+  # placeholder for the per-language SDK runtime libraries that
+  # ADR-049's vsock substitution depends on (the libraries
+  # themselves land in plan 74 W4; this flake reserves the
+  # directory layout today so the boot path is stable).
   #
   # The flake produces, per supported system, a `$out/` containing:
   #
@@ -233,6 +235,7 @@
             mkdir -p "$staging"
             cp ${guest}/bin/mvm-guest-agent      "$staging/agent"
             cp ${guest}/bin/mvm-seccomp-apply    "$staging/seccomp-apply"
+            cp ${guest}/bin/mvm-guest-netinit    "$staging/netinit"
             cp ${runner}/bin/mvm-runner          "$staging/runner"
 
             # SDK runtime library placeholders. plan 74 W4 fills

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -268,6 +268,34 @@ fn mk_guest_installs_netinit_at_boot() {
     );
 }
 
+/// Plan 74 W2 (deferred-list item) — the runtime overlay flake
+/// must stage `mvm-guest-netinit` at the canonical `/netinit`
+/// path inside the overlay so OCI-imported workloads get
+/// Layer 1 network defense too. The `mk-guest.nix` /init prefers
+/// `/mvm/runtime/netinit` over the baked-in copy; without this
+/// line, the prefer-overlay fallback falls through silently on
+/// OCI workloads (which don't have a baked-in copy at all).
+#[test]
+fn runtime_overlay_flake_stages_netinit_binary() {
+    let path = nix_dir()
+        .join("images")
+        .join("runtime-overlay")
+        .join("flake.nix");
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("nix/images/runtime-overlay/flake.nix must be present: {e}"));
+
+    assert!(
+        content.contains("cp ${guest}/bin/mvm-guest-netinit    \"$staging/netinit\""),
+        "runtime-overlay flake must stage `mvm-guest-netinit` at \
+         `/netinit` inside the overlay ext4. The W1.4b mkGuest \
+         /init resolution prefers `/mvm/runtime/netinit`; if the \
+         overlay doesn't stage the binary, OCI workloads silently \
+         fall through to the no-defense path. Pinned exact-string \
+         match (with the canonical column alignment) to catch a \
+         drop or rename in one regression-shaped commit."
+    );
+}
+
 #[test]
 fn flake_lock_pins_microvm_input_by_hash() {
     // The flake.lock must exist and pin the microvm.nix input by


### PR DESCRIPTION
## Summary
- The runtime-overlay flake now stages `mvm-guest-netinit` at `/netinit` inside the verity-sealed ext4, alongside `agent`, `seccomp-apply`, and `runner`.
- mkGuest's `/init` resolution already prefers `/mvm/runtime/netinit` over the baked-in `/usr/local/bin/mvm-guest-netinit`, so this slice flips Layer 1 (guest-side blackhole routes for `MANDATORY_DENY_RANGES`) on for OCI-imported workloads — which previously fell through silently because they don't carry a baked-in copy.
- Adds a `nix_flake_structure.rs` guard test pinning the exact `cp` line (with the canonical column alignment) so a rename or accidental drop is caught as one regression-shaped commit rather than a silent loss-of-defense.

This is one of the deferred items called out in plan 74's W2 status block (`specs/plans/74-claim-safe-sandbox-parity.md`). No CLI surface, no runtime flag, no API change.

## Why it matters
Before this PR:

- Nix-built workloads got Layer 1 defense (the baked-in `/usr/local/bin/mvm-guest-netinit` from mkGuest).
- OCI-imported workloads got *zero* Layer 1 defense — they have no `mvm-guest-netinit` baked in, and the runtime overlay didn't stage one, so mkGuest's prefer-overlay fallback resolved to the no-op path.

After this PR both kinds of workload converge on the same Layer 1 enforcement (mandatory-deny blackhole routes for cloud metadata, link-local, CGNAT, host loopback).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --test nix_flake_structure` (7/7 passing — new test plus all pre-existing checks)
- [ ] CI green
- [ ] On a host with Nix: `nix flake check ./nix/images/runtime-overlay --no-build` (verified locally before commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)