### PR TITLE
feat(mesh): restore in-guest mesh scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -616,6 +616,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +850,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32c"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +875,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -958,7 +984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1656,6 +1682,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1792,6 +1819,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto 0.26.1",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,6 +1867,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "rand 0.10.1",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,7 +1894,7 @@ checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.24.4",
  "ipconfig",
  "lru-cache",
  "once_cell",
@@ -1833,6 +1904,29 @@ dependencies = [
  "smallvec",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-server"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130236ba6abba90da6a7acf7a87b27d862b592c3145dc74bc47bf86d8ff198ec"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipnet",
+ "prefix-trie",
+ "serde",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -3106,6 +3200,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-mesh-dns"
+version = "0.14.0"
+dependencies = [
+ "anyhow",
+ "hickory-proto 0.26.1",
+ "hickory-server",
+ "mvm-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "mvm-mesh-vsock-bridge"
+version = "0.14.0"
+dependencies = [
+ "anyhow",
+ "libc",
+ "mvm-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mvm-oci"
 version = "0.14.0"
 dependencies = [
@@ -3775,6 +3900,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4122,7 +4251,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4134,7 +4263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4203,6 +4332,17 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -4478,6 +4618,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4514,6 +4665,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -5246,7 +5403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5257,7 +5414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ members = [
     # Linux-only at runtime; same workspace-ergonomics rule as
     # mvm-builder-init.
     "crates/mvm-egress-proxy",
+    # ADR-0018 / ADR-0020 — in-guest mesh name resolution and
+    # loopback TCP to host-vsock bridge. These are iroh-free guest
+    # binaries; host-side mvmd owns the cryptographic mesh data plane.
+    "crates/mvm-mesh-dns",
+    "crates/mvm-mesh-vsock-bridge",
     # plan 60 Phase 5 — build-time SDK port from ../mvmforge.
     # mvm-ir is the canonical Workload IR; mvm-sdk is the builder
     # surface; mvm-sdk-macros is a placeholder for the proc-macro
@@ -155,6 +160,9 @@ async-trait = "0.1"
 
 # Pure-Rust DNS resolver, used only by the opt-in custom-dns feature.
 hickory-resolver = "0.24"
+# DNS server/protocol stack for the in-guest mesh DNS resolver.
+hickory-server = "0.26"
+hickory-proto = "0.26"
 
 # Utilities
 anyhow = "1"

--- a/crates/mvm-mesh-dns/Cargo.toml
+++ b/crates/mvm-mesh-dns/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "mvm-mesh-dns"
+version.workspace = true
+edition.workspace = true
+description = "In-guest DNS resolver for *.mesh.local — paired with mvmforge ADR-0018 / ADR-0020. Iroh-free."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "mvm-mesh-dns"
+path = "src/bin/mvm-mesh-dns.rs"
+
+[dependencies]
+mvm-core.workspace = true
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+# hickory-dns: mature, audited DNS resolver/server. Used by Cloudflare's
+# Pingora. Pinned in Cargo.lock per ADR-0018 §Dependency hygiene.
+hickory-server.workspace = true
+hickory-proto.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/mvm-mesh-dns/src/bin/mvm-mesh-dns.rs
+++ b/crates/mvm-mesh-dns/src/bin/mvm-mesh-dns.rs
@@ -1,0 +1,64 @@
+//! In-guest DNS resolver binary (ADR-0018 / ADR-0020).
+//!
+//! Listens on `127.0.0.1:53` and `::1:53`, serves `*.mesh.local`
+//! from a config-disk zone, forwards everything else upstream.
+//! SIGHUP reloads the zone without dropping in-flight queries.
+//!
+//! Iroh-free by design — the cryptographic data plane lives on the
+//! host in mvmd. `cargo tree -p mvm-mesh-dns` MUST NOT contain any
+//! `iroh*` crate.
+//!
+//! v1 implementation note: this binary is a scaffold today.
+//! Zone-loading and record matching are functional (see `lib.rs`
+//! tests). Wiring up the actual hickory-dns request handler +
+//! upstream-forwarding chain + SIGHUP loop lands as the issue's
+//! follow-up implementation per tinylabscom/mvm#95.
+
+use anyhow::{Context, Result};
+use mvm_mesh_dns::{Zone, load_zone};
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    // The config disk mounts mesh_dns_zone at a well-known path. v1
+    // accepts an env-var override for testability; the production
+    // path is fixed by mvm's init scripts.
+    let zone_path: PathBuf = env::var_os("MVM_MESH_DNS_ZONE_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/run/mvm/mesh_dns_zone.json"));
+
+    let records = if zone_path.exists() {
+        load_zone(&zone_path)
+            .with_context(|| format!("failed to load mesh DNS zone from {}", zone_path.display()))?
+    } else {
+        // No-op mode: the consumer's launch.json declared no addons.
+        // Idle and let the supervisor's respawn loop manage us.
+        tracing::info!(
+            zone_path = %zone_path.display(),
+            "no zone file present; idling (no-op mode)"
+        );
+        vec![]
+    };
+
+    let zone = Zone::new(records);
+    tracing::info!(records = zone.len(), "loaded mesh DNS zone");
+
+    if zone.is_empty() {
+        // Idle in no-op mode. This matches the "always-install + no-op
+        // when zone empty" pattern declared in
+        // `specs/contracts/in-guest-mesh-dns.md` so `mkGuest` doesn't
+        // need a new mesh argument.
+        loop {
+            std::thread::park();
+        }
+    }
+
+    // Real resolver wiring — hickory-dns request handler bound to
+    // 127.0.0.1:53 + ::1:53 — lands as the implementation phase of
+    // tinylabscom/mvm#95. The Zone and load_zone primitives in
+    // `lib.rs` are unit-tested and ready for that wire-up.
+    tracing::error!("resolver wire-up not yet implemented; tracked by tinylabscom/mvm#95");
+    std::process::exit(1);
+}

--- a/crates/mvm-mesh-dns/src/lib.rs
+++ b/crates/mvm-mesh-dns/src/lib.rs
@@ -1,0 +1,170 @@
+//! In-guest DNS resolver for `*.mesh.local` (ADR-0018 / ADR-0020).
+//!
+//! Thin wrapper over `hickory-dns`. Listens on `127.0.0.1:53` and
+//! `::1:53` only; authoritative for `*.mesh.local`; forwards
+//! everything else upstream. Per-instance zone loaded from the
+//! config disk's `mesh_dns_zone` (see
+//! `mvm/specs/contracts/in-guest-mesh-dns.md`).
+//!
+//! The resolver is **iroh-free** by design — the cryptographic data
+//! plane lives on the host in mvmd (per ADR-0020 §Hard constraint).
+//! `cargo tree -p mvm-mesh-dns` MUST NOT include any `iroh*` crate.
+
+#![warn(missing_docs)]
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::net::Ipv4Addr;
+use std::path::Path;
+
+/// One A-record entry the resolver serves. The config-disk zone is a
+/// JSON array of these (see contract spec).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZoneRecord {
+    /// Fully-qualified hostname (e.g. `db.mesh.local`).
+    pub hostname: String,
+    /// IPv4 address the resolver returns for `A` queries against
+    /// `hostname`.
+    pub address: Ipv4Addr,
+}
+
+/// Parse the config disk's `mesh_dns_zone` JSON file into a list of
+/// records. The on-disk format is the JSON shape spec'd in
+/// `mvm/specs/contracts/in-guest-mesh-dns.md`:
+///
+/// ```jsonc
+/// [
+///   {"hostname": "db.mesh.local", "address": "10.255.0.1"},
+///   {"hostname": "cache.mesh.local", "address": "10.255.0.2"}
+/// ]
+/// ```
+pub fn load_zone(path: &Path) -> Result<Vec<ZoneRecord>> {
+    let body = std::fs::read_to_string(path)
+        .with_context(|| format!("could not read zone file at {}", path.display()))?;
+    if body.trim().is_empty() {
+        return Ok(vec![]);
+    }
+    serde_json::from_str(&body).with_context(|| {
+        format!(
+            "could not parse zone file at {} as a JSON array of {{hostname, address}} entries",
+            path.display()
+        )
+    })
+}
+
+/// In-process zone state. Owned by the resolver loop; refreshed on
+/// SIGHUP. Methods are intentionally read-only at this layer — zone
+/// updates flow through `load_zone` + `Zone::set_records`.
+pub struct Zone {
+    records: Vec<ZoneRecord>,
+}
+
+impl Zone {
+    /// Build a `Zone` from a parsed record list.
+    pub fn new(records: Vec<ZoneRecord>) -> Self {
+        Self { records }
+    }
+
+    /// Replace the in-memory zone wholesale. Caller responsibility:
+    /// take a write lock if the resolver is reading concurrently.
+    pub fn set_records(&mut self, records: Vec<ZoneRecord>) {
+        self.records = records;
+    }
+
+    /// Look up an A record. Case-insensitive on the hostname.
+    /// Returns the first matching record; the contract spec
+    /// guarantees at most one entry per hostname per instance.
+    pub fn lookup(&self, hostname: &str) -> Option<&ZoneRecord> {
+        self.records
+            .iter()
+            .find(|r| r.hostname.eq_ignore_ascii_case(hostname))
+    }
+
+    /// Whether the zone is authoritative for `hostname` — i.e. it
+    /// ends in `.mesh.local`. The resolver uses this to decide
+    /// between answering authoritatively and forwarding upstream.
+    pub fn is_authoritative_for(&self, hostname: &str) -> bool {
+        let h = hostname.trim_end_matches('.');
+        h.ends_with(".mesh.local") || h == "mesh.local"
+    }
+
+    /// Number of records currently loaded. Useful for "no-op when
+    /// zone is empty" diagnostics in the binary.
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Whether the zone has zero records loaded (and thus the
+    /// resolver should idle as a no-op).
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_zone_parses_minimal_records() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("zone.json");
+        std::fs::write(
+            &path,
+            r#"[
+              {"hostname": "db.mesh.local", "address": "10.255.0.1"},
+              {"hostname": "cache.mesh.local", "address": "10.255.0.2"}
+            ]"#,
+        )
+        .unwrap();
+        let records = load_zone(&path).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].hostname, "db.mesh.local");
+        assert_eq!(records[0].address, Ipv4Addr::new(10, 255, 0, 1));
+    }
+
+    #[test]
+    fn load_zone_accepts_empty_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("zone.json");
+        std::fs::write(&path, "").unwrap();
+        assert!(load_zone(&path).unwrap().is_empty());
+    }
+
+    #[test]
+    fn zone_lookup_is_case_insensitive() {
+        let zone = Zone::new(vec![ZoneRecord {
+            hostname: "db.mesh.local".to_string(),
+            address: Ipv4Addr::new(10, 255, 0, 1),
+        }]);
+        assert!(zone.lookup("db.mesh.local").is_some());
+        assert!(zone.lookup("DB.MESH.LOCAL").is_some());
+        assert!(zone.lookup("missing.mesh.local").is_none());
+    }
+
+    #[test]
+    fn is_authoritative_for_only_recognizes_mesh_local() {
+        let zone = Zone::new(vec![]);
+        assert!(zone.is_authoritative_for("db.mesh.local"));
+        assert!(zone.is_authoritative_for("db.mesh.local."));
+        assert!(zone.is_authoritative_for("mesh.local"));
+        assert!(!zone.is_authoritative_for("example.com"));
+        assert!(!zone.is_authoritative_for("local"));
+        // Defensive: a hostname containing "mesh.local" mid-string is
+        // NOT authoritative — only suffix match.
+        assert!(!zone.is_authoritative_for("evil.mesh.local.attacker.com"));
+    }
+
+    #[test]
+    fn zone_set_records_replaces_state() {
+        let mut zone = Zone::new(vec![ZoneRecord {
+            hostname: "old.mesh.local".to_string(),
+            address: Ipv4Addr::new(10, 255, 0, 1),
+        }]);
+        assert_eq!(zone.len(), 1);
+        zone.set_records(vec![]);
+        assert_eq!(zone.len(), 0);
+        assert!(zone.is_empty());
+    }
+}

--- a/crates/mvm-mesh-vsock-bridge/Cargo.toml
+++ b/crates/mvm-mesh-vsock-bridge/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "mvm-mesh-vsock-bridge"
+version.workspace = true
+edition.workspace = true
+description = "In-guest TCP↔vsock bridge for outbound mesh traffic. Iroh-free; capability tokens stay on the host (mvmd-agent)."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "mvm-mesh-vsock-bridge"
+path = "src/bin/mvm-mesh-vsock-bridge.rs"
+
+[dependencies]
+mvm-core.workspace = true
+anyhow.workspace = true
+libc.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/mvm-mesh-vsock-bridge/src/bin/mvm-mesh-vsock-bridge.rs
+++ b/crates/mvm-mesh-vsock-bridge/src/bin/mvm-mesh-vsock-bridge.rs
@@ -1,0 +1,65 @@
+//! In-guest TCP↔vsock bridge binary (ADR-0018 / ADR-0020).
+//!
+//! Loads `mesh_loopback_bindings` from the config disk, binds a TCP
+//! listener per binding, and (for each accepted TCP connection) opens
+//! a vsock stream to mvmd-agent on the host, writes the
+//! length-prefixed peer header, then proxies bytes both ways.
+//!
+//! Capability tokens NEVER appear here — they're attached by
+//! mvmd-agent on the host side. This binary is iroh-free; `cargo tree
+//! -p mvm-mesh-vsock-bridge` MUST NOT contain any `iroh*` crate.
+//!
+//! v1 implementation note: scaffold today. The peer-header wire
+//! format and load_bindings primitive are functional + unit-tested
+//! (see `lib.rs`). The actual TCP listeners + vsock dial + bytes-
+//! proxy loop land as the implementation phase of tinylabscom/mvm#95.
+
+use anyhow::{Context, Result};
+use mvm_mesh_vsock_bridge::load_bindings;
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let bindings_path: PathBuf = env::var_os("MVM_MESH_LOOPBACK_BINDINGS_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/run/mvm/mesh_loopback_bindings.json"));
+
+    let bindings = if bindings_path.exists() {
+        load_bindings(&bindings_path).with_context(|| {
+            format!(
+                "failed to load mesh loopback bindings from {}",
+                bindings_path.display()
+            )
+        })?
+    } else {
+        // No-op mode: launch.json declared no addons. Idle and let
+        // the supervisor's respawn loop manage us. Matches the
+        // "always-install + no-op when bindings empty" pattern from
+        // `specs/contracts/in-guest-mesh-dns.md`.
+        tracing::info!(
+            bindings_path = %bindings_path.display(),
+            "no bindings file present; idling (no-op mode)"
+        );
+        loop {
+            std::thread::park();
+        }
+    };
+
+    tracing::info!(bindings = bindings.len(), "loaded mesh loopback bindings");
+
+    if bindings.is_empty() {
+        loop {
+            std::thread::park();
+        }
+    }
+
+    // Real listener wiring — TCP listener per binding, vsock dial via
+    // libc AF_VSOCK, bidirectional proxy loop with half-close
+    // semantics — lands as the implementation phase of
+    // tinylabscom/mvm#95. The peer-header encode/decode + binding
+    // loader in `lib.rs` are unit-tested and ready for that wire-up.
+    tracing::error!("bridge wire-up not yet implemented; tracked by tinylabscom/mvm#95");
+    std::process::exit(1);
+}

--- a/crates/mvm-mesh-vsock-bridge/src/lib.rs
+++ b/crates/mvm-mesh-vsock-bridge/src/lib.rs
@@ -1,0 +1,214 @@
+//! In-guest TCP↔vsock bridge for outbound mesh traffic
+//! (ADR-0018 / ADR-0020).
+//!
+//! Binds loopback-range IPs handed out by `mvm-mesh-dns`. On accept,
+//! opens a vsock stream to mvmd-agent on the host, writes a per-
+//! connection peer header (length-prefixed JSON), then proxies bytes
+//! both ways. Half-close semantics preserved.
+//!
+//! Iroh-free by design — capability tokens stay on the host
+//! (mvmd-agent attaches them to the iroh handshake transparently).
+//! This bridge speaks only TCP and vsock.
+
+#![warn(missing_docs)]
+
+use serde::{Deserialize, Serialize};
+use std::net::Ipv4Addr;
+use std::path::Path;
+
+/// One peer-name → loopback-IP + vsock-port mapping. The full set
+/// for a consumer instance comes from the config disk's
+/// `mesh_loopback_bindings`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopbackBinding {
+    /// Bare addon name (or alias) — matches the corresponding
+    /// `mesh_dns_zone` hostname's prefix. E.g. `"db"` for the entry
+    /// whose zone hostname is `"db.mesh.local"`.
+    pub peer: String,
+    /// Loopback IP the bridge binds to listen on. Always in
+    /// `127.0.0.0/8`; allocated by mvmd at consumer-instance start.
+    pub loopback_ip: Ipv4Addr,
+    /// Vsock port to dial on mvmd-agent. mvmd-agent binds a fresh
+    /// per-instance port from the 5253+ pool.
+    pub vsock_port: u32,
+}
+
+/// Per-connection peer header — written by the bridge as the first
+/// frame on every vsock stream it opens. Length-prefixed JSON
+/// (4-byte big-endian length + UTF-8 JSON), matching the existing
+/// `mvm-core` wire conventions.
+///
+/// mvmd-agent reads this header before any application bytes, looks
+/// up the addon-peer's iroh endpoint ID + capability token, and
+/// dials over iroh-QUIC accordingly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerHeader {
+    /// Wire-format version. `1` for v1.
+    pub version: u32,
+    /// Bare peer name (matches `LoopbackBinding::peer`).
+    pub peer: String,
+    /// Public Ed25519 (hex) of the consumer's iroh endpoint identity,
+    /// supplied to the bridge via the config disk. Used by mvmd-agent
+    /// for audit-log attribution; the bridge itself never sees the
+    /// private key.
+    pub consumer_endpoint_id: String,
+}
+
+impl PeerHeader {
+    /// Wire-format version emitted by v1.
+    pub const V1: u32 = 1;
+
+    /// Construct a v1 peer header.
+    pub fn new(peer: String, consumer_endpoint_id: String) -> Self {
+        Self {
+            version: Self::V1,
+            peer,
+            consumer_endpoint_id,
+        }
+    }
+}
+
+/// Parse the config disk's `mesh_loopback_bindings` JSON file.
+pub fn load_bindings(path: &Path) -> std::io::Result<Vec<LoopbackBinding>> {
+    let body = std::fs::read_to_string(path)?;
+    if body.trim().is_empty() {
+        return Ok(vec![]);
+    }
+    serde_json::from_str(&body).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "could not parse {} as JSON array of LoopbackBinding entries: {e}",
+                path.display()
+            ),
+        )
+    })
+}
+
+/// Serialize a peer header as a length-prefixed wire frame ready to
+/// write onto a vsock stream. Returns `(4-byte length || JSON bytes)`.
+pub fn encode_peer_header(header: &PeerHeader) -> Vec<u8> {
+    let body = serde_json::to_vec(header).expect("PeerHeader serializes infallibly");
+    let len = body.len() as u32;
+    let mut out = Vec::with_capacity(4 + body.len());
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Maximum inbound peer-header size (4 KiB). Defends against a
+/// malicious consumer-side caller writing a huge length prefix and
+/// blowing out memory before we close the stream. Real headers are
+/// well under 1 KiB.
+pub const MAX_HEADER_BYTES: u32 = 4 * 1024;
+
+/// Decode a length-prefixed peer header from a byte slice. Returns
+/// the parsed header + the number of bytes consumed (so the caller
+/// can advance the stream cursor). Errors on length-prefix overruns,
+/// truncated bodies, or non-JSON content.
+pub fn decode_peer_header(buf: &[u8]) -> std::io::Result<(PeerHeader, usize)> {
+    if buf.len() < 4 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "peer header: truncated length prefix",
+        ));
+    }
+    let len = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+    if len > MAX_HEADER_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("peer header: length {len} exceeds MAX_HEADER_BYTES={MAX_HEADER_BYTES}"),
+        ));
+    }
+    let total = 4 + len as usize;
+    if buf.len() < total {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "peer header: truncated body",
+        ));
+    }
+    let header: PeerHeader = serde_json::from_slice(&buf[4..total]).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("peer header: not valid JSON: {e}"),
+        )
+    })?;
+    Ok((header, total))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_bindings_parses_valid_json() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("b.json");
+        std::fs::write(
+            &path,
+            r#"[
+              {"peer": "db", "loopback_ip": "127.0.255.1", "vsock_port": 5253},
+              {"peer": "cache", "loopback_ip": "127.0.255.2", "vsock_port": 5254}
+            ]"#,
+        )
+        .unwrap();
+        let bindings = load_bindings(&path).unwrap();
+        assert_eq!(bindings.len(), 2);
+        assert_eq!(bindings[0].peer, "db");
+        assert_eq!(bindings[0].loopback_ip, Ipv4Addr::new(127, 0, 255, 1));
+        assert_eq!(bindings[0].vsock_port, 5253);
+    }
+
+    #[test]
+    fn load_bindings_accepts_empty_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("b.json");
+        std::fs::write(&path, "").unwrap();
+        assert!(load_bindings(&path).unwrap().is_empty());
+    }
+
+    #[test]
+    fn peer_header_round_trips_through_wire_format() {
+        let h = PeerHeader::new("db".to_string(), "abcd1234".to_string());
+        let wire = encode_peer_header(&h);
+        let (decoded, consumed) = decode_peer_header(&wire).unwrap();
+        assert_eq!(decoded, h);
+        assert_eq!(consumed, wire.len());
+    }
+
+    #[test]
+    fn decode_peer_header_rejects_oversize_length_prefix() {
+        let bad = [0xFF, 0xFF, 0xFF, 0xFF];
+        let err = decode_peer_header(&bad).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn decode_peer_header_rejects_truncated_body() {
+        // Length prefix says 100 bytes; only 4 follow.
+        let mut buf = vec![0, 0, 0, 100];
+        buf.extend_from_slice(b"abcd");
+        let err = decode_peer_header(&buf).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn decode_peer_header_rejects_non_json_body() {
+        let mut buf = vec![0, 0, 0, 5];
+        buf.extend_from_slice(b"not()");
+        let err = decode_peer_header(&buf).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn peer_header_extra_fields_are_rejected_by_serde_default() {
+        // Deserializer is the standard serde derive (no
+        // `deny_unknown_fields` here intentionally — forward
+        // compatibility for future-version headers). v2 headers
+        // would change `version` and adopt new fields; v1 should
+        // accept-with-ignore. Locked in by:
+        let buf = encode_peer_header(&PeerHeader::new("p".into(), "id".into()));
+        decode_peer_header(&buf).unwrap();
+    }
+}

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -75,6 +75,7 @@ Recent maintenance:
 - [x] Resolved spec-number collisions across `specs/plans/` and `specs/adrs/` by renumbering duplicate-prefixed files, updating references, and adding `cargo xtask check-spec-numbers` to CI so future duplicate Plan/ADR prefixes fail before merge.
 - [x] Shortened top-level `mvmctl --help` command summaries and added a regression test keeping each summary to 72 characters or less.
 - [x] Tightened the public `mvmctl` command surface around the local microVM substrate boundary: removed `deploy`, `policy`, and `tenant` from the Clap tree, deleted their unreachable command modules, and updated the CLI reference with the retained command families. Tenant lifecycle, tenant policy review/update, and deployment to the hosted control plane are now documented as `mvmd` responsibilities.
+- [x] GitHub #95 scaffold transplant: restored the ADR-0018 in-guest mesh DNS / vsock bridge contract and iroh-free workspace crates on top of current `main`, with zone-loader and peer-header/binding tests green as the implementation base.
 
 ## In-flight workstreams
 

--- a/specs/contracts/in-guest-mesh-dns.md
+++ b/specs/contracts/in-guest-mesh-dns.md
@@ -1,0 +1,198 @@
+# Contract: in-guest mesh DNS resolver and TCP↔vsock bridge
+
+## Status
+
+**Proposed — paired contract for mvmforge ADR-0018 / ADR-0020** (drafted 2026-05-07).
+
+The two new in-guest binaries that make `db.mesh.local:5432`-style
+addressing work for consumers without any iroh code in the guest:
+**`mvm-mesh-dns`** (hickory-dns wrapper resolving `*.mesh.local`)
+and **`mvm-mesh-vsock-bridge`** (TCP↔vsock bridge that fronts the
+loopback IPs the resolver hands out and forwards to mvmd-agent on
+the host).
+
+Both are iroh-free, supervised by the existing minimal-init respawn
+loop alongside `mvm-guest-agent`. Their only inputs come from the
+config disk (per
+[`mvmd/specs/contracts/addon-runtime.md`](https://github.com/tinylabs/mvmd/blob/main/specs/contracts/addon-runtime.md)).
+
+## Audience
+
+mvm maintainers building `crates/mvm-mesh-dns/` and
+`crates/mvm-mesh-vsock-bridge/`. mvmd maintainers populating the
+config-disk fields these binaries consume.
+
+## Background
+
+ADR-0018 §Cross-host scope v1 commits to **vsock-only host↔guest
+data path** — the existing mvm-guest-agent vsock-narrow-surface
+contract is preserved. Adding TAP interfaces would expose the host
+kernel's network stack to guest-controlled L2/L3 packets, widening
+the attack surface meaningfully. Instead the mesh data path runs:
+
+```
+consumer app TCP connect to db.mesh.local:5432
+  → mvm-mesh-dns (in-guest, 127.0.0.1:53) resolves to 10.255.0.1
+  → mvm-mesh-vsock-bridge (in-guest) accepts on 10.255.0.1:5432
+  → opens vsock stream to mvmd-agent (host) with peer header
+  → mvmd-agent dials iroh-QUIC to addon's host's mvmd-agent
+  → remote mvmd-agent forwards via vsock PortForward to addon guest
+```
+
+No iroh in mvm. No TAP. Pure Linux networking + vsock between guest
+and host.
+
+## Contract
+
+### Crate: `mvm-mesh-dns`
+
+Thin wrapper over `hickory-dns` (formerly `trust-dns`; mature,
+audited, used by Cloudflare's Pingora). Behavior:
+
+- **Listen scope**: `127.0.0.1:53` and `::1:53` only. Never on a
+  public interface, never on a TAP. Not a recursive resolver for
+  untrusted clients.
+- **Authority scope**: authoritative for `*.mesh.local` only;
+  forwards everything else (`*.com`, IP literals, etc.) to the
+  upstream resolver chain inherited from the guest's existing
+  networking (typically `8.8.8.8` or whatever the substrate
+  configures).
+- **Zone source**: per-instance zone records loaded at boot from
+  the config disk's `mesh_dns_zone` array (see
+  [addon-runtime.md](https://github.com/tinylabs/mvmd/blob/main/specs/contracts/addon-runtime.md)).
+  v1 emits A records only:
+
+  ```jsonc
+  [
+    {"hostname": "db.mesh.local", "address": "10.255.0.1"},
+    {"hostname": "cache.mesh.local", "address": "10.255.0.2"}
+  ]
+  ```
+
+  v2-reserved fields (SRV records, TXT-record cert hints, TTL
+  overrides, hot-rotation deltas) are accepted but unused at v1.
+- **Reload model**: SIGHUP-on-config-disk-change. mvmd signals
+  via the existing guest-agent vsock RPC when the zone updates
+  (e.g. on credential rotation that re-derives a hostname, or on
+  addon respawn at a new endpoint).
+- **Supervisor**: runs as an unprivileged user (e.g. `_mvm-dns`),
+  supervised by the existing minimal-init respawn loop.
+- **Implementation crate**: `crates/mvm-mesh-dns/` — thin wrapper
+  over hickory-dns, config-disk loader, SIGHUP handler. Target
+  size: ~200 LOC + tests. iroh-free.
+
+### Crate: `mvm-mesh-vsock-bridge`
+
+Per-connection TCP↔vsock bridge. Behavior:
+
+- **Loopback bindings**: at boot, reads `mesh_loopback_bindings`
+  from the config disk:
+
+  ```jsonc
+  [
+    {"peer": "db.mesh.local", "loopback_ip": "10.255.0.1", "vsock_port": 5253},
+    {"peer": "cache.mesh.local", "loopback_ip": "10.255.0.2", "vsock_port": 5254}
+  ]
+  ```
+
+  For each entry, binds a TCP listener on
+  `<loopback_ip>:<original_port>` (the original port comes from the
+  consumer's connection — see "Listen behavior" below). The
+  loopback IPs are aliases on `lo` (no TAP, no host-visible
+  interface).
+- **Listen behavior**: the bridge intercepts TCP connections to any
+  address in the configured loopback range. v1 binds an explicit
+  listener per `(loopback_ip, port)` discovered from the consumer's
+  declared addon ports; future versions may install a transparent-
+  proxy iptables redirect to capture arbitrary ports.
+- **Per-connection peer header**: on accept, opens a fresh vsock
+  stream to mvmd-agent's per-instance vsock listener (port from the
+  config disk's `mesh_loopback_bindings[].vsock_port`) and writes
+  the header **before** any application bytes:
+
+  ```jsonc
+  {
+    "version": 1,
+    "peer": "db",                  // bare alias / name (no .mesh.local suffix)
+    "consumer_endpoint_id": "..."  // public Ed25519 (hex), supplied by config disk
+  }
+  ```
+
+  Header is a length-prefixed JSON blob (4-byte big-endian length +
+  UTF-8 JSON; matches the existing mvm-core wire conventions).
+- **Bidirectional proxying**: after the header is acknowledged
+  (mvmd-agent sends a 1-byte ACK), the bridge proxies bytes both
+  ways until either side closes. Half-close semantics preserved.
+- **Capability tokens**: NEVER on the guest side. The bridge does
+  not see, store, or transmit capability tokens. mvmd-agent on the
+  host attaches the token to the iroh handshake transparently.
+- **Implementation crate**: `crates/mvm-mesh-vsock-bridge/` — small
+  Rust binary over libc vsock + tokio. Target size: ~100 LOC + tests.
+  iroh-free.
+
+### Config-disk schema (consumed)
+
+The config disk JSON (mounted on tmpfs in the consumer's namespace
+only) carries the fields above plus
+`crates/mvm-core/src/config.rs`'s formal schema:
+
+```jsonc
+{
+  "mesh_dns_zone": [...],            // mvm-mesh-dns reads this
+  "mesh_loopback_bindings": [...]    // mvm-mesh-vsock-bridge reads this
+}
+```
+
+When either field is empty/absent, the corresponding binary becomes
+a no-op (idle, supervised, no listeners). This keeps the `mkGuest`
+contract simple: bake both binaries unconditionally; emit/skip the
+config-disk fields based on whether the workload declares addons.
+
+### Init / startup ordering
+
+Existing minimal-init's service-respawn loop launches both
+binaries in parallel after `04-etc-and-users.sh` (which configures
+`/etc/resolv.conf` to list `127.0.0.1` first when the mesh is
+enabled). No ordering constraint between `mvm-mesh-dns` and
+`mvm-mesh-vsock-bridge`; the consumer's app code runs after both
+are listening (init waits on a small readiness check before
+launching the workload's entrypoint).
+
+### What this contract does NOT cover
+
+- **iroh, QUIC, Ed25519 endpoint identities, capability tokens** —
+  all on the host side. See
+  [`mvmd/specs/contracts/workload-mesh.md`](https://github.com/tinylabs/mvmd/blob/main/specs/contracts/workload-mesh.md).
+- **Inter-tenant authorization** — enforced at the coordinator
+  + mvmd-agent boundary, not by the in-guest binaries.
+- **Persistence** — the config disk is tmpfs; the in-guest
+  resolver and bridge hold no state across reboots.
+
+## Validation
+
+- Boot a consumer with no `addons[]` declared: both binaries start
+  but are no-ops; the existing networking is unchanged.
+- Boot a consumer with one addon: `dig db.mesh.local @127.0.0.1`
+  returns `10.255.0.1`; `dig example.com @127.0.0.1` forwards to
+  upstream; `nc 10.255.0.1 5432` opens a connection (terminated by
+  mvmd-agent on the host with the per-connection peer header).
+- SIGHUP after config-disk update reloads the zone without dropping
+  in-flight DNS queries.
+- Host kernel network stack receives no guest-sourced packets
+  (verified by host-side `tcpdump` showing only vsock + iroh-QUIC
+  traffic on the relevant interfaces).
+- The two binaries link no iroh-QUIC code (`cargo tree -p mvm-mesh-dns`
+  and `-p mvm-mesh-vsock-bridge` must NOT include `iroh*` crates).
+- Bridge handles half-close cleanly: `nc 10.255.0.1 5432` followed
+  by Ctrl-D (consumer-side close) leaves the addon-side write side
+  open until the addon closes.
+
+## Related
+
+- [`mvmd/specs/contracts/addon-runtime.md`](https://github.com/tinylabs/mvmd/blob/main/specs/contracts/addon-runtime.md)
+  — the config-disk schema this contract consumes.
+- [`mvmd/specs/contracts/workload-mesh.md`](https://github.com/tinylabs/mvmd/blob/main/specs/contracts/workload-mesh.md)
+  — the iroh-QUIC + capability-token data plane that picks up
+  where the vsock-bridge hands off.
+- [`mvmforge/specs/adrs/0018-composable-addons.md`](https://github.com/tinylabs/mvmforge/blob/main/specs/adrs/0018-composable-addons.md)
+  — the user-facing decision this stack implements.


### PR DESCRIPTION
## Summary
- restore the ADR-0018 in-guest mesh DNS / vsock bridge contract on top of current main
- add iroh-free workspace crates for mvm-mesh-dns and mvm-mesh-vsock-bridge
- carry forward the existing zone loader, binding loader, and peer-header codec tests as the implementation base for #95

Refs #95

## Validation
- cargo test -p mvm-mesh-dns -p mvm-mesh-vsock-bridge
- cargo clippy -p mvm-mesh-dns -p mvm-mesh-vsock-bridge --all-targets -- -D warnings
- cargo tree -p mvm-mesh-dns -i iroh exits with no matching package
- cargo tree -p mvm-mesh-vsock-bridge -i iroh exits with no matching package