### PR TITLE
feat(libkrun): passt FFI + supervisor (Plan 87 W1 + W2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,9 @@ dependencies = [
  "mvm-providers",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
+ "which 7.0.3",
 ]
 
 [[package]]

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1425,7 +1425,11 @@ mod tests {
     fn defaults_match_plan_72_w1() {
         let vm = LibkrunBuilderVm::default();
         assert_eq!(vm.vcpus, 4);
-        assert_eq!(vm.memory_mib, 4096);
+        // Plan 72 W5.D bullet 9 bumped this from 4 GiB to 8 GiB
+        // (in-VM nix builds peak ~5-6 GiB and OOM-kill the link step
+        // at the lower default). Hardcoded here so a regression that
+        // accidentally reverts the bump fails fast.
+        assert_eq!(vm.memory_mib, 8192);
         assert_eq!(vm.nix_store_mib, 65536);
     }
 

--- a/crates/mvm-libkrun/Cargo.toml
+++ b/crates/mvm-libkrun/Cargo.toml
@@ -57,6 +57,11 @@ serde = { workspace = true }
 # dev-deps are excluded from cycle analysis.
 mvm-providers = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
+# Plan 87 W2 — `passt` module probes $PATH for the `passt` binary
+# before spawning it. `which` is already in the workspace dep tree
+# (mvm-cli/mvm-build); pulling it in here keeps the dep graph
+# uniform and avoids reinventing PATH search.
+which.workspace = true
 
 [build-dependencies]
 # `bindgen` is required only when the `libkrun-sys` feature is on; we
@@ -77,6 +82,8 @@ libkrun-sys = [
 ]
 
 [dev-dependencies]
+# Plan 87 W2 — passt supervisor tests stage scratch dirs.
+tempfile.workspace = true
 # The plan 57 W3 smoke example shares `GUEST_AGENT_PORT` with the
 # production vsock plumbing.
 mvm-guest.workspace = true

--- a/crates/mvm-libkrun/build.rs
+++ b/crates/mvm-libkrun/build.rs
@@ -51,8 +51,14 @@ fn main() {
         .clang_arg(format!("-I{}", include_dir.display()))
         // Keep the generated surface small — only the symbols we wrap in
         // sys.rs plus the KRUN_* constants we need at the type level.
+        // Plan 87: also surface NET_FEATURE_*` + `COMPAT_NET_FEATURES`
+        // for the passt virtio-net backend (`krun_add_net_unixstream`'s
+        // `features` arg expects a bitwise-or of those).
         .allowlist_function("krun_.*")
         .allowlist_var("KRUN_.*")
+        .allowlist_var("NET_FEATURE_.*")
+        .allowlist_var("COMPAT_NET_FEATURES")
+        .allowlist_var("NET_FLAG_.*")
         .layout_tests(false)
         .generate_comments(false)
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -28,6 +28,13 @@ mod sys;
 #[cfg(feature = "libkrun-sys")]
 pub use sys::{BundledKernel, KernelFormat, LogLevel, extract_bundled_kernel, set_log_level};
 
+// Plan 87 / ADR-055 — passt-backed virtio-net. The supervisor owns the
+// passt child process and exposes the socket fd `KrunContext::Passt`
+// consumes. Only Linux / macOS — Windows has neither libkrun nor
+// passt. Tests are gated on a host-side passt install probe.
+#[cfg(target_family = "unix")]
+pub mod passt;
+
 /// Errors returned by this crate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
@@ -245,6 +252,48 @@ pub struct KrunContext {
     /// always set a stable per-VM dir under `~/.mvm/vms/<name>/`
     /// so cross-process clients can find it.
     pub vsock_socket_dir: Option<String>,
+    /// Plan 87 — networking backend for the guest. `Tsi` (default)
+    /// uses libkrun's built-in syscall-hijack TSI mode; `Passt`
+    /// attaches a virtio-net device backed by a unixstream socket
+    /// the caller has handed off to a passt child process. See
+    /// `NetworkingMode` for the trade-offs.
+    #[serde(default)]
+    pub networking: NetworkingMode,
+}
+
+/// Libkrun networking backend. Plan 87 / ADR-055.
+///
+/// `Tsi` is libkrun's default — AF_INET syscall hijacking, no
+/// virtio-net device in the guest, no DHCP. Works for trivial HTTP
+/// (single GET) but breaks on HTTP/2 multiplexing, HTTPS redirect
+/// chains, and nix's substituter probes. Kept as an opt-out for
+/// debugging and for runtime microVMs that legitimately don't need
+/// a network stack.
+///
+/// `Passt` configures a real virtio-net device wired through a
+/// unixstream socket to a host-side passt child process. The guest
+/// sees a normal eth0 + DHCP + DNS. This is the production-ready
+/// networking mode for Stage 0 and steady-state builder VMs.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkingMode {
+    /// libkrun's built-in TSI backend (no virtio-net, no DHCP).
+    #[default]
+    Tsi,
+    /// virtio-net via passt. The host-side passt process is owned
+    /// by `mvm-libkrun::passt::PasstSupervisor`; this variant carries
+    /// the parent end of the socketpair libkrun consumes.
+    Passt {
+        /// File descriptor for the unixstream socket libkrun reads
+        /// virtio-net frames from. Caller (typically
+        /// `PasstSupervisor::spawn`) owns the inverse half handed
+        /// to passt. libkrun takes ownership at `start_enter`.
+        socket_fd: i32,
+        /// MAC address for the guest's eth0. 6 bytes; the first
+        /// octet must have bit 0x02 set (locally-administered) to
+        /// avoid colliding with real hardware allocations.
+        mac: [u8; 6],
+    },
 }
 
 impl KrunContext {
@@ -268,7 +317,15 @@ impl KrunContext {
             virtio_fs_mounts: Vec::new(),
             console_output_path: None,
             vsock_socket_dir: None,
+            networking: NetworkingMode::Tsi,
         }
+    }
+
+    /// Switch the guest to passt-backed virtio-net. The caller owns the
+    /// `PasstSupervisor` whose `socket_fd` is passed in here. Plan 87.
+    pub fn with_passt(mut self, socket_fd: i32, mac: [u8; 6]) -> Self {
+        self.networking = NetworkingMode::Passt { socket_fd, mac };
+        self
     }
 
     /// Resolve the host-side unix socket path libkrun should pair
@@ -445,6 +502,25 @@ fn configure(ctx: &KrunContext) -> Result<sys::Context, Error> {
     }
     if let Some(console_path) = &ctx.console_output_path {
         krun.set_console_output(Path::new(console_path))?;
+    }
+    // Plan 87 / ADR-055: networking backend dispatch. TSI is the
+    // default (auto-enabled when no virtio-net device is added);
+    // Passt adds a virtio-net device via krun_add_net_unixstream and
+    // implicitly disables TSI. The two are mutually exclusive at the
+    // libkrun layer.
+    match &ctx.networking {
+        NetworkingMode::Tsi => {
+            // Nothing to do — libkrun enables TSI implicitly when no
+            // virtio-net device is added.
+        }
+        NetworkingMode::Passt { socket_fd, mac } => {
+            krun.add_net_unixstream_fd(
+                *socket_fd,
+                mac,
+                sys::PASST_NET_FEATURES,
+                /* flags = */ 0,
+            )?;
+        }
     }
     Ok(krun)
 }

--- a/crates/mvm-libkrun/src/passt.rs
+++ b/crates/mvm-libkrun/src/passt.rs
@@ -1,0 +1,368 @@
+//! Passt-backed virtio-net supervisor (Plan 87 W2 / ADR-055).
+//!
+//! `passt` is a userspace network gateway that translates between
+//! virtio-net frames the libkrun guest writes to a unixstream socket
+//! and AF_INET sockets on the host. Together with libkrun's
+//! `krun_add_net_unixstream` (W1, exposed via
+//! [`crate::sys::Context::add_net_unixstream_fd`]) it replaces
+//! libkrun's TSI mode, which breaks on the HTTP patterns nix relies
+//! on for substituter / source fetches (Plan 86 §"Problem").
+//!
+//! Boot sequence:
+//!
+//! 1. Host calls [`spawn`]. It creates a
+//!    `socketpair(AF_UNIX, SOCK_STREAM, 0)`, spawns `passt` with
+//!    `--fd=N` pointing at one half, and keeps the other half on
+//!    [`PasstHandle::socket_fd`].
+//! 2. Host stuffs that fd into [`crate::KrunContext`] via
+//!    [`crate::KrunContext::with_passt`].
+//! 3. libkrun's `start_enter` consumes the fd. From that point on
+//!    the guest's `eth0` is bridged to passt's network namespace.
+//! 4. When the host drops the [`PasstHandle`], the supervisor
+//!    `SIGTERM`s passt, waits up to [`SHUTDOWN_GRACE`], then
+//!    `SIGKILL`s on timeout.
+//!
+//! Lifetime invariant: the [`PasstHandle`] must outlive
+//! `start_enter` — `Drop` runs in any error path, so callers don't
+//! need to manage cleanup explicitly.
+
+use std::ffi::OsString;
+use std::io;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::os::unix::io::FromRawFd;
+use std::path::PathBuf;
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+/// Grace period between SIGTERM and SIGKILL during shutdown. passt's
+/// own teardown is fast (it drops its socket + closes file
+/// descriptors); two seconds is generous without making a hung
+/// process block `mvmctl` shutdown for long.
+pub const SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
+
+/// Default MAC address assigned to the guest's `eth0`. The first
+/// octet has bit `0x02` set (locally-administered, unicast) per
+/// IEEE 802 so the address never collides with real hardware.
+/// Stable across boots so the guest's NetworkManager / udev does
+/// not reshuffle interface names.
+pub const DEFAULT_GUEST_MAC: [u8; 6] = [0xAE, 0xAD, 0xBE, 0xEF, 0x00, 0x01];
+
+/// Errors the supervisor can return. Mirrors the
+/// [`crate::Error`] shape so consumers can surface a single error
+/// type, but keeps passt-specific failures distinguishable.
+#[derive(Debug)]
+pub enum PasstError {
+    /// `passt` binary not found on `$PATH`. Includes the install
+    /// hint string for whichever platform the host is on.
+    NotInstalled { install_hint: &'static str },
+    /// `socketpair(2)` returned an error.
+    Socketpair(io::Error),
+    /// Spawning the passt child process failed.
+    Spawn(io::Error),
+    /// passt exited before we could verify it was listening on
+    /// its end of the socketpair.
+    EarlyExit { status: std::process::ExitStatus },
+    /// Filesystem I/O — usually the scratch dir for passt's PID
+    /// file / log output.
+    Io { context: String, source: io::Error },
+}
+
+impl std::fmt::Display for PasstError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PasstError::NotInstalled { install_hint } => {
+                write!(f, "`passt` binary not found on $PATH. {install_hint}")
+            }
+            PasstError::Socketpair(e) => write!(f, "socketpair failed: {e}"),
+            PasstError::Spawn(e) => write!(f, "spawning passt failed: {e}"),
+            PasstError::EarlyExit { status } => write!(
+                f,
+                "passt exited before initialisation completed (status: {status:?})"
+            ),
+            PasstError::Io { context, source } => write!(f, "{context}: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for PasstError {}
+
+/// Suggested install command for the current host platform.
+/// Surfaced both in `PasstError::NotInstalled` and by `mvmctl
+/// doctor` (Plan 87 W5).
+pub fn install_hint() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "Install with: brew install passt"
+    } else if cfg!(target_os = "linux") {
+        "Install with: apt install passt  (Debian/Ubuntu) / dnf install passt  (Fedora)"
+    } else {
+        "Install passt via your platform's package manager: https://passt.top/"
+    }
+}
+
+/// Probe `$PATH` for `passt`. Returns the absolute path on success.
+pub fn locate_passt() -> Option<PathBuf> {
+    // Prefer `which` from the workspace dep so the search semantics
+    // match other binary probes in the codebase (e.g.
+    // `mvm-cli::commands::env::doctor`).
+    which::which("passt").ok()
+}
+
+/// Owning handle to a running passt child process. `Drop` cleans up
+/// the child (SIGTERM, grace period, SIGKILL on timeout). Cloning
+/// is not supported — the fd hand-off to libkrun is one-shot.
+#[derive(Debug)]
+pub struct PasstHandle {
+    child: Option<Child>,
+    /// Parent end of the socketpair. Owned here until libkrun
+    /// consumes it via `start_enter`; on Drop without consumption
+    /// the socket is closed and the child exits naturally.
+    parent_socket: Option<OwnedFd>,
+}
+
+impl PasstHandle {
+    /// Raw fd for the unixstream socket libkrun will read virtio-net
+    /// frames from. The fd remains owned by the [`PasstHandle`]; do
+    /// not close it manually — pass it to
+    /// [`crate::KrunContext::with_passt`] and let libkrun consume
+    /// it at `start_enter`.
+    pub fn socket_fd(&self) -> RawFd {
+        self.parent_socket
+            .as_ref()
+            .expect("PasstHandle::socket_fd called after the handle was dropped")
+            .as_raw_fd()
+    }
+
+    /// Take ownership of the parent socket. Returns the OwnedFd so
+    /// the caller can decide what to do with it (close, hand to
+    /// libkrun, dup, …). After this call [`Self::socket_fd`] panics.
+    /// libkrun's `start_enter` semantics consume the fd implicitly,
+    /// so most callers never need this.
+    pub fn into_socket(mut self) -> OwnedFd {
+        self.parent_socket
+            .take()
+            .expect("PasstHandle::into_socket called twice")
+    }
+}
+
+/// Spawn a passt child process and return a handle to its
+/// socketpair fd. The child is wired to log to `scratch_dir/passt.log`
+/// (best effort — passt's `--log-file` is optional).
+///
+/// The returned [`PasstHandle`] must outlive any libkrun
+/// configuration consuming `socket_fd()`. On Drop the child is
+/// killed gracefully.
+pub fn spawn(scratch_dir: &std::path::Path) -> Result<PasstHandle, PasstError> {
+    let passt_bin = locate_passt().ok_or_else(|| PasstError::NotInstalled {
+        install_hint: install_hint(),
+    })?;
+
+    std::fs::create_dir_all(scratch_dir).map_err(|e| PasstError::Io {
+        context: format!("creating passt scratch dir {}", scratch_dir.display()),
+        source: e,
+    })?;
+
+    // SAFETY: socketpair writes two valid fds to `fds` on success
+    // and returns 0; on failure it returns -1 and writes nothing.
+    let (parent_fd, child_fd) = make_socketpair()?;
+
+    let log_path = scratch_dir.join("passt.log");
+
+    // passt args:
+    //   --fd <N>          — connect to libkrun via the socketpair
+    //   --foreground      — stay attached so Drop's SIGTERM reaches it
+    //   --no-pid          — we don't need a pidfile; Child owns the pid
+    //   --log-file <path> — diagnostic log; failures are non-fatal
+    //   --quiet           — drop the boot-time chatter (still logs to file)
+    //   --mtu 65520       — match libkrun's COMPAT_NET_FEATURES MTU
+    let mut cmd = Command::new(&passt_bin);
+    cmd.arg("--fd")
+        .arg(child_fd.as_raw_fd().to_string())
+        .arg("--foreground")
+        .arg("--no-pid")
+        .arg("--quiet")
+        .arg("--mtu")
+        .arg("65520")
+        .arg("--log-file")
+        .arg(OsString::from(&log_path));
+
+    // The child needs `child_fd` to NOT have FD_CLOEXEC, otherwise
+    // it disappears when the new image takes over. socketpair(2)
+    // creates fds without CLOEXEC by default, but Rust's `OwnedFd`
+    // sets CLOEXEC when wrapping. Clear it explicitly on the child
+    // end so passt can read its argv-supplied fd number after the
+    // process image is replaced. (The parent fd may keep CLOEXEC
+    // — libkrun will dup it across the start_enter boundary.)
+    clear_cloexec(child_fd.as_raw_fd()).map_err(|e| PasstError::Io {
+        context: format!(
+            "clearing CLOEXEC on passt child fd {}",
+            child_fd.as_raw_fd()
+        ),
+        source: e,
+    })?;
+
+    let child = cmd.spawn().map_err(PasstError::Spawn)?;
+
+    // Close the child end on the parent side — the child inherits
+    // its own copy across the spawn. Holding both ends would prevent
+    // EOF from propagating to libkrun if the child died.
+    drop(child_fd);
+
+    // Sanity check: passt should not exit before we're done
+    // handing the fd to libkrun. Sleep briefly and probe — if
+    // it died, surface that instead of letting libkrun fail with
+    // a cryptic socket error later. 50ms is enough to catch the
+    // immediate exits (missing arg, spawn failure) without
+    // measurably slowing dev up.
+    std::thread::sleep(Duration::from_millis(50));
+    let mut child = child;
+    if let Some(status) = child.try_wait().map_err(PasstError::Spawn)? {
+        return Err(PasstError::EarlyExit { status });
+    }
+
+    Ok(PasstHandle {
+        child: Some(child),
+        parent_socket: Some(parent_fd),
+    })
+}
+
+impl Drop for PasstHandle {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+
+        // Already-dead is fine.
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return;
+        }
+
+        // SIGTERM, wait up to SHUTDOWN_GRACE, then SIGKILL.
+        let pid = child.id() as i32;
+        // SAFETY: pid is valid until we wait. SIGTERM on a stale pid
+        // returns ESRCH which we treat as "already gone".
+        unsafe { libc::kill(pid, libc::SIGTERM) };
+
+        let deadline = Instant::now() + SHUTDOWN_GRACE;
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                _ => break,
+            }
+        }
+
+        // Still alive — SIGKILL + reap.
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+        let _ = child.wait();
+    }
+}
+
+fn make_socketpair() -> Result<(OwnedFd, OwnedFd), PasstError> {
+    let mut fds: [libc::c_int; 2] = [-1, -1];
+    // SAFETY: socketpair fills `fds` with two valid file descriptors
+    // on success (return 0). On failure (return -1) the fds are
+    // untouched and we return errno.
+    let rc = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+    if rc != 0 {
+        return Err(PasstError::Socketpair(io::Error::last_os_error()));
+    }
+    // SAFETY: the kernel returned two valid fds in fds[]; FromRawFd
+    // gives us ownership semantics for each.
+    let parent = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+    let child = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+    Ok((parent, child))
+}
+
+fn clear_cloexec(fd: RawFd) -> io::Result<()> {
+    // SAFETY: fcntl(F_GETFD)/F_SETFD on an owned fd is a standard
+    // operation; both return -1 on error.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let new = flags & !libc::FD_CLOEXEC;
+    if new == flags {
+        return Ok(());
+    }
+    let rc = unsafe { libc::fcntl(fd, libc::F_SETFD, new) };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_hint_is_platform_specific() {
+        let hint = install_hint();
+        assert!(!hint.is_empty());
+        if cfg!(target_os = "macos") {
+            assert!(hint.contains("brew install passt"), "hint: {hint}");
+        }
+    }
+
+    #[test]
+    fn locate_passt_is_optional() {
+        // Whether passt is installed is host-dependent; the function
+        // just shouldn't panic. Either Some or None is acceptable.
+        let _ = locate_passt();
+    }
+
+    #[test]
+    fn spawn_without_passt_returns_not_installed() {
+        // Hide passt from PATH for this test by setting PATH to
+        // an empty dir.
+        let tmp = tempfile::tempdir().unwrap();
+        let original_path = std::env::var_os("PATH");
+        // SAFETY: tests are single-threaded by default in Rust;
+        // set_var is fine here as long as we restore.
+        unsafe {
+            std::env::set_var("PATH", tmp.path());
+        }
+        let result = spawn(tmp.path());
+        unsafe {
+            match original_path {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+        match result {
+            Err(PasstError::NotInstalled { install_hint }) => {
+                assert!(!install_hint.is_empty());
+            }
+            other => panic!("expected NotInstalled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn make_socketpair_returns_two_fds() {
+        let (a, b) = make_socketpair().expect("socketpair");
+        assert_ne!(a.as_raw_fd(), b.as_raw_fd());
+        assert!(a.as_raw_fd() >= 0);
+        assert!(b.as_raw_fd() >= 0);
+    }
+
+    /// Spawn passt and immediately drop the handle. Verifies the
+    /// Drop impl kills the child cleanly (no zombies, no
+    /// timeout-to-SIGKILL escalation in the happy path). Skipped
+    /// when passt isn't installed.
+    #[test]
+    fn spawn_then_drop_reaps_child() {
+        let Some(_) = locate_passt() else {
+            eprintln!("test skipped: passt not on PATH");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let handle = spawn(tmp.path()).expect("spawn passt");
+        let fd = handle.socket_fd();
+        assert!(fd >= 0);
+        drop(handle);
+        // If Drop hung we'd have timed out; reaching here means the
+        // child was reaped before the test thread's local Drop ran.
+    }
+}

--- a/crates/mvm-libkrun/src/sys.rs
+++ b/crates/mvm-libkrun/src/sys.rs
@@ -28,6 +28,19 @@ mod bindings {
     include!(concat!(env!("OUT_DIR"), "/libkrun_sys.rs"));
 }
 
+/// Plan 87: the `features` mask `krun_add_net_unixstream` expects for
+/// passt as the userspace network proxy. Mirrors the
+/// `COMPAT_NET_FEATURES` macro in libkrun.h:344 — a compound `|` of
+/// the NET_FEATURE_* constants that bindgen can't always fold into a
+/// single value. Re-deriving in Rust keeps the canonical mask close
+/// to the call site that uses it.
+pub const PASST_NET_FEATURES: u32 = (1 << 0)   // NET_FEATURE_CSUM
+    | (1 << 1)   // NET_FEATURE_GUEST_CSUM
+    | (1 << 7)   // NET_FEATURE_GUEST_TSO4
+    | (1 << 10)  // NET_FEATURE_GUEST_UFO
+    | (1 << 11)  // NET_FEATURE_HOST_TSO4
+    | (1 << 14); // NET_FEATURE_HOST_UFO
+
 /// Kernel-format constants exposed to callers without leaking the
 /// bindgen-generated identifier names.
 #[derive(Debug, Clone, Copy)]
@@ -178,6 +191,51 @@ impl Context {
     pub fn set_console_output(&self, host_path: &Path) -> Result<(), Error> {
         let path = cstring(host_path)?;
         check(unsafe { bindings::krun_set_console_output(self.ctx_id, path.as_ptr()) })
+    }
+
+    /// Add a virtio-net device backed by a unixstream userspace network
+    /// proxy (Plan 87 W1 — passt + virtio-net replacing TSI).
+    ///
+    /// `fd` is one end of an `AF_UNIX SOCK_STREAM` socketpair; the other
+    /// end is handed to the network proxy (passt) at spawn. libkrun
+    /// owns its half of the socket from this point — it must remain
+    /// open until `start_enter` is called, after which libkrun consumes
+    /// it.
+    ///
+    /// Calling this disables libkrun's default TSI backend (per
+    /// `libkrun.h:358`: "If no network interface is added, libkrun
+    /// will automatically enable the TSI backend"). Subsequent
+    /// `krun_set_port_map` calls return -ENOTSUP — passt manages port
+    /// forwarding via its own DHCP + NAT path.
+    ///
+    /// `mac` is a 6-byte hardware address. Pass [0xAE, 0xAD, 0xBE,
+    /// 0xEF, 0x00, 0x01] (locally-administered, unicast) for the
+    /// default mvm builder VM.
+    ///
+    /// `features` is the virtio-net feature mask; for passt the
+    /// canonical value is `COMPAT_NET_FEATURES` (definition mirrored
+    /// from `libkrun.h:344`).
+    pub fn add_net_unixstream_fd(
+        &self,
+        fd: i32,
+        mac: &[u8; 6],
+        features: u32,
+        flags: u32,
+    ) -> Result<(), Error> {
+        // libkrun's `krun_add_net_unixstream` takes `c_path` and `fd`
+        // as mutually-exclusive args (one is null/-1, the other is
+        // populated). We always take the fd path — the socketpair
+        // lives entirely in the parent process, no path on disk.
+        check(unsafe {
+            bindings::krun_add_net_unixstream(
+                self.ctx_id,
+                std::ptr::null(),
+                fd,
+                mac.as_ptr() as *mut u8,
+                features,
+                flags,
+            )
+        })
     }
 
     /// Returns the shutdown eventfd. The caller is responsible for


### PR DESCRIPTION
## Summary

First implementation slice for Plan 87 / ADR-055 — replacing libkrun's TSI mode with passt-backed virtio-net.

**W1 — FFI surface:**
- `krun_add_net_unixstream` exposed via `sys::Context::add_net_unixstream_fd`
- `KrunContext.networking: NetworkingMode { Tsi (default), Passt { fd, mac } }`
- `configure()` dispatches; TSI stays the default so no consumer behavior changes yet

**W2 — Host-side `PasstSupervisor`:**
- `passt::spawn(scratch_dir)` creates a socketpair, spawns `passt --fd=N --foreground --no-pid --quiet --mtu 65520 --log-file <scratch>/passt.log`, returns a `PasstHandle`
- `PasstHandle::socket_fd()` exposes the parent fd for `KrunContext::with_passt`
- `Drop` runs SIGTERM → 2s grace → SIGKILL → reap
- `install_hint()` + `locate_passt()` ready for the W5 doctor probe
- `DEFAULT_GUEST_MAC` constant (locally-administered, stable)

No consumers yet — `LibkrunBuilderVm` defaults stay on TSI. The opt-in flag (PR2 in Plan 87) is the next slice.

## Test plan

- [x] `cargo test -p mvm-libkrun --features libkrun-sys` — all 16 tests pass
- [x] `cargo test -p mvm-libkrun` (no feature) — 16 tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo clippy -p mvm-libkrun --features libkrun-sys --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Live test `spawn_then_drop_reaps_child` passes on this host (passt installed via homebrew)
- [ ] Linux CI passes the no-feature build (the deferred libkrun-sys default-on is staying out of this PR — see PR #351's closure comment)

Also bumps a stale `defaults_match_plan_72_w1` assertion in mvm-build to the post-Plan-72-W5.D 8 GiB default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)