### PR TITLE
feat(libkrun): wire passt into Stage 0 + ur-seed DHCP hook (Plan 87 W3 + W4)

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -103,6 +103,42 @@ pub const GUEST_NIX_DIR: &str = "/nix";
 /// under this path (read-write virtio-fs). Plan 72 W4 wires this.
 pub const GUEST_JOB_DIR: &str = "/job";
 
+/// Plan 87 W3: caller-visible networking-backend preference. Read from
+/// the `MVM_NETWORKING` env var at every VM-launch site. Default
+/// stays Tsi for backward compat; PR3 in Plan 87 flips this once W4
+/// in-VM udhcpc wiring lands and CI installs the host-side deps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkingPreference {
+    /// libkrun's built-in TSI (no virtio-net, no DHCP). Default.
+    Tsi,
+    /// virtio-net via passt. Requires libkrun-sys + passt installed on
+    /// the host. The supervisor process spawns passt as a child.
+    Passt,
+}
+
+/// Read `MVM_NETWORKING` from the env. Accepts `tsi` and `passt`
+/// (case-insensitive); anything else falls back to `Tsi` and emits a
+/// debug log so a typo is visible without aborting.
+pub fn resolve_networking_mode() -> NetworkingPreference {
+    match std::env::var("MVM_NETWORKING")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("passt") => NetworkingPreference::Passt,
+        Some("tsi") | None | Some("") => NetworkingPreference::Tsi,
+        Some(other) => {
+            tracing::warn!(
+                value = other,
+                "MVM_NETWORKING unrecognised; falling back to TSI (accepted: tsi, passt)"
+            );
+            NetworkingPreference::Tsi
+        }
+    }
+}
+
 /// Libkrun-backed builder VM driver.
 ///
 /// Configuration only — `run_build` consumes it to spin a per-job
@@ -260,6 +296,20 @@ impl LibkrunBuilderVm {
                 disk.id.as_str(),
                 path_to_str(&disk.path, "extra_disk")?,
                 disk.read_only,
+            );
+        }
+
+        // Plan 87 W3: opt into passt-backed virtio-net when
+        // MVM_NETWORKING=passt. The supervisor spawns the passt child
+        // and logs to <vm_state_dir>/passt.log; libkrun's
+        // `krun_add_net_unixstream` consumes the fd. Without the env
+        // var (or with any other value) we stay on TSI for backward
+        // compat — Plan 87 PR3 flips the default once the W4 in-VM
+        // wiring lands and CI installs passt + libkrunfw.
+        if resolve_networking_mode() == NetworkingPreference::Passt {
+            krun = krun.with_passt(
+                mvm_libkrun::passt::DEFAULT_GUEST_MAC,
+                path_to_str(&vm_state_dir, "vm_state_dir")?,
             );
         }
 
@@ -492,7 +542,7 @@ impl BuilderVm for LibkrunBuilderVm {
         // hvc0 output silently and "supervisor running, then exits 1"
         // is the only observable signal.
         let console_log = vm_state_dir.join("console.log");
-        let krun = KrunContext::new(
+        let mut krun = KrunContext::new(
             &vm_name,
             path_to_str(&image.kernel_path, "kernel_path")?,
             path_to_str(&image.rootfs_path, "rootfs_path")?,
@@ -509,6 +559,18 @@ impl BuilderVm for LibkrunBuilderVm {
         .add_virtio_fs("work", path_to_str(&mounts.flake_src, "flake_src")?)
         .add_virtio_fs("out", path_to_str(&mounts.artifact_out, "artifact_out")?)
         .add_virtio_fs("job", path_to_str(&job_dir, "job_dir")?);
+
+        // Plan 87 W3: same env-var opt-in as the shell-job path. See
+        // `LibkrunBuilderVm::dispatch_shell_job` for the rationale —
+        // when `MVM_NETWORKING=passt` is set the supervisor spawns
+        // passt and libkrun consumes its socket fd. Default stays TSI
+        // until PR3 flips it.
+        if resolve_networking_mode() == NetworkingPreference::Passt {
+            krun = krun.with_passt(
+                mvm_libkrun::passt::DEFAULT_GUEST_MAC,
+                path_to_str(&vm_state_dir, "vm_state_dir")?,
+            );
+        }
 
         // 8. Drive the supervisor: pipe `SupervisorConfig` to
         //    stdin and **wait** for the child to exit. Unlike
@@ -1431,6 +1493,35 @@ mod tests {
         // accidentally reverts the bump fails fast.
         assert_eq!(vm.memory_mib, 8192);
         assert_eq!(vm.nix_store_mib, 65536);
+    }
+
+    #[test]
+    fn resolve_networking_mode_parses_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: tests guarded by ENV_LOCK; env mutation in test
+        // process is fine when serialized.
+        unsafe {
+            std::env::remove_var("MVM_NETWORKING");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+
+            std::env::set_var("MVM_NETWORKING", "passt");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
+
+            std::env::set_var("MVM_NETWORKING", "PASST");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Passt);
+
+            std::env::set_var("MVM_NETWORKING", " tsi ");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+
+            std::env::set_var("MVM_NETWORKING", "");
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+
+            std::env::set_var("MVM_NETWORKING", "gvproxy");
+            // Unknown value → fall back to TSI without panic.
+            assert_eq!(resolve_networking_mode(), NetworkingPreference::Tsi);
+
+            std::env::remove_var("MVM_NETWORKING");
+        }
     }
 
     #[test]

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -672,8 +672,37 @@ mod linux {
     }
 
     fn setup_network() -> Result<(), String> {
-        let status = Command::new("/sbin/udhcpc")
-            .args(["-i", "eth0", "-n", "-q"])
+        // Plan 87 W4: seed /run/resolv.conf from the fallback before
+        // udhcpc runs. /etc/resolv.conf is a symlink into /run, so
+        // libc resolvers have a usable nameserver list from boot 1
+        // even if DHCP fails (TSI mode, or passt mid-handoff).
+        // Failure here is non-fatal — the symlink might not exist
+        // on a guest built before Plan 87, in which case udhcpc's
+        // own write to /etc/resolv.conf (if -s is set) is the
+        // only path.
+        let fallback = std::path::Path::new("/etc/resolv.conf.fallback");
+        if fallback.is_file() {
+            if let Err(e) = std::fs::copy(fallback, "/run/resolv.conf") {
+                eprintln!(
+                    "mvm-builder-init: copy /etc/resolv.conf.fallback -> \
+                     /run/resolv.conf: {e} (continuing — udhcpc may fix it)"
+                );
+            }
+        }
+
+        // Plan 87 W4: when /etc/udhcpc/default.script exists (passt
+        // path / ur-seed-built rootfs), use it so the DHCP lease
+        // writes /run/resolv.conf with the leased DNS. Older rootfs
+        // builds without the script keep the legacy `-i eth0 -n -q`
+        // shape — udhcpc still sets the IP but resolv.conf stays at
+        // the fallback content.
+        let script = "/etc/udhcpc/default.script";
+        let mut cmd = Command::new("/sbin/udhcpc");
+        cmd.args(["-i", "eth0", "-n", "-q"]);
+        if std::path::Path::new(script).is_file() {
+            cmd.args(["-s", script]);
+        }
+        let status = cmd
             .status()
             .map_err(|e| format!("spawn /sbin/udhcpc: {e}"))?;
         if !status.success() {

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -280,19 +280,22 @@ pub enum NetworkingMode {
     /// libkrun's built-in TSI backend (no virtio-net, no DHCP).
     #[default]
     Tsi,
-    /// virtio-net via passt. The host-side passt process is owned
-    /// by `mvm-libkrun::passt::PasstSupervisor`; this variant carries
-    /// the parent end of the socketpair libkrun consumes.
+    /// virtio-net via passt. The supervisor process (whichever links
+    /// `libkrun-sys`) spawns a passt child inside `run_supervisor`,
+    /// hands its socket fd to `krun_add_net_unixstream`, and reaps
+    /// passt when libkrun exits. mvmctl (and any other JSON-consuming
+    /// caller) just declares the intent here — the live fd never
+    /// survives JSON serialization, so we keep it out of this struct.
     Passt {
-        /// File descriptor for the unixstream socket libkrun reads
-        /// virtio-net frames from. Caller (typically
-        /// `PasstSupervisor::spawn`) owns the inverse half handed
-        /// to passt. libkrun takes ownership at `start_enter`.
-        socket_fd: i32,
         /// MAC address for the guest's eth0. 6 bytes; the first
         /// octet must have bit 0x02 set (locally-administered) to
         /// avoid colliding with real hardware allocations.
         mac: [u8; 6],
+        /// Host directory where the supervisor stages passt's log
+        /// file (`<scratch_dir>/passt.log`). Typically
+        /// `<vm_state_dir>` so the per-VM artifact set stays
+        /// co-located. The supervisor creates it if absent.
+        scratch_dir: String,
     },
 }
 
@@ -321,10 +324,14 @@ impl KrunContext {
         }
     }
 
-    /// Switch the guest to passt-backed virtio-net. The caller owns the
-    /// `PasstSupervisor` whose `socket_fd` is passed in here. Plan 87.
-    pub fn with_passt(mut self, socket_fd: i32, mac: [u8; 6]) -> Self {
-        self.networking = NetworkingMode::Passt { socket_fd, mac };
+    /// Switch the guest to passt-backed virtio-net. The supervisor
+    /// process owns the passt child; we just declare the intent and
+    /// the destination for passt's log file. Plan 87.
+    pub fn with_passt(mut self, mac: [u8; 6], scratch_dir: impl Into<String>) -> Self {
+        self.networking = NetworkingMode::Passt {
+            mac,
+            scratch_dir: scratch_dir.into(),
+        };
         self
     }
 
@@ -443,14 +450,60 @@ pub fn start(ctx: &KrunContext) -> Result<(), Error> {
 /// Apply every `KrunContext` field to a freshly-allocated libkrun
 /// configuration context. Shared between [`start`] (W1: configure +
 /// drop) and [`start_enter`] (W3: configure + boot).
+///
+/// Plan 87 split this into `configure_pre_net` (everything except
+/// networking) + a per-caller networking decision. `configure` itself
+/// is the TSI-only path used by the spike/smoke binaries; real
+/// consumers go through `run_supervisor`, which owns a passt child
+/// process for the libkrun lifetime via `configure_with_passt`.
 #[cfg(feature = "libkrun-sys")]
 fn configure(ctx: &KrunContext) -> Result<sys::Context, Error> {
+    let krun = configure_pre_net(ctx)?;
+    if matches!(ctx.networking, NetworkingMode::Passt { .. }) {
+        return Err(Error::Io {
+            context: "NetworkingMode::Passt requires the supervisor entry point; \
+                 call `run_supervisor` rather than `start` / `start_enter` directly"
+                .to_string(),
+        });
+    }
+    Ok(krun)
+}
+
+/// Plan 87 W1+W2 — configure() variant that owns a `PasstSupervisor`
+/// for the lifetime of the returned context. Used by [`run_supervisor`]
+/// when `NetworkingMode::Passt` is set. The handle Drop's after libkrun
+/// finishes consuming the fd and the guest exits.
+#[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+fn configure_with_passt(
+    ctx: &KrunContext,
+) -> Result<(sys::Context, Option<passt::PasstHandle>), Error> {
+    let krun = configure_pre_net(ctx)?;
+    let handle = match &ctx.networking {
+        NetworkingMode::Tsi => None,
+        NetworkingMode::Passt { mac, scratch_dir } => {
+            let handle =
+                passt::spawn(std::path::Path::new(scratch_dir)).map_err(|e| Error::Io {
+                    context: format!("spawning passt for NetworkingMode::Passt: {e}"),
+                })?;
+            krun.add_net_unixstream_fd(
+                handle.socket_fd(),
+                mac,
+                sys::PASST_NET_FEATURES,
+                /* flags = */ 0,
+            )?;
+            Some(handle)
+        }
+    };
+    Ok((krun, handle))
+}
+
+/// Plan 87 — every part of `configure` that doesn't touch the
+/// networking backend. Shared between the plain `configure` path
+/// (TSI-only) and `configure_with_passt`.
+#[cfg(feature = "libkrun-sys")]
+fn configure_pre_net(ctx: &KrunContext) -> Result<sys::Context, Error> {
     let krun = sys::Context::new()?;
     krun.set_vm_config(ctx.vcpus, ctx.ram_mib)?;
-    // ARM64 Linux kernels build as the "Image" format (a flat binary
-    // header + payload, not ELF). libkrun's `RAW` kernel format consumes
-    // them directly. x86_64 bzImage is also `RAW`. ELF-format kernels
-    // (rare outside test fixtures) would need `KernelFormat::Elf`.
     krun.set_kernel(
         Path::new(&ctx.kernel_path),
         sys::KernelFormat::Raw,
@@ -461,66 +514,15 @@ fn configure(ctx: &KrunContext) -> Result<sys::Context, Error> {
     for disk in &ctx.extra_disks {
         krun.add_disk(&disk.id, Path::new(&disk.path), disk.read_only)?;
     }
-    // virtio-fs shares (Plan 72 W4): each entry becomes a
-    // `mount -t virtiofs <tag>` target inside the guest. libkrun
-    // spawns one virtiofsd daemon per share internally.
     for mount in &ctx.virtio_fs_mounts {
         krun.add_virtiofs(&mount.tag, Path::new(&mount.host_path))?;
     }
-    // libkrun's vsock model — refined by plan 57 W4 after a closer
-    // read of `libkrun.h`:
-    //
-    // - TSI (Transparent Socket Impersonation) is auto-enabled when
-    //   no virtio-net device is added. The libkrun README is
-    //   explicit: "TSI for AF_INET and AF_INET6 is automatically
-    //   enabled when no network interface is added to the VM." We
-    //   never call `krun_add_net_*`, so TSI is always on, and the
-    //   virtio-vsock device exists implicitly.
-    //
-    // - `krun_add_vsock` is for *adding a second independent*
-    //   virtio-vsock device, and requires `krun_disable_implicit_vsock`
-    //   first. Because TSI already provides one, naively calling it
-    //   returns `-EEXIST` (verified on libkrun 1.17.4). Do not use
-    //   from mvm's path.
-    //
-    // - **Direction matters.** `krun_add_vsock_port` (no `_2`)
-    //   documents "port that the guest will connect to for IPC" —
-    //   guest is the client, host is the server, host binds the
-    //   listener. `krun_add_vsock_port2(..., listen=true)` flips
-    //   it: "guest expects connections to be initiated from host
-    //   side" — guest is the server, libkrun creates the unix
-    //   socket file as a listener, host processes connect as
-    //   clients. mvm's guest agent always *listens* on
-    //   `GUEST_AGENT_PORT`, so `listen=true` is the right mode for
-    //   every vsock port we register here. The W3.3 PR used
-    //   `add_vsock_port` (no `_2`); that was the wrong direction
-    //   but happened to boot because nothing in the guest actually
-    //   tried to use vsock. W4 corrects it.
     for &port in &ctx.vsock_ports {
         let socket = ctx.vsock_socket_path(port);
         krun.add_vsock_port2(port, &socket, /* listen = */ true)?;
     }
     if let Some(console_path) = &ctx.console_output_path {
         krun.set_console_output(Path::new(console_path))?;
-    }
-    // Plan 87 / ADR-055: networking backend dispatch. TSI is the
-    // default (auto-enabled when no virtio-net device is added);
-    // Passt adds a virtio-net device via krun_add_net_unixstream and
-    // implicitly disables TSI. The two are mutually exclusive at the
-    // libkrun layer.
-    match &ctx.networking {
-        NetworkingMode::Tsi => {
-            // Nothing to do — libkrun enables TSI implicitly when no
-            // virtio-net device is added.
-        }
-        NetworkingMode::Passt { socket_fd, mac } => {
-            krun.add_net_unixstream_fd(
-                *socket_fd,
-                mac,
-                sys::PASST_NET_FEATURES,
-                /* flags = */ 0,
-            )?;
-        }
     }
     Ok(krun)
 }
@@ -700,7 +702,22 @@ pub fn run_supervisor(cfg: &SupervisorConfig) -> Result<std::convert::Infallible
     std::fs::write(&pid_path, &pid).map_err(|e| Error::Io {
         context: format!("write pid file {}: {e}", pid_path.display()),
     })?;
-    start_enter(&cfg.krun)
+
+    if !is_available() {
+        return Err(Error::NotInstalled {
+            install_hint: install_hint(),
+        });
+    }
+
+    // Plan 87 W3: when NetworkingMode::Passt is set, the supervisor
+    // owns the passt child process. `_passt_handle` lives until the
+    // end of this function; libkrun's `start_enter` calls `exit()`
+    // on the success path, so the handle's Drop runs as part of
+    // process teardown when the guest powers off. On error paths
+    // the handle Drops normally and SIGTERMs passt before we return.
+    let (krun, _passt_handle) = configure_with_passt(&cfg.krun)?;
+    install_shutdown_handler(&krun)?;
+    krun.start_enter()
 }
 
 /// Non-FFI-feature stub so callers can reference the function name

--- a/nix/ur-seed/flake.nix
+++ b/nix/ur-seed/flake.nix
@@ -322,6 +322,50 @@
           '';
           urSeedCmdlineFile = pkgs.writeText "cmdline.txt"
             "console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/sbin/ur-seed-init";
+
+          # Plan 87 W4 — busybox udhcpc default script. When
+          # `udhcpc -s /etc/udhcpc/default.script` runs after passt
+          # hands out a DHCP lease, busybox calls this hook with the
+          # action ("deconfig" / "bound" / "renew") in $1 and the
+          # lease fields in env vars ($ip, $mask, $router, $dns, …).
+          # We:
+          #   * bring eth0 up with the leased IP + mask on "bound"/"renew"
+          #   * install the default route via $router
+          #   * write nameservers from $dns into /etc/resolv.conf
+          # /etc is on the read-only rootfs, but /etc/resolv.conf is a
+          # symlink (set up at boot) to /run/resolv.conf — /run is a
+          # tmpfs mvm-builder-init mounts. The dev image flake's
+          # equivalent script (`nix/lib/udhcpc-default.script`) follows
+          # the same shape.
+          udhcpcDefaultScript = pkgs.writeScript "udhcpc-default.script" ''
+            #!/bin/sh
+            set -eu
+            case "$1" in
+              deconfig)
+                ip link set "$interface" up || true
+                ip -4 addr flush dev "$interface" || true
+                ;;
+              renew|bound)
+                ip link set "$interface" up
+                ip -4 addr flush dev "$interface"
+                ip -4 addr add "$ip/$mask" dev "$interface"
+                if [ -n "''${router:-}" ]; then
+                  for r in $router; do
+                    ip -4 route add default via "$r" dev "$interface" || true
+                  done
+                fi
+                # /run is tmpfs (mounted by mvm-builder-init); /etc/resolv.conf
+                # is symlinked there by the rootfs build.
+                : > /run/resolv.conf
+                if [ -n "''${domain:-}" ]; then
+                  printf 'search %s\n' "$domain" >> /run/resolv.conf
+                fi
+                for ns in ''${dns:-}; do
+                  printf 'nameserver %s\n' "$ns" >> /run/resolv.conf
+                done
+                ;;
+            esac
+          '';
         in
         pkgs.runCommand "mvm-ur-seed-${system}"
           {
@@ -419,8 +463,24 @@
             cp ${passwdFile}   $staging/etc/passwd
             cp ${groupFile}    $staging/etc/group
             cp ${nsswitchFile} $staging/etc/nsswitch.conf
-            cp ${resolvFile}   $staging/etc/resolv.conf
             cp ${manifestJson} $staging/etc/mvm-ur-seed.json
+
+            # Plan 87 W4 — resolv.conf is a symlink into /run/resolv.conf
+            # (tmpfs, mounted by mvm-builder-init). Pre-create the symlink
+            # so udhcpc's hook script writes the right file from boot 1.
+            # The static fallback content (1.1.1.1 / 8.8.8.8) is staged
+            # at /etc/resolv.conf.fallback — Plan 87 W4's udhcpc hook
+            # uses it before the DHCP lease lands; the TSI fallback
+            # path also reads it.
+            ln -sf /run/resolv.conf $staging/etc/resolv.conf
+            cp ${resolvFile} $staging/etc/resolv.conf.fallback
+
+            # Plan 87 W4 — busybox udhcpc default hook. Installed
+            # under `/etc/udhcpc/default.script` so
+            # `udhcpc -s /etc/udhcpc/default.script` picks it up.
+            mkdir -p $staging/etc/udhcpc
+            cp ${udhcpcDefaultScript} $staging/etc/udhcpc/default.script
+            chmod +x $staging/etc/udhcpc/default.script
 
             # Kernel modules. mvm-builder-init runs
             # `modprobe virtiofs fuse` before mounting the host shares;


### PR DESCRIPTION
Builds on the merged Plan 87 W1 + W2 (PR #354).

## Summary

**W3 — Consumer wiring:**
- `NetworkingMode::Passt` redesigned to carry `{ mac, scratch_dir }` only — fds don't survive JSON serialization across the mvmctl → supervisor process boundary, so the supervisor owns the passt child. `run_supervisor()` uses `configure_with_passt()` which spawns passt and holds the `PasstHandle` for the libkrun process lifetime.
- `mvm-build::libkrun_builder` reads `MVM_NETWORKING={tsi,passt}` env var (case-insensitive, default `tsi`) at every VM launch site. Both `dispatch_shell_job` and `run_build` paths call `KrunContext::with_passt(DEFAULT_GUEST_MAC, vm_state_dir)` when opted in.
- Plain `configure()` hard-errors if `NetworkingMode::Passt` is passed (only the supervisor entry point handles it).

**W4 — In-VM DHCP + resolv.conf wiring:**
- `nix/ur-seed/flake.nix` adds `/etc/udhcpc/default.script` (writes /run/resolv.conf from DHCP lease), pre-symlinks `/etc/resolv.conf -> /run/resolv.conf`, and stages a static fallback at `/etc/resolv.conf.fallback`.
- `mvm-builder-init::setup_network` seeds /run/resolv.conf from the fallback before udhcpc (DNS works from boot 1 even if DHCP fails) and passes `-s /etc/udhcpc/default.script` when the hook exists.

## Test plan

- [x] `cargo test --workspace --lib` — 242 mvm-build tests pass (including new `resolve_networking_mode_parses_env`), 16 mvm-libkrun tests pass in both feature modes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] End-to-end smoke: `MVM_NETWORKING=passt cargo run -- dev up` (gated on PR3 — needs a rebuilt ur-seed tarball + libkrun-sys default-on for the mvmctl binary)

## What's left for Plan 87

- **PR3**: flip default, CI installs libkrun + libkrunfw + passt, libkrun-sys default-on for the mvmctl binary
- **PR4**: `mvmctl doctor` passt probe + install docs + ADR-055 update

🤖 Generated with [Claude Code](https://claude.com/claude-code)