### PR TITLE
plan(87) + adr(055): libkrun networking via passt + virtio-net

### DIFF
--- a/specs/adrs/055-passt-virtio-net.md
+++ b/specs/adrs/055-passt-virtio-net.md
@@ -1,0 +1,140 @@
+# ADR-055 — libkrun networking via passt + virtio-net
+
+**Status:** proposed 2026-05-18, implements Plan 87.
+
+## Context
+
+Since Plan 72 W5 (libkrun cutover) the libkrun-backed VMs mvm boots
+have relied on libkrun's TSI (Transparent Socket Impersonation)
+networking mode. TSI hijacks the guest's `AF_INET` socket calls at
+the syscall layer and forwards them to a host-side proxy, so the
+guest kernel doesn't need a network stack and there's no virtio-net
+device or DHCP dance. ADR-046 §"Two artifact layers" treats this as
+an internal libkrun detail.
+
+Plan 86's end-to-end smoke proved TSI doesn't actually support the
+HTTP behavior nix relies on:
+
+| Behavior                            | TSI result                                  |
+| ----------------------------------- | ------------------------------------------- |
+| Single HTTP GET (e.g. flake tarball)| works                                       |
+| nix's internet-availability probe   | fails → `warning: you don't have Internet…` |
+| HTTPS with 302 redirect             | `HTTP error 302 (curl SSL connect error)`   |
+| HTTP/2 multiplexed connection       | `Server returned nothing (curl 52)`         |
+| Substituter chatter to cache.nixos.org | never even attempted                     |
+
+The result is that `nix build` falls back to source builds for 2800+
+derivations, most of which then fail to fetch their tarballs. Stage 0
+cannot complete. The same TSI mode is used by the steady-state
+builder VM (downstream of Stage 0) and the runtime microVMs, so the
+failure pattern is universal across every libkrun-backed VM.
+
+This is not an mvm bug. TSI is an experimental libkrun mode designed
+for "this guest only ever opens one socket and reads a response";
+modern HTTP — connection reuse, HTTP/2 multiplexing, HTTPS handshake
+sequencing, redirect chains — is outside its design envelope. Plan 86
+W3 v3 implemented `extract_bundled_kernel()` to source the kernel
+patches from libkrunfw's own bundled kernel (the patches are
+validated against libkrunfw's specific kernel revision), which fixes
+a kernel-oops class but not the TSI proxy behavior.
+
+## Decision
+
+Migrate every libkrun-backed VM from TSI to **passt + virtio-net**.
+
+Passt is a userspace network gateway (Red Hat project, single-binary,
+no kernel patches or `CAP_NET_ADMIN` required) that translates
+between virtio-net frames in the guest and `AF_INET` sockets on the
+host. libkrun has first-class passt support via `krun_set_passt_fd()`
+(libkrun 1.17+).
+
+The guest sees a normal `eth0`, gets a DHCP lease from passt's
+built-in DHCP server, resolves DNS through its own resolver, and
+reaches the host's network the same way any normal Linux VM would.
+HTTP/HTTPS patterns that work on the host work in the guest.
+
+Implementation lives in Plan 87:
+
+- New `mvm-libkrun::sys::set_passt_fd()` FFI wrapper.
+- New `mvm-libkrun::passt::PasstSupervisor` host-side child that
+  socketpair's with libkrun, spawns passt, owns its lifecycle.
+- `KrunContext::networking: NetworkingMode { Tsi, Passt {..} }`.
+- libkrun-backed VMs (builder-VM + dev-VM + runtime microVMs)
+  default to `Passt`; `Tsi` stays available behind an env var for
+  debugging.
+- `mvmctl doctor` probes for `passt` and emits an install hint when
+  missing.
+
+## Alternatives considered
+
+- **Stay on TSI, work around the edge cases.** Rejected: the
+  workarounds (force-substituters, retry-on-redirect, alternative
+  HTTP clients) would have to live in every workstream that touches
+  the guest's network. Replacing the substrate once eliminates the
+  workaround surface area.
+- **Use Apple Virtualization.framework's vmnet directly.** Rejected:
+  vmnet is closed-source, macOS-only, and tied to the host's network
+  stack. mvm runs the same code on Linux KVM via Firecracker where
+  vmnet doesn't exist. Passt is cross-platform and decoupled from
+  the hypervisor.
+- **Implement a TSI-aware HTTP shim in the guest.** Rejected:
+  building a working subset of HTTP/2 + redirect chains + HTTPS
+  handshake on top of TSI's existing semantics is a multi-quarter
+  effort with no upside vs. just using a real network stack.
+- **Pin libkrunfw to a version where TSI is more complete.** Rejected
+  as a non-fix — TSI's design constraints don't disappear with
+  libkrunfw bumps. The libkrun upstream itself has been moving
+  toward passt as the recommended default.
+- **Switch to gvproxy** (the rootless-podman gateway). Considered.
+  gvproxy and passt occupy the same niche; passt is simpler, faster,
+  and the libkrun integration is documented. Bumping or migrating to
+  gvproxy later is a one-line change in the supervisor.
+
+## Consequences
+
+- **All libkrun VMs gain a virtio-net interface.** mvm-builder-init
+  already handles `udhcpc` (currently a no-op because there's no
+  interface); the change is transparent to the in-guest init.
+- **New host-side dependency: `passt`.** `brew install passt` on
+  macOS, distro package on Linux. Doctor probe + install hint added.
+- **TSI patches in the kernel become dead code from mvm's
+  perspective.** libkrunfw's bundled kernel still carries them, which
+  is fine — we just don't enable that path from the host side. The
+  in-repo TSI patch port under `nix/images/builder-vm/kernel/`
+  becomes legacy; Plan 87 W6 moves or removes it.
+- **`mvm-egress-proxy` (Plan 73 Followup B.2.y / ADR-047)** remains
+  load-bearing for production microVMs running untrusted workloads.
+  This ADR is about the network substrate, not the policy layer; the
+  egress allowlist runs on top of passt-virtio-net the same way it
+  ran on top of TSI.
+- **The contributor onboarding sequence gains one step** (install
+  passt). Documented in the Plan 87 W5 doctor probe + CLAUDE.md
+  update.
+
+## Security model
+
+The host-side passt process runs as the contributor's user (not
+root). It cannot bind privileged ports or modify the host's
+firewall — its entire job is to relay packets between an `AF_UNIX`
+socket and the host's TCP/UDP stack via standard userspace sockets.
+The host kernel is the final policy layer for outbound traffic.
+
+In production microVM contexts (running untrusted workloads), the
+guest's egress allowlist is enforced by `mvm-egress-proxy` inside
+the VM (Plan 73 Followup B.2.x). passt is the transport; the policy
+is independent.
+
+CLAUDE.md security claim 1 ("no host-fs access from a guest beyond
+explicit shares") is unaffected: passt doesn't see the guest's
+filesystem, only its virtio-net frames. Claim 9 (deps-volume
+hash-lock + audit) is unaffected for the same reason.
+
+## References
+
+- Plan 87 — `specs/plans/87-passt-virtio-net.md`
+- Plan 86 — `specs/plans/86-ur-seed-stage0-bootstrap.md`
+  (end-to-end smoke that exposed TSI's edge cases)
+- Plan 72 W5.D — the prior round of libkrun debugging notes
+- libkrun upstream: https://github.com/containers/libkrun
+- passt upstream: https://passt.top/
+- libkrun's `krun_set_passt_fd` API documented in `libkrun.h`

--- a/specs/plans/87-passt-virtio-net.md
+++ b/specs/plans/87-passt-virtio-net.md
@@ -1,0 +1,255 @@
+# Plan 87 — Replace libkrun TSI with passt-backed virtio-net
+
+**Status:** drafted 2026-05-18, awaiting review.
+**Pairs with:** ADR-055 (`specs/adrs/055-passt-virtio-net.md`, lands with this plan).
+
+## Problem
+
+libkrun's TSI (Transparent Socket Impersonation) mode is the default
+"no network stack in the guest" path the project has relied on since
+Plan 72 W5 (the libkrun cutover). TSI hijacks the guest's AF_INET
+socket calls at the syscall layer and forwards them to a host-side
+proxy, so the guest kernel doesn't need a network stack and there's
+no virtio-net device or DHCP dance.
+
+Plan 86 verified TSI works for the simple HTTP fetch (the initial
+nixpkgs flake tarball downloads cleanly from github.com), but breaks
+on the patterns nix actually relies on for substituter and source
+fetches:
+
+- nix's internet-availability pre-check fails → `warning: you don't
+  have Internet access; disabling some network-dependent features`
+- `cache.nixos.org` is never even queried by nix in the guest
+- HTTPS-with-redirect destinations bail with `HTTP error 302 (curl
+  SSL connect error)`
+- Tarball mirrors with HTTP/2 hit `Server returned nothing (no
+  headers, no data) (52) Empty reply from server`
+
+The result: every in-VM `nix build` falls back to source builds for
+2800+ derivations, and most of those source builds fail to fetch
+their tarballs. Stage 0 cannot finish.
+
+This isn't an mvm bug in the conventional sense — it's TSI's edge
+cases. TSI is an experimental libkrun mode; it works well enough for
+"open one socket, read one response" but does not transparently
+proxy modern HTTP behavior (HTTP/2 multiplexing, HTTPS handshake
+sequencing, connection reuse, redirect chains). The same TSI mode is
+why the steady-state builder VM (downstream of Stage 0) fails the
+same way — this is not a Stage-0-specific issue.
+
+## Goal
+
+Migrate every libkrun-backed VM mvm boots — Stage 0 ur-seed, the
+steady-state builder VM, and the runtime microVMs — from TSI to
+`passt`-backed virtio-net. Passt is a userspace network gateway
+(Red Hat project, single binary, no kernel/setuid required) that
+translates between virtio-net frames in the guest and AF_INET sockets
+on the host. libkrun has first-class passt support via
+`krun_set_passt_fd()`.
+
+After this plan: the guest sees a normal `eth0`, gets a DHCP lease
+from passt's built-in DHCP server, resolves DNS through its own
+resolver, and reaches the host's network the same way any normal
+Linux VM would. Every HTTP/HTTPS pattern that works on the host
+works in the guest.
+
+## Design
+
+### Components
+
+```
++------------------------------------------------------------+
+| Host (macOS or Linux)                                      |
+|                                                            |
+|   +---------+  AF_UNIX (fd handoff)  +---------+           |
+|   | libkrun |------------------------| passt   |           |
+|   | ctx     |                        | child   |           |
+|   +----+----+                        +----+----+           |
+|        | vmnet/Hypervisor.framework       | AF_INET socks  |
+|        v                                  v                |
+|   +-----------------------------------+                    |
+|   | Linux guest (libkrunfw kernel)    |                    |
+|   |   virtio-net -> eth0              |                    |
+|   |   udhcpc -> 192.168.0.2/24        |                    |
+|   |   gateway 192.168.0.1 (passt)     |                    |
+|   |   DNS via passt's resolver        |                    |
+|   +-----------------------------------+                    |
++------------------------------------------------------------+
+```
+
+`PasstSupervisor` (new) owns the passt child process lifetime,
+exposes the fd-pair, and tears down on Drop.
+
+### Workstreams
+
+**W1 — `mvm-libkrun` FFI surface (~½ day).**
+
+- Add `krun_set_passt_fd` to the bindgen allowlist (already in
+  libkrun.h on hosts with libkrun-1.17+).
+- New `sys::set_passt_fd(ctx, fd) -> Result<(), Error>`.
+- New `KrunContext::networking: NetworkingMode` enum:
+  ```
+  enum NetworkingMode {
+      Tsi,                    // legacy, libkrun's default when no NIC
+      Passt { socket_fd: i32 } // virtio-net via passt
+  }
+  ```
+- `configure()` dispatches: TSI → no extra FFI; Passt → call
+  `set_passt_fd` before `start_enter`.
+- Unit tests: `KrunContext::with_passt_socket(fd)` accessor; round-trip
+  through `KrunContext`'s serde to preserve the fd handle.
+
+**W2 — `PasstSupervisor` host-side child (~1 day).**
+
+- New crate-internal module `mvm-libkrun::passt`.
+- `PasstSupervisor::spawn(scratch_dir) -> Result<PasstHandle>`:
+  - `socketpair(AF_UNIX, SOCK_STREAM, 0)`
+  - spawn `passt` with args `["--fd=N", "--no-pid",
+    "--no-resolv-conf", "--no-tcp-init", "--mtu=65520"]` — flags
+    pinned per ADR-055 discussion of which TCP/UDP profile we want
+  - Parent keeps one socket end → returned as `socket_fd`
+  - Child inherits the other end via the `--fd=N` arg
+- `Drop` impl: SIGTERM the child, wait with timeout, SIGKILL on
+  timeout. Same pattern as `mvm-libkrun-supervisor`'s own shutdown
+  path.
+- `PasstHandle::socket_fd() -> RawFd` — fed to `KrunContext::Passt`.
+- Host-side install probe: `which passt` + version pin → friendly
+  error on missing dep with `brew install passt` / distro hint.
+- Unit tests: spawn + immediate-shutdown roundtrip; spawn + simulate
+  hang + Drop-kill timeout.
+
+**W3 — Builder VM and runtime defaults (~½ day).**
+
+- `mvm-build::libkrun_builder::LibkrunBuilderVm` defaults to
+  `NetworkingMode::Passt`. TSI remains available as an opt-in
+  (`with_networking(NetworkingMode::Tsi)`) for debugging.
+- `mvm-backend::libkrun::LibkrunBackend` (runtime path) ditto.
+- Builder VM flake's `cmd.sh` drops the `substituters = …` /
+  `trusted-public-keys = …` lines — defaults pull from nix's
+  built-in config once network actually works.
+- Stage 0 ur-seed path threads through unchanged — the change is
+  transparent to mvm-builder-init.
+
+**W4 — In-VM `udhcpc` + resolv.conf wiring (~½ day).**
+
+- `mvm-builder-init::network::setup_network()` already calls
+  `udhcpc` and treats the failure as non-fatal. With virtio-net
+  present, the call succeeds and produces `/etc/resolv.conf` from
+  the DHCP option.
+- Verify: `udhcpc -i eth0 -s /etc/udhcpc/default.script` writes
+  the right resolv.conf. Add an explicit script under
+  `nix/lib/udhcpc-default.script` so the busybox-default doesn't
+  surprise us (it tries to call `/etc/resolv.conf.head` etc.).
+- ur-seed flake's `cmd.sh` drops its manual cacert symlink —
+  resolv.conf comes from DHCP, ca-bundle.crt remains for HTTPS.
+- Smoke target: `mvmctl dev up` from clean cache reaches
+  `Built builder VM image at ...`.
+
+**W5 — Host install + bootstrap (~½ day).**
+
+- macOS: `passt` is in homebrew (`brew install passt`). Add to the
+  `mvmctl doctor` host-dep probe alongside libkrun + libkrunfw.
+- Linux: standard distro packages (`apt install passt`,
+  `dnf install passt`).
+- New `mvm-libkrun::passt::install_hint()` mirroring the existing
+  libkrun install-hint pattern.
+- `mvmctl doctor` reports `passt: <version>` / `passt: not found
+  (run brew install passt)` so contributors hit the missing-dep
+  error before `dev up` fails.
+
+**W6 — TSI removal + ADR (~½ day).**
+
+- ADR-055 lands describing the TSI→passt migration: why TSI fails,
+  why passt is the production-ready substitute, why TSI stays
+  available as an opt-in.
+- Memory note `reference_libkrun_gotchas.md` updated to record the
+  passt path as the canonical one and TSI's edge-case failures.
+- Remove the in-repo TSI kernel patches under
+  `nix/images/builder-vm/kernel/patches/` — they're no longer used
+  (libkrunfw's bundled kernel still has TSI, which is fine, we just
+  don't enable it from the host side anymore). Or keep them under a
+  `legacy/` subdir with a README pointing at ADR-055 for context.
+- Update SPRINT.md.
+
+### Migration path
+
+The existing `mvmctl dev up` invariants stay intact:
+
+- `ensure_dev_image` / `bootstrap_builder_vm_image` paths unchanged.
+- Stage 0 ur-seed cache layout unchanged.
+- The only user-visible change: an extra `passt` install on first
+  host setup. Documented in CLAUDE.md + the install runbook.
+
+### Why not virtio-net via vmnet directly
+
+Apple Virtualization.framework's vmnet API is closed-source and tied
+to the macOS host's network stack. Using vmnet directly means
+shelling out the network plumbing into Apple's hands — fine for the
+Apple Container backend (Plan 72 W5.C / Plan 75) but mvm runs the
+same code on Linux KVM via Firecracker, where vmnet doesn't exist.
+Passt is a single binary, cross-platform, and decoupled from any
+hypervisor — the same code path works on macOS libkrun, Linux
+libkrun, and (with the obvious wiring) Linux Firecracker.
+
+### Why now
+
+TSI works for the trivial case (one socket, one response). The
+moment mvm tries to do anything realistic — nix builds, mvm-oci
+image pulls, dev-shell `curl`, deps-install fetches — TSI's edge
+cases surface. Every workstream downstream of `dev up` either
+inherits TSI's flakiness or adds workarounds. Replacing the
+network substrate once removes the workarounds from every
+downstream feature.
+
+## Non-goals
+
+- **No re-design of libkrun's host integration.** This plan uses
+  libkrun's existing `krun_set_passt_fd` API; the Rust wrapper +
+  PasstSupervisor are additive.
+- **No virtio-net for Apple Container or Firecracker backends.**
+  Apple Container has its own network model (the Apple
+  Virtualization.framework vmnet path) and Firecracker on Linux has
+  TAP + bridge — both already work. The TSI problem is specific to
+  libkrun.
+- **No DNS or HTTP/firewall policy changes in the guest.** The
+  Plan 73 deps-install egress proxy (mvm-egress-proxy) remains
+  load-bearing for production microVMs running untrusted
+  workloads. This plan is about the Stage 0 / builder-VM / dev-VM
+  trust boundary where the contributor is the only principal.
+- **No fork of passt.** Bumping the pinned version is a one-line
+  change in `nix/ur-seed/flake.nix` (or wherever the doctor probe
+  lives); upstream passt is well-maintained.
+
+## Success criteria
+
+1. `cargo run -- dev up` from a clean cache (no
+   `~/.cache/mvm/builder-vm/aarch64/` and a fresh
+   `~/.cache/mvm/ur-seed/aarch64/`) completes end-to-end and
+   produces a usable builder VM image, with the in-VM nix build
+   using `cache.nixos.org` substitutes (visible "copying path" log
+   lines).
+2. `cargo test --workspace` clean; `cargo clippy --workspace --
+   -D warnings` clean.
+3. `mvmctl doctor` reports `passt: <version>` when installed,
+   `passt: not found` with the install hint when missing.
+4. The steady-state builder VM (post-Stage-0) does in-VM Nix builds
+   that hit cache.nixos.org without the "no Internet" warning.
+5. Memory `reference_libkrun_gotchas.md` updated.
+
+## Order of operations
+
+W1 + W2 ship together (small, mechanical FFI + child-process
+plumbing). W3 + W4 are dependent on W1/W2 (need the FFI live).
+W5 + W6 are docs/install plumbing and land alongside or after.
+
+Suggested PR sequence:
+
+- PR1: W1 + W2 (passt FFI + supervisor, no consumers yet)
+- PR2: W3 + W4 (consumers, behind opt-in flag —
+  `MVM_NETWORKING=passt` env var)
+- PR3: flip default; ADR-055; W6 cleanup
+- PR4: W5 doctor probe + install docs
+
+This sequence keeps every PR independently revertible. PR3 (the
+default flip) is the one to gate on end-to-end smoke against the
+contributor's `cargo run -- dev up`.


### PR DESCRIPTION
## Summary

Plan 87 + ADR-055 propose replacing libkrun's TSI mode with passt-backed virtio-net for every libkrun-backed VM (Stage 0 ur-seed, steady-state builder VM, runtime microVMs).

**Why:** Plan 86 verified TSI works for the trivial HTTP case (single GET) but breaks on every modern HTTP pattern nix needs — HTTP/2 multiplexing, HTTPS redirect chains, connection reuse, and even nix's internet-availability probe fails through TSI. Result: in-VM `nix build` falls back to source builds for 2800+ derivations, most of which fail. Stage 0 cannot complete and the steady-state builder VM inherits the same failure.

**What:** Use `krun_set_passt_fd` (libkrun 1.17+ first-class API) plus a host-side `PasstSupervisor` that owns the passt child process lifecycle. The guest gets a normal `eth0`, DHCP lease, resolv.conf — every HTTP pattern that works on the host works in the guest.

**Workstreams:** W1 FFI surface, W2 PasstSupervisor, W3 default flip, W4 in-VM udhcpc/resolv.conf, W5 doctor probe + install docs, W6 TSI removal + SPRINT update. Suggested PR sequence keeps each independently revertible.

This is doc-only — no code changes. Implementation lives in follow-up PRs.

## Test plan

- [ ] Review the design rationale (does the W1-W6 split make sense?)
- [ ] Confirm `krun_set_passt_fd` is available in the homebrew libkrun-1.17.4 build (we already link libkrun on macOS)
- [ ] Decide on the `MVM_NETWORKING=` env var name / shape for the opt-in flip (PR2)
- [ ] Decide whether to remove the in-repo TSI kernel patches in W6 or move them to a `legacy/` subdir with a README

🤖 Generated with [Claude Code](https://claude.com/claude-code)