### PR TITLE
feat(builder): add Cachix substituter for Stage 0 acceleration (Plan 89)

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -1,0 +1,79 @@
+name: cache-push
+
+# Plan 89 — push the builder VM closure to Cachix on every `main`
+# merge so contributor `mvmctl dev up` and fresh CI runners can
+# substitute instead of source-building the four heavy derivations
+# (TSI/passt kernel + mvm-builder-init + mvm-egress-proxy +
+# mvm-guest-agent). Stage 0 has free egress and reads from the
+# cache; steady state cannot reach it (iptables OUTPUT default-deny
+# per ADR-047) and falls back to its warm local /nix.
+#
+# Requires the `CACHIX_AUTH_TOKEN` repo secret (Plan 89 one-time
+# user provisioning). Without the secret the job fails closed,
+# which is preferable to silently shipping unsigned closures.
+#
+# Security: this workflow consumes no PR/issue/comment fields and
+# nothing user-controlled. The only ${{ … }} interpolations are
+# matrix.arch (set by this file) and secrets.CACHIX_AUTH_TOKEN
+# (repo secret). Per the GitHub Actions injection hardening guide,
+# `matrix.arch` is forwarded through `env:` to a shell variable
+# rather than spliced into the run script.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # Only re-push when the inputs that change the builder VM
+      # closure hash change. Doc-only / unrelated edits skip the
+      # job entirely.
+      - 'nix/images/builder-vm/**'
+      - 'crates/mvm-builder-init/**'
+      - 'crates/mvm-egress-proxy/**'
+      - 'crates/mvm-guest/**'
+      - 'Cargo.lock'
+      - '.github/workflows/cache-push.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  push-builder-vm:
+    strategy:
+      # Don't bail on the other arch if one fails — one half of a
+      # closure is better than none.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+          - arch: x86_64
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v15
+        with:
+          name: mvm
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # cachix-action also wires `mvm.cachix.org` as a substituter
+          # for this job's nix evaluation, so subsequent main pushes
+          # only build what genuinely changed since the last push.
+
+      - name: Build + push builder VM closure
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          SYSTEM="${ARCH}-linux"
+          # `--print-out-paths --no-link` is the same shape the
+          # release.yml `builder-vm-image` job uses; the cachix-action
+          # `pushFilter` watches the store and pushes the produced
+          # closure on success.
+          nix build "./nix/images/builder-vm#packages.${SYSTEM}.default" \
+            --no-link --print-out-paths

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -863,11 +863,22 @@ cd /work
 # otherwise fail with "the group 'nixbld' specified in
 # 'build-users-group' does not exist". The builder VM IS the
 # isolation boundary, so an in-guest sandbox is redundant.
+#
+# `mvm.cachix.org` is our own substituter for the four derivations
+# cache.nixos.org doesn't host (the TSI/passt kernel +
+# `mvm-builder-init` / `mvm-egress-proxy` / `mvm-guest-agent`). The
+# `<USER_PROVISIONS_THIS>` placeholder is filled per Plan 89's
+# one-time setup. Active during Stage 0 (free egress); silently
+# unreachable during steady state (iptables OUTPUT default-deny per
+# ADR-047). `connect-timeout = 5` caps the steady-state retry wait
+# at 5s per cache-miss derivation instead of the default ~63s TCP
+# SYN-retry timeout.
 export NIX_CONFIG="experimental-features = nix-command flakes
 sandbox = false
 build-users-group =
-substituters = https://cache.nixos.org/
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+substituters = https://cache.nixos.org/ https://mvm.cachix.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= mvm.cachix.org-1:<USER_PROVISIONS_THIS>
+connect-timeout = 5"
 # Plan 72 W0's flake convention: workspace-path env var so
 # flakes that reference the workspace root don't depend on
 # relative-path resolution against the store-copied flake dir.
@@ -1861,6 +1872,12 @@ mod tests {
         assert!(cmd.starts_with("#!/bin/sh"));
         assert!(cmd.contains("set -eu"));
         assert!(cmd.contains("cd /work"));
+        // Plan 89 — Cachix substituter, public-key placeholder, and a
+        // short connect-timeout so steady-state firewall drops don't
+        // stall cache-miss derivations.
+        assert!(cmd.contains("https://mvm.cachix.org"));
+        assert!(cmd.contains("mvm.cachix.org-1:<USER_PROVISIONS_THIS>"));
+        assert!(cmd.contains("connect-timeout = 5"));
         assert!(cmd.contains("printf '%s\\n' \"$NIX_OUT\" > /job/store-path"));
     }
 

--- a/specs/plans/89-cachix-substituter-stage0.md
+++ b/specs/plans/89-cachix-substituter-stage0.md
@@ -1,0 +1,163 @@
+# Plan 89 — Cachix substituter for Stage 0 acceleration
+
+**Status:** drafted 2026-05-18, awaiting review + one-time user provisioning.
+**Pairs with:** nothing (no ADR — see "Why no ADR" below).
+**Depends on:** Plan 87 PR3/PR4 (passt as default; merged as #360).
+
+## Problem
+
+A cold `mvmctl dev up` rebuilds four derivations from source inside
+the Stage 0 builder VM because cache.nixos.org doesn't host them:
+
+- the TSI / passt kernel under `nix/images/builder-vm/kernel/`
+- `mvm-builder-init`
+- `mvm-egress-proxy`
+- `mvm-guest-agent`
+
+These are our derivations. Source builds dominate the first-run wall
+clock — typically several minutes of `rustc` + `make` before the
+builder VM even comes up. Every fresh checkout, every fresh CI runner,
+and every `~/.mvm` reset pays the cost again.
+
+Cache.nixos.org can't host them (they're our outputs, not nixpkgs').
+A binary cache we control would fix this with a Stage-0-only substituter
+fetch.
+
+## Goal
+
+After this plan: a `mvmctl dev up` on a fresh machine pulls the four
+big derivations as pre-built binaries from `https://mvm.cachix.org`
+in seconds instead of minutes. CI runners get the same win.
+
+Steady-state user-flake builds are explicitly out of scope (see "What
+this does NOT help" below). The cache only fires during Stage 0.
+
+## Why no ADR
+
+Three reasons:
+
+1. The trust model is the same one ADR-002 already enumerates for
+   `cache.nixos.org` — a `trusted-public-keys` entry that gates
+   accepting any substituted closure. We're adding one more entry, not
+   inventing a new mechanism.
+2. The blast radius is bounded: a compromised cachix.org host can
+   ship bytes, but Nix refuses any closure not signed by our key, so
+   the attacker also has to compromise our CI signing token. The
+   pre-existing `cache.nixos.org-1:…` trust already has the same
+   shape.
+3. The scope is narrow: Stage-0-only. Steady state remains air-gapped
+   per ADR-047's existing posture.
+
+If reviewers want an ADR captured anyway, ADR-056 is the next free
+slot.
+
+## Design
+
+### One substituter line in `cmd.sh`'s `NIX_CONFIG`
+
+`crates/mvm-build/src/libkrun_builder.rs` emits the `cmd.sh` that
+runs inside both Stage 0 and steady-state builder VMs. The
+`NIX_CONFIG` block grows two entries (compared to today):
+
+```
+substituters       = https://cache.nixos.org/ https://mvm.cachix.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= \
+                      mvm.cachix.org-1:<USER_PROVISIONS_THIS>
+connect-timeout    = 5
+```
+
+`connect-timeout = 5` is defense against the steady-state iptables
+lockdown: in steady state the substituter URL is unreachable
+(`OUTPUT` chain default-deny), and without a connect timeout Nix
+would block ~63 seconds per cache-miss derivation waiting for the
+default TCP SYN retries. Five seconds is enough for Stage 0's
+network to be honest about reachability and short enough that a
+steady-state miss doesn't visibly stall.
+
+### CI workflow that pushes closures on every `main` merge
+
+`.github/workflows/cache-push.yml` runs on `push` to `main`:
+
+1. Build `nix/images/builder-vm#packages.{x86_64,aarch64}-linux.default`
+   on a Linux runner.
+2. `cachix push mvm <result>` against the produced closure.
+3. Optional follow-up: push the `nix/images/builder/` (dev-shell)
+   closure too once we measure how much it adds to Stage 0 budget.
+
+The workflow needs `CACHIX_AUTH_TOKEN` as a repo secret (one-time
+user provisioning).
+
+### What this does NOT help
+
+- **Steady-state user-flake builds.** `mvm-builder-init` installs an
+  iptables `OUTPUT` default-deny rule before `cmd.sh` runs in steady
+  state. The substituter URL is present but unreachable; Nix falls
+  back to local store (warm from Stage 0). Making the cache work in
+  steady state would require either (a) opening the egress allowlist
+  for `mvm.cachix.org` (ADR-047 surface growth) or (b) extending
+  `mvm-egress-proxy` to gate the substituter fetch like it does for
+  the installer fetches. Deferred to a separate plan if/when steady-
+  state cache hits become a measured pain point.
+- **Contributor edits to the builder VM flake / kernel / workspace
+  `Cargo.lock`.** Input hash changes → cache miss → local rebuild.
+  Intentional: preserves the CLAUDE.md "source-checkout never depends
+  on mvm-published artifacts" invariant.
+- **Bug fixes to mvmctl Rust code** that don't touch Nix derivations.
+  No `nix build` happens — Cachix is irrelevant.
+
+## One-time user provisioning
+
+This plan ships placeholders. Before the cache becomes functional,
+exactly four things have to happen on the user side (~10 minutes):
+
+1. Sign up at https://app.cachix.org/ and create a public cache
+   named `mvm` (open-source plan — free).
+2. Run `cachix generate-keypair mvm`. Save the private key in a
+   password manager; copy the printed **public** key.
+3. Replace the placeholder `<USER_PROVISIONS_THIS>` in
+   `crates/mvm-build/src/libkrun_builder.rs` with the public key.
+   (Only one place — the cache-push workflow consumes the key
+   through the `cachix/cachix-action` setup, not as a literal
+   string.)
+4. Add `CACHIX_AUTH_TOKEN` (from `cachix authtoken`) to the GitHub
+   repo secrets at Settings → Secrets and variables → Actions.
+
+Until step 3 is done the substituter line points at a key Nix won't
+trust; signed closures from the (real) cache get rejected and Nix
+falls back to source builds — same behavior as no Cachix at all,
+just slightly more network traffic. Until step 4 the CI push job
+fails closed.
+
+## Workstreams (one PR each)
+
+This plan splits into one PR because the pieces only make sense
+together; reviewing them separately wastes everyone's time. The PR
+contains:
+
+- `specs/plans/89-cachix-substituter-stage0.md` — this file
+- `crates/mvm-build/src/libkrun_builder.rs` — substituter + key + timeout
+- `crates/mvm-build/src/libkrun_builder.rs` tests — locked
+- `.github/workflows/cache-push.yml` — new
+- `README.md` (or appropriate contributor doc) — one-time setup section
+
+## Followups (not in this PR)
+
+- Measure Stage 0 wall-clock with/without cache hit. Today's
+  "estimated minutes → seconds" is a heuristic; a real number lives
+  in `specs/runbooks/<runbook>.md`.
+- Decide whether to push the `nix/images/builder/` (dev-shell)
+  closure too.
+- Decide whether to amend ADR-047 to allow steady-state cache hits.
+- Decide whether to mirror to Attic (Hetzner self-hosted) if Cachix's
+  open-source tier ever caps us.
+
+## References
+
+- CLAUDE.md §"Source-checkout builds never depend on mvm-published
+  artifacts" — the constraint that bounds when the cache fires.
+- ADR-002 — security claim 6 (pre-built dev image hash-verify) is
+  the precedent for trusting binary closures over the network.
+- ADR-047 — the iptables lockdown that prevents steady-state cache
+  use; would need amendment to extend Cachix beyond Stage 0.
+- Plan 87 / PR #360 — passt becoming the default networking layer
+  (unblocked this plan; substituter HTTP works now).


### PR DESCRIPTION
## Summary

- Adds `https://mvm.cachix.org` to the in-VM `cmd.sh` `NIX_CONFIG` (`crates/mvm-build/src/libkrun_builder.rs`) so a fresh `mvmctl dev up` substitutes the four self-built derivations (TSI/passt kernel, `mvm-builder-init`, `mvm-egress-proxy`, `mvm-guest-agent`) from our public Cachix cache instead of source-building them. Stage 0 has free egress; steady state falls back to local `/nix` warmed at Stage 0.
- Adds `connect-timeout = 5` to the same `NIX_CONFIG` so a steady-state cache miss (firewall-dropped) fails fast instead of hanging on the default ~63s TCP SYN-retry.
- Adds `.github/workflows/cache-push.yml` — on main merge, build the `nix/images/builder-vm` closure for both arches and push to Cachix. Path-filtered so doc-only edits skip the job.
- Adds `specs/plans/89-cachix-substituter-stage0.md` with the scope (Stage 0 only), trust model (signed closures), and what this does NOT help (steady-state user-flake builds, contributor input-hash changes, host-side Rust edits).

## One-time user provisioning before this is functional

Plan 89 §\"One-time user provisioning\" — short version:

1. Create cache `mvm` at https://app.cachix.org/ on the open-source plan (free).
2. `cachix generate-keypair mvm` — save private key in 1Password.
3. Replace `<USER_PROVISIONS_THIS>` in `crates/mvm-build/src/libkrun_builder.rs` with the printed **public** key. (Single place — the workflow uses `cachix-action` with the auth token, not the literal key.)
4. Add `CACHIX_AUTH_TOKEN` (from `cachix authtoken`) to Settings → Secrets → Actions.

Until step 3, signed closures from the real cache get rejected (wrong public key) — same effective behavior as no Cachix at all. Until step 4 the CI push job fails closed.

## Why no ADR

Three reasons in Plan 89 §\"Why no ADR\" — same trust mechanism as the existing `cache.nixos.org` substituter, bounded blast radius, narrow Stage-0-only scope. ADR-056 is the next free slot if reviewers want one.

## Stacks on top of

Independent of PR #358 (`max-jobs = auto`) — same `NIX_CONFIG` block but different lines. Either order merges cleanly; both wins are additive.

## Test plan

- [x] `cargo test -p mvm-build --lib --features builder-vm libkrun_builder::tests::stage_job_dir_writes_cmd_sh_with_escaped_inputs` — pass (asserts the three new `NIX_CONFIG` entries are emitted)
- [x] `cargo test --workspace --all-features` — green
- [x] `cargo clippy --workspace --all-features --tests -- -D warnings` — clean
- [ ] After user provisioning lands, verify a fresh `mvmctl dev up` hits the cache (closure substituted, not source-built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)