### PR TITLE
Add Linux volume test Dockerfile

### DIFF
--- a/tests/Dockerfile.volume-linux
+++ b/tests/Dockerfile.volume-linux
@@ -1,0 +1,21 @@
+FROM rust:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        clang \
+        cmake \
+        git \
+        libssl-dev \
+        pkg-config \
+        protobuf-compiler \
+        xz-utils \
+        zstd \
+    && ln -sf /usr/local/cargo/bin/* /usr/local/bin/ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work


### PR DESCRIPTION
## Summary
- add a Dockerfile under tests/ for Linux volume-encryption smoke validation
- install the native Linux packages needed to build and run the CLI lifecycle test in Docker

## Verification
- docker build -f tests/Dockerfile.volume-linux -t mvm-volume-linux-test:local tests
- docker run --rm mvm-volume-linux-test:local bash -c 'cargo --version; rustc --version'
- Linux Docker lifecycle smoke: create locked mvm-managed volume, unlock, write proof, lock, verify plaintext dir removed, unlock, read proof
