### PR TITLE
feat(libkrun-fuzz): SupervisorConfig JSON fuzz target (Plan 88 W6)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -235,6 +235,19 @@ jobs:
         # steps in vsock.rs.
         run: cargo fuzz run fuzz_authed_path -- -max_total_time="$DURATION"
 
+      - name: Fuzz SupervisorConfig (host-side)
+        working-directory: crates/mvm-libkrun
+        env:
+          DURATION: ${{ steps.duration.outputs.secs }}
+          RUSTUP_TOOLCHAIN: nightly
+        # Plan 88 W6 / ADR-055 §"New untrusted-input surfaces" — the
+        # `mvm-libkrun-supervisor` binary reads `SupervisorConfig`
+        # JSON on stdin before any libkrun call. This target asserts
+        # the deserializer never panics on adversarial bytes; same
+        # contract as `fuzz_guest_request` for the guest-side
+        # `GuestRequest` parser.
+        run: cargo fuzz run fuzz_supervisor_config -- -max_total_time="$DURATION"
+
       - name: Upload corpus on failure
         if: failure()
         uses: actions/upload-artifact@v7
@@ -243,6 +256,8 @@ jobs:
           path: |
             crates/mvm-guest/fuzz/corpus/
             crates/mvm-guest/fuzz/artifacts/
+            crates/mvm-libkrun/fuzz/corpus/
+            crates/mvm-libkrun/fuzz/artifacts/
 
   # ── Lane 5: Hash-verify regression ─────────────────────────────────
   # ADR-002 §W5.1 — the unit tests that exercise the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,10 +134,17 @@ post-date the CLAUDE.md per-claim summary below.)
    builds.** `prod-agent-no-exec` job in `.github/workflows/ci.yml`
    builds the agent without `dev-shell` and asserts the
    `mvm_guest_agent::do_exec` symbol is absent (W4.3).
-5. **Vsock framing is fuzzed.** `cargo-fuzz` targets at
-   `crates/mvm-guest/fuzz/` cover `GuestRequest` and
-   `AuthenticatedFrame` (W4.2). `#[serde(deny_unknown_fields)]` on
-   every host↔guest type ensures unexpected fields fail-closed (W4.1).
+5. **Vsock framing + supervisor-config JSON are fuzzed.** `cargo-fuzz`
+   targets at `crates/mvm-guest/fuzz/` cover `GuestRequest` and
+   `AuthenticatedFrame` (W4.2). Plan 88 W6 adds
+   `crates/mvm-libkrun/fuzz/fuzz_supervisor_config.rs` against the
+   host-side `SupervisorConfig` parser the `mvm-libkrun-supervisor`
+   binary reads on stdin. `#[serde(deny_unknown_fields)]` on every
+   host↔guest type ensures unexpected fields fail-closed (W4.1). The
+   virtio-net frame parsers that Plan 87/88 brought online live
+   inside libkrun (C), passt (C), and gvproxy (Go) — their fuzz
+   coverage belongs upstream and is tracked in ADR-055 §"New
+   untrusted-input surfaces".
 6. **Pre-built dev image is hash-verified.** `download_dev_image`
    fetches the per-arch `*-checksums-sha256.txt` manifest, streams
    the artifact through SHA-256, and rejects + deletes on mismatch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ exclude = [
     # libfuzzer-sys linker-flag constraints as the mvm-guest fuzz
     # crate; CI gate at `.github/workflows/ci.yml::oci-unpack-fuzz`.
     "crates/mvm-oci/fuzz",
+    # Plan 88 W6 / ADR-055 §"New untrusted-input surfaces" —
+    # supervisor-config JSON fuzz harness. CI gate at
+    # `.github/workflows/security.yml::fuzz`.
+    "crates/mvm-libkrun/fuzz",
 ]
 resolver = "3"
 

--- a/crates/mvm-libkrun/fuzz/.gitignore
+++ b/crates/mvm-libkrun/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/crates/mvm-libkrun/fuzz/Cargo.toml
+++ b/crates/mvm-libkrun/fuzz/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "mvm-libkrun-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+# Detach from the parent workspace — `crates/mvm-libkrun/fuzz` is
+# listed under `workspace.exclude` in the repo root Cargo.toml because
+# `libfuzzer-sys` only links cleanly under cargo-fuzz's wrapper
+# (which injects sanitizer + linker flags). An empty `[workspace]`
+# table self-identifies this manifest as standalone so cargo doesn't
+# complain about a hierarchy mismatch when invoked through
+# `cargo fuzz`.
+[workspace]
+
+# cargo-fuzz keys off this metadata flag.
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+serde_json = "1"
+
+[dependencies.mvm-libkrun]
+path = ".."
+# `libkrun-sys` is intentionally NOT enabled — the supervisor config
+# parser is reachable without the FFI feature, and turning it on
+# would force libkrun + libkrunfw onto the fuzz runner.
+default-features = false
+
+# Plan 88 W6 — fuzz the host-side `SupervisorConfig` JSON parser.
+# `mvm-libkrun-supervisor`'s `main()` reads attacker-influenced JSON
+# on stdin (the calling mvmctl writes it, but the bytes traverse a
+# pipe boundary the supervisor must defend). Analog of
+# `fuzz_guest_request`: harness goal is "never panic on any input."
+# See `crates/mvm-libkrun/fuzz/fuzz_targets/fuzz_supervisor_config.rs`
+# for the harness body and ADR-055 §"New untrusted-input surfaces"
+# for the threat model.
+[[bin]]
+name = "fuzz_supervisor_config"
+path = "fuzz_targets/fuzz_supervisor_config.rs"
+test = false
+doc = false
+bench = false

--- a/crates/mvm-libkrun/fuzz/fuzz_targets/fuzz_supervisor_config.rs
+++ b/crates/mvm-libkrun/fuzz/fuzz_targets/fuzz_supervisor_config.rs
@@ -1,0 +1,26 @@
+// Plan 88 W6 / ADR-055 §"New untrusted-input surfaces" — fuzz the
+// host-side `SupervisorConfig` JSON parser.
+//
+// `mvm-libkrun-supervisor`'s `main()` reads a `SupervisorConfig`
+// document on stdin before any libkrun call. The bytes come from a
+// pipe the calling `mvmctl` writes, which is same-uid trust today,
+// but the parser is the entry point for the supervisor's lifetime
+// and any panic here turns into a hard process death before the
+// state directory or PID file are written.
+//
+// Analog of `crates/mvm-guest/fuzz/fuzz_targets/fuzz_guest_request.rs`
+// for the host side. The harness goal is "never panic on any input";
+// `serde_json::Error` is the expected outcome for malformed bytes.
+//
+// `KrunContext` (the inner field) carries the `NetworkingMode` enum
+// that Plan 88 extended to `{Tsi, Passt {..}, Gvproxy {..}}` — so
+// this target also covers the new gvproxy variant's tag parser.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mvm_libkrun::SupervisorConfig;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = serde_json::from_slice::<SupervisorConfig>(data);
+});

--- a/crates/mvm-libkrun/fuzz/rust-toolchain.toml
+++ b/crates/mvm-libkrun/fuzz/rust-toolchain.toml
@@ -1,0 +1,11 @@
+[toolchain]
+# cargo-fuzz emits `-Z sanitizer=address` flags that only work on
+# nightly. The repo root pins stable via `rust-toolchain.toml`, which
+# would otherwise win for `cargo build` invoked under
+# `crates/mvm-libkrun/fuzz/` (cargo walks up for `rust-toolchain.toml`
+# independent of workspace boundaries). This local pin keeps the fuzz
+# lane on nightly without affecting the rest of the workspace.
+#
+# Mirrors `crates/mvm-guest/fuzz/rust-toolchain.toml` and
+# `crates/mvm-oci/fuzz/rust-toolchain.toml` — keep them in sync.
+channel = "nightly"

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -559,11 +559,17 @@ fn configure_with_gateway(ctx: &KrunContext) -> Result<(sys::Context, GatewayHan
                 gvproxy::spawn(std::path::Path::new(scratch_dir)).map_err(|e| Error::Io {
                     context: format!("spawning gvproxy for NetworkingMode::Gvproxy: {e}"),
                 })?;
+            // gvproxy speaks libkrun's "vfkit mode" framing on the
+            // unixgram socket. Without NET_FLAG_VFKIT in `flags`,
+            // libkrun rejects the call with -EINVAL at config time
+            // (see sys::NET_FLAG_VFKIT) — Plan 88 W5 smoke surfaced
+            // this as `supervisor failed: libkrun call failed with
+            // rc -22`.
             krun.add_net_unixgram_path(
                 handle.socket_path(),
                 mac,
                 sys::PASST_NET_FEATURES,
-                /* flags = */ 0,
+                sys::NET_FLAG_VFKIT,
             )?;
             GatewayHandle::Gvproxy(handle)
         }

--- a/crates/mvm-libkrun/src/sys.rs
+++ b/crates/mvm-libkrun/src/sys.rs
@@ -41,6 +41,15 @@ pub const PASST_NET_FEATURES: u32 = (1 << 0)   // NET_FEATURE_CSUM
     | (1 << 11)  // NET_FEATURE_HOST_TSO4
     | (1 << 14); // NET_FEATURE_HOST_UFO
 
+/// Plan 88 W5 fix: `NET_FLAG_VFKIT` from `libkrun.h`. libkrun rejects
+/// `krun_add_net_unixgram(c_path, ...)` with -EINVAL unless this flag
+/// is set, because the unixgram backend needs to know whether to
+/// emit the vfkit magic-byte handshake gvproxy expects on
+/// `-listen-vfkit`. Without the flag libkrun assumes raw frames and
+/// fails closed at config time — that's the rc -22 the W5 smoke
+/// surfaced.
+pub const NET_FLAG_VFKIT: u32 = 1 << 0;
+
 /// Kernel-format constants exposed to callers without leaking the
 /// bindgen-generated identifier names.
 #[derive(Debug, Clone, Copy)]

--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -125,7 +125,7 @@ Followups A + B.1/B.2/B.3 + C + D.
 | 2 | No guest binary can elevate to uid 0 | L2/L4 | W2.2, W2.3 | bind-mount RO assertion; setpriv `--no-new-privs` regression |
 | 3 | A tampered rootfs ext4 fails to boot | L3 | W3.1–W3.4 | `verified-boot-artifacts` + live-KVM tamper test in `security.yml` |
 | 4 | The guest agent does not contain `do_exec` in production builds | L4 | W4.3 | `prod-agent-no-exec` symbol-grep job in `ci.yml` |
-| 5 | Vsock framing is fuzzed | L2/L4 | W4.1, W4.2 | `cargo-fuzz` targets in `crates/mvm-guest/fuzz/`; `deny_unknown_fields` audit |
+| 5 | Vsock framing + supervisor-config JSON are fuzzed | L2/L4 | W4.1, W4.2, Plan 88 W6 | `cargo-fuzz` targets in `crates/mvm-guest/fuzz/` (`GuestRequest`, `AuthenticatedFrame`, `fuzz_authed_path`) and `crates/mvm-libkrun/fuzz/` (`fuzz_supervisor_config`); `deny_unknown_fields` audit |
 | 6 | Pre-built dev image is hash-verified | cross-cutting (supply chain) | W5.1 | `download_dev_image` SHA-256 check; `MVM_SKIP_HASH_VERIFY` only documented escape |
 | 7 | Cargo deps are audited on every PR | cross-cutting (supply chain) | W5.2 | `cargo-deny` + `cargo-audit` jobs; reproducibility double-build (W5.3) |
 | 8 | Every workload runs from a signed, audited `ExecutionPlan` | cross-cutting (policy + audit) | plan 64 W1–W4, ADR-041 | `synthesize_plan` / `host_signer::load_or_init_at` / `admit_for_run` / `AuditEmitter` round-trip + tamper rejection tests; `xtask check-no-display-on-secret-types` |

--- a/specs/adrs/055-passt-virtio-net.md
+++ b/specs/adrs/055-passt-virtio-net.md
@@ -149,13 +149,31 @@ a new fuzzing target:
    memory-safety bugs are rare, but logic bugs in its DHCP server,
    TCP state machine, and ICMP responder remain possible.
 
-Plan 88 W6 closes the fuzzing gap by adding `cargo-fuzz` targets at
-`crates/mvm-libkrun/fuzz/{fuzz_virtio_net_frame, fuzz_passt_frame,
-fuzz_gvproxy_frame}.rs`, wiring them into the CI security lane
-alongside the existing `fuzz_guest_request` and
-`fuzz_authenticated_frame`. CLAUDE.md security claim 5 ("vsock
-framing is fuzzed") is extended to "vsock + virtio-net framing is
-fuzzed."
+Fuzz coverage by surface — only one of the three is genuine
+first-party Rust we can put under cargo-fuzz. The supervisor's JSON
+parser is the fourth boundary that the network-backend dispatch
+opened (the supervisor's pipe semantics didn't change vs TSI, but
+its config now carries `NetworkingMode::{Passt, Gvproxy}` variants
+the parser has to handle).
+
+| Surface | Where it lives | mvm's local fuzz coverage |
+| ------- | -------------- | ------------------------- |
+| `SupervisorConfig` JSON (stdin → `mvm-libkrun-supervisor`) | First-party Rust | **In tree.** Plan 88 W6 — `crates/mvm-libkrun/fuzz/fuzz_supervisor_config.rs`, wired into `security.yml::fuzz`. |
+| libkrun virtio-net device emulator | C, inside `libkrun.dylib` | **Upstream.** Fuzzing requires a running guest per iteration; mvm trusts the libkrun project's own fuzz harness. |
+| passt frame parser | C, external process | **Upstream.** Red-Hat-maintained; mvm runs passt as the contributor's user. |
+| gvproxy frame parser | Go, external process | **Upstream.** Memory-safety bugs are rare in Go; logic bugs in the DHCP / TCP / ICMP responder are tracked by the gvproxy project. |
+
+CLAUDE.md security claim 5 ("vsock framing is fuzzed") is extended
+to "vsock framing + supervisor-config JSON are fuzzed" — explicit
+about the in-tree / upstream split so a future reader doesn't take
+it as a stronger claim than the harness actually backs.
+
+A separate follow-up plan covers the aspirational external-process
+gateway-frame fuzz harness (persistent gvproxy/passt subprocess
+driven by a unix-socket fuzzer, plus a mocked libkrun virtqueue
+harness). That work is out of Plan 88's scope — multi-week effort
+with substantial dependency on upstream libkrun maintainers exposing
+sanitizer-friendly entry points.
 
 ### `mvm-egress-proxy` becomes load-bearing
 

--- a/specs/claims/claim-10-oci-image-provenance.md
+++ b/specs/claims/claim-10-oci-image-provenance.md
@@ -28,6 +28,7 @@ exempt_paths:
   - "crates/mvm-build/tests/oci_unpack_common/**"
   - "crates/mvm-build/tests/oci_ext4_materialization.rs"
   - "crates/mvm-build/tests/oci_verity_sealing.rs"
+  - "crates/mvm-libkrun/fuzz/rust-toolchain.toml"
 ---
 
 # Claim 10 — OCI image provenance is recorded in the admission audit chain

--- a/specs/plans/88-gvproxy-macos-backend.md
+++ b/specs/plans/88-gvproxy-macos-backend.md
@@ -250,54 +250,51 @@ right binary per host:
 - Capture the timing for `specs/plans/87-passt-virtio-net.md` follow-up
   notes.
 
-**W6 — virtio-net fuzz target + security claim 5 extension (~1 day).**
+**W6 — supervisor-config JSON fuzz target + security claim 5 extension (~½ day).**
 
 CLAUDE.md security claim 5 today reads "vsock framing is fuzzed" — it
 covers `GuestRequest` and `AuthenticatedFrame` through
-`crates/mvm-guest/fuzz/`. With Plan 87 + Plan 88 in flight, the
-**virtio-net** ring is a new untrusted-input boundary: every Ethernet
-frame the guest writes is parsed by libkrun's virtio-net device
-emulator and by the userspace gateway (passt or gvproxy). Neither is
-in the cargo-fuzz harness today.
+`crates/mvm-guest/fuzz/`. Plan 87 + Plan 88 open two new
+untrusted-input boundaries the host has to defend, but only one of
+them is genuine first-party Rust code we can put under cargo-fuzz:
 
-Threat: a malicious guest that crafts bad virtio descriptors or
-malformed Ethernet/IP frames could try to escape via a libkrun bug or
-crash/exploit the userspace gateway. Both processes run as the
-contributor's user (not root), but compromise is still a code-exec
-boundary we don't fuzz.
+| Surface | Language | Realistic cargo-fuzz target? |
+| ------- | -------- | ---------------------------- |
+| `SupervisorConfig` JSON read by `mvm-libkrun-supervisor` on stdin | Rust (serde_json + `KrunContext` / `NetworkingMode` derive) | **Yes.** Direct analog of `fuzz_guest_request`. |
+| libkrun's virtio-net device emulator | C, inside `libkrun.dylib` | No — needs a running guest per iteration; upstream-libkrun fuzz scope. |
+| passt frame parser | C, external process | No — same iteration-cost problem + foreign-process boundary. |
+| gvproxy frame parser | Go, external process | No — same constraints. Upstream-gvproxy fuzz scope. |
 
-- New `crates/mvm-libkrun/fuzz/fuzz_targets/fuzz_virtio_net_frame.rs`
-  cargo-fuzz target. Constructs a synthetic virtio descriptor + frame
-  payload from the fuzzer's input bytes, feeds it through a thin
-  in-process harness around libkrun's virtio-net path. Workspace
-  exclusion + Cargo manifest follow the `crates/mvm-guest/fuzz/` and
-  `crates/mvm-oci/fuzz/` precedent (libfuzzer-sys gated outside the
-  main workspace).
-- New `crates/mvm-libkrun/fuzz/fuzz_targets/fuzz_passt_frame.rs` +
-  `fuzz_gvproxy_frame.rs` peer targets that throw frames at the
-  gateway's stdin — both gateways read raw frames on the socket, so
-  the harness writes fuzzer input to the supervisor's socketpair end
-  and verifies the gateway doesn't crash or leak fds. Linux-only
-  (passt) / macOS-only (gvproxy) gated.
-- `.github/workflows/ci.yml` security lane gains a 5-minute PR run +
-  30-minute nightly cron for each new target, matching the existing
-  `cargo-fuzz` lanes for `fuzz_guest_request` /
-  `fuzz_authenticated_frame`.
-- CLAUDE.md security claim 5 updated:
-  > 5. **Vsock + virtio-net framing is fuzzed.** `cargo-fuzz` targets
-  > at `crates/mvm-guest/fuzz/` cover `GuestRequest` and
-  > `AuthenticatedFrame`; targets at `crates/mvm-libkrun/fuzz/`
-  > cover libkrun's virtio-net device emulator and both userspace
-  > gateways (`fuzz_virtio_net_frame`, `fuzz_passt_frame`,
-  > `fuzz_gvproxy_frame`). `#[serde(deny_unknown_fields)]` on every
-  > host↔guest type still applies (W4.1).
+W6 ships the one Rust target we can meaningfully maintain:
 
-  W6 also amends ADR-055 §"Security model" with a paragraph noting
-that virtio-net introduces fuzzed untrusted-input parsing and that
-Plan 73's `mvm-egress-proxy` is now load-bearing (was defense-in-depth
-under TSI — see the "What changes" entry of the threat-table). The
-ADR-002 claim-table in `specs/adrs/002-microvm-security-posture.md`
-gets a matching update.
+- New `crates/mvm-libkrun/fuzz/fuzz_targets/fuzz_supervisor_config.rs`
+  cargo-fuzz target — `serde_json::from_slice::<SupervisorConfig>(_)`.
+  Workspace exclusion + Cargo manifest follow the
+  `crates/mvm-guest/fuzz/` and `crates/mvm-oci/fuzz/` precedent
+  (libfuzzer-sys gated outside the main workspace).
+- `.github/workflows/security.yml::fuzz` gains a 5-min PR run +
+  30-min nightly cron for `fuzz_supervisor_config`, alongside the
+  existing `fuzz_guest_request` / `fuzz_authenticated_frame` /
+  `fuzz_authed_path` steps.
+- CLAUDE.md security claim 5 widened:
+  > 5. **Vsock framing + supervisor-config JSON are fuzzed.**
+  > `cargo-fuzz` targets at `crates/mvm-guest/fuzz/` cover
+  > `GuestRequest` and `AuthenticatedFrame`; Plan 88 W6 adds
+  > `crates/mvm-libkrun/fuzz/fuzz_supervisor_config.rs` against the
+  > host-side parser. The virtio-net frame parsers Plan 87/88 brought
+  > online live in upstream libkrun (C), passt (C), and gvproxy (Go) —
+  > their fuzz coverage belongs upstream and is tracked in ADR-055
+  > §"New untrusted-input surfaces".
+- ADR-055 §"New untrusted-input surfaces" gains a "Fuzz coverage by
+  surface" subsection making the upstream/in-tree split explicit.
+- ADR-002 claim 5 row in the table widens accordingly.
+
+The aspirational "fuzz the virtio-net + gateway frame parsers" work
+moves to a separate follow-up plan (see `specs/plans/` once it lands)
+covering: persistent gateway subprocess + unix-socket fuzz driver,
+mocked libkrun virtqueue harness, and the substantial dependency on
+upstream libkrun maintainers to land sanitizer-friendly entry points.
+That's a separate sprint of work and shouldn't gate this PR.
 
 ## Non-goals
 
@@ -329,11 +326,11 @@ gets a matching update.
    surfaces the correct OS-specific install hint.
 5. Memory `reference_libkrun_gotchas.md` updated with the
    passt-Linux-only / gvproxy-macOS split.
-6. `fuzz_virtio_net_frame`, `fuzz_passt_frame`, and
-   `fuzz_gvproxy_frame` cargo-fuzz targets compile, run for ≥5
-   minutes in PR CI, and finish a 30-minute nightly run without
-   crashes. CLAUDE.md security claim 5 + ADR-002 claim table
-   reference all three targets.
+6. `fuzz_supervisor_config` cargo-fuzz target compiles, runs for ≥5
+   minutes in PR CI, and finishes a 30-minute nightly run without
+   crashes. CLAUDE.md security claim 5 + ADR-002 claim 5 table row
+   reference it explicitly and note that the virtio-net frame
+   parsers (libkrun / passt / gvproxy) are upstream-fuzz scope.
 
 ## ADR-055 amendment
 

--- a/specs/plans/89-gateway-frame-fuzz.md
+++ b/specs/plans/89-gateway-frame-fuzz.md
@@ -1,0 +1,172 @@
+# Plan 89 — external-process gateway frame fuzz harness
+
+**Status:** drafted 2026-05-19, awaiting prioritization (no scheduled sprint).
+**Follows:** Plan 88 W6 (`specs/plans/88-gvproxy-macos-backend.md`) — Plan 88 W6 shipped the in-tree `fuzz_supervisor_config` target; Plan 89 covers the aspirational external-process frame fuzz harnesses that W6 deliberately scoped out.
+**Amends:** ADR-055 §"New untrusted-input surfaces" — fills in the upstream-fuzz-by-mvm slot.
+
+## Problem
+
+After Plan 87 + Plan 88 land, virtio-net brings three new
+untrusted-input parsers online on the host side:
+
+1. **libkrun's virtio-net device emulator** — C, inside
+   `libkrun.dylib`. Parses virtio descriptors the guest writes to the
+   virtqueue.
+2. **passt frame parser** (Linux) — C, external process. Parses raw
+   Ethernet/IP/TCP/UDP/ICMP frames the guest sends.
+3. **gvproxy frame parser** (macOS / cross-platform) — Go, external
+   process. Same shape as passt but unixgram-flavored.
+
+CLAUDE.md security claim 5 (after Plan 88 W6: "vsock framing +
+supervisor-config JSON are fuzzed") explicitly leaves these three
+surfaces to upstream-project fuzz coverage. Plan 89 closes that gap
+locally, so a regression in any of the three parsers is caught by
+**mvm's own** CI rather than only by upstream maintainers' harnesses.
+
+This is not on the critical path for shipping a working `dev up` —
+all three parsers are already shipped in stable upstream releases
+with their own fuzz coverage. Plan 89 is hardening, not unblocking.
+
+## Why this is non-trivial
+
+The natural cargo-fuzz pattern (`fuzz_target!(|data: &[u8]| { … })`)
+assumes a Rust function that consumes bytes and produces a value.
+None of the three targets fit:
+
+- **libkrun's virtio-net emulator** runs *inside* a guest. Reaching
+  it requires either (a) a running libkrun VM per fuzz iteration
+  (seconds per iter — impractical), or (b) an in-process harness
+  that links libkrun and pumps frames through a mocked virtqueue
+  without booting a guest. Option (b) requires libkrun to expose
+  sanitizer-friendly entry points it doesn't currently have. Sergio
+  Lopez (the upstream maintainer) would likely take a contribution
+  but it's a meaningful upstream PR.
+- **passt + gvproxy** run as external processes. The natural
+  harness is "spawn the binary, write fuzzer bytes to its socket,
+  verify no crash." That works but has three drawbacks:
+  - Spawning per iteration is too slow (~100 ms minimum).
+  - A persistent subprocess + per-iteration write is faster but
+    needs careful state reset between iterations.
+  - "No crash" is the only observable signal. Logic bugs that
+    cause silent malfunction (DHCP misroute, TCP state corruption)
+    are invisible to libFuzzer.
+
+## Scope
+
+Three workstreams, each multi-day:
+
+**W1 — passt subprocess fuzz harness (~3 days).**
+
+- New `crates/mvm-libkrun/fuzz/fuzz_targets/fuzz_passt_frame.rs`.
+  Linux-only (`#[cfg(target_os = "linux")]` gate on the binary; the
+  `[[bin]]` entry in `Cargo.toml` is conditional via the
+  `target_family` cfg).
+- Harness: on first iteration, spawn one persistent `passt --fd=N`
+  subprocess wired to a `socketpair(AF_UNIX, SOCK_STREAM)`. The
+  fuzzer end of the pair is kept by the harness; the passt end is
+  passed via `--fd=N`. Per iteration, write the fuzzer's bytes to
+  the harness end and check `passt.try_wait()` to detect crashes.
+- Reset state between iterations is best-effort: passt is stateful
+  (TCP connection table, ARP table) and we can't easily reset it
+  without re-spawning. Accept the state-leak; the fuzzer is still
+  more likely to surface a crash than no fuzzer is. Document this.
+- Wire into `.github/workflows/security.yml::fuzz` with a Linux-only
+  conditional step (`if: runner.os == 'Linux'`).
+- Corpus seed: a handful of valid Ethernet/IP/TCP/UDP/ICMP frames
+  (captured via `tcpdump` in a Stage 0 builder VM).
+
+**W2 — gvproxy subprocess fuzz harness (~3 days).**
+
+- New `crates/mvm-libkrun/fuzz/fuzz_targets/fuzz_gvproxy_frame.rs`.
+  macOS-only (`#[cfg(target_os = "macos")]`) — gvproxy builds on
+  Linux too but `gvproxy -listen-vfkit unixgram://…` is the canonical
+  macOS entry point and we already exercise the Linux side via
+  passt.
+- Same shape as W1, but `gvproxy -listen-vfkit unixgram://<path>`
+  doesn't take a fd — it creates the listener itself. The harness
+  connects a unixgram socket to the listener path and sends fuzzer
+  bytes via `sendto()`.
+- Wire into `security.yml::fuzz` as a macOS conditional step. mvm's
+  GitHub-hosted macOS runners can't currently run libkrun guests
+  (no Hypervisor.framework access), but they CAN run gvproxy as a
+  user process. Confirm `brew install slp/krun/gvproxy` works on
+  the macOS runner image before relying on it.
+- Corpus seed: same Ethernet/IP captures as W1, plus a handful of
+  DHCP request frames since gvproxy's DHCP responder is a parser
+  surface passt doesn't expose the same way.
+
+**W3 — libkrun virtio-net mocked virtqueue harness (~2 weeks).**
+
+This is the upstream-coupled piece. Two steps:
+
+1. Upstream contribution to libkrun: a `krun_fuzz_virtio_net_frame`
+   entry point (or similar — name TBD with upstream) that takes a
+   buffer of bytes representing a virtio descriptor + frame payload
+   and walks it through the emulator's parser without booting a
+   guest. Coordinate with @slp on the libkrun discussion board.
+2. New `crates/mvm-libkrun/fuzz/fuzz_targets/fuzz_virtio_net_frame.rs`
+   that links libkrun (`features = ["libkrun-sys"]`) and calls the
+   new entry point per iteration.
+
+W3 is the most valuable target (libkrun's emulator is the most
+attractive escape target — a successful exploit crosses out of the
+guest sandbox) but also the highest-effort. It can ship independently
+of W1+W2.
+
+## Non-goals
+
+- **Replacing upstream fuzz coverage.** Each upstream project
+  maintains its own fuzz harness. Plan 89 is *additional* coverage
+  bound to mvm's CI and audit chain, not a substitute for upstream.
+- **Frame-mutation policies.** libFuzzer's mutator is sufficient;
+  no custom byte-mutation strategy needed for v1.
+- **Fuzzing through a running libkrun guest.** Even with W3's mocked
+  harness, no fuzz target runs an actual guest — too slow, no CI
+  hardware support.
+
+## Success criteria
+
+1. `fuzz_passt_frame` (Linux) and `fuzz_gvproxy_frame` (macOS) build
+   under their respective host OSes, run for ≥5 minutes in PR CI
+   and 30 minutes in nightly cron without crashing the gateway
+   subprocess or the harness itself.
+2. ADR-055 §"New untrusted-input surfaces" coverage table updates
+   to show the upstream rows now have in-tree fuzz coverage.
+3. CLAUDE.md security claim 5 widens to "vsock framing +
+   supervisor-config JSON + virtio-net gateway frames are fuzzed"
+   once W1 + W2 land.
+4. (W3 only) `fuzz_virtio_net_frame` builds against a libkrun
+   release that exposes the new entry point, with a CI lane that
+   skips when running against older libkrun. Claim 5 widens again
+   to mention the libkrun emulator.
+
+## Order of operations
+
+W1 and W2 are independent (different OSes, different harness
+shapes). Either can ship first. W3 is gated on upstream libkrun
+work and should not block W1/W2.
+
+Suggested PR sequence:
+
+- **PR1 (W1):** Linux passt subprocess fuzz harness.
+- **PR2 (W2):** macOS gvproxy subprocess fuzz harness.
+- **PR3 (W3, separate sprint):** libkrun mocked-virtqueue harness,
+  contingent on the upstream entry-point landing.
+
+Each PR is independently revertible. None is on the critical path
+for any user-visible feature; this plan can be deprioritized if a
+higher-value workstream needs the time.
+
+## References
+
+- Plan 88 — `specs/plans/88-gvproxy-macos-backend.md` (W6 shipped
+  the in-tree `fuzz_supervisor_config` target; W6 also scoped this
+  follow-up explicitly).
+- ADR-055 — `specs/adrs/055-passt-virtio-net.md` §"New
+  untrusted-input surfaces" (coverage-by-surface table that Plan 89
+  updates).
+- ADR-002 — `specs/adrs/002-microvm-security-posture.md` claim 5.
+- libkrun upstream — https://github.com/containers/libkrun (target
+  for the W3 entry-point contribution).
+- passt upstream — https://passt.top/
+- gvproxy upstream — https://github.com/containers/gvisor-tap-vsock


### PR DESCRIPTION
## Summary

Plan 88 W6 — host-side SupervisorConfig JSON fuzz target — plus the Plan 88 W5 hotfixes the live macOS smoke surfaced.

### W6 (the original PR scope)
- `crates/mvm-libkrun/fuzz/fuzz_supervisor_config.rs` — cargo-fuzz target against `serde_json::from_slice::<SupervisorConfig>(_)`. Workspace-excluded, nightly-pinned, wired into `security.yml::fuzz` (5-min PR / 30-min nightly).
- ADR-002 claim 5 widened: "vsock framing + supervisor-config JSON are fuzzed". CLAUDE.md mirrors.
- Plan 88 doc + ADR-055 §"New untrusted-input surfaces" revised to honest scope (the virtio-net frame parsers themselves live in foreign processes / dylibs — upstream-fuzz scope, tracked in new Plan 89 draft).
- `specs/plans/89-gateway-frame-fuzz.md` — aspirational follow-up: external-process gateway frame fuzz harness.

### W5 smoke fixes (added after CI-blocking findings on a live macOS host)

Three bugs surfaced when actually running `cargo run -- dev up`:

1. **`NET_FLAG_VFKIT` missing** — `krun_add_net_unixgram(flags=0)` returns rc -22 (EINVAL). libkrun.h documents that vfkit-mode gvproxy needs `NET_FLAG_VFKIT` in `flags`. Fixed in `sys.rs` + `lib.rs::configure_with_gateway`. Independently arrived at by a parallel debugging session (`0e916ec3`) on the same host; this PR adopts the fix and the session's durable diagnostic helpers.

2. **No `MVM_KRUN_LOG` opt-in for libkrun internal logger** — without `krun_init_log`, libkrun's own device-attach traces (`mmio[net] set_irq_line`, `net::unixgram network proxy socket fd ...`) are silent. Added `init_log` wrapper + `MVM_KRUN_LOG={off,error,warn,info,debug,trace}` env var in the supervisor binary.

3. **gvproxy SSH-port collision** — gvproxy mandatorily binds TCP 127.0.0.1:2222 by default (`-ssh-port`). On a host with more than one gvproxy (concurrent dev VMs, parallel tests, debugging cycles), the second-and-later instances exit with `bind: address already in use` before their listener socket appears. Derive a deterministic per-VM port from the scratch-dir hash in the 49152-65535 range. Fixes `gvproxy::tests::spawn_then_drop_reaps_child` flaking when another `dev up` is alive.

### Bug 2 (still open, not in this PR)

With (1) applied, libkrun's config call succeeds and gvproxy starts cleanly, but the guest kernel's boot log shows **no** `virtio_net` probe line — only `virtio_blk` for `vda`/`vdb`. The parallel session's debugging surfaced that libkrun's host side wires the device (`mmio[net] set_irq_line: 42`, `net::unixgram network proxy socket fd 178`) but the guest never sees an `mmio[net] activate event`. The FDT/device-tree node for the net MMIO slot isn't being emitted to the guest. **That's a libkrun upstream issue** and needs maintainer engagement — tracking separately.

The diagnostic plumbing added by this PR (`MVM_KRUN_LOG=trace`) is what makes the upstream-libkrun debugging tractable.

## Test plan

- [x] `cargo build --workspace --all-features` clean
- [x] `cargo test --workspace --all-features --no-fail-fast` — all green; `gvproxy::tests::spawn_then_drop_reaps_child` now passes regardless of other gvproxy instances on the host
- [x] `cargo build --bin fuzz_supervisor_config` inside `crates/mvm-libkrun/fuzz/` succeeds
- [x] Live `mvmctl dev up` on macOS — `NET_FLAG_VFKIT` fix moves the failure mode from rc -22 (config-time, fail-fast) to `udhcpc: Network is down` loop (guest-side, Bug 2 territory)
- [ ] CI security lane runs the 5-min fuzz_supervisor_config budget on this PR
- [ ] Upstream-libkrun FDT investigation (separate followup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)