### PR TITLE
fix(libkrun): harden gvproxy networking diagnostics

### DIFF
--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -674,7 +674,9 @@ mod linux {
             .args(["link", "set", "eth0", "up"])
             .status()
         {
-            eprintln!("mvm-builder-init: ip link set eth0 up: {e} (continuing — udhcpc may still try)");
+            eprintln!(
+                "mvm-builder-init: ip link set eth0 up: {e} (continuing — udhcpc may still try)"
+            );
         }
 
         // Plan 87 W4: when /etc/udhcpc/default.script exists (passt

--- a/crates/mvm-builder-init/src/main.rs
+++ b/crates/mvm-builder-init/src/main.rs
@@ -661,6 +661,22 @@ mod linux {
             }
         }
 
+        // Plan 88 W5: bring eth0 admin-up before udhcpc tries to
+        // broadcast. libkrun's virtio-net device registers eth0 in
+        // the IFF state the kernel boots it in (admin-down for ARM
+        // virt boards by default); without this, udhcpc's first
+        // `sendto()` returns ENETDOWN and the daemon spins on
+        // "Network is down, reopening socket" until the build times
+        // out. busybox `ip link set eth0 up` is the minimal fix.
+        // Failure is non-fatal: if `eth0` is missing entirely (TSI
+        // mode) udhcpc will error out on its own and we surface that.
+        if let Err(e) = Command::new("/sbin/ip")
+            .args(["link", "set", "eth0", "up"])
+            .status()
+        {
+            eprintln!("mvm-builder-init: ip link set eth0 up: {e} (continuing — udhcpc may still try)");
+        }
+
         // Plan 87 W4: when /etc/udhcpc/default.script exists (passt
         // path / ur-seed-built rootfs), use it so the DHCP lease
         // writes /run/resolv.conf with the leased DNS. Older rootfs

--- a/crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs
@@ -45,7 +45,7 @@
 use std::io::Read;
 use std::process::ExitCode;
 
-use mvm_libkrun::{SupervisorConfig, run_supervisor};
+use mvm_libkrun::{LogLevel, SupervisorConfig, init_log, run_supervisor, set_log_level};
 
 fn main() -> ExitCode {
     // macOS Hypervisor.framework rejects any process without
@@ -54,6 +54,36 @@ fn main() -> ExitCode {
     // invocations are silent (`MVM_SIGNED=1`). Without this,
     // `krun_start_enter` fails at VM creation with rc -22.
     mvm_providers::apple_container::ensure_signed();
+
+    // Plan 88 W5 diagnostic: opt-in libkrun internal logger. Set
+    // `MVM_KRUN_LOG={off,error,warn,info,debug,trace}` to surface
+    // device-attach traces and virtio MMIO events that don't appear
+    // via `krun_set_log_level` alone. Tried `krun_init_log` first
+    // (full-featured); falls back to `krun_set_log_level` on older
+    // libkrun builds that don't export it. Failures are non-fatal —
+    // the supervisor still runs, just without verbose logging.
+    if let Ok(level) = std::env::var("MVM_KRUN_LOG") {
+        let parsed = match level.trim().to_ascii_lowercase().as_str() {
+            "off" => Some(LogLevel::Off),
+            "error" => Some(LogLevel::Error),
+            "warn" => Some(LogLevel::Warn),
+            "info" => Some(LogLevel::Info),
+            "debug" => Some(LogLevel::Debug),
+            "trace" => Some(LogLevel::Trace),
+            _ => None,
+        };
+        if let Some(lvl) = parsed {
+            if let Err(e) = init_log(2, lvl, 0, 0) {
+                eprintln!(
+                    "mvm-libkrun-supervisor: krun_init_log failed ({e}); \
+                     falling back to set_log_level"
+                );
+                if let Err(e2) = set_log_level(lvl) {
+                    eprintln!("mvm-libkrun-supervisor: krun_set_log_level failed: {e2}");
+                }
+            }
+        }
+    }
 
     let mut json = String::new();
     if let Err(e) = std::io::stdin().read_to_string(&mut json) {

--- a/crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-libkrun/src/bin/mvm-libkrun-supervisor.rs
@@ -72,15 +72,15 @@ fn main() -> ExitCode {
             "trace" => Some(LogLevel::Trace),
             _ => None,
         };
-        if let Some(lvl) = parsed {
-            if let Err(e) = init_log(2, lvl, 0, 0) {
-                eprintln!(
-                    "mvm-libkrun-supervisor: krun_init_log failed ({e}); \
-                     falling back to set_log_level"
-                );
-                if let Err(e2) = set_log_level(lvl) {
-                    eprintln!("mvm-libkrun-supervisor: krun_set_log_level failed: {e2}");
-                }
+        if let Some(lvl) = parsed
+            && let Err(e) = init_log(2, lvl, 0, 0)
+        {
+            eprintln!(
+                "mvm-libkrun-supervisor: krun_init_log failed ({e}); \
+                 falling back to set_log_level"
+            );
+            if let Err(e2) = set_log_level(lvl) {
+                eprintln!("mvm-libkrun-supervisor: krun_set_log_level failed: {e2}");
             }
         }
     }

--- a/crates/mvm-libkrun/src/gvproxy.rs
+++ b/crates/mvm-libkrun/src/gvproxy.rs
@@ -118,6 +118,28 @@ pub fn locate_gvproxy() -> Option<PathBuf> {
     which::which("gvproxy").ok()
 }
 
+/// Pick a TCP port for gvproxy's mandatory SSH-forward listener,
+/// derived deterministically from the per-VM scratch dir. gvproxy's
+/// `-ssh-port` arg is *mandatory* (default 2222) and gvproxy binds
+/// it on every start — so a host running more than one gvproxy
+/// fails the second-and-later instances with `bind: address already
+/// in use`. Plan 88 W5 surfaced this when the supervisor unit tests
+/// collided with a live `mvmctl dev up` gvproxy instance.
+///
+/// Range: 49152..=65535 (IANA dynamic / private ports). The mapping
+/// is deterministic on the dir path so a given VM's gvproxy always
+/// picks the same port (helps log/debug reproducibility); collisions
+/// across simultaneous VMs are improbable in practice but not
+/// impossible — if they happen, the second gvproxy still exits with
+/// a clear bind error and the caller's `EarlyExit` path reports it.
+fn ssh_port_for(scratch_dir: &Path) -> u16 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    scratch_dir.hash(&mut hasher);
+    let dynamic_range: u32 = 65535 - 49152 + 1;
+    49152u16 + ((hasher.finish() as u32) % dynamic_range) as u16
+}
+
 /// Owning handle to a running gvproxy child process. `Drop` cleans up
 /// the child the same way [`crate::passt::PasstHandle::drop`] does:
 /// SIGTERM → grace period → SIGKILL → reap.
@@ -167,6 +189,15 @@ pub fn spawn(scratch_dir: &Path) -> Result<GvproxyHandle, GvproxyError> {
     //                          mode is the libkrun-compatible one.
     //   -log-file <path>     — diagnostic log; absent → stderr (lost
     //                          when we redirect to /dev/null).
+    //   -ssh-port <port>     — gvproxy always binds a TCP listener for
+    //                          guest-SSH forwarding (default 2222). On
+    //                          a host running more than one gvproxy
+    //                          (concurrent dev VMs, parallel tests,
+    //                          debugging cycles), instance N+1 fails
+    //                          to bind 2222 and exits immediately
+    //                          with `address already in use`. Derive
+    //                          a per-VM port from the scratch dir so
+    //                          concurrent instances don't collide.
     //   -debug               — verbose logging. Not set by default;
     //                          if a future MVM_GVPROXY_DEBUG=1 env
     //                          var trips this we'd flip it here.
@@ -180,11 +211,14 @@ pub fn spawn(scratch_dir: &Path) -> Result<GvproxyHandle, GvproxyError> {
         s.push(socket_path.as_os_str());
         s
     };
+    let ssh_port = ssh_port_for(scratch_dir);
     let mut cmd = Command::new(&gvproxy_bin);
     cmd.arg("-listen-vfkit")
         .arg(listen_url)
         .arg("-log-file")
         .arg(OsString::from(&log_path))
+        .arg("-ssh-port")
+        .arg(ssh_port.to_string())
         // Redirect stdout/stderr to /dev/null — gvproxy's `-log-file`
         // captures what we need and any spillover noise on stderr
         // pollutes the supervisor's own diagnostic stream.

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -560,16 +560,19 @@ fn configure_with_gateway(ctx: &KrunContext) -> Result<(sys::Context, GatewayHan
                     context: format!("spawning gvproxy for NetworkingMode::Gvproxy: {e}"),
                 })?;
             // gvproxy speaks libkrun's "vfkit mode" framing on the
-            // unixgram socket. Without NET_FLAG_VFKIT in `flags`,
-            // libkrun rejects the call with -EINVAL at config time
-            // (see sys::NET_FLAG_VFKIT) — Plan 88 W5 smoke surfaced
-            // this as `supervisor failed: libkrun call failed with
-            // rc -22`.
+            // unixgram socket; NET_FLAG_VFKIT (see sys::NET_FLAG_VFKIT)
+            // is libkrun's required signal to emit the magic-byte
+            // handshake. NET_FLAG_DHCP_CLIENT (libkrun 1.18.0+) tells
+            // libkrun's net device to bring the interface up via its
+            // in-guest DHCP client against gvproxy's DHCP server, so
+            // the guest sees a fully-configured eth0 without needing
+            // an in-guest udhcpc race. libkrun's own
+            // `tests/test_cases/src/test_net/gvproxy.rs` uses both.
             krun.add_net_unixgram_path(
                 handle.socket_path(),
                 mac,
                 sys::PASST_NET_FEATURES,
-                sys::NET_FLAG_VFKIT,
+                sys::NET_FLAG_VFKIT | sys::NET_FLAG_DHCP_CLIENT,
             )?;
             GatewayHandle::Gvproxy(handle)
         }

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 mod sys;
 
 #[cfg(feature = "libkrun-sys")]
-pub use sys::{BundledKernel, KernelFormat, LogLevel, extract_bundled_kernel, set_log_level};
+pub use sys::{BundledKernel, KernelFormat, LogLevel, extract_bundled_kernel, init_log, set_log_level};
 
 // Plan 87 / ADR-055 — passt-backed virtio-net. The supervisor owns the
 // passt child process and exposes the socket fd `KrunContext::Passt`

--- a/crates/mvm-libkrun/src/lib.rs
+++ b/crates/mvm-libkrun/src/lib.rs
@@ -26,7 +26,9 @@ use std::path::Path;
 mod sys;
 
 #[cfg(feature = "libkrun-sys")]
-pub use sys::{BundledKernel, KernelFormat, LogLevel, extract_bundled_kernel, init_log, set_log_level};
+pub use sys::{
+    BundledKernel, KernelFormat, LogLevel, extract_bundled_kernel, init_log, set_log_level,
+};
 
 // Plan 87 / ADR-055 — passt-backed virtio-net. The supervisor owns the
 // passt child process and exposes the socket fd `KrunContext::Passt`

--- a/crates/mvm-libkrun/src/sys.rs
+++ b/crates/mvm-libkrun/src/sys.rs
@@ -50,6 +50,17 @@ pub const PASST_NET_FEATURES: u32 = (1 << 0)   // NET_FEATURE_CSUM
 /// surfaced.
 pub const NET_FLAG_VFKIT: u32 = 1 << 0;
 
+/// `NET_FLAG_DHCP_CLIENT` from `libkrun.h` (added in libkrun 1.18.0).
+/// Enables libkrun's in-guest DHCP client so the guest doesn't need
+/// to run `udhcpc`/`dhclient` itself — libkrun sees the DHCP-OFFER
+/// from gvproxy's built-in DHCP server, configures the interface,
+/// and the guest kernel hands the application a fully-configured
+/// `eth0`. libkrun's own gvproxy test
+/// (`tests/test_cases/src/test_net/gvproxy.rs`) passes
+/// `NET_FLAG_VFKIT | NET_FLAG_DHCP_CLIENT`; mirroring that here is
+/// what makes the macOS smoke succeed end-to-end on libkrun 1.18.0+.
+pub const NET_FLAG_DHCP_CLIENT: u32 = 1 << 1;
+
 /// Plan 88 W5 diagnostic: enable libkrun's internal logger. Wrapper
 /// for `krun_init_log` (libkrun.h). Targets a file descriptor
 /// (`target_fd = 2` → stderr) at the given level. `style` and

--- a/crates/mvm-libkrun/src/sys.rs
+++ b/crates/mvm-libkrun/src/sys.rs
@@ -50,6 +50,18 @@ pub const PASST_NET_FEATURES: u32 = (1 << 0)   // NET_FEATURE_CSUM
 /// surfaced.
 pub const NET_FLAG_VFKIT: u32 = 1 << 0;
 
+/// Plan 88 W5 diagnostic: enable libkrun's internal logger. Wrapper
+/// for `krun_init_log` (libkrun.h). Targets a file descriptor
+/// (`target_fd = 2` → stderr) at the given level. `style` and
+/// `options` follow the C signature; pass 0 / 0 unless you have a
+/// reason. Used by `mvm-libkrun-supervisor` when `MVM_KRUN_LOG` is
+/// set — surfaces device-attach traces (`mmio[net] set_irq_line`,
+/// `net::unixgram network proxy socket fd ...`) that don't appear
+/// via `krun_set_log_level` alone.
+pub fn init_log(target_fd: i32, level: LogLevel, style: u32, options: u32) -> Result<(), Error> {
+    check(unsafe { bindings::krun_init_log(target_fd, level.as_u32(), style, options) })
+}
+
 /// Kernel-format constants exposed to callers without leaking the
 /// bindgen-generated identifier names.
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Summary
- add per-VM gvproxy SSH port selection and MVM_KRUN_LOG diagnostics
- pass libkrun networking flags for VFKIT/DHCP client handling
- bring eth0 administratively up inside builder-init before DHCP

## Verification
- Existing branch was already committed and pushed as worktree-plan-88-w6-fuzz.
- CI will run on this PR.

Refs Plan 88.