### PR TITLE
Wire local addon bridge runner

### DIFF
--- a/crates/mvm-addon-vsock-bridge/src/bin/mvm-addon-vsock-bridge.rs
+++ b/crates/mvm-addon-vsock-bridge/src/bin/mvm-addon-vsock-bridge.rs
@@ -5,17 +5,13 @@
 //! a vsock stream to the host addon proxy, writes the
 //! length-prefixed peer header, then proxies bytes both ways.
 //!
-//! v1 implementation note: scaffold today. The peer-header wire
-//! format and load_bindings primitive are functional + unit-tested
-//! (see `lib.rs`). The actual TCP listeners + vsock dial + bytes-
-//! proxy loop land as the implementation phase.
-
 use anyhow::{Context, Result};
-use mvm_addon_vsock_bridge::load_bindings;
+use mvm_addon_vsock_bridge::{load_bindings, run_bridge};
 use std::env;
 use std::path::PathBuf;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let bindings_path: PathBuf = env::var_os("MVM_ADDON_LOOPBACK_BINDINGS_PATH")
@@ -51,11 +47,7 @@ fn main() -> Result<()> {
         }
     }
 
-    // Real listener wiring — TCP listener per binding, vsock dial via
-    // libc AF_VSOCK, bidirectional proxy loop with half-close
-    // semantics — lands as a follow-up. The peer-header encode/decode
-    // + binding loader in `lib.rs` are unit-tested and ready for that
-    // wire-up.
-    tracing::error!("bridge wire-up not yet implemented");
-    std::process::exit(1);
+    run_bridge(bindings)
+        .await
+        .context("addon vsock bridge failed")
 }

--- a/crates/mvm-addon-vsock-bridge/src/lib.rs
+++ b/crates/mvm-addon-vsock-bridge/src/lib.rs
@@ -125,9 +125,7 @@ pub async fn run_bridge(bindings: Vec<LoopbackBinding>) -> std::io::Result<()> {
         tokio::spawn(accept_loop(listener, binding));
     }
 
-    std::future::pending::<()>().await;
-    #[allow(unreachable_code)]
-    Ok(())
+    std::future::pending::<std::io::Result<()>>().await
 }
 
 async fn accept_loop(listener: TcpListener, binding: LoopbackBinding) {

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -76,6 +76,7 @@ Recent maintenance:
 - [x] Shortened top-level `mvmctl --help` command summaries and added a regression test keeping each summary to 72 characters or less.
 - [x] Tightened the public `mvmctl` command surface around the local microVM substrate boundary: removed `deploy`, `policy`, and `tenant` from the Clap tree, deleted their unreachable command modules, and updated the CLI reference with the retained command families. Tenant lifecycle, tenant policy review/update, and deployment to the hosted control plane are now documented as `mvmd` responsibilities.
 - [x] GitHub #95 scaffold retarget: narrowed the in-guest DNS / vsock bridge work to local addon developer plumbing (`mvm-addon-dns` + `mvm-addon-vsock-bridge`) and documented that distributed mesh, tenant policy, and cryptographic routing belong in `mvmd`; zone-loader and peer-header/binding tests remain the implementation base.
+- [x] GitHub #95 bridge slice: `mvm-addon-vsock-bridge` now loads loopback bindings with explicit `tcp_port`, starts one TCP listener per loopback IP/port, dials the host addon proxy over vsock, writes the peer header before application bytes, and proxies bidirectionally with binding validation and regression coverage.
 
 ## In-flight workstreams
 

--- a/specs/contracts/local-addon-dns.md
+++ b/specs/contracts/local-addon-dns.md
@@ -99,8 +99,8 @@ v1 binding shape:
 
 ```json
 [
-  {"peer": "db", "loopback_ip": "127.0.255.1", "vsock_port": 5253},
-  {"peer": "cache", "loopback_ip": "127.0.255.2", "vsock_port": 5254}
+  {"peer": "db", "loopback_ip": "127.0.255.1", "tcp_port": 5432, "vsock_port": 5253},
+  {"peer": "cache", "loopback_ip": "127.0.255.2", "tcp_port": 6379, "vsock_port": 5254}
 ]
 ```
 


### PR DESCRIPTION
## Summary
- have the addon vsock bridge binary call the bridge runner instead of exiting after config load
- simplify the runner pending future return without an unreachable-code allowance
- align the local addon contract binding example with the implemented tcp_port field

## Verification
- cargo test -p mvm-addon-vsock-bridge
- cargo clippy -p mvm-addon-vsock-bridge --all-targets -- -D warnings