### PR TITLE
Keep Stage 0 builder temp state on Nix store disk

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -770,15 +770,14 @@ set -eu
 FLAKE_REF='{flake_ref}'
 ATTR_PATH='{attr_path}'
 
-# Point HOME and Nix's cache/state dirs at the writable tmpfs (`/tmp`).
-# The rootfs is mounted `ro`, so nix tries `~/.cache/nix` and bails
-# with "creating directory '//.cache/nix': Read-only file system"
-# when HOME stays at the default `/`. /tmp is tmpfs, lives only for
-# this VM's lifetime — fine for a single-shot build.
-export HOME=/tmp
-export XDG_CACHE_HOME=/tmp/.cache
-export XDG_STATE_HOME=/tmp/.local/state
-mkdir -p /tmp/.cache /tmp/.local/state
+# Point HOME and Nix's cache/state/temp dirs at the writable persistent
+# Nix disk, not `/tmp`. `/tmp` is a RAM-backed tmpfs and can fill during
+# flake evaluation; `/nix` is the persistent virtio-blk store image.
+export HOME=/nix/var/mvm-builder-home
+export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_STATE_HOME="$HOME/.local/state"
+export TMPDIR="$HOME/tmp"
+mkdir -p "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$TMPDIR"
 
 # CA certs for TLS to cache.nixos.org / api.github.com.
 export CURL_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
@@ -1757,6 +1756,9 @@ mod tests {
         assert!(cmd.starts_with("#!/bin/sh"));
         assert!(cmd.contains("set -eu"));
         assert!(cmd.contains("cd /work"));
+        assert!(cmd.contains("export HOME=/nix/var/mvm-builder-home"));
+        assert!(cmd.contains(r#"export XDG_CACHE_HOME="$HOME/.cache""#));
+        assert!(cmd.contains(r#"export TMPDIR="$HOME/tmp""#));
         assert!(cmd.contains("printf '%s\\n' \"$NIX_OUT\" > /job/store-path"));
     }
 


### PR DESCRIPTION
## Summary
- move Stage 0 builder HOME, XDG cache/state, and TMPDIR onto the persistent /nix disk
- keep tmp-heavy Nix evaluation work off the RAM-backed /tmp tmpfs
- cover the generated cmd.sh environment in the builder-vm unit test

## Tests
- cargo test -p mvm-build --features builder-vm --lib libkrun_builder::tests::stage_job_dir_writes_cmd_sh_with_escaped_inputs -- --exact
- cargo clippy -p mvm-build --features builder-vm --all-targets -- -D warnings