### PR TITLE
Make mvmctl secrets write-only after storage

### DIFF
--- a/crates/mvm-cli/src/commands/ops/secret.rs
+++ b/crates/mvm-cli/src/commands/ops/secret.rs
@@ -2,10 +2,9 @@
 //!
 //! Local CRUD for secret namespaces. Values never appear in
 //! logs, error chains, or process listings — `put` accepts the
-//! value via flag, stdin, or file; `get` writes to stdout only when
-//! it's not a TTY (so a script using `$(mvmctl secret get …)`
-//! works but an interactive `mvmctl secret get foo` doesn't dump
-//! the value into the user's terminal).
+//! value via an interactive hidden prompt, stdin, flag, or file;
+//! `get` verifies that a secret exists but never prints the stored
+//! value.
 //!
 //! ## Audit
 //!
@@ -34,7 +33,7 @@ use clap::{Args as ClapArgs, Subcommand};
 use mvm_plan::TenantId;
 use mvm_security::secret_store::{self, SecretStore};
 use mvm_supervisor::{EventCategory, FileAuditSigner, Recorder};
-use secrecy::{ExposeSecret, SecretBox};
+use secrecy::SecretBox;
 
 use mvm_core::user_config::MvmConfig;
 
@@ -50,9 +49,11 @@ pub(in crate::commands) struct Args {
 
 #[derive(Subcommand, Debug, Clone)]
 pub(in crate::commands) enum SecretAction {
-    /// Store a local secret. Value source: `--value <V>` (inline,
-    /// shell-history risk), `--value -` (read from stdin), or
-    /// `--value-file <PATH>`. The value never appears in logs.
+    /// Store or replace a local secret. With no value source,
+    /// prompts interactively when stdin is a TTY or reads piped
+    /// stdin otherwise. Explicit sources remain available:
+    /// `--value <V>` (inline, shell-history risk), `--value -`
+    /// (read from stdin), or `--value-file <PATH>`.
     Put {
         /// Name to store the secret under (alphanumeric + `_-`).
         name: String,
@@ -68,17 +69,12 @@ pub(in crate::commands) enum SecretAction {
         value_file: Option<PathBuf>,
     },
 
-    /// Retrieve a local secret. Writes the raw value to stdout
-    /// (no trailing newline) only when stdout is not a TTY. Pass
-    /// `--force` to bypass the TTY guard.
+    /// Check whether a local secret exists. Never prints the raw
+    /// secret value.
     Get {
         name: String,
         #[arg(long, default_value = "local")]
         tenant: String,
-        /// Bypass the TTY guard. Use with care — surfaces the
-        /// value on the user's terminal.
-        #[arg(long)]
-        force: bool,
     },
 
     /// List secret names stored for a tenant.
@@ -111,11 +107,7 @@ pub(in crate::commands) fn run_with_store(store: &dyn SecretStore, args: Args) -
             value,
             value_file,
         } => cmd_put(store, &audit, tenant, name, value, value_file),
-        SecretAction::Get {
-            name,
-            tenant,
-            force,
-        } => cmd_get(store, &audit, tenant, name, force),
+        SecretAction::Get { name, tenant } => cmd_get(store, &audit, tenant, name),
         SecretAction::Ls { tenant } => cmd_ls(store, &audit, tenant),
         SecretAction::Rm { name, tenant } => cmd_rm(store, &audit, tenant, name),
     }
@@ -134,7 +126,7 @@ fn cmd_put(
     value_file: Option<PathBuf>,
 ) -> Result<()> {
     let result = (|| {
-        let raw = resolve_value(value, value_file)?;
+        let raw = resolve_value(value, value_file, &name)?;
         let secret = SecretBox::new(Box::new(raw));
         store.put(&tenant, &name, &secret)
     })();
@@ -144,31 +136,11 @@ fn cmd_put(
     Ok(())
 }
 
-fn cmd_get(
-    store: &dyn SecretStore,
-    audit: &AuditLog,
-    tenant: String,
-    name: String,
-    force: bool,
-) -> Result<()> {
-    if std::io::stdout().is_terminal() && !force {
-        let err: Result<()> = Err(anyhow::anyhow!(
-            "refusing to print secret to an interactive terminal; \
-             redirect stdout to a file/pipe or pass `--force`"
-        ));
-        audit.record("get", &tenant, &name, &err)?;
-        return err;
-    }
+fn cmd_get(store: &dyn SecretStore, audit: &AuditLog, tenant: String, name: String) -> Result<()> {
     let result = store.get(&tenant, &name);
     audit.record("get", &tenant, &name, &result.as_ref().map(|_| ()))?;
-    let value = result?;
-    // Stderr message names what's happening so a `$()` capture knows
-    // what came through. The actual value goes to stdout, raw, no
-    // trailing newline.
-    eprintln!("Wrote secret '{name}' for tenant '{tenant}' to stdout.");
-    std::io::stdout()
-        .write_all(value.expose_secret().as_bytes())
-        .context("writing secret to stdout")?;
+    result?;
+    println!("Secret '{name}' is set for tenant '{tenant}'.");
     Ok(())
 }
 
@@ -201,38 +173,50 @@ fn cmd_rm(store: &dyn SecretStore, audit: &AuditLog, tenant: String, name: Strin
 // Value resolution — flag / stdin / file
 // ============================================================================
 
-fn resolve_value(value: Option<String>, value_file: Option<PathBuf>) -> Result<String> {
+fn resolve_value(
+    value: Option<String>,
+    value_file: Option<PathBuf>,
+    secret_name: &str,
+) -> Result<String> {
     match (value, value_file) {
-        (Some(v), None) if v == "-" => {
-            let mut buf = String::new();
-            std::io::stdin()
-                .read_to_string(&mut buf)
-                .context("reading secret value from stdin")?;
-            // Strip a single trailing newline — `echo "x" | mvmctl
-            // secret put …` shouldn't include the LF in the stored
-            // value.
-            if buf.ends_with('\n') {
-                buf.pop();
-                if buf.ends_with('\r') {
-                    buf.pop();
-                }
-            }
-            Ok(buf)
-        }
+        (Some(v), None) if v == "-" => read_secret_from_stdin(),
         (Some(v), None) => Ok(v),
         (None, Some(path)) => std::fs::read_to_string(&path)
             .with_context(|| format!("reading secret value from {}", path.display())),
-        (None, None) => {
-            anyhow::bail!(
-                "no value source — pass --value <V>, --value - (stdin), or --value-file <PATH>"
-            )
-        }
+        (None, None) => read_secret_from_prompt_or_stdin(secret_name),
         (Some(_), Some(_)) => {
             // Clap should prevent this via conflicts_with, but
             // double-check at runtime in case the API drifts.
             anyhow::bail!("--value and --value-file are mutually exclusive")
         }
     }
+}
+
+fn read_secret_from_prompt_or_stdin(secret_name: &str) -> Result<String> {
+    if std::io::stdin().is_terminal() {
+        inquire::Password::new(&format!("Secret value for '{secret_name}'"))
+            .without_confirmation()
+            .prompt()
+            .context("reading secret value from interactive prompt")
+    } else {
+        read_secret_from_stdin()
+    }
+}
+
+fn read_secret_from_stdin() -> Result<String> {
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .context("reading secret value from stdin")?;
+    // Strip a single trailing newline — `echo "x" | mvmctl
+    // secret put …` shouldn't include the LF in the stored value.
+    if buf.ends_with('\n') {
+        buf.pop();
+        if buf.ends_with('\r') {
+            buf.pop();
+        }
+    }
+    Ok(buf)
 }
 
 // ============================================================================
@@ -484,7 +468,7 @@ mod tests {
 
     #[test]
     fn resolve_value_inline_returns_value() {
-        let v = resolve_value(Some("hello".into()), None).unwrap();
+        let v = resolve_value(Some("hello".into()), None, "api_token").unwrap();
         assert_eq!(v, "hello");
     }
 
@@ -492,24 +476,31 @@ mod tests {
     fn resolve_value_file_reads_file_contents() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(tmp.path(), b"from-file").unwrap();
-        let v = resolve_value(None, Some(tmp.path().to_path_buf())).unwrap();
+        let v = resolve_value(None, Some(tmp.path().to_path_buf()), "api_token").unwrap();
         assert_eq!(v, "from-file");
     }
 
     #[test]
-    fn resolve_value_missing_returns_clear_error() {
-        let err = resolve_value(None, None).unwrap_err();
-        assert!(err.to_string().contains("no value source"), "got: {err}");
+    fn resolve_value_rejects_inline_and_file_together() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let err = resolve_value(
+            Some("inline".into()),
+            Some(tmp.path().to_path_buf()),
+            "api_token",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("--value and --value-file are mutually exclusive"),
+            "got: {err}"
+        );
     }
 
     // ──────────────────────────────────────────────────────────────
     // Subcommand handlers — happy paths
     //
-    // We can't easily test `cmd_get` against the TTY guard from a
-    // unit test because stdout's terminal status is process-wide;
-    // the guard's correctness is exercised through manual QA and
-    // the predicates::cli integration tests in tests/cli.rs once
-    // those land.
+    // `cmd_get` is intentionally a presence check only: it verifies
+    // the entry exists but never exposes the raw value.
     // ──────────────────────────────────────────────────────────────
 
     #[test]
@@ -546,6 +537,29 @@ mod tests {
         .unwrap();
         cmd_rm(&store, &audit, "acme".into(), "k".into()).unwrap();
         assert!(store.list("acme").unwrap().is_empty());
+    }
+
+    #[test]
+    fn cmd_get_checks_presence_without_returning_secret() {
+        let tmp_store = tempfile::tempdir().unwrap();
+        let store = FileSecretStore::with_dir(tmp_store.path());
+        let (_audit_dir, audit) = temp_audit();
+        cmd_put(
+            &store,
+            &audit,
+            "acme".into(),
+            "api_token".into(),
+            Some("secret-xyz".into()),
+            None,
+        )
+        .unwrap();
+        cmd_get(&store, &audit, "acme".into(), "api_token".into()).unwrap();
+        let log = read_audit(&audit);
+        assert!(log.contains("\"action\":\"get\""), "got: {log}");
+        assert!(
+            !log.contains("secret-xyz"),
+            "audit log must not contain the secret value: {log}"
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -11,7 +11,7 @@ use super::build::build;
 use super::build::compile;
 use super::catalog;
 use super::env::{cleanup, dev, init, uninstall};
-use super::ops::{audit, cache, config, metrics};
+use super::ops::{audit, cache, config, metrics, secret};
 use super::vm::{console, cp, down, exec, forward, sandbox, up, volume};
 
 use audit::AuditAction;
@@ -1545,6 +1545,40 @@ fn test_console_with_command() {
         }
         _ => panic!("Expected Console command"),
     }
+}
+
+// --- Secret CLI tests ---
+
+#[test]
+fn secret_put_without_value_source_parses_for_interactive_prompt() {
+    let cli = Cli::try_parse_from(["mvmctl", "secret", "put", "api-key"]).expect("parse");
+    match cli.command {
+        Commands::Secret(secret::Args {
+            action:
+                secret::SecretAction::Put {
+                    name,
+                    tenant,
+                    value,
+                    value_file,
+                },
+        }) => {
+            assert_eq!(name, "api-key");
+            assert_eq!(tenant, "local");
+            assert!(value.is_none());
+            assert!(value_file.is_none());
+        }
+        _ => panic!("Expected Secret put command"),
+    }
+}
+
+#[test]
+fn secret_get_rejects_force_flag() {
+    let err = Cli::try_parse_from(["mvmctl", "secret", "get", "api-key", "--force"])
+        .expect_err("secret get must not accept --force");
+    assert!(
+        err.to_string().contains("unexpected argument '--force'"),
+        "got: {err}"
+    );
 }
 
 // --- Exec CLI tests ---

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -160,6 +160,23 @@ The intentionally kept top-level command families are:
 | `mvmctl audit tail -n <N>` | Show the last N audit events |
 | `mvmctl audit tail -f` | Follow audit log output (poll until Ctrl-C) |
 
+## Local Secrets
+
+| Command | Description |
+|---------|-------------|
+| `mvmctl secret put <name>` | Store or replace a local secret using hidden interactive input when stdin is a terminal, or piped stdin otherwise |
+| `mvmctl secret put <name> --value -` | Store or replace a local secret from stdin |
+| `mvmctl secret put <name> --value-file <path>` | Store or replace a local secret from a file |
+| `mvmctl secret put <name> --value <value>` | Store or replace a local secret from an inline value. Avoid in interactive shells because the value may be saved in shell history |
+| `mvmctl secret get <name>` | Verify that a local secret exists without printing the value |
+| `mvmctl secret ls` | List stored secret names only |
+| `mvmctl secret rm <name>` | Remove a local secret |
+| `mvmctl secret <put|get|ls|rm> --tenant <tenant>` | Use a non-default local tenant namespace. Default: `local` |
+
+Secret values are write-only through the CLI after storage: `get` is a presence
+check and never emits the raw value. Replace a secret by running `secret put`
+again with the same name.
+
 ## Policy Contracts
 
 `mvmctl up` still synthesizes and admits signed execution plans with policy

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -79,6 +79,7 @@ Recent maintenance:
 - [x] Tightened the public `mvmctl` command surface around the local microVM substrate boundary: removed `deploy`, `policy`, and `tenant` from the Clap tree, deleted their unreachable command modules, and updated the CLI reference with the retained command families. Tenant lifecycle, tenant policy review/update, and deployment to the hosted control plane are now documented as `mvmd` responsibilities.
 - [x] GitHub #95 scaffold retarget: narrowed the in-guest DNS / vsock bridge work to local addon developer plumbing (`mvm-addon-dns` + `mvm-addon-vsock-bridge`) and documented that distributed mesh, tenant policy, and cryptographic routing belong in `mvmd`; zone-loader and peer-header/binding tests remain the implementation base.
 - [x] GitHub #95 bridge slice: `mvm-addon-vsock-bridge` now loads loopback bindings with explicit `tcp_port`, starts one TCP listener per loopback IP/port, dials the host addon proxy over vsock, writes the peer header before application bytes, and proxies bidirectionally with binding validation and regression coverage.
+- [x] Hardened `mvmctl secret`: `put` now prompts with hidden interactive input when no value source is supplied and still accepts stdin/file/inline sources, while `get` is now a presence check only and can never print the raw secret value. CLI docs and ADR-042 were updated to reflect the write-only-after-set contract.
 
 ## In-flight workstreams
 

--- a/specs/adrs/042-encryption-substrate.md
+++ b/specs/adrs/042-encryption-substrate.md
@@ -102,8 +102,8 @@ Chunked wire format (24-byte header + N chunks of nonce(12) + ciphertext_with_ta
 
 ### Operator-facing surface
 
-- `mvmctl secret put <name> --tenant <T> [--value V | --value - | --value-file PATH]` — stores a value. Inline / stdin / file. Overwrites silently. Never logs the value.
-- `mvmctl secret get <name> --tenant <T> [--force]` — emits the raw value to stdout (no trailing newline) **only when stdout is non-tty**. The TTY guard prevents shoulder-surfing during interactive use; scripts using `$(mvmctl secret get …)` work because the pipe makes stdout non-tty.
+- `mvmctl secret put <name> --tenant <T> [--value V | --value - | --value-file PATH]` — stores or replaces a value. With no explicit source, prompts with hidden terminal input when stdin is a TTY, or reads piped stdin otherwise. Inline / stdin / file remain supported. Never logs the value.
+- `mvmctl secret get <name> --tenant <T>` — verifies that the secret exists and prints only presence metadata. It never emits the raw value; secrets can be replaced with `put` but not viewed after storage.
 - `mvmctl secret ls --tenant <T>` — names only.
 - `mvmctl secret rm <name> --tenant <T>`.
 - Audit emissions for every CRUD operation appear at `~/.mvm/audit/secrets.jsonl` carrying `(timestamp, action, tenant, name, outcome, pid, error?)`. Values are never recorded.

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -1888,23 +1888,15 @@ fn secret_put_emits_put_action_in_secret_audit_log() {
 
 #[test]
 fn secret_get_emits_get_action_in_secret_audit_log() {
-    // Put first, then get with `--force` to bypass the TTY guard
-    // (subprocess stdout is a pipe, not a TTY — the guard would
-    // otherwise refuse). Assert a `get` entry lands in the
+    // Put first, then verify presence. `secret get` never prints
+    // the raw value; it only asserts the entry exists and emits the
     // per-action audit JSONL.
     let sandbox = AuditSandbox::new();
     put_a_secret(&sandbox, "test-tenant", "api-key", "deadbeef");
 
     let output = sandbox
         .mvmctl()
-        .args([
-            "secret",
-            "get",
-            "api-key",
-            "--tenant",
-            "test-tenant",
-            "--force",
-        ])
+        .args(["secret", "get", "api-key", "--tenant", "test-tenant"])
         .output()
         .expect("spawn mvmctl get");
     assert!(


### PR DESCRIPTION
## Summary
- make `mvmctl secret put <name>` prompt with hidden interactive input when no source is supplied, while preserving stdin/file/inline sources
- change `mvmctl secret get <name>` into a presence check that never prints the raw secret and remove `--force`
- update secret CLI tests, live audit coverage, CLI docs, ADR-042, and sprint status

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p mvm-cli secret`
- `cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy -p mvm-cli -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings` (host)
- `cargo run -p xtask -- check-no-display-on-secret-types`
- smoke: piped stdin `secret put TEST_NAME` then `secret get TEST_NAME` prints only presence metadata

Note: the Linux builder-VM clippy gate still needs to run in the project builder VM/CI; this environment does not expose a non-interactive builder command runner.