### PR TITLE
feat(libkrun): gvproxy FFI + supervisor (Plan 88 W1 + W2)

### DIFF
--- a/crates/mvm-libkrun/src/gvproxy.rs
+++ b/crates/mvm-libkrun/src/gvproxy.rs
@@ -1,0 +1,329 @@
+//! Gvproxy-backed virtio-net supervisor (Plan 88 W2 / ADR-055
+//! cross-platform amendment).
+//!
+//! `gvproxy` is a userspace network gateway (containers/gvisor-tap-vsock
+//! project, Apache-2.0, single statically-linked binary) that translates
+//! between virtio-net frames the libkrun guest writes to a unix-domain
+//! socket and AF_INET sockets on the host. The slp/krun Homebrew tap
+//! ships it as the canonical macOS networking backend for libkrun,
+//! filling the role passt fills on Linux (passt itself doesn't build on
+//! macOS — see ADR-055 §"Cross-platform backends").
+//!
+//! The integration model differs from passt:
+//!
+//! - passt: parent creates a socketpair, hands one end to passt via
+//!   `--fd=N`, keeps the other end; libkrun consumes the parent end.
+//! - gvproxy: gvproxy itself creates a listening unix-domain socket
+//!   when invoked with `--listen-vfkit <path>`; libkrun connects to
+//!   that path via `krun_add_net_unixgram(ctx, c_path, fd=-1, …)`.
+//!
+//! Boot sequence:
+//!
+//! 1. Host calls [`spawn`]. It picks a socket path under the
+//!    scratch dir, spawns `gvproxy --listen-vfkit <socket>
+//!    --log-file <log>`, then polls for the socket file to appear
+//!    (gvproxy creates it ~tens of ms after spawn).
+//! 2. Host stuffs the socket path into [`crate::KrunContext`] via
+//!    [`crate::KrunContext::with_gvproxy`].
+//! 3. libkrun's `start_enter` opens the socket and consumes the
+//!    virtio-net frames.
+//! 4. When the host drops the [`GvproxyHandle`], the supervisor
+//!    `SIGTERM`s gvproxy, waits up to [`SHUTDOWN_GRACE`], then
+//!    `SIGKILL`s.
+
+use std::ffi::OsString;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+/// Grace period between SIGTERM and SIGKILL during shutdown. Matches
+/// the [`crate::passt::SHUTDOWN_GRACE`] knob so both backends behave
+/// the same way under cleanup pressure.
+pub const SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
+
+/// How long [`spawn`] waits for gvproxy's listener socket to appear
+/// on disk. gvproxy creates the file within ~tens of milliseconds on
+/// macOS Apple Silicon (no `bind(2)` blocking). 500ms is generous
+/// without measurably slowing `dev up`.
+pub const SOCKET_READY_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Default MAC for the guest's `eth0`. Locally-administered (bit
+/// `0x02` set), unicast, stable across boots. Matches
+/// [`crate::passt::DEFAULT_GUEST_MAC`] so the in-guest udev rules
+/// don't reshuffle the interface name when a contributor switches
+/// between backends.
+pub const DEFAULT_GUEST_MAC: [u8; 6] = [0xAE, 0xAD, 0xBE, 0xEF, 0x00, 0x01];
+
+/// Errors the supervisor can return.
+#[derive(Debug)]
+pub enum GvproxyError {
+    /// `gvproxy` binary not found on `$PATH`.
+    NotInstalled { install_hint: &'static str },
+    /// Spawning the gvproxy child process failed.
+    Spawn(io::Error),
+    /// gvproxy exited before the listener socket appeared on disk.
+    EarlyExit { status: std::process::ExitStatus },
+    /// `SOCKET_READY_TIMEOUT` elapsed without gvproxy creating its
+    /// listener socket. Typically a permission issue on the scratch
+    /// dir or a fatal error gvproxy logged before listening.
+    SocketTimeout { socket_path: PathBuf },
+    /// Filesystem I/O failure (scratch dir create, etc.).
+    Io { context: String, source: io::Error },
+}
+
+impl std::fmt::Display for GvproxyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GvproxyError::NotInstalled { install_hint } => {
+                write!(f, "`gvproxy` binary not found on $PATH. {install_hint}")
+            }
+            GvproxyError::Spawn(e) => write!(f, "spawning gvproxy failed: {e}"),
+            GvproxyError::EarlyExit { status } => write!(
+                f,
+                "gvproxy exited before its listener socket appeared (status: {status:?})"
+            ),
+            GvproxyError::SocketTimeout { socket_path } => write!(
+                f,
+                "gvproxy did not create its listener socket at {} within {} ms",
+                socket_path.display(),
+                SOCKET_READY_TIMEOUT.as_millis()
+            ),
+            GvproxyError::Io { context, source } => write!(f, "{context}: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for GvproxyError {}
+
+/// Suggested install command for the current host platform. Surfaced
+/// both in `GvproxyError::NotInstalled` and `mvmctl doctor`.
+pub fn install_hint() -> &'static str {
+    if cfg!(target_os = "macos") {
+        // slp/krun is the same tap that ships libkrun + libkrunfw, so
+        // pointing at it keeps the doc story consistent.
+        "Install with: brew install slp/krun/gvproxy"
+    } else if cfg!(target_os = "linux") {
+        // Most distros don't package gvproxy. Building from source is
+        // a single `go build` against
+        // github.com/containers/gvisor-tap-vsock.
+        "Install from source: https://github.com/containers/gvisor-tap-vsock"
+    } else {
+        "Install gvproxy: https://github.com/containers/gvisor-tap-vsock"
+    }
+}
+
+/// Probe `$PATH` for `gvproxy`. Returns the absolute path on success.
+pub fn locate_gvproxy() -> Option<PathBuf> {
+    which::which("gvproxy").ok()
+}
+
+/// Owning handle to a running gvproxy child process. `Drop` cleans up
+/// the child the same way [`crate::passt::PasstHandle::drop`] does:
+/// SIGTERM → grace period → SIGKILL → reap.
+#[derive(Debug)]
+pub struct GvproxyHandle {
+    child: Option<Child>,
+    socket_path: PathBuf,
+}
+
+impl GvproxyHandle {
+    /// Path to the unix-domain socket gvproxy listens on. Hand this
+    /// to [`crate::KrunContext::with_gvproxy`] (or directly to
+    /// [`crate::sys::Context::add_net_unixgram_path`] for advanced
+    /// callers).
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+}
+
+/// Spawn a gvproxy child process and return a handle to its listener
+/// socket path. The child logs to `scratch_dir/gvproxy.log`.
+///
+/// The returned [`GvproxyHandle`] must outlive any libkrun
+/// configuration referencing `socket_path()`. On Drop the child is
+/// killed gracefully and the socket file is deleted (best-effort —
+/// libkrun may have already consumed it).
+pub fn spawn(scratch_dir: &Path) -> Result<GvproxyHandle, GvproxyError> {
+    let gvproxy_bin = locate_gvproxy().ok_or_else(|| GvproxyError::NotInstalled {
+        install_hint: install_hint(),
+    })?;
+
+    std::fs::create_dir_all(scratch_dir).map_err(|e| GvproxyError::Io {
+        context: format!("creating gvproxy scratch dir {}", scratch_dir.display()),
+        source: e,
+    })?;
+
+    let socket_path = scratch_dir.join("gvproxy.sock");
+    let log_path = scratch_dir.join("gvproxy.log");
+
+    // Remove a stale socket from a previous run before spawning —
+    // gvproxy refuses to bind if the file exists.
+    let _ = std::fs::remove_file(&socket_path);
+
+    // gvproxy args we care about:
+    //   -listen-vfkit <path> — unix-domain socket libkrun connects to
+    //                          via `krun_add_net_unixgram`. "vfkit"
+    //                          mode is the libkrun-compatible one.
+    //   -log-file <path>     — diagnostic log; absent → stderr (lost
+    //                          when we redirect to /dev/null).
+    //   -debug               — verbose logging. Not set by default;
+    //                          if a future MVM_GVPROXY_DEBUG=1 env
+    //                          var trips this we'd flip it here.
+    // gvproxy expects the `-listen-vfkit` arg as a URL —
+    // `unixgram://<path>`. A bare path errors out with
+    // "vfkit listen address must be unixgram:// address" before the
+    // listener is created. The libkrun-end of the socket connects
+    // to the absolute path; the URL prefix only carries the scheme.
+    let listen_url = {
+        let mut s = OsString::from("unixgram://");
+        s.push(socket_path.as_os_str());
+        s
+    };
+    let mut cmd = Command::new(&gvproxy_bin);
+    cmd.arg("-listen-vfkit")
+        .arg(listen_url)
+        .arg("-log-file")
+        .arg(OsString::from(&log_path))
+        // Redirect stdout/stderr to /dev/null — gvproxy's `-log-file`
+        // captures what we need and any spillover noise on stderr
+        // pollutes the supervisor's own diagnostic stream.
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    let mut child = cmd.spawn().map_err(GvproxyError::Spawn)?;
+
+    // Poll for the socket to appear, with a bounded budget. gvproxy
+    // creates the file synchronously inside its main loop on startup,
+    // so this should resolve within ~tens of ms. We also re-check
+    // `try_wait()` every iteration so an early exit (missing arg,
+    // permission denied, etc.) surfaces immediately instead of as
+    // a SocketTimeout.
+    let deadline = Instant::now() + SOCKET_READY_TIMEOUT;
+    loop {
+        if socket_path.exists() {
+            return Ok(GvproxyHandle {
+                child: Some(child),
+                socket_path,
+            });
+        }
+        if let Some(status) = child.try_wait().map_err(GvproxyError::Spawn)? {
+            return Err(GvproxyError::EarlyExit { status });
+        }
+        if Instant::now() >= deadline {
+            // Kill the still-running child before bailing — leaking it
+            // would block whatever the caller does next.
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(GvproxyError::SocketTimeout { socket_path });
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+impl Drop for GvproxyHandle {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+
+        // Already-dead is fine.
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            let _ = std::fs::remove_file(&self.socket_path);
+            return;
+        }
+
+        // SIGTERM → wait → SIGKILL.
+        let pid = child.id() as i32;
+        // SAFETY: pid is valid until we wait; SIGTERM on a stale pid
+        // returns ESRCH which we treat as "already gone".
+        unsafe { libc::kill(pid, libc::SIGTERM) };
+
+        let deadline = Instant::now() + SHUTDOWN_GRACE;
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                _ => break,
+            }
+        }
+
+        if matches!(child.try_wait(), Ok(None)) {
+            unsafe { libc::kill(pid, libc::SIGKILL) };
+            let _ = child.wait();
+        }
+
+        // Best-effort socket cleanup — if libkrun was holding the fd
+        // open, the inode goes away when the last fd closes, but the
+        // path entry remains. Removing it explicitly keeps
+        // `~/.cache/mvm/builder-vm/vms/<vm>/` tidy.
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TEST_ENV_LOCK as ENV_LOCK;
+
+    #[test]
+    fn install_hint_is_platform_specific() {
+        let hint = install_hint();
+        assert!(!hint.is_empty());
+        if cfg!(target_os = "macos") {
+            assert!(hint.contains("brew install"), "hint: {hint}");
+        }
+    }
+
+    #[test]
+    fn locate_gvproxy_is_optional() {
+        let _ = locate_gvproxy();
+    }
+
+    #[test]
+    fn spawn_without_gvproxy_returns_not_installed() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let original_path = std::env::var_os("PATH");
+        // SAFETY: tests are single-threaded; serialize env mutation.
+        unsafe {
+            std::env::set_var("PATH", tmp.path());
+        }
+        let result = spawn(tmp.path());
+        unsafe {
+            match original_path {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+        match result {
+            Err(GvproxyError::NotInstalled { install_hint }) => {
+                assert!(!install_hint.is_empty());
+            }
+            other => panic!("expected NotInstalled, got {other:?}"),
+        }
+    }
+
+    /// Spawn gvproxy, verify the socket path exists, then drop the
+    /// handle. Skipped when gvproxy isn't installed.
+    #[test]
+    fn spawn_then_drop_reaps_child() {
+        let Some(_) = locate_gvproxy() else {
+            eprintln!("test skipped: gvproxy not on PATH");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let handle = spawn(tmp.path()).expect("spawn gvproxy");
+        let socket = handle.socket_path().to_path_buf();
+        assert!(socket.exists(), "socket missing: {}", socket.display());
+        drop(handle);
+        // After Drop the socket file is cleaned up.
+        assert!(
+            !socket.exists(),
+            "socket lingered after Drop: {}",
+            socket.display()
+        );
+    }
+}

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -35,6 +35,24 @@ pub use sys::{BundledKernel, KernelFormat, LogLevel, extract_bundled_kernel, set
 #[cfg(target_family = "unix")]
 pub mod passt;
 
+// Plan 88 / ADR-055 cross-platform amendment — gvproxy-backed
+// virtio-net. The macOS counterpart to passt; both modules share the
+// same shape (spawn child, hand its socket to libkrun, kill on Drop)
+// but gvproxy uses libkrun's `krun_add_net_unixgram` (path-based)
+// where passt uses `krun_add_net_unixstream` (fd-passed). Same unix
+// gate as passt — Windows has neither.
+#[cfg(target_family = "unix")]
+pub mod gvproxy;
+
+/// Cross-module env mutation serializer. Both `passt::tests` and
+/// `gvproxy::tests` mutate `$PATH` to verify their `NotInstalled`
+/// error paths; `cargo test`'s default parallelism would race them
+/// otherwise and leak the "set PATH to a tmp dir" state across the
+/// two tests, making one's spawn call see the other's modified env.
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
 /// Errors returned by this crate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
@@ -297,6 +315,23 @@ pub enum NetworkingMode {
         /// co-located. The supervisor creates it if absent.
         scratch_dir: String,
     },
+    /// virtio-net via gvproxy — Plan 88. The supervisor spawns a
+    /// gvproxy child inside `run_supervisor`, points libkrun's
+    /// `krun_add_net_unixgram` at the listener socket gvproxy
+    /// creates, and reaps gvproxy on guest exit. Same model as
+    /// `Passt` but unixgram-flavored: libkrun connects to a path
+    /// on disk rather than receiving a pre-opened socket fd. This
+    /// is the canonical macOS backend (passt is Linux-only — see
+    /// ADR-055 §"Cross-platform backends").
+    Gvproxy {
+        /// MAC address for the guest's eth0. Same shape as the
+        /// `Passt` variant.
+        mac: [u8; 6],
+        /// Host directory where the supervisor stages gvproxy's
+        /// listener socket (`<scratch_dir>/gvproxy.sock`) + log
+        /// file (`<scratch_dir>/gvproxy.log`).
+        scratch_dir: String,
+    },
 }
 
 impl KrunContext {
@@ -322,6 +357,18 @@ impl KrunContext {
             vsock_socket_dir: None,
             networking: NetworkingMode::Tsi,
         }
+    }
+
+    /// Switch the guest to gvproxy-backed virtio-net. Same shape as
+    /// [`Self::with_passt`] but uses libkrun's unixgram backend; the
+    /// supervisor spawns gvproxy with `--listen-vfkit <socket>` and
+    /// hands the socket path to `krun_add_net_unixgram`. Plan 88.
+    pub fn with_gvproxy(mut self, mac: [u8; 6], scratch_dir: impl Into<String>) -> Self {
+        self.networking = NetworkingMode::Gvproxy {
+            mac,
+            scratch_dir: scratch_dir.into(),
+        };
+        self
     }
 
     /// Switch the guest to passt-backed virtio-net. The supervisor
@@ -459,27 +506,41 @@ pub fn start(ctx: &KrunContext) -> Result<(), Error> {
 #[cfg(feature = "libkrun-sys")]
 fn configure(ctx: &KrunContext) -> Result<sys::Context, Error> {
     let krun = configure_pre_net(ctx)?;
-    if matches!(ctx.networking, NetworkingMode::Passt { .. }) {
+    if !matches!(ctx.networking, NetworkingMode::Tsi) {
         return Err(Error::Io {
-            context: "NetworkingMode::Passt requires the supervisor entry point; \
-                 call `run_supervisor` rather than `start` / `start_enter` directly"
-                .to_string(),
+            context: format!(
+                "{:?} requires the supervisor entry point; call \
+                 `run_supervisor` rather than `start` / `start_enter` directly",
+                ctx.networking
+            ),
         });
     }
     Ok(krun)
 }
 
-/// Plan 87 W1+W2 — configure() variant that owns a `PasstSupervisor`
-/// for the lifetime of the returned context. Used by [`run_supervisor`]
-/// when `NetworkingMode::Passt` is set. The handle Drop's after libkrun
-/// finishes consuming the fd and the guest exits.
+/// Plan 88 — owning handle to whichever userspace network gateway
+/// the supervisor spawned for this guest. Lives for the libkrun
+/// process lifetime so the gateway is reaped when the guest exits.
 #[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
-fn configure_with_passt(
-    ctx: &KrunContext,
-) -> Result<(sys::Context, Option<passt::PasstHandle>), Error> {
+pub enum GatewayHandle {
+    /// Not using a virtio-net backend — TSI is enabled implicitly.
+    None,
+    /// passt child (Linux).
+    Passt(passt::PasstHandle),
+    /// gvproxy child (macOS / cross-platform fallback).
+    Gvproxy(gvproxy::GvproxyHandle),
+}
+
+/// Plan 87 W1+W2 / Plan 88 W1+W2 — configure() variant that owns the
+/// network-gateway child process for the lifetime of the returned
+/// context. Used by [`run_supervisor`] when
+/// `NetworkingMode::{Passt, Gvproxy}` is set. The handle Drop's after
+/// libkrun finishes consuming the socket and the guest exits.
+#[cfg(all(feature = "libkrun-sys", target_family = "unix"))]
+fn configure_with_gateway(ctx: &KrunContext) -> Result<(sys::Context, GatewayHandle), Error> {
     let krun = configure_pre_net(ctx)?;
     let handle = match &ctx.networking {
-        NetworkingMode::Tsi => None,
+        NetworkingMode::Tsi => GatewayHandle::None,
         NetworkingMode::Passt { mac, scratch_dir } => {
             let handle =
                 passt::spawn(std::path::Path::new(scratch_dir)).map_err(|e| Error::Io {
@@ -491,7 +552,20 @@ fn configure_with_passt(
                 sys::PASST_NET_FEATURES,
                 /* flags = */ 0,
             )?;
-            Some(handle)
+            GatewayHandle::Passt(handle)
+        }
+        NetworkingMode::Gvproxy { mac, scratch_dir } => {
+            let handle =
+                gvproxy::spawn(std::path::Path::new(scratch_dir)).map_err(|e| Error::Io {
+                    context: format!("spawning gvproxy for NetworkingMode::Gvproxy: {e}"),
+                })?;
+            krun.add_net_unixgram_path(
+                handle.socket_path(),
+                mac,
+                sys::PASST_NET_FEATURES,
+                /* flags = */ 0,
+            )?;
+            GatewayHandle::Gvproxy(handle)
         }
     };
     Ok((krun, handle))
@@ -715,7 +789,7 @@ pub fn run_supervisor(cfg: &SupervisorConfig) -> Result<std::convert::Infallible
     // on the success path, so the handle's Drop runs as part of
     // process teardown when the guest powers off. On error paths
     // the handle Drops normally and SIGTERMs passt before we return.
-    let (krun, _passt_handle) = configure_with_passt(&cfg.krun)?;
+    let (krun, _gateway_handle) = configure_with_gateway(&cfg.krun)?;
     install_shutdown_handler(&krun)?;
     krun.start_enter()
 }

--- a/crates/mvm-libkrun/src/passt.rs
+++ b/crates/mvm-libkrun/src/passt.rs
@@ -296,6 +296,7 @@ fn clear_cloexec(fd: RawFd) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::TEST_ENV_LOCK as ENV_LOCK;
 
     #[test]
     fn install_hint_is_platform_specific() {
@@ -315,6 +316,7 @@ mod tests {
 
     #[test]
     fn spawn_without_passt_returns_not_installed() {
+        let _guard = ENV_LOCK.lock().unwrap();
         // Hide passt from PATH for this test by setting PATH to
         // an empty dir.
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/mvm-libkrun/src/sys.rs
+++ b/crates/mvm-libkrun/src/sys.rs
@@ -238,6 +238,45 @@ impl Context {
         })
     }
 
+    /// Add a virtio-net device backed by a unixgram userspace network
+    /// proxy (Plan 88 W1 — gvproxy on macOS replacing passt). Mirror
+    /// of [`Self::add_net_unixstream_fd`] but uses libkrun's
+    /// `krun_add_net_unixgram` which takes a *path* to a listening
+    /// unix-domain socket rather than a pre-opened fd — gvproxy
+    /// creates the listener itself when invoked with
+    /// `--listen-vfkit <path>`, and libkrun's host-side code
+    /// connects to that path.
+    ///
+    /// `c_path` and `fd` are mutually exclusive in the C API; we
+    /// always take the path arm so the caller (typically
+    /// `mvm-libkrun::gvproxy::spawn`) owns the socket lifecycle.
+    /// Pass `socket_path` as the path the gvproxy child listens on.
+    ///
+    /// Calling this disables libkrun's TSI backend (same as the
+    /// unixstream wrapper). `features` should be
+    /// [`super::PASST_NET_FEATURES`] — the macro is named after
+    /// passt but `COMPAT_NET_FEATURES` in `libkrun.h:344` applies
+    /// to both passt and gvproxy (`krun_set_gvproxy_path` lists it).
+    pub fn add_net_unixgram_path(
+        &self,
+        socket_path: &Path,
+        mac: &[u8; 6],
+        features: u32,
+        flags: u32,
+    ) -> Result<(), Error> {
+        let path = cstring(socket_path)?;
+        check(unsafe {
+            bindings::krun_add_net_unixgram(
+                self.ctx_id,
+                path.as_ptr(),
+                /* fd = */ -1,
+                mac.as_ptr() as *mut u8,
+                features,
+                flags,
+            )
+        })
+    }
+
     /// Returns the shutdown eventfd. The caller is responsible for
     /// closing it (libkrun documents that the fd is owned by the
     /// caller once returned).


### PR DESCRIPTION
First implementation slice of Plan 88 (proposed in #361). Adds gvproxy as the macOS networking backend; passt remains the Linux backend.

## W1 — `krun_add_net_unixgram` FFI

- `sys::Context::add_net_unixgram_path(socket_path, mac, features, flags)` wraps libkrun's path-based unixgram backend. Mirror of `add_net_unixstream_fd` (passt path) but uses the `c_path != NULL` / `fd = -1` arm.
- `NetworkingMode::Gvproxy { mac, scratch_dir }` variant; `KrunContext::with_gvproxy(mac, dir)` builder method.

## W2 — Host-side `GvproxyHandle`

- `mvm-libkrun::gvproxy::spawn(scratch_dir)` invokes `gvproxy -listen-vfkit unixgram://<scratch>/gvproxy.sock -log-file <scratch>/gvproxy.log`. gvproxy expects the `-listen-vfkit` value as a URL (`unixgram://<path>`), not a bare path — discovered by running it manually. 500ms poll for the socket to appear.
- `GvproxyHandle::socket_path()` for `KrunContext::with_gvproxy`.
- `Drop`: SIGTERM → 2s grace → SIGKILL → reap + best-effort socket cleanup.
- `install_hint()` + `locate_gvproxy()` ready for the Plan 88 W4 doctor probe.
- `DEFAULT_GUEST_MAC` matches the passt module's so udev doesn't reshuffle interface names when a contributor switches backends.

## Refactor

- `configure_with_passt` → `configure_with_gateway`, returns `(sys::Context, GatewayHandle)` where `GatewayHandle ∈ {None, Passt(_), Gvproxy(_)}`.
- `configure()` (plain path) now blocks any non-Tsi `NetworkingMode` — both backends require the supervisor entry point.

## Test isolation

Closed a parallel-test flake: both modules' `spawn_without_*_returns_not_installed` tests mutate `$PATH`. Added a shared `crate::TEST_ENV_LOCK` so the two modules serialize across each other.

No consumers wired yet. `LibkrunBuilderVm` defaults stay where Plan 87 left them — opt into gvproxy via `MVM_NETWORKING=gvproxy` once Plan 88 W3 lands (next PR).

## Test plan

- [x] `cargo test -p mvm-libkrun --features libkrun-sys` — 22 tests pass
- [x] `cargo test -p mvm-libkrun` — 20 tests pass (no feature)
- [x] 5 consecutive runs of the full mvm-libkrun test suite all 20-pass — no parallel-test flake
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Live test `spawn_then_drop_reaps_child` passes against gvproxy 0.8.8 from `brew install slp/krun/gvproxy` on this host

🤖 Generated with [Claude Code](https://claude.com/claude-code)