### PR TITLE
Plan 74 W2 — overlay-aware admission gate

### DIFF
--- a/crates/mvm-backend/Cargo.toml
+++ b/crates/mvm-backend/Cargo.toml
@@ -37,6 +37,11 @@ authors.workspace = true
 mvm-core.workspace = true
 mvm-guest.workspace = true
 mvm-base.workspace = true
+# `mvm-build` for the W2 overlay-aware admission gate
+# (`builder_vm::admit_overlay_aware`) called from every backend's
+# `start` impl. The mvm-base sidecar reader already pulls
+# `mvm-build`, so this doesn't widen the dependency graph.
+mvm-build.workspace = true
 mvm-providers.workspace = true
 mvm-libkrun.workspace = true
 
@@ -54,9 +59,6 @@ tempfile.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
-
-[dev-dependencies]
-mvm-build.workspace = true
 
 [features]
 default = []

--- a/crates/mvm-backend/src/apple_container.rs
+++ b/crates/mvm-backend/src/apple_container.rs
@@ -91,6 +91,17 @@ impl VmBackend for AppleContainerBackend {
             );
         }
 
+        // Plan 74 W2 / ADR-051 admission gate — refuse pre-W1.4b
+        // rootfs that lack the `/mvm/runtime` mount point. Runs
+        // before the CoW clone so a refusal exits clean (no
+        // per-instance disk written, no half-formed VM state).
+        // Sidecar lives next to the *source* rootfs.
+        let original_rootfs = std::path::Path::new(&config.rootfs_path);
+        let original_dir = original_rootfs
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
+        mvm_build::builder_vm::admit_overlay_aware(original_dir)?;
+
         // Plan 53 Plan D: clone the rootfs to a per-instance path so
         // each running VM owns its disk image. Apple VZ refuses to
         // attach the same writable disk to two VMs concurrently; the
@@ -103,7 +114,6 @@ impl VmBackend for AppleContainerBackend {
         // per-instance clone is a CoW copy under a different name; the
         // sidecar lives next to the source). Populates the
         // accessible/sealed flag for `mvmctl console`'s gate.
-        let original_rootfs = std::path::Path::new(&config.rootfs_path);
         mvm_base::runtime_meta::record_from_rootfs(
             &config.name,
             StartMode::Detached,

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -128,6 +128,12 @@ impl VmBackend for FirecrackerBackend {
         // (build pipeline bug); a missing sidecar defaults to
         // accessible=true.
         let rootfs = std::path::Path::new(&config.rootfs_path);
+        // Plan 74 W2 / ADR-051 admission gate — refuse pre-W1.4b
+        // rootfs that lack the `/mvm/runtime` mount point. Runs
+        // before `microvm::run_from_build` so a refusal exits
+        // clean — no FC API socket, no VM dir half-populated.
+        let rootfs_dir = rootfs.parent().unwrap_or_else(|| std::path::Path::new("."));
+        mvm_build::builder_vm::admit_overlay_aware(rootfs_dir)?;
         mvm_base::runtime_meta::record_from_rootfs(&config.name, StartMode::Detached, rootfs)?;
         microvm::run_from_build(&fc_config.run_config)?;
         Ok(VmId(fc_config.run_config.name.clone()))

--- a/crates/mvm-backend/src/cloud_hypervisor.rs
+++ b/crates/mvm-backend/src/cloud_hypervisor.rs
@@ -127,6 +127,12 @@ impl VmBackend for CloudHypervisorBackend {
         // backends. Records `accessible` from the sidecar so
         // `mvmctl console` enforces the gate consistently.
         let rootfs = std::path::Path::new(&config.rootfs_path);
+        // Plan 74 W2 / ADR-051 admission gate — refuse pre-W1.4b
+        // rootfs that lack the `/mvm/runtime` mount point. Runs
+        // before any backend-side work so a refusal exits clean
+        // (no daemon started, no PID file left behind).
+        let rootfs_dir = rootfs.parent().unwrap_or_else(|| std::path::Path::new("."));
+        mvm_build::builder_vm::admit_overlay_aware(rootfs_dir)?;
         mvm_base::runtime_meta::record_from_rootfs(&config.name, StartMode::Detached, rootfs)?;
 
         // Spawn the daemon. Waits for the API socket.

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -106,6 +106,12 @@ impl VmBackend for LibkrunBackend {
         // gate on libkrun-launched VMs the same way as on the
         // libkrun/Firecracker paths.
         let rootfs = Path::new(&config.rootfs_path);
+        // Plan 74 W2 / ADR-051 admission gate — refuse pre-W1.4b
+        // rootfs that lack the `/mvm/runtime` mount point. Fires
+        // before the supervisor spawn so a refusal leaves no PID
+        // file or krun handle behind.
+        let rootfs_dir = rootfs.parent().unwrap_or_else(|| Path::new("."));
+        mvm_build::builder_vm::admit_overlay_aware(rootfs_dir)?;
         mvm_base::runtime_meta::record_from_rootfs(&config.name, StartMode::Detached, rootfs)?;
 
         let vcpus = u8::try_from(config.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);

--- a/crates/mvm-base/src/runtime_meta.rs
+++ b/crates/mvm-base/src/runtime_meta.rs
@@ -300,6 +300,7 @@ mod tests {
             agent_binary: "real".to_string(),
             rootless_entrypoint: true,
             hypervisor: "firecracker".to_string(),
+            overlay_aware: true,
         };
         sidecar.write_to_dir(tmp.path()).expect("write sidecar");
         let meta = from_sidecar(StartMode::Detached, tmp.path()).expect("ok");

--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -209,6 +209,19 @@ pub struct ArtifactSidecar {
     pub rootless_entrypoint: bool,
     /// Active hypervisor declaration.
     pub hypervisor: String,
+    /// Plan 74 W2 / ADR-051 — whether the rootfs carries the
+    /// `/mvm/runtime` bind-mount target and a mkGuest `/init` that
+    /// prefers the overlay-resident agent/seccomp-apply/netinit.
+    ///
+    /// Set by mkGuest's `passthru.mvm.overlayAware = true` since
+    /// W1.4b.3c. Sidecars written *before* the field existed
+    /// deserialize as `false` (via `serde(default)`), which the
+    /// [`admit_overlay_aware`] gate refuses — pre-W1.4b cached
+    /// templates have no `/mvm/runtime` mount point, so attaching
+    /// the overlay disk to them would either fail or silently
+    /// degrade.
+    #[serde(default)]
+    pub overlay_aware: bool,
 }
 
 impl ArtifactSidecar {
@@ -229,6 +242,13 @@ impl ArtifactSidecar {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         std::fs::write(&path, format!("{body}\n"))?;
         Ok(path)
+    }
+
+    /// Whether the rootfs is overlay-aware (carries `/mvm/runtime` +
+    /// uses mkGuest's overlay-preferring `/init`). Plan 74 W2
+    /// admission gate consults this; see [`admit_overlay_aware`].
+    pub fn is_overlay_aware(&self) -> bool {
+        self.overlay_aware
     }
 
     /// Read the sidecar from a directory. Returns `Ok(None)` if the
@@ -403,6 +423,52 @@ pub fn emit_sidecar_via_passthru_query(
     }
 }
 
+/// Plan 74 W2 / ADR-051 admission gate — refuse to start a VM whose
+/// rootfs is not overlay-aware.
+///
+/// Reads `mvm-meta.json` from `rootfs_dir` and inspects
+/// `overlay_aware`. The rootfs is overlay-aware when the sidecar
+/// exists and reports `overlay_aware: true`. Anything else fails:
+///
+/// - **Sidecar missing** → refuse. Either the build pipeline that
+///   produced the rootfs predates the sidecar emit (W6.2), or the
+///   sidecar was deleted out from under us. Either way, attaching
+///   a runtime overlay to an unknown rootfs is unsafe.
+/// - **Sidecar present, `overlay_aware: false`** → refuse. This is
+///   the pre-W1.4b cached-template case: the rootfs has no
+///   `/mvm/runtime` mount point, so the overlay disk has nowhere
+///   to land. mkGuest's `/init` would either fail or silently
+///   degrade to the baked-in agent path.
+/// - **Sidecar malformed** → propagate. Same posture as
+///   [`ArtifactSidecar::read_from_dir`].
+///
+/// The error message is wordy on purpose: an operator hitting this
+/// gate needs the recovery path (rebuild with current mkGuest, or
+/// drop the cached template) in one glance.
+pub fn admit_overlay_aware(rootfs_dir: &Path) -> Result<(), anyhow::Error> {
+    let sidecar = ArtifactSidecar::read_from_dir(rootfs_dir)?;
+    match sidecar {
+        None => Err(anyhow::anyhow!(
+            "refusing to start VM: rootfs at {} has no `mvm-meta.json` sidecar. \
+             The build pipeline that produced this rootfs predates the W6.2 \
+             sidecar emit, which means it also predates W1.4b runtime overlay \
+             (no `/mvm/runtime` mount point in the rootfs). Rebuild the image \
+             with current mkGuest, or drop the cached template.",
+            rootfs_dir.display()
+        )),
+        Some(s) if !s.is_overlay_aware() => Err(anyhow::anyhow!(
+            "refusing to start VM: rootfs at {} has `overlay_aware: false` \
+             in its `mvm-meta.json` sidecar. Pre-W1.4b cached templates have \
+             no `/mvm/runtime` mount point; attaching the runtime overlay disk \
+             to them would either fail or silently degrade to the baked-in \
+             agent. Rebuild the image with current mkGuest \
+             (`passthru.mvm.overlayAware = true`).",
+            rootfs_dir.display()
+        )),
+        Some(_) => Ok(()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -488,6 +554,7 @@ mod tests {
             agent_binary: "stub".to_string(),
             rootless_entrypoint: false,
             hypervisor: "libkrun".to_string(),
+            overlay_aware: true,
         }
     }
 
@@ -517,6 +584,93 @@ mod tests {
             .expect("write malformed");
         let result = ArtifactSidecar::read_from_dir(tmp.path());
         assert!(result.is_err(), "malformed sidecar should error");
+    }
+
+    #[test]
+    fn sidecar_overlay_aware_round_trips_camel_case() {
+        // Field maps to `overlayAware` on disk (matches the
+        // `passthru.mvm.overlayAware` Nix key one-to-one) so a
+        // future `nix eval --json passthru.mvm` lands straight
+        // into the struct.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fixture_sidecar().write_to_dir(tmp.path()).expect("write");
+        let body = std::fs::read_to_string(tmp.path().join(SIDECAR_FILENAME)).expect("read raw");
+        assert!(body.contains("\"overlayAware\""), "got: {body}");
+        let read = ArtifactSidecar::read_from_dir(tmp.path())
+            .expect("read")
+            .expect("present");
+        assert!(read.is_overlay_aware());
+    }
+
+    #[test]
+    fn sidecar_missing_overlay_aware_field_deserializes_as_false() {
+        // Pre-W1.4b sidecars on disk don't carry `overlayAware`.
+        // `#[serde(default)]` must read them as `false` so the
+        // admission gate refuses them rather than silently
+        // boot-attempting a non-overlay-aware rootfs.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let legacy_json = r#"{
+            "name": "legacy",
+            "accessible": true,
+            "sealed": false,
+            "entrypointKind": "shell",
+            "initSystem": "busybox",
+            "expectedBootMs": 300,
+            "agentBinary": "real",
+            "rootlessEntrypoint": false,
+            "hypervisor": "libkrun"
+        }"#;
+        std::fs::write(tmp.path().join(SIDECAR_FILENAME), legacy_json).expect("write legacy");
+        let read = ArtifactSidecar::read_from_dir(tmp.path())
+            .expect("legacy must parse")
+            .expect("present");
+        assert!(
+            !read.is_overlay_aware(),
+            "missing overlayAware field must default to false"
+        );
+    }
+
+    #[test]
+    fn admit_overlay_aware_accepts_w14b_sidecar() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fixture_sidecar().write_to_dir(tmp.path()).expect("write");
+        admit_overlay_aware(tmp.path()).expect("overlay_aware: true must admit");
+    }
+
+    #[test]
+    fn admit_overlay_aware_refuses_missing_sidecar() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let err = admit_overlay_aware(tmp.path()).expect_err("missing sidecar must refuse");
+        let msg = err.to_string();
+        assert!(msg.contains("no `mvm-meta.json` sidecar"), "got: {msg}");
+        assert!(msg.contains("predates W1.4b"), "got: {msg}");
+    }
+
+    #[test]
+    fn admit_overlay_aware_refuses_pre_w14b_sidecar() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Write a sidecar with overlay_aware=false (mirrors a
+        // pre-W1.4b cached template or a sidecar that lost the
+        // field).
+        let mut stale = fixture_sidecar();
+        stale.overlay_aware = false;
+        stale.write_to_dir(tmp.path()).expect("write stale");
+        let err = admit_overlay_aware(tmp.path()).expect_err("overlay_aware: false must refuse");
+        let msg = err.to_string();
+        assert!(msg.contains("overlay_aware: false"), "got: {msg}");
+        assert!(msg.contains("Rebuild the image"), "got: {msg}");
+    }
+
+    #[test]
+    fn admit_overlay_aware_propagates_malformed_sidecar() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join(SIDECAR_FILENAME), "{not valid json")
+            .expect("write malformed");
+        let err = admit_overlay_aware(tmp.path()).expect_err("malformed sidecar must error");
+        // Error chain bubbles up from `read_from_dir`'s parse error;
+        // we just assert it surfaces *some* parse-shaped message so
+        // an operator can debug without guessing.
+        assert!(format!("{err:#}").contains("parsing"), "got: {err:#}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds an admission gate that refuses to start a VM when the rootfs is **not overlay-aware** (i.e. predates W1.4b). Without this gate, attaching the runtime overlay disk to a stale rootfs silently degrades to the baked-in agent path or, on Firecracker, fails late inside `/init`.
- The gate reads `mvm-meta.json` next to the rootfs and refuses three cases: sidecar missing entirely (pre-W6.2 builds), sidecar present with `overlay_aware: false` (pre-W1.4b cached template), or malformed sidecar (propagates the parse error like before).
- Wires the gate into every real backend's `start` impl — libkrun, Apple Container, Cloud Hypervisor, Firecracker — *before* any side-effects (CoW clone, FC API socket, krun supervisor spawn, ch_daemon launch). A refusal leaves no half-formed VM state behind.

## Plan 74 deferred-list status
This closes the **`overlayAware` admission gate** item on Plan 74 W2's deferred list (`specs/plans/74-claim-safe-sandbox-parity.md` §"mvm-side W2 deferreds"). Remaining mvm-side W2 deferreds are:
- IPv6 mandatory-deny (blocked on bridge v6 wiring).
- iptables-LOG → nflog consumer (per-flow audit events).

## Wire-format / serde shape
- `ArtifactSidecar` gains `overlay_aware: bool` with `#[serde(default)]` so legacy sidecars on disk (no `overlayAware` key) deserialize as `false` — exactly what the gate is set up to refuse.
- `mkGuest`'s `passthru.mvm.overlayAware = true` already flows through unchanged because the sidecar emit uses `nix eval --json` against the whole `passthru.mvm` object; the new field gets picked up automatically.
- ` #[serde(rename_all = ""camelCase"")] ` means the on-disk key is `overlayAware` — see the new `sidecar_overlay_aware_round_trips_camel_case` test.

## Dependency change
`mvm-backend` already pulled `mvm-build` as a dev-dependency; this PR promotes it to a regular dependency so the gate is reachable from the four `start` impls. `mvm-base` (a regular dep of `mvm-backend`) already pulls `mvm-build`, so the dependency graph isn't widened — just made consistent.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p mvm-build` (16/16 passing, 6 new)
- [x] `cargo test -p mvm-base -p mvm-build -p mvm-backend` (all green)
- [ ] CI green (mvm-providers gets SIGKILL'd under heavy workspace test parallelism on my host but passes solo and is unrelated to this slice — expecting CI's beefier runners to handle it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)