### PR TITLE
ci: drop macos-13 from Vz lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,10 +490,9 @@ jobs:
         if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
         run: cargo clippy -p mvm-libkrun --features libkrun-sys --all-targets -- -D warnings
 
-  # ── Lane: Vz / Virtualization.framework (macOS matrix, paths-gated) ──
+  # ── Lane: Vz / Virtualization.framework (macOS, paths-gated) ──
   # Plan 97 §"macOS minor-version compatibility matrix". Runs the
-  # Swift package build + Rust mvm-vz/mvm-backend test surface across
-  # the supported floor (macos-13) and the currently-shipping
+  # Swift package build + Rust mvm-vz/mvm-backend test surface on
   # macos-latest. No untrusted inputs are interpolated into run:
   # blocks — only matrix.runner, steps.filter.outputs.vz, runner.os.
   vz-macos:
@@ -502,7 +501,6 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - macos-13      # Plan 97 floor — full virtio surface lands here
           - macos-latest  # current shipping; covers Apple Container coexistence
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
## Summary

The `Vz / Virtualization.framework (macos-13)` job consumes a slot in every PR's check matrix without providing a unique signal — `macos-latest` covers the same Vz surface, and macos-13 runners are reaching EOL anyway. Drops the `macos-13` entry from the `vz-macos` matrix and rewords the surrounding comment.

Plan 97 §"macOS minor-version compatibility matrix" referenced macos-13 as the declared floor; that decision is being walked back here for CI velocity. The Vz backend's macos-13 compatibility is still asserted by Plan 97 / ADR-056 — that's a release-validation concern, not a per-PR CI concern.

## Follow-up

If branch protection lists `Vz / Virtualization.framework (macos-13)` as a required check on `main`, that requirement needs to be removed in the GitHub UI separately (repo-admin action, not something this PR can do).

## Test plan

- [x] Workflow YAML still parses (single matrix entry remains).
- [ ] After merge, confirm PRs no longer show the macos-13 job in their check list.
- [ ] Branch protection settings audited for the now-stale required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)