### PR TITLE
perf(builder): parallelize in-VM nix build

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -796,6 +796,8 @@ cd /work
 export NIX_CONFIG="experimental-features = nix-command flakes
 sandbox = false
 build-users-group =
+max-jobs = auto
+cores = 0
 substituters = https://cache.nixos.org/
 trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
 # Plan 72 W0's flake convention: workspace-path env var so
@@ -1761,6 +1763,8 @@ mod tests {
         assert!(cmd.starts_with("#!/bin/sh"));
         assert!(cmd.contains("set -eu"));
         assert!(cmd.contains("cd /work"));
+        assert!(cmd.contains("max-jobs = auto"));
+        assert!(cmd.contains("cores = 0"));
         assert!(cmd.contains("printf '%s\\n' \"$NIX_OUT\" > /job/store-path"));
     }
 


### PR DESCRIPTION
## Summary

- Adds `max-jobs = auto` and `cores = 0` to the `NIX_CONFIG` emitted by `LibkrunBuilderVm`'s `cmd.sh`. Previously the block inherited the default `max-jobs = 1`, so the four independent derivations the builder VM compiles from source (TSI kernel + `mvm-builder-init` / `mvm-egress-proxy` / `mvm-guest-agent` `buildRustPackage` outputs) serialized despite a 4-vCPU VM.
- One-line extension to `stage_job_dir_writes_cmd_sh_with_escaped_inputs` to lock the new settings.

## Why not also add a Cachix/Attic substituter?

Considered and deferred. Plan 87 W3 (`worktree-passt-w3-w4`, already on a branch) drops the explicit `substituters = …` / `trusted-public-keys = …` lines from this same `NIX_CONFIG` in favor of nix's built-in defaults once passt is the network backend — adding a substituter today would conflict with that work and not actually function (per Plan 87's diagnosis, every in-VM nix build currently falls back to source builds because TSI breaks substituter HTTP patterns). Revisit once Plan 87 W5 lands and passt is the default.

## Test plan

- [x] `cargo test -p mvm-build --lib --features builder-vm libkrun_builder::` — 43/43 pass (post-rebase)
- [x] `cargo test --workspace --all-features` — green (pre-rebase; post-rebase OOM'd on `mvm-providers` due to leftover dev-VM memory pressure, but the crate passes cleanly in isolation; no actual test regression)
- [x] `cargo clippy --workspace --all-features --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)