### PR TITLE
Audit secret storage posture

### DIFF
--- a/crates/mvm-cli/src/commands/ops/secret.rs
+++ b/crates/mvm-cli/src/commands/ops/secret.rs
@@ -10,15 +10,17 @@
 //!
 //! Every put/get/delete/list emits one JSON line to
 //! `~/.mvm/audit/secrets.jsonl` carrying
-//! `(timestamp, action, namespace, name, outcome, pid, error?)`.
-//! Values are never logged. The audit file is NOT chain-signed in
-//! v0 — that's plan 64's territory (plan-64 audit chain covers
-//! workload-admission events; secret events get their own stream).
+//! `(timestamp, action, namespace, name, outcome, pid,
+//! secret_visibility, storage_security, error?)`. Values are never
+//! logged. When the chain recorder is available, the same posture
+//! labels are emitted on the chain-signed `secret.*` event.
 //!
 //! ## Backend choice
 //!
 //! Goes through [`secret_store::default_secret_store`]:
-//! - `KeyringSecretStore` when the OS keystore is reachable.
+//! - Auto store when the OS keystore is reachable: writes prefer
+//!   `KeyringSecretStore`, while reads/lists/deletes keep
+//!   file-backed secrets visible.
 //! - `FileSecretStore` everywhere else (CI Linux, headless hosts).
 //!
 //! Tests inject `FileSecretStore::with_dir` via [`run_with_store`].
@@ -224,6 +226,8 @@ fn read_secret_from_stdin() -> Result<String> {
 // ============================================================================
 
 const AUDIT_FILENAME: &str = "secrets.jsonl";
+const SECRET_VISIBILITY_AUDIT_VALUE: &str = "write_only";
+const STORAGE_SECURITY_AUDIT_VALUE: &str = "encrypted_at_rest";
 
 /// Resolve `~/.mvm/audit/secrets.jsonl`. Falls back to a no-op log
 /// when `$HOME` is unset (CI sandboxes, daemons without a home dir)
@@ -326,6 +330,8 @@ impl AuditLog {
                 "name": name,
                 "outcome": outcome_str,
                 "pid": std::process::id(),
+                "secret_visibility": SECRET_VISIBILITY_AUDIT_VALUE,
+                "storage_security": STORAGE_SECURITY_AUDIT_VALUE,
                 "error": error,
             });
             let mut line = serde_json::to_vec(&entry).context("serialize audit entry")?;
@@ -380,6 +386,14 @@ fn emit_through_recorder(
         ("name".to_string(), name.to_string()),
         ("outcome".to_string(), outcome.to_string()),
         ("pid".to_string(), std::process::id().to_string()),
+        (
+            "secret_visibility".to_string(),
+            SECRET_VISIBILITY_AUDIT_VALUE.to_string(),
+        ),
+        (
+            "storage_security".to_string(),
+            STORAGE_SECURITY_AUDIT_VALUE.to_string(),
+        ),
     ];
     if let Some(err) = error {
         extras.push(("error".to_string(), err.to_string()));
@@ -433,6 +447,8 @@ mod tests {
         assert!(log.contains("\"tenant\":\"acme\""));
         assert!(log.contains("\"name\":\"api_token\""));
         assert!(log.contains("\"outcome\":\"ok\""));
+        assert!(log.contains("\"secret_visibility\":\"write_only\""));
+        assert!(log.contains("\"storage_security\":\"encrypted_at_rest\""));
     }
 
     #[test]
@@ -449,6 +465,8 @@ mod tests {
         assert!(!log.contains("\"plaintext\""));
         assert!(log.contains("\"outcome\":\"err\""));
         assert!(log.contains("\"error\":\"boom\""));
+        assert!(log.contains("\"secret_visibility\":\"write_only\""));
+        assert!(log.contains("\"storage_security\":\"encrypted_at_rest\""));
     }
 
     #[test]
@@ -628,6 +646,8 @@ mod tests {
         let log = read_audit(&audit);
         assert!(log.contains("\"action\":\"put\""), "got: {log}");
         assert!(log.contains("\"tenant\":\"acme\""));
+        assert!(log.contains("\"secret_visibility\":\"write_only\""));
+        assert!(log.contains("\"storage_security\":\"encrypted_at_rest\""));
 
         // Recorder (plan-60 Phase 4 stream) — entry carries the
         // canonical `secret.put` event name and per-action tenant
@@ -642,6 +662,14 @@ mod tests {
             Some(&"api_token".to_string())
         );
         assert_eq!(entries[0].labels.get("outcome"), Some(&"ok".to_string()));
+        assert_eq!(
+            entries[0].labels.get("secret_visibility"),
+            Some(&"write_only".to_string())
+        );
+        assert_eq!(
+            entries[0].labels.get("storage_security"),
+            Some(&"encrypted_at_rest".to_string())
+        );
         // category label is injected by the Recorder substrate.
         assert_eq!(
             entries[0].labels.get("category"),
@@ -663,6 +691,14 @@ mod tests {
         assert_eq!(entries[0].event, "secret.get");
         assert_eq!(entries[0].labels.get("outcome"), Some(&"err".to_string()));
         assert_eq!(entries[0].labels.get("error"), Some(&"boom".to_string()));
+        assert_eq!(
+            entries[0].labels.get("secret_visibility"),
+            Some(&"write_only".to_string())
+        );
+        assert_eq!(
+            entries[0].labels.get("storage_security"),
+            Some(&"encrypted_at_rest".to_string())
+        );
     }
 
     #[test]

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -181,6 +181,9 @@ stores AES-256-GCM encrypted records with mode-0600 files and a mode-0600 local
 store key. Auto backend mode keeps file-backed secrets visible when the OS
 keyring is reachable, so a backend probe change cannot hide an existing secret.
 Legacy plaintext file records are refused; replace them with `secret put`.
+Secret audit entries in `~/.mvm/audit/secrets.jsonl` record the operation
+metadata plus `secret_visibility: "write_only"` and
+`storage_security: "encrypted_at_rest"`; secret values are never logged.
 
 ## Policy Contracts
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -83,7 +83,8 @@ Recent maintenance:
 - [x] GitHub #95 bridge slice: `mvm-addon-vsock-bridge` now loads loopback bindings with explicit `tcp_port`, starts one TCP listener per loopback IP/port, dials the host addon proxy over vsock, writes the peer header before application bytes, and proxies bidirectionally with binding validation and regression coverage.
 - [x] Hardened `mvmctl secret`: `put` now prompts with hidden interactive input when no value source is supplied and still accepts stdin/file/inline sources, while `get` is now a presence check only and can never print the raw secret value. CLI docs and ADR-042 were updated to reflect the write-only-after-set contract.
 - [x] GitHub #109 bootstrap unblock: source-checkout builder-VM cache misses now prefer local Stage 0 dev images but can fall back to the signed/hash-verified published dev image as a seed only, while still refusing to download published builder-VM images so local `nix/images/builder-vm/` changes are built from source.
-- [x] Encrypted the file-backed local secret store at rest: `FileSecretStore` now writes only `MVMS1` AES-256-GCM records, refuses legacy plaintext records, keeps its store key in the OS keyring when reachable or a mode-0600 local fallback, keeps file-backed entries visible in auto backend mode, and tests no-plaintext-on-disk plus tamper rejection.
+- [x] Encrypted the file-backed local secret store at rest: `FileSecretStore` now writes only `MVMS1` AES-256-GCM records, refuses legacy plaintext records, keeps its local store key mode 0600, keeps file-backed entries visible in auto backend mode, and tests no-plaintext-on-disk plus tamper rejection.
+- [x] Stamped the secret audit contract into both audit sinks: JSONL and chain-signed `secret.*` events now carry `secret_visibility=write_only` and `storage_security=encrypted_at_rest` without exposing secret values.
 
 ## In-flight workstreams
 

--- a/tests/audit_emissions_live.rs
+++ b/tests/audit_emissions_live.rs
@@ -1884,6 +1884,14 @@ fn secret_put_emits_put_action_in_secret_audit_log() {
         log.contains("\"outcome\":\"ok\""),
         "audit entry must record outcome=ok on success. Full log:\n{log}"
     );
+    assert!(
+        log.contains("\"secret_visibility\":\"write_only\""),
+        "audit entry must record write-only secret posture. Full log:\n{log}"
+    );
+    assert!(
+        log.contains("\"storage_security\":\"encrypted_at_rest\""),
+        "audit entry must record encrypted-at-rest storage posture. Full log:\n{log}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add write-only and encrypted-at-rest posture fields to secret audit JSONL entries
- add the same posture labels to chain-signed secret.* recorder events
- pin the fields in unit and live audit tests
- document the audit metadata in the CLI reference and sprint notes

## Verification
- cargo fmt --all -- --check
- cargo test -p mvm-cli secret
- cargo test -p mvmctl --test audit_emissions_live secret_
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace