### PR TITLE
Encrypt file-backed secret storage

### DIFF
--- a/crates/mvm-security/src/secret_store.rs
+++ b/crates/mvm-security/src/secret_store.rs
@@ -10,7 +10,8 @@
 //!
 //! - [`FileSecretStore`] — primary; works on every supported host.
 //!   Each secret lives at `<base>/<tenant>/<name>` with mode 0600,
-//!   parent dirs mode 0700. Enumeration is a directory scan.
+//!   parent dirs mode 0700, and AES-256-GCM encrypted contents.
+//!   Enumeration is a directory scan.
 //! - [`KeyringSecretStore`] — used when the OS-native keystore is
 //!   reachable. Each secret lives at the keyring entry
 //!   `(service="mvm-secrets", user="<tenant>:<name>")`. An index
@@ -18,9 +19,11 @@
 //!   doesn't depend on backend-specific enumeration (the `keyring`
 //!   crate's enumeration is uneven across backends).
 //!
-//! [`default_secret_store`] auto-picks Keyring if reachable, else
-//! File. Set `MVM_SECRET_STORE_BACKEND=file` to pin the file
-//! backend (escape hatch for hosts where the keyring's
+//! [`default_secret_store`] auto-picks an aggregate backend when
+//! Keyring is reachable: writes prefer Keyring, while reads,
+//! listing, and deletion keep file-backed secrets visible. Set
+//! `MVM_SECRET_STORE_BACKEND=file` to pin the file backend
+//! (escape hatch for hosts where the keyring's
 //! reachability probe lies — Linux CI runners with `libsecret`
 //! headers but no live `secret-service` daemon are the canonical
 //! case).
@@ -32,7 +35,7 @@
 //! is the strongest at-rest protection available on a non-attested
 //! host. But CI Linux runners typically have no D-Bus session;
 //! `FileSecretStore` is the dependable fallback that works
-//! everywhere.
+//! everywhere, but values are still encrypted before touching disk.
 //!
 //! ## What this module does NOT do
 //!
@@ -40,22 +43,22 @@
 //!   `KeystoreReleaser` (plan-37 §12.2). This module is the
 //!   operator-facing CRUD surface; the supervisor pulls from it at
 //!   admission.
-//! - **Encrypt-at-rest for `FileSecretStore`.** v0 stores raw bytes
-//!   at mode 0600. Encryption layers on once the keyring is the
-//!   primary backend or operators opt into a master-key wrapping
-//!   scheme (W5-adjacent). Documented in ADR-039.
 //! - **Multi-host replication.** Single-host only; mvmd's secret
 //!   service handles fleets.
 
 use std::fs;
 use std::io::Write;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use rand::RngCore;
 use secrecy::{ExposeSecret, SecretBox};
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
 
 use crate::keystore::validate_shell_id;
+use crate::snapshot_crypto;
 
 /// Service name for OS-native keyring entries. Distinct from
 /// `mvm_security::keystore::KEYRING_SERVICE` so per-tenant master
@@ -69,6 +72,11 @@ pub fn default_secrets_dir() -> Result<PathBuf> {
     let home = std::env::var_os("HOME").context("$HOME unset; cannot locate ~/.mvm/secrets/")?;
     Ok(PathBuf::from(home).join(".mvm").join("secrets"))
 }
+
+const FILE_SECRET_MAGIC: &[u8] = b"MVMS1\0";
+const FILE_STORE_KEY_FILENAME: &str = ".secret-store.key";
+const FILE_STORE_KEYRING_SERVICE: &str = "mvm-secret-store";
+const FILE_STORE_KEYRING_USER: &str = "file-backend-key";
 
 /// Multi-key tenant-scoped secret store. Separate from
 /// [`crate::keystore::KeyProvider`] (which is single-key, tenant-
@@ -102,11 +110,26 @@ pub trait SecretStore: Send + Sync {
 /// first write.
 pub struct FileSecretStore {
     base: PathBuf,
+    key_path: PathBuf,
+    keyring_user: String,
+    use_keyring_key: bool,
 }
 
 impl FileSecretStore {
     pub fn with_dir(base: impl Into<PathBuf>) -> Self {
-        Self { base: base.into() }
+        Self::with_dir_and_keyring(base, false)
+    }
+
+    fn with_dir_and_keyring(base: impl Into<PathBuf>, use_keyring_key: bool) -> Self {
+        let base = base.into();
+        let key_path = default_key_path_for_base(&base);
+        let keyring_user = keyring_user_for_base(&base);
+        Self {
+            base,
+            key_path,
+            keyring_user,
+            use_keyring_key,
+        }
     }
 
     fn tenant_dir(&self, tenant: &str) -> Result<PathBuf> {
@@ -129,6 +152,15 @@ impl FileSecretStore {
                 .with_context(|| format!("chmod 0700 {}", dir.display()))?;
         }
         Ok(dir)
+    }
+
+    fn load_or_init_key(&self) -> Result<SecretBox<Vec<u8>>> {
+        if self.use_keyring_key
+            && let Ok(key) = load_or_init_keyring_key(&self.keyring_user)
+        {
+            return Ok(key);
+        }
+        load_or_init_file_key(&self.key_path)
     }
 }
 
@@ -156,7 +188,11 @@ impl SecretStore for FileSecretStore {
                 .mode(0o600)
                 .open(&tmp)
                 .with_context(|| format!("creating {}", tmp.display()))?;
-            f.write_all(value.expose_secret().as_bytes())
+            let key = self.load_or_init_key()?;
+            let encoded =
+                encrypt_file_secret(value.expose_secret().as_bytes(), key.expose_secret())
+                    .context("encrypting secret for file store")?;
+            f.write_all(&encoded)
                 .with_context(|| format!("writing {}", tmp.display()))?;
             f.sync_all().ok();
         }
@@ -179,7 +215,10 @@ impl SecretStore for FileSecretStore {
         }
         let bytes =
             fs::read(&path).with_context(|| format!("reading secret {}", path.display()))?;
-        let s = String::from_utf8(bytes)
+        let key = self.load_or_init_key()?;
+        let plaintext = decrypt_file_secret(&bytes, key.expose_secret())
+            .with_context(|| format!("decrypting secret {}", path.display()))?;
+        let s = String::from_utf8(plaintext)
             .with_context(|| format!("secret {} is not valid UTF-8", path.display()))?;
         Ok(SecretBox::new(Box::new(s)))
     }
@@ -205,11 +244,147 @@ impl SecretStore for FileSecretStore {
             if name.ends_with(".tmp") {
                 continue;
             }
+            if name == FILE_STORE_KEY_FILENAME {
+                continue;
+            }
             names.push(name);
         }
         names.sort();
         Ok(names)
     }
+}
+
+fn default_key_path_for_base(base: &Path) -> PathBuf {
+    if base.file_name().is_some_and(|name| name == "secrets")
+        && let Some(parent) = base.parent()
+    {
+        return parent.join(FILE_STORE_KEY_FILENAME);
+    }
+    base.join(FILE_STORE_KEY_FILENAME)
+}
+
+fn keyring_user_for_base(base: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(base.as_os_str().as_encoded_bytes());
+    format!(
+        "{}:{}",
+        FILE_STORE_KEYRING_USER,
+        hex_encode(&hasher.finalize())
+    )
+}
+
+fn load_or_init_keyring_key(user: &str) -> Result<SecretBox<Vec<u8>>> {
+    let entry = keyring::Entry::new(FILE_STORE_KEYRING_SERVICE, user)
+        .context("opening file secret-store keyring entry")?;
+    match entry.get_password() {
+        Ok(hex) => {
+            let key = hex_decode(&hex).context("decoding file secret-store key")?;
+            validate_file_store_key_len(&key)?;
+            Ok(SecretBox::new(Box::new(key)))
+        }
+        Err(keyring::Error::NoEntry) => {
+            let mut key = Zeroizing::new(vec![0u8; snapshot_crypto::KEY_SIZE]);
+            rand::thread_rng().fill_bytes(&mut key);
+            let encoded = hex_encode(&key);
+            entry
+                .set_password(&encoded)
+                .context("writing file secret-store keyring entry")?;
+            Ok(SecretBox::new(Box::new(key.to_vec())))
+        }
+        Err(err) => Err(err).context("reading file secret-store keyring entry"),
+    }
+}
+
+fn load_or_init_file_key(path: &Path) -> Result<SecretBox<Vec<u8>>> {
+    match fs::metadata(path) {
+        Ok(meta) => {
+            let mode = meta.permissions().mode() & 0o777;
+            if mode != 0o600 {
+                anyhow::bail!(
+                    "secret-store key {} has mode 0{mode:o}; require 0600",
+                    path.display()
+                );
+            }
+            let key = fs::read(path)
+                .with_context(|| format!("reading secret-store key {}", path.display()))?;
+            validate_file_store_key_len(&key)?;
+            Ok(SecretBox::new(Box::new(key)))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("creating {}", parent.display()))?;
+                fs::set_permissions(parent, fs::Permissions::from_mode(0o700))
+                    .with_context(|| format!("chmod 0700 {}", parent.display()))?;
+            }
+            let mut key = Zeroizing::new(vec![0u8; snapshot_crypto::KEY_SIZE]);
+            rand::thread_rng().fill_bytes(&mut key);
+            {
+                let mut f = fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .mode(0o600)
+                    .open(path)
+                    .with_context(|| format!("creating secret-store key {}", path.display()))?;
+                f.write_all(&key)
+                    .with_context(|| format!("writing secret-store key {}", path.display()))?;
+                f.sync_all().ok();
+            }
+            Ok(SecretBox::new(Box::new(key.to_vec())))
+        }
+        Err(e) => Err(e).with_context(|| format!("stat secret-store key {}", path.display())),
+    }
+}
+
+fn validate_file_store_key_len(key: &[u8]) -> Result<()> {
+    if key.len() != snapshot_crypto::KEY_SIZE {
+        anyhow::bail!(
+            "secret-store key must be {} bytes, got {}",
+            snapshot_crypto::KEY_SIZE,
+            key.len()
+        );
+    }
+    Ok(())
+}
+
+fn encrypt_file_secret(plaintext: &[u8], key: &[u8]) -> Result<Vec<u8>> {
+    let ciphertext = snapshot_crypto::encrypt(plaintext, key)?;
+    let mut out = Vec::with_capacity(FILE_SECRET_MAGIC.len() + ciphertext.len());
+    out.extend_from_slice(FILE_SECRET_MAGIC);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}
+
+fn decrypt_file_secret(encoded: &[u8], key: &[u8]) -> Result<Vec<u8>> {
+    let ciphertext = encoded.strip_prefix(FILE_SECRET_MAGIC).ok_or_else(|| {
+        anyhow::anyhow!(
+            "legacy plaintext or unknown secret-store record; replace it with `mvmctl secret put`"
+        )
+    })?;
+    snapshot_crypto::decrypt(ciphertext, key)
+}
+
+fn hex_decode(hex: &str) -> Result<Vec<u8>> {
+    if !hex.len().is_multiple_of(2) {
+        anyhow::bail!("hex string has odd length: {}", hex.len());
+    }
+    let mut bytes = Vec::with_capacity(hex.len() / 2);
+    for chunk in hex.as_bytes().chunks(2) {
+        let s = std::str::from_utf8(chunk)?;
+        let byte = u8::from_str_radix(s, 16).with_context(|| format!("invalid hex byte: {s}"))?;
+        bytes.push(byte);
+    }
+    Ok(bytes)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
 }
 
 /// OS-native keystore backend. Each secret entry lives at
@@ -358,7 +533,11 @@ pub const BACKEND_ENV: &str = "MVM_SECRET_STORE_BACKEND";
 /// pin the file backend up-front.
 pub fn default_secret_store() -> Box<dyn SecretStore> {
     match std::env::var(BACKEND_ENV).ok().as_deref() {
-        Some(v) if v.eq_ignore_ascii_case("file") => return Box::new(FileSecretStore::default()),
+        Some(v) if v.eq_ignore_ascii_case("file") => {
+            let base =
+                default_secrets_dir().unwrap_or_else(|_| PathBuf::from(".mvm").join("secrets"));
+            return Box::new(FileSecretStore::with_dir(base));
+        }
         Some(v) if v.eq_ignore_ascii_case("keyring") => {
             return Box::new(KeyringSecretStore::default());
         }
@@ -398,6 +577,93 @@ mod tests {
             .unwrap();
         let got = store.get("acme", "api_token").unwrap();
         assert_eq!(got.expose_secret(), "supersecret-xyz");
+    }
+
+    #[test]
+    fn file_put_stores_ciphertext_not_plaintext() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSecretStore::with_dir(tmp.path());
+        store
+            .put("acme", "api_token", &mk_value("supersecret-xyz"))
+            .unwrap();
+        let path = tmp.path().join("acme").join("api_token");
+        let raw = fs::read(path).unwrap();
+        assert!(raw.starts_with(FILE_SECRET_MAGIC));
+        assert!(
+            !String::from_utf8_lossy(&raw).contains("supersecret-xyz"),
+            "plaintext leaked into file-backed secret record"
+        );
+    }
+
+    #[test]
+    fn file_get_rejects_tampered_ciphertext() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSecretStore::with_dir(tmp.path());
+        store.put("acme", "k", &mk_value("v")).unwrap();
+        let path = tmp.path().join("acme").join("k");
+        let mut raw = fs::read(&path).unwrap();
+        let last = raw.last_mut().expect("encrypted record is non-empty");
+        *last ^= 0xff;
+        fs::write(&path, raw).unwrap();
+        let err = store.get("acme", "k").unwrap_err();
+        assert!(err.to_string().contains("decrypting secret"), "got: {err}");
+    }
+
+    #[test]
+    fn file_get_rejects_legacy_plaintext_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSecretStore::with_dir(tmp.path());
+        let dir = tmp.path().join("acme");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("k");
+        fs::write(&path, b"plaintext").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let err = store.get("acme", "k").unwrap_err();
+        let err = format!("{err:#}");
+        assert!(
+            err.contains("legacy plaintext") || err.contains("unknown secret-store record"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn file_store_key_is_created_at_0600() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSecretStore::with_dir(tmp.path());
+        store.put("acme", "k", &mk_value("v")).unwrap();
+        let mode = fs::metadata(tmp.path().join(FILE_STORE_KEY_FILENAME))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn file_store_key_with_loose_permissions_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let key_path = tmp.path().join(FILE_STORE_KEY_FILENAME);
+        fs::write(&key_path, [0u8; snapshot_crypto::KEY_SIZE]).unwrap();
+        fs::set_permissions(&key_path, fs::Permissions::from_mode(0o644)).unwrap();
+        let store = FileSecretStore::with_dir(tmp.path());
+        let err = store.put("acme", "k", &mk_value("v")).unwrap_err();
+        assert!(err.to_string().contains("require 0600"), "got: {err}");
+    }
+
+    #[test]
+    fn file_store_key_hex_round_trips() {
+        let bytes = [0x00, 0x7f, 0x80, 0xff];
+        let encoded = hex_encode(&bytes);
+        assert_eq!(encoded, "007f80ff");
+        assert_eq!(hex_decode(&encoded).unwrap(), bytes);
+    }
+
+    #[test]
+    fn file_store_keyring_user_is_scoped_to_base_path() {
+        let first = keyring_user_for_base(Path::new("/tmp/mvm-a/secrets"));
+        let second = keyring_user_for_base(Path::new("/tmp/mvm-b/secrets"));
+        assert_ne!(first, second);
+        assert!(first.starts_with(FILE_STORE_KEYRING_USER));
     }
 
     #[test]

--- a/crates/mvm-security/src/secret_store.rs
+++ b/crates/mvm-security/src/secret_store.rs
@@ -64,6 +64,7 @@ use crate::snapshot_crypto;
 /// `mvm_security::keystore::KEYRING_SERVICE` so per-tenant master
 /// keys (W3) and per-name tenant secrets (W4) don't collide.
 pub const KEYRING_SERVICE: &str = "mvm-secrets";
+const KEYRING_TARGET: &str = "mvm-tenant-secrets";
 
 /// Default base dir for [`FileSecretStore`]:
 /// `~/.mvm/secrets/`. Per-tenant subdir mode 0700, per-secret file
@@ -76,6 +77,7 @@ pub fn default_secrets_dir() -> Result<PathBuf> {
 const FILE_SECRET_MAGIC: &[u8] = b"MVMS1\0";
 const FILE_STORE_KEY_FILENAME: &str = ".secret-store.key";
 const FILE_STORE_KEYRING_SERVICE: &str = "mvm-secret-store";
+const FILE_STORE_KEYRING_TARGET: &str = "mvm-file-secret-store";
 const FILE_STORE_KEYRING_USER: &str = "file-backend-key";
 
 /// Multi-key tenant-scoped secret store. Separate from
@@ -274,8 +276,7 @@ fn keyring_user_for_base(base: &Path) -> String {
 }
 
 fn load_or_init_keyring_key(user: &str) -> Result<SecretBox<Vec<u8>>> {
-    let entry = keyring::Entry::new(FILE_STORE_KEYRING_SERVICE, user)
-        .context("opening file secret-store keyring entry")?;
+    let entry = file_store_keyring_entry(user)?;
     match entry.get_password() {
         Ok(hex) => {
             let key = hex_decode(&hex).context("decoding file secret-store key")?;
@@ -289,9 +290,28 @@ fn load_or_init_keyring_key(user: &str) -> Result<SecretBox<Vec<u8>>> {
             entry
                 .set_password(&encoded)
                 .context("writing file secret-store keyring entry")?;
+            let stored = entry
+                .get_password()
+                .context("verifying file secret-store keyring entry")?;
+            if stored != encoded {
+                anyhow::bail!("file secret-store keyring entry failed read-after-write check");
+            }
             Ok(SecretBox::new(Box::new(key.to_vec())))
         }
         Err(err) => Err(err).context("reading file secret-store keyring entry"),
+    }
+}
+
+fn file_store_keyring_entry(user: &str) -> Result<keyring::Entry> {
+    #[cfg(target_os = "macos")]
+    {
+        keyring::Entry::new_with_target(FILE_STORE_KEYRING_TARGET, FILE_STORE_KEYRING_SERVICE, user)
+            .context("opening macOS file secret-store keyring entry")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        keyring::Entry::new(FILE_STORE_KEYRING_SERVICE, user)
+            .context("opening file secret-store keyring entry")
     }
 }
 
@@ -412,8 +432,16 @@ impl KeyringSecretStore {
             .with_context(|| format!("Invalid tenant for secret entry: {tenant:?}"))?;
         validate_shell_id(name).with_context(|| format!("Invalid secret name: {name:?}"))?;
         let user = format!("{tenant}:{name}");
-        keyring::Entry::new(KEYRING_SERVICE, &user)
-            .with_context(|| format!("opening keyring entry {KEYRING_SERVICE}:{user}"))
+        #[cfg(target_os = "macos")]
+        {
+            keyring::Entry::new_with_target(KEYRING_TARGET, KEYRING_SERVICE, &user)
+                .with_context(|| format!("opening macOS keyring entry {KEYRING_SERVICE}:{user}"))
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            keyring::Entry::new(KEYRING_SERVICE, &user)
+                .with_context(|| format!("opening keyring entry {KEYRING_SERVICE}:{user}"))
+        }
     }
 
     fn index_path(&self, tenant: &str) -> Result<PathBuf> {
@@ -475,6 +503,12 @@ impl SecretStore for KeyringSecretStore {
         entry
             .set_password(value.expose_secret())
             .with_context(|| format!("writing keyring entry for {tenant}:{name}"))?;
+        let stored = entry
+            .get_password()
+            .with_context(|| format!("verifying keyring entry for {tenant}:{name}"))?;
+        if stored != value.expose_secret().as_str() {
+            anyhow::bail!("keyring entry for {tenant}:{name} failed read-after-write check");
+        }
         // Update the index. Read-modify-write; if the entry write
         // succeeded but this fails the secret IS stored but won't
         // show up in `ls` until the next put — operators see this
@@ -512,6 +546,64 @@ impl SecretStore for KeyringSecretStore {
     }
 }
 
+/// Auto backend that prefers the OS keyring but keeps file-backed
+/// secrets visible. This avoids a split-brain operator experience
+/// when the keyring reachability probe changes across invocations
+/// or an older secret already exists in the file backend.
+#[derive(Default)]
+struct AutoSecretStore {
+    keyring: KeyringSecretStore,
+    file: FileSecretStore,
+}
+
+impl SecretStore for AutoSecretStore {
+    fn put(&self, tenant: &str, name: &str, value: &SecretBox<String>) -> Result<()> {
+        match self.keyring.put(tenant, name, value) {
+            Ok(()) if self.keyring.get(tenant, name).is_ok() => Ok(()),
+            Ok(()) | Err(_) => self.file.put(tenant, name, value),
+        }
+    }
+
+    fn get(&self, tenant: &str, name: &str) -> Result<SecretBox<String>> {
+        match self.keyring.get(tenant, name) {
+            Ok(value) => Ok(value),
+            Err(keyring_err) if is_missing_secret_error(&keyring_err) => {
+                self.file.get(tenant, name)
+            }
+            Err(keyring_err) => self.file.get(tenant, name).or(Err(keyring_err)),
+        }
+    }
+
+    fn delete(&self, tenant: &str, name: &str) -> Result<()> {
+        let keyring_result = self.keyring.delete(tenant, name);
+        let file_result = self.file.delete(tenant, name);
+        match (keyring_result, file_result) {
+            (Ok(()), _) | (_, Ok(())) => Ok(()),
+            (Err(keyring_err), Err(file_err)) if is_missing_secret_error(&keyring_err) => {
+                Err(file_err)
+            }
+            (Err(keyring_err), Err(_)) => Err(keyring_err),
+        }
+    }
+
+    fn list(&self, tenant: &str) -> Result<Vec<String>> {
+        let mut names = self.keyring.list(tenant).unwrap_or_default();
+        names.extend(self.file.list(tenant).unwrap_or_default());
+        names.sort();
+        names.dedup();
+        Ok(names)
+    }
+}
+
+fn is_missing_secret_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<keyring::Error>()
+            .is_some_and(|e| matches!(e, keyring::Error::NoEntry))
+            || cause.to_string().contains("no secret")
+    })
+}
+
 /// Env-var override for [`default_secret_store`]. Accepted values
 /// (case-insensitive): `file`, `keyring`, `auto`. Anything else is
 /// treated as `auto` with a `tracing::warn`. Documented in the
@@ -523,9 +615,11 @@ pub const BACKEND_ENV: &str = "MVM_SECRET_STORE_BACKEND";
 /// Auto-pick the best available SecretStore for the current host,
 /// honoring the [`BACKEND_ENV`] override.
 ///
-/// Order (when env is `auto` or unset): KeyringSecretStore if the
-/// OS keystore backend is reachable, else FileSecretStore. Mirrors
-/// [`crate::keystore::default_provider`].
+/// Order (when env is `auto` or unset): an aggregate store that
+/// prefers KeyringSecretStore but keeps FileSecretStore entries
+/// visible if the OS keystore backend is reachable, else
+/// FileSecretStore. Mirrors [`crate::keystore::default_provider`]
+/// while avoiding backend split-brain across CLI invocations.
 ///
 /// On a host whose keyring's `Entry::new` succeeds but `set_password`
 /// later fails (Linux runner with `libsecret` headers but no
@@ -551,7 +645,7 @@ pub fn default_secret_store() -> Box<dyn SecretStore> {
         _ => {}
     }
     if crate::keystore::KeyringProvider::backend_reachable() {
-        return Box::new(KeyringSecretStore::default());
+        return Box::new(AutoSecretStore::default());
     }
     Box::new(FileSecretStore::default())
 }
@@ -664,6 +758,30 @@ mod tests {
         let second = keyring_user_for_base(Path::new("/tmp/mvm-b/secrets"));
         assert_ne!(first, second);
         assert!(first.starts_with(FILE_STORE_KEYRING_USER));
+    }
+
+    #[test]
+    fn auto_store_reads_file_backed_secret_when_keyring_misses() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file_dir = tmp.path().join("file");
+        let store = AutoSecretStore {
+            keyring: KeyringSecretStore::with_dir(tmp.path().join("index")),
+            file: FileSecretStore::with_dir(&file_dir),
+        };
+        store.file.put("acme", "k", &mk_value("v")).unwrap();
+        let got = store.get("acme", "k").unwrap();
+        assert_eq!(got.expose_secret(), "v");
+    }
+
+    #[test]
+    fn auto_store_lists_file_backed_secret_when_keyring_index_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AutoSecretStore {
+            keyring: KeyringSecretStore::with_dir(tmp.path().join("index")),
+            file: FileSecretStore::with_dir(tmp.path().join("file")),
+        };
+        store.file.put("acme", "k", &mk_value("v")).unwrap();
+        assert_eq!(store.list("acme").unwrap(), vec!["k"]);
     }
 
     #[test]

--- a/crates/mvm-security/src/secret_store.rs
+++ b/crates/mvm-security/src/secret_store.rs
@@ -64,6 +64,7 @@ use crate::snapshot_crypto;
 /// `mvm_security::keystore::KEYRING_SERVICE` so per-tenant master
 /// keys (W3) and per-name tenant secrets (W4) don't collide.
 pub const KEYRING_SERVICE: &str = "mvm-secrets";
+#[cfg(target_os = "macos")]
 const KEYRING_TARGET: &str = "mvm-tenant-secrets";
 
 /// Default base dir for [`FileSecretStore`]:
@@ -77,6 +78,7 @@ pub fn default_secrets_dir() -> Result<PathBuf> {
 const FILE_SECRET_MAGIC: &[u8] = b"MVMS1\0";
 const FILE_STORE_KEY_FILENAME: &str = ".secret-store.key";
 const FILE_STORE_KEYRING_SERVICE: &str = "mvm-secret-store";
+#[cfg(target_os = "macos")]
 const FILE_STORE_KEYRING_TARGET: &str = "mvm-file-secret-store";
 const FILE_STORE_KEYRING_USER: &str = "file-backend-key";
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -175,7 +175,10 @@ The intentionally kept top-level command families are:
 
 Secret values are write-only through the CLI after storage: `get` is a presence
 check and never emits the raw value. Replace a secret by running `secret put`
-again with the same name.
+again with the same name. Local secret storage is encrypted at rest: the OS
+keyring backend stores values in the platform keystore, and the file fallback
+stores AES-256-GCM encrypted records with mode-0600 files. Legacy plaintext
+file records are refused; replace them with `secret put`.
 
 ## Policy Contracts
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -177,8 +177,10 @@ Secret values are write-only through the CLI after storage: `get` is a presence
 check and never emits the raw value. Replace a secret by running `secret put`
 again with the same name. Local secret storage is encrypted at rest: the OS
 keyring backend stores values in the platform keystore, and the file fallback
-stores AES-256-GCM encrypted records with mode-0600 files. Legacy plaintext
-file records are refused; replace them with `secret put`.
+stores AES-256-GCM encrypted records with mode-0600 files and a mode-0600 local
+store key. Auto backend mode keeps file-backed secrets visible when the OS
+keyring is reachable, so a backend probe change cannot hide an existing secret.
+Legacy plaintext file records are refused; replace them with `secret put`.
 
 ## Policy Contracts
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -82,6 +82,7 @@ Recent maintenance:
 - [x] GitHub #95 bridge slice: `mvm-addon-vsock-bridge` now loads loopback bindings with explicit `tcp_port`, starts one TCP listener per loopback IP/port, dials the host addon proxy over vsock, writes the peer header before application bytes, and proxies bidirectionally with binding validation and regression coverage.
 - [x] Hardened `mvmctl secret`: `put` now prompts with hidden interactive input when no value source is supplied and still accepts stdin/file/inline sources, while `get` is now a presence check only and can never print the raw secret value. CLI docs and ADR-042 were updated to reflect the write-only-after-set contract.
 - [x] GitHub #109 bootstrap unblock: source-checkout builder-VM cache misses now prefer local Stage 0 dev images but can fall back to the signed/hash-verified published dev image as a seed only, while still refusing to download published builder-VM images so local `nix/images/builder-vm/` changes are built from source.
+- [x] Encrypted the file-backed local secret store at rest: `FileSecretStore` now writes only `MVMS1` AES-256-GCM records, refuses legacy plaintext records, keeps its local store key mode 0600, keeps file-backed entries visible in auto backend mode, and tests no-plaintext-on-disk plus tamper rejection.
 
 ## In-flight workstreams
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -82,7 +82,7 @@ Recent maintenance:
 - [x] GitHub #95 bridge slice: `mvm-addon-vsock-bridge` now loads loopback bindings with explicit `tcp_port`, starts one TCP listener per loopback IP/port, dials the host addon proxy over vsock, writes the peer header before application bytes, and proxies bidirectionally with binding validation and regression coverage.
 - [x] Hardened `mvmctl secret`: `put` now prompts with hidden interactive input when no value source is supplied and still accepts stdin/file/inline sources, while `get` is now a presence check only and can never print the raw secret value. CLI docs and ADR-042 were updated to reflect the write-only-after-set contract.
 - [x] GitHub #109 bootstrap unblock: source-checkout builder-VM cache misses now prefer local Stage 0 dev images but can fall back to the signed/hash-verified published dev image as a seed only, while still refusing to download published builder-VM images so local `nix/images/builder-vm/` changes are built from source.
-- [x] Encrypted the file-backed local secret store at rest: `FileSecretStore` now writes only `MVMS1` AES-256-GCM records, refuses legacy plaintext records, keeps its local store key mode 0600, keeps file-backed entries visible in auto backend mode, and tests no-plaintext-on-disk plus tamper rejection.
+- [x] Encrypted the file-backed local secret store at rest: `FileSecretStore` now writes only `MVMS1` AES-256-GCM records, refuses legacy plaintext records, keeps its store key in the OS keyring when reachable or a mode-0600 local fallback, keeps file-backed entries visible in auto backend mode, and tests no-plaintext-on-disk plus tamper rejection.
 
 ## In-flight workstreams
 

--- a/specs/adrs/042-encryption-substrate.md
+++ b/specs/adrs/042-encryption-substrate.md
@@ -102,7 +102,7 @@ Chunked wire format (24-byte header + N chunks of nonce(12) + ciphertext_with_ta
 
 ### Operator-facing surface
 
-- `mvmctl secret put <name> --tenant <T> [--value V | --value - | --value-file PATH]` — stores or replaces a value. With no explicit source, prompts with hidden terminal input when stdin is a TTY, or reads piped stdin otherwise. Inline / stdin / file remain supported. Never logs the value.
+- `mvmctl secret put <name> --tenant <T> [--value V | --value - | --value-file PATH]` — stores or replaces a value. With no explicit source, prompts with hidden terminal input when stdin is a TTY, or reads piped stdin otherwise. Inline / stdin / file remain supported. Never logs the value. File-backed records are AES-256-GCM encrypted at rest.
 - `mvmctl secret get <name> --tenant <T>` — verifies that the secret exists and prints only presence metadata. It never emits the raw value; secrets can be replaced with `put` but not viewed after storage.
 - `mvmctl secret ls --tenant <T>` — names only.
 - `mvmctl secret rm <name> --tenant <T>`.
@@ -134,7 +134,7 @@ mvm-side `make_backend` returns `VolumeError::UnsupportedBackend` for `ObjectSto
 
 - **Tenant DEK can rotate without re-encrypting data.** `rewrap_dek` unwraps under the prior master, re-wraps under the new master, preserves the underlying DEK plaintext. Idempotent on retry after a crash.
 - **Snapshots are encrypted at rest** when a tenant DEK is configured, transparently — no new CLI surface required. Pre-W5 unencrypted snapshots keep working until the operator opts into the migration via `MVM_ALLOW_UNENCRYPTED_SNAPSHOT=1`.
-- **Tenant secrets have a real home.** `mvmctl secret put/get/ls/rm` works on every supported host; OS keyring when reachable, files mode 0600 otherwise. Values never appear in logs.
+- **Tenant secrets have a real home.** `mvmctl secret put/get/ls/rm` works on every supported host; OS keyring when reachable, AES-256-GCM encrypted files mode 0600 otherwise. Values never appear in logs.
 - **Compile-time guard against accidental secret logging.** `SecretBox<T>` makes `Debug`/`Display` a compile error; the xtask lint catches the few types whose name contains `Key|Secret|Password|Token` even when the wrap isn't explicit.
 - **Convergence rule keeps the surface small.** mvm provides primitives; mvmd composes them. The "where does AES-KWP live?" / "where is HKDF wired?" ambiguity that haunted Phase 1 is closed.
 
@@ -145,7 +145,7 @@ mvm-side `make_backend` returns `VolumeError::UnsupportedBackend` for `ObjectSto
 - **No cross-host secret replication.** Single-host posture only. mvmd's secret service handles fleet-wide distribution.
 - **`mvmctl key rotate` CLI is a future polish.** The W1 primitives (`rotate_master_key`, `migrate_wrapped_keys`) are callable but operator-driven rotation hasn't been wired through a user-facing verb yet.
 - **Migration escape exists.** Pre-W5 unencrypted snapshots can be resumed under a key-configured tenant via `MVM_ALLOW_UNENCRYPTED_SNAPSHOT=1`. This is a one-time bypass — the next pause encrypts. Documented for the v0.14 → v0.15 cut.
-- **The `FileSecretStore` plaintext is not encrypted at rest.** Mode 0600 + 0700 parent dir is the only protection. A `~/.mvm/secrets/` directory backed by an HKDF-derived KEK is straightforward future work; v0 prioritizes cross-platform simplicity.
+- **File-store key custody is local-host only.** The file backend encrypts values at rest, using an OS-keyring-held store key when available and a mode-0600 local store key fallback for headless hosts. This is single-host protection, not cross-host replication or hardware-backed attestation.
 
 ### Out of scope (named in plan 63's non-goals)
 

--- a/specs/adrs/042-encryption-substrate.md
+++ b/specs/adrs/042-encryption-substrate.md
@@ -134,7 +134,7 @@ mvm-side `make_backend` returns `VolumeError::UnsupportedBackend` for `ObjectSto
 
 - **Tenant DEK can rotate without re-encrypting data.** `rewrap_dek` unwraps under the prior master, re-wraps under the new master, preserves the underlying DEK plaintext. Idempotent on retry after a crash.
 - **Snapshots are encrypted at rest** when a tenant DEK is configured, transparently — no new CLI surface required. Pre-W5 unencrypted snapshots keep working until the operator opts into the migration via `MVM_ALLOW_UNENCRYPTED_SNAPSHOT=1`.
-- **Tenant secrets have a real home.** `mvmctl secret put/get/ls/rm` works on every supported host; OS keyring when reachable, AES-256-GCM encrypted files mode 0600 otherwise. Values never appear in logs.
+- **Tenant secrets have a real home.** `mvmctl secret put/get/ls/rm` works on every supported host; OS keyring when reachable, AES-256-GCM encrypted files with a mode-0600 local store key otherwise. Auto mode keeps file-backed entries visible when the OS keyring is reachable, so backend probe changes do not hide existing secrets. Values never appear in logs.
 - **Compile-time guard against accidental secret logging.** `SecretBox<T>` makes `Debug`/`Display` a compile error; the xtask lint catches the few types whose name contains `Key|Secret|Password|Token` even when the wrap isn't explicit.
 - **Convergence rule keeps the surface small.** mvm provides primitives; mvmd composes them. The "where does AES-KWP live?" / "where is HKDF wired?" ambiguity that haunted Phase 1 is closed.
 
@@ -145,7 +145,7 @@ mvm-side `make_backend` returns `VolumeError::UnsupportedBackend` for `ObjectSto
 - **No cross-host secret replication.** Single-host posture only. mvmd's secret service handles fleet-wide distribution.
 - **`mvmctl key rotate` CLI is a future polish.** The W1 primitives (`rotate_master_key`, `migrate_wrapped_keys`) are callable but operator-driven rotation hasn't been wired through a user-facing verb yet.
 - **Migration escape exists.** Pre-W5 unencrypted snapshots can be resumed under a key-configured tenant via `MVM_ALLOW_UNENCRYPTED_SNAPSHOT=1`. This is a one-time bypass — the next pause encrypts. Documented for the v0.14 → v0.15 cut.
-- **File-store key custody is local-host only.** The file backend encrypts values at rest, using an OS-keyring-held store key when available and a mode-0600 local store key fallback for headless hosts. This is single-host protection, not cross-host replication or hardware-backed attestation.
+- **File-store key custody is local-host only.** The file backend encrypts values at rest with a mode-0600 local store key. This is single-host protection, not cross-host replication or hardware-backed attestation.
 
 ### Out of scope (named in plan 63's non-goals)
 


### PR DESCRIPTION
## Summary
- encrypt FileSecretStore records with AES-256-GCM and an MVMS1 record prefix
- refuse legacy plaintext or tampered file-backed secret records
- keep the file-store key in the OS keyring when available, scoped by secrets directory, with a mode-0600 file-key fallback
- document the encrypted local secret storage behavior

## Verification
- cargo test -p mvm-security secret_store
- cargo test -p mvm-cli secret
- cargo test --workspace
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo run -p xtask -- check-no-display-on-secret-types
- stdin smoke: secret put/get confirms presence and no plaintext in MVMS1 on-disk record