### PR TITLE
Plan 98 Phase 1: selection user surface (auto-detect + --builder + doctor + grace guard)

### DIFF
--- a/crates/mvm-build/src/builder_backend_select.rs
+++ b/crates/mvm-build/src/builder_backend_select.rs
@@ -1,28 +1,37 @@
-//! Plan 97 Phase C — builder-runtime backend selection.
+//! Plan 97 Phase C / Plan 98 — builder-runtime backend selection.
 //!
-//! Picks between [`libkrun_builder::LibkrunBuilderVm`] (default) and
-//! [`vz_builder::VzBuilderVm`] (opt-in via `MVM_BUILDER_BACKEND=vz`).
-//! Returns `Box<dyn BuilderVm>` so callers do not need to switch on
-//! the concrete type — both drivers implement
-//! [`builder_vm::BuilderVm`] with byte-identical artifact contracts
-//! (`finalize_flake_job` / `finalize_install_job` from PRs #436/#437
-//! produce the same [`builder_vm::BuilderArtifacts`] shape regardless
-//! of which hypervisor booted the guest).
+//! Picks between [`libkrun_builder::LibkrunBuilderVm`] and
+//! [`vz_builder::VzBuilderVm`]. Returns `Box<dyn BuilderVm>` so
+//! callers do not need to switch on the concrete type — both drivers
+//! implement [`builder_vm::BuilderVm`] with byte-identical artifact
+//! contracts (`finalize_flake_job` / `finalize_install_job` from PRs
+//! #436/#437 produce the same [`builder_vm::BuilderArtifacts`] shape
+//! regardless of which hypervisor booted the guest).
 //!
-//! ## Env-var dispatch
+//! ## Selection priority (Plan 98)
 //!
-//! - `MVM_BUILDER_BACKEND` unset → libkrun (the default)
-//! - `MVM_BUILDER_BACKEND=libkrun` → libkrun (explicit)
-//! - `MVM_BUILDER_BACKEND=vz` → Vz
-//! - Any other value → libkrun, with a `tracing::warn!` so a typo is
-//!   visible without aborting the build.
+//! 1. **CLI flag** (`--builder <libkrun|vz>`, plumbed in by callers as
+//!    a typed `Option<BuilderBackendChoice>`) — highest priority.
+//! 2. **Env var** `MVM_BUILDER_BACKEND` — `vz` / `libkrun`,
+//!    case-insensitive, surrounding whitespace trimmed.
+//! 3. **Auto-detect** by host platform when neither override is set:
+//!    macOS 26+ Apple Silicon → Vz; everywhere else → libkrun.
 //!
-//! Case-insensitive on both halves: `Vz`, `VZ`, `vz` all parse the
-//! same; surrounding whitespace is trimmed.
+//! An unrecognised env value (typo, removed backend) falls through to
+//! auto-detect with a `tracing::warn!` so the operator sees the
+//! problem without aborting the build. Empty / unset env is treated
+//! the same as "no override."
+//!
+//! Auto-detect mirrors the runtime backend selection's Apple Container
+//! tier: macOS 26+ on Apple Silicon is the deployment target Apple
+//! ships first-class virtualization for, so the *builder* defaults
+//! match the *runtime* default there. Older macOS and Linux contributors
+//! keep libkrun as the cross-platform path they were already using.
 
 use crate::builder_vm::BuilderVm;
 use crate::libkrun_builder::LibkrunBuilderVm;
 use crate::vz_builder::VzBuilderVm;
+use mvm_core::platform::current;
 
 /// Env-var name the dispatch consults. Surfaced as a constant so
 /// `mvmctl doctor` can reference it without re-deriving the string.
@@ -51,40 +60,95 @@ impl BuilderBackendChoice {
     }
 }
 
-/// Resolve the env var to a [`BuilderBackendChoice`]. Pure function
-/// so unit tests can exercise the parsing without spawning a VM.
-/// Unset and unrecognised values both resolve to
-/// [`BuilderBackendChoice::Libkrun`] — the latter logs a warning
-/// via `tracing::warn!` so a typo is visible without aborting the
-/// build.
-pub fn resolve_choice() -> BuilderBackendChoice {
-    let Some(raw) = std::env::var_os(MVM_BUILDER_BACKEND_ENV) else {
-        return BuilderBackendChoice::Libkrun;
-    };
+/// Pure auto-detect from a single boolean: "is this host macOS 26+
+/// on Apple Silicon?" Lifted out so unit tests are fully hermetic
+/// — they don't have to spoof the live OS version or the
+/// compile-time `cfg!(target_arch)` macro.
+///
+/// Decision: macOS 26+ Apple Silicon → Vz; everything else → libkrun.
+/// This mirrors the runtime backend tier — Apple ships first-class
+/// virtualization for that target, and the *builder* defaults match
+/// the *runtime* default there.
+pub fn auto_detect_default_for(is_macos_26_apple_silicon: bool) -> BuilderBackendChoice {
+    if is_macos_26_apple_silicon {
+        BuilderBackendChoice::Vz
+    } else {
+        BuilderBackendChoice::Libkrun
+    }
+}
+
+/// Auto-detect using the live runtime platform + compile-time arch.
+/// `has_apple_containers()` already enforces `Platform::MacOS` +
+/// `is_macos_26_or_later()`; the arch check completes the "Apple
+/// Silicon" half of the predicate.
+pub fn auto_detect_default() -> BuilderBackendChoice {
+    let is_target = current().has_apple_containers() && cfg!(target_arch = "aarch64");
+    auto_detect_default_for(is_target)
+}
+
+/// Parse the env var on its own, without applying auto-detect when
+/// the var is unset or empty. Returns `None` for "no override
+/// present" so a caller can disambiguate "user set this to libkrun"
+/// from "user set nothing."
+///
+/// Unrecognised values log a warning and return `None` — the caller
+/// then falls through to auto-detect, matching the
+/// fail-without-aborting policy.
+pub fn resolve_env_override() -> Option<BuilderBackendChoice> {
+    let raw = std::env::var_os(MVM_BUILDER_BACKEND_ENV)?;
     let s = raw.to_string_lossy();
     let trimmed = s.trim();
     match trimmed.to_ascii_lowercase().as_str() {
-        "" | "libkrun" => BuilderBackendChoice::Libkrun,
-        "vz" => BuilderBackendChoice::Vz,
+        "" => None,
+        "libkrun" => Some(BuilderBackendChoice::Libkrun),
+        "vz" => Some(BuilderBackendChoice::Vz),
         other => {
             tracing::warn!(
                 value = %other,
-                "{MVM_BUILDER_BACKEND_ENV} value not recognised; falling back to libkrun"
+                "{MVM_BUILDER_BACKEND_ENV} value not recognised; falling through to auto-detect"
             );
-            BuilderBackendChoice::Libkrun
+            None
         }
     }
 }
 
-/// Construct the builder driver the env var selects. Returns a
-/// boxed trait object so callers don't have to enumerate concrete
+/// Apply the override priority: CLI flag > env var > auto-detect.
+/// `flag` is the typed `--builder` value the CLI plumbs in (`None`
+/// when the flag isn't supplied).
+pub fn resolve_choice_with_override(flag: Option<BuilderBackendChoice>) -> BuilderBackendChoice {
+    if let Some(c) = flag {
+        return c;
+    }
+    if let Some(c) = resolve_env_override() {
+        return c;
+    }
+    auto_detect_default()
+}
+
+/// Resolve the choice with no CLI flag — env var + auto-detect only.
+/// Existing callers that don't yet plumb the `--builder` flag use
+/// this; Phase 1 will migrate them to `resolve_choice_with_override`.
+pub fn resolve_choice() -> BuilderBackendChoice {
+    resolve_choice_with_override(None)
+}
+
+/// Construct the builder driver the selection resolves to. Returns
+/// a boxed trait object so callers don't have to enumerate concrete
 /// types at the call site.
 ///
 /// Both drivers construct via `::default()` — neither does I/O at
 /// construction time. The first I/O happens inside `run_build`
 /// (image lookup, lock acquire, supervisor spawn).
 pub fn resolve_builder_backend() -> Box<dyn BuilderVm> {
-    match resolve_choice() {
+    resolve_builder_backend_with_override(None)
+}
+
+/// As [`resolve_builder_backend`] but accepts an explicit CLI flag
+/// override at the highest priority. Used by CLI dispatch.
+pub fn resolve_builder_backend_with_override(
+    flag: Option<BuilderBackendChoice>,
+) -> Box<dyn BuilderVm> {
+    match resolve_choice_with_override(flag) {
         BuilderBackendChoice::Libkrun => Box::new(LibkrunBuilderVm::default()),
         BuilderBackendChoice::Vz => Box::new(VzBuilderVm::new()),
     }
@@ -120,63 +184,137 @@ mod tests {
         result
     }
 
+    // ── Auto-detect (pure, hermetic — no env / OS / arch sensitivity) ──
+
     #[test]
-    fn resolve_choice_unset_picks_libkrun() {
+    fn auto_detect_default_for_macos_26_apple_silicon_picks_vz() {
+        assert_eq!(auto_detect_default_for(true), BuilderBackendChoice::Vz);
+    }
+
+    #[test]
+    fn auto_detect_default_for_everything_else_picks_libkrun() {
+        // Linux, macOS Intel, macOS 13-25 Apple Silicon, Windows, WSL2 —
+        // they all collapse into the same "not macOS 26 + AS" bucket,
+        // which means libkrun.
+        assert_eq!(
+            auto_detect_default_for(false),
+            BuilderBackendChoice::Libkrun
+        );
+    }
+
+    // ── Env-var parsing (hermetic via ENV_LOCK + explicit values) ──
+
+    #[test]
+    fn resolve_env_override_returns_none_when_unset() {
         with_env(None, || {
-            assert_eq!(resolve_choice(), BuilderBackendChoice::Libkrun);
+            assert_eq!(resolve_env_override(), None);
         });
     }
 
     #[test]
-    fn resolve_choice_explicit_libkrun_picks_libkrun() {
+    fn resolve_env_override_returns_none_for_empty_string() {
+        // `MVM_BUILDER_BACKEND=` shows up in tooling that exports
+        // every shell var unconditionally; treat as unset so
+        // auto-detect runs.
+        with_env(Some(""), || {
+            assert_eq!(resolve_env_override(), None);
+        });
+    }
+
+    #[test]
+    fn resolve_env_override_libkrun_explicit() {
         with_env(Some("libkrun"), || {
-            assert_eq!(resolve_choice(), BuilderBackendChoice::Libkrun);
+            assert_eq!(resolve_env_override(), Some(BuilderBackendChoice::Libkrun));
         });
     }
 
     #[test]
-    fn resolve_choice_lowercase_vz_picks_vz() {
+    fn resolve_env_override_vz_lowercase() {
         with_env(Some("vz"), || {
-            assert_eq!(resolve_choice(), BuilderBackendChoice::Vz);
+            assert_eq!(resolve_env_override(), Some(BuilderBackendChoice::Vz));
         });
     }
 
     #[test]
-    fn resolve_choice_uppercase_vz_picks_vz() {
+    fn resolve_env_override_vz_uppercase() {
         // Case-insensitive matters because operators set this in
         // shell rc files and the convention varies. `Vz` is the
         // crate name; `VZ` is the entitlement string. Both should
         // work.
         with_env(Some("VZ"), || {
-            assert_eq!(resolve_choice(), BuilderBackendChoice::Vz);
+            assert_eq!(resolve_env_override(), Some(BuilderBackendChoice::Vz));
         });
     }
 
     #[test]
-    fn resolve_choice_surrounding_whitespace_is_trimmed() {
+    fn resolve_env_override_strips_whitespace() {
         with_env(Some("  vz  "), || {
-            assert_eq!(resolve_choice(), BuilderBackendChoice::Vz);
+            assert_eq!(resolve_env_override(), Some(BuilderBackendChoice::Vz));
         });
     }
 
     #[test]
-    fn resolve_choice_unrecognised_value_falls_back_to_libkrun() {
-        // Typo / future backend / accidental value all surface as
-        // libkrun. The tracing::warn! is observed manually in
-        // production logs.
+    fn resolve_env_override_returns_none_for_unrecognised() {
+        // Typo / removed backend / accidental value: log a warning
+        // and fall through to auto-detect (the caller's job).
         with_env(Some("firecracker"), || {
-            assert_eq!(resolve_choice(), BuilderBackendChoice::Libkrun);
+            assert_eq!(resolve_env_override(), None);
+        });
+    }
+
+    // ── Priority: flag > env > auto-detect ──
+
+    #[test]
+    fn override_flag_beats_env_var() {
+        // Flag says libkrun, env says vz → flag wins.
+        with_env(Some("vz"), || {
+            assert_eq!(
+                resolve_choice_with_override(Some(BuilderBackendChoice::Libkrun)),
+                BuilderBackendChoice::Libkrun,
+            );
         });
     }
 
     #[test]
-    fn resolve_choice_empty_string_picks_libkrun() {
-        // `MVM_BUILDER_BACKEND=` shows up in tooling that exports
-        // every shell var unconditionally; treat as unset.
-        with_env(Some(""), || {
-            assert_eq!(resolve_choice(), BuilderBackendChoice::Libkrun);
+    fn override_flag_beats_auto_detect() {
+        // No env, flag explicit → flag wins regardless of host.
+        with_env(None, || {
+            assert_eq!(
+                resolve_choice_with_override(Some(BuilderBackendChoice::Vz)),
+                BuilderBackendChoice::Vz,
+            );
+            assert_eq!(
+                resolve_choice_with_override(Some(BuilderBackendChoice::Libkrun)),
+                BuilderBackendChoice::Libkrun,
+            );
         });
     }
+
+    #[test]
+    fn env_var_beats_auto_detect_when_no_flag() {
+        with_env(Some("vz"), || {
+            assert_eq!(resolve_choice_with_override(None), BuilderBackendChoice::Vz,);
+        });
+        with_env(Some("libkrun"), || {
+            assert_eq!(
+                resolve_choice_with_override(None),
+                BuilderBackendChoice::Libkrun,
+            );
+        });
+    }
+
+    #[test]
+    fn no_flag_no_env_falls_through_to_auto_detect() {
+        // We can't assert the resulting choice without spoofing the
+        // host's platform — that's covered by `auto_detect_default_for`
+        // tests. Here we just pin the wiring: an unset env with no
+        // flag must produce *some* choice (no panic, no crash).
+        with_env(None, || {
+            let _ = resolve_choice_with_override(None);
+        });
+    }
+
+    // ── Naming + factory wiring ──
 
     #[test]
     fn backend_choice_name_round_trips() {
@@ -185,20 +323,24 @@ mod tests {
     }
 
     #[test]
-    fn resolve_builder_backend_constructs_libkrun_by_default() {
-        // resolve_builder_backend doesn't expose the concrete type,
-        // so we can only assert the call returns *some* driver.
-        // The other tests cover the choice mapping; this one pins
-        // the wiring through the dispatch.
-        with_env(None, || {
+    fn resolve_builder_backend_constructs_some_driver() {
+        // The factory doesn't expose the concrete type. This test
+        // pins the wiring: env override path constructs successfully
+        // without panicking. The choice-mapping is covered above.
+        with_env(Some("libkrun"), || {
+            let _backend = resolve_builder_backend();
+        });
+        with_env(Some("vz"), || {
             let _backend = resolve_builder_backend();
         });
     }
 
     #[test]
-    fn resolve_builder_backend_constructs_vz_when_env_picks_vz() {
+    fn resolve_builder_backend_with_override_honours_flag() {
         with_env(Some("vz"), || {
-            let _backend = resolve_builder_backend();
+            // Flag forces libkrun even though env says vz.
+            let _backend =
+                resolve_builder_backend_with_override(Some(BuilderBackendChoice::Libkrun));
         });
     }
 }

--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -243,7 +243,39 @@ fn cmd_dev_libkrun_status() -> Result<()> {
     Ok(())
 }
 
-pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
+/// Plan 98 §2.C1 grace-guard predicate. Returns `true` when the
+/// requested `dev` action should be refused because the user
+/// explicitly asked for Vz (via flag or env) but the persistent
+/// Vz `dev` driver is not yet implemented (Phase 2 work).
+///
+/// Pure on its inputs so it can be unit-tested hermetically
+/// without touching the real process env. Matching rules:
+///
+/// - `cli_builder == Some("vz")` (any case) → wants Vz.
+/// - `env == Some("vz")` after trim + lowercase → wants Vz.
+/// - The action is `Up` / `Rebuild` / `Shell` (the three verbs
+///   that boot or attach to the dev VM). `Down` / `Status` /
+///   `Cache` / `ImportImage` are not affected — `dev down` of a
+///   misconfigured state must still succeed.
+fn dev_action_blocked_by_vz_guard(
+    cli_builder: Option<&str>,
+    env: Option<&str>,
+    action: &DevAction,
+) -> bool {
+    let wants_vz = cli_builder
+        .map(|v| v.trim().eq_ignore_ascii_case("vz"))
+        .unwrap_or(false)
+        || env
+            .map(|v| v.trim().eq_ignore_ascii_case("vz"))
+            .unwrap_or(false);
+    wants_vz
+        && matches!(
+            action,
+            DevAction::Up { .. } | DevAction::Rebuild { .. } | DevAction::Shell { .. }
+        )
+}
+
+pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
     let action = args.action.unwrap_or(DevAction::Up {
         cpus: 8,
         memory: 16,
@@ -252,6 +284,31 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         watch_config: false,
         shell: false,
     });
+
+    // Plan 98 §2.C1 grace guard. `--builder vz` already routes the
+    // *builder* VM (Nix builds, `mvmctl up --prod` Install jobs)
+    // through Vz, but the *dev* VM (the long-lived shell environment
+    // `mvmctl dev` boots) still goes through `current_backend()` and
+    // doesn't yet know about Vz. Phase 2 adds `VzPersistentBuilderVm`
+    // and rewires this dispatch; until then, accepting Vz for
+    // `dev up/rebuild/shell` would silently boot libkrun against
+    // the user's intent. Fail loud instead.
+    //
+    // The check covers both the `--builder vz` flag and a bare
+    // `MVM_BUILDER_BACKEND=vz` env var (the env-var path bypasses
+    // `cli.builder` entirely; the flag-folds-into-env step in
+    // `commands::run` writes the env so this read picks up either
+    // override path).
+    let env_var = std::env::var("MVM_BUILDER_BACKEND").ok();
+    if dev_action_blocked_by_vz_guard(cli.builder.as_deref(), env_var.as_deref(), &action) {
+        anyhow::bail!(
+            "Vz builder backend with `dev up`/`dev rebuild`/`dev shell` is not yet supported \
+             (the Vz persistent dev VM lands in Plan 98 Phase 2). \
+             For now use `--builder libkrun` (or omit the flag / unset \
+             MVM_BUILDER_BACKEND) for `dev` commands. \
+             Vz already works for `mvmctl build` and `mvmctl up --prod`."
+        );
+    }
 
     let backend = current_backend();
     match action {
@@ -411,5 +468,130 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
                 DevBackend::Unsupported => bail_no_dev_backend(),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DevAction, DevCacheAction, dev_action_blocked_by_vz_guard};
+
+    fn up() -> DevAction {
+        DevAction::Up {
+            cpus: 8,
+            memory: 16,
+            project: None,
+            metrics_port: 0,
+            watch_config: false,
+            shell: false,
+        }
+    }
+    fn down() -> DevAction {
+        DevAction::Down { reset: false }
+    }
+    fn shell() -> DevAction {
+        DevAction::Shell { project: None }
+    }
+    fn status() -> DevAction {
+        DevAction::Status
+    }
+    fn cache() -> DevAction {
+        DevAction::Cache {
+            action: DevCacheAction::Inspect { json: false },
+        }
+    }
+    fn rebuild() -> DevAction {
+        DevAction::Rebuild {
+            cpus: 8,
+            memory: 16,
+            shell: false,
+        }
+    }
+
+    // ── Flag path ──
+
+    #[test]
+    fn flag_vz_blocks_up() {
+        assert!(dev_action_blocked_by_vz_guard(Some("vz"), None, &up()));
+    }
+    #[test]
+    fn flag_vz_blocks_rebuild() {
+        assert!(dev_action_blocked_by_vz_guard(Some("vz"), None, &rebuild()));
+    }
+    #[test]
+    fn flag_vz_blocks_shell() {
+        assert!(dev_action_blocked_by_vz_guard(Some("vz"), None, &shell()));
+    }
+    #[test]
+    fn flag_libkrun_allows_up() {
+        assert!(!dev_action_blocked_by_vz_guard(
+            Some("libkrun"),
+            None,
+            &up()
+        ));
+    }
+    #[test]
+    fn flag_unset_allows_up() {
+        assert!(!dev_action_blocked_by_vz_guard(None, None, &up()));
+    }
+
+    // ── Env-var path (the §0.1 gap fix — the bug Phase 1 originally shipped with) ──
+
+    #[test]
+    fn env_vz_blocks_up_even_without_flag() {
+        assert!(dev_action_blocked_by_vz_guard(None, Some("vz"), &up()));
+    }
+    #[test]
+    fn env_vz_blocks_rebuild_even_without_flag() {
+        assert!(dev_action_blocked_by_vz_guard(None, Some("vz"), &rebuild()));
+    }
+    #[test]
+    fn env_vz_blocks_shell_even_without_flag() {
+        assert!(dev_action_blocked_by_vz_guard(None, Some("vz"), &shell()));
+    }
+    #[test]
+    fn env_vz_case_insensitive() {
+        assert!(dev_action_blocked_by_vz_guard(None, Some("VZ"), &up()));
+        assert!(dev_action_blocked_by_vz_guard(None, Some("Vz"), &up()));
+    }
+    #[test]
+    fn env_vz_whitespace_stripped() {
+        assert!(dev_action_blocked_by_vz_guard(None, Some("  vz  "), &up()));
+    }
+    #[test]
+    fn env_libkrun_allows_up() {
+        assert!(!dev_action_blocked_by_vz_guard(
+            None,
+            Some("libkrun"),
+            &up()
+        ));
+    }
+    #[test]
+    fn env_empty_allows_up() {
+        assert!(!dev_action_blocked_by_vz_guard(None, Some(""), &up()));
+    }
+    #[test]
+    fn env_unknown_value_allows_up() {
+        // Mirrors `resolve_env_override`'s warn-and-fall-through
+        // semantics: an unrecognised value isn't Vz, so the guard
+        // doesn't trip. Selection layer logs the warning separately.
+        assert!(!dev_action_blocked_by_vz_guard(None, Some("bogus"), &up()));
+    }
+
+    // ── Verbs that should never trip the guard ──
+
+    #[test]
+    fn vz_does_not_block_down() {
+        assert!(!dev_action_blocked_by_vz_guard(Some("vz"), None, &down()));
+        assert!(!dev_action_blocked_by_vz_guard(None, Some("vz"), &down()));
+    }
+    #[test]
+    fn vz_does_not_block_status() {
+        assert!(!dev_action_blocked_by_vz_guard(Some("vz"), None, &status()));
+        assert!(!dev_action_blocked_by_vz_guard(None, Some("vz"), &status()));
+    }
+    #[test]
+    fn vz_does_not_block_cache() {
+        assert!(!dev_action_blocked_by_vz_guard(Some("vz"), None, &cache()));
+        assert!(!dev_action_blocked_by_vz_guard(None, Some("vz"), &cache()));
     }
 }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -34,6 +34,13 @@ pub(in crate::commands) struct Cli {
     #[arg(long, global = true)]
     pub fc_version: Option<String>,
 
+    /// Override which hypervisor drives the builder VM
+    /// (Plan 98). Highest priority — beats `MVM_BUILDER_BACKEND`
+    /// env and the platform-default auto-detect (macOS 26+ Apple
+    /// Silicon → vz; everywhere else → libkrun).
+    #[arg(long, global = true, value_parser = ["libkrun", "vz"])]
+    pub builder: Option<String>,
+
     /// Show verbose `[mvm]` progress messages. Implied when `RUST_LOG` is set.
     #[arg(long, global = true, alias = "debug")]
     pub verbose: bool,
@@ -175,6 +182,17 @@ pub fn run() -> Result<()> {
     // SAFETY: called once at startup before any threads are spawned.
     if let Some(ref version) = cli.fc_version {
         unsafe { std::env::set_var("MVM_FC_VERSION", version) };
+    }
+
+    // Apply builder-backend override before any subcommand reads it.
+    // Plumbing the flag through every call site that consults
+    // `resolve_builder_backend()` would touch a lot of files for
+    // little value; setting the env here makes the existing env-var
+    // dispatch in `mvm_build::builder_backend_select` honour the
+    // flag transparently. Same single-threaded-startup invariant as
+    // the `fc_version` block above.
+    if let Some(ref backend) = cli.builder {
+        unsafe { std::env::set_var("MVM_BUILDER_BACKEND", backend) };
     }
 
     // Verbose `[mvm]` chatter: explicit flag, or any RUST_LOG set.

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2639,3 +2639,54 @@ fn test_compile_default_no_from_flags_leaves_them_none() {
         _ => panic!("Expected Compile command"),
     }
 }
+
+// ── Plan 98 — `--builder` global flag (Phase 1 §1.4 + §0.2) ──
+
+#[test]
+fn builder_flag_appears_in_help() {
+    // Renders the top-level clap Command's help via the same code
+    // path `mvmctl --help` exercises. Asserts the new global flag
+    // surfaces in `mvmctl --help` without spawning the binary.
+    let cmd = cli_command();
+    let help = cmd.clone().render_help().to_string();
+    assert!(
+        help.contains("--builder"),
+        "`--builder` flag not surfaced in `mvmctl --help`; help text was:\n{help}"
+    );
+    assert!(
+        help.contains("libkrun") && help.contains("vz"),
+        "`--builder` value choices missing from help; help text was:\n{help}"
+    );
+}
+
+#[test]
+fn builder_flag_accepts_libkrun() {
+    let cli = Cli::try_parse_from(["mvmctl", "--builder", "libkrun", "doctor"]).expect("parse");
+    assert_eq!(cli.builder.as_deref(), Some("libkrun"));
+}
+
+#[test]
+fn builder_flag_accepts_vz() {
+    let cli = Cli::try_parse_from(["mvmctl", "--builder", "vz", "doctor"]).expect("parse");
+    assert_eq!(cli.builder.as_deref(), Some("vz"));
+}
+
+#[test]
+fn builder_flag_rejects_unknown_value() {
+    // Clap's `value_parser = ["libkrun", "vz"]` should refuse
+    // anything outside that set. Catches typos like `=vmz` early
+    // rather than letting `MVM_BUILDER_BACKEND_ENV`'s
+    // warn-and-fall-through path eat them.
+    let err = Cli::try_parse_from(["mvmctl", "--builder", "bogus", "doctor"]).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid value") || msg.contains("possible values") || msg.contains("bogus"),
+        "expected a clap value-parser error mentioning 'bogus', got: {msg}"
+    );
+}
+
+#[test]
+fn builder_flag_unset_by_default() {
+    let cli = Cli::try_parse_from(["mvmctl", "doctor"]).expect("parse");
+    assert_eq!(cli.builder, None);
+}

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -215,6 +215,7 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
     checks.push(apple_container_check(plat));
     checks.push(vz_check(plat));
     checks.push(libkrun_check(plat));
+    checks.push(builder_backend_check(plat));
     checks.push(network_backend_check(plat));
     checks.push(docker_check(plat));
     checks.push(ts_runner_check());
@@ -1024,6 +1025,76 @@ fn libkrun_check(plat: Platform) -> Check {
             ok: true, // Optional; not a failure.
             info: format!("not available ({})", mvm_libkrun::install_hint()),
         }
+    }
+}
+
+/// Plan 98 — surface which builder-VM backend the selection layer
+/// resolves to on this host, plus the override source if any.
+///
+/// `mvm_build::builder_backend_select` enforces priority
+/// `--builder` flag > `MVM_BUILDER_BACKEND` env > platform default
+/// (macOS 26+ Apple Silicon → vz; everywhere else → libkrun). The
+/// flag is folded into the env at startup (`commands::run`), so by
+/// the time doctor runs every override is observable via env.
+///
+/// The check is informational — it never fails. A missing libkrun
+/// or Vz prereq is reported by the platform-level `libkrun_check`
+/// / `vz_check` already in the report; this check is about the
+/// *selection*, not the availability.
+#[cfg(feature = "builder-vm")]
+fn builder_backend_check(plat: Platform) -> Check {
+    use mvm_build::builder_backend_select::{
+        BuilderBackendChoice, MVM_BUILDER_BACKEND_ENV, auto_detect_default, resolve_env_override,
+    };
+
+    let env_override = resolve_env_override();
+    let auto = auto_detect_default();
+    let resolved = env_override.unwrap_or(auto);
+
+    // Best-effort: detect whether the override came from the
+    // `--builder` flag or the env var. The flag is folded into the
+    // env at startup, so we can't distinguish them after the fact;
+    // surface both possibilities so an operator reading the report
+    // knows where to look.
+    let source = match env_override {
+        Some(_) => format!("override via --builder / ${MVM_BUILDER_BACKEND_ENV}"),
+        None => format!("auto-detected (default: {})", auto.name()),
+    };
+
+    let availability = match resolved {
+        BuilderBackendChoice::Libkrun => {
+            if plat.has_libkrun() {
+                "libkrun available".to_string()
+            } else {
+                format!("libkrun NOT available ({})", mvm_libkrun::install_hint())
+            }
+        }
+        BuilderBackendChoice::Vz => {
+            if plat.has_vz() {
+                "Vz available".to_string()
+            } else {
+                "Vz NOT available (requires macOS 13+)".to_string()
+            }
+        }
+    };
+
+    Check {
+        name: "builder backend",
+        category: "platform",
+        ok: true,
+        info: format!("{} — {} — {}", resolved.name(), source, availability),
+    }
+}
+
+/// Stub when `builder-vm` feature is off (CLI built without the
+/// builder support — e.g. dependency-light packaging).
+#[cfg(not(feature = "builder-vm"))]
+fn builder_backend_check(_plat: Platform) -> Check {
+    Check {
+        name: "builder backend",
+        category: "platform",
+        ok: true,
+        info: "n/a (mvm-cli built without `builder-vm` feature)".to_string(),
     }
 }
 
@@ -2678,5 +2749,110 @@ mod tests {
         // `all_ok` over the filtered set is `true`.
         let all_ok_filtered = filtered.iter().all(|c| c.ok);
         assert!(all_ok_filtered);
+    }
+
+    // ── Plan 98 §0.3 — builder-backend check format on Linux ──
+    //
+    // The selection layer's `auto_detect_default()` queries the real
+    // host platform (not the `Platform` enum passed to the check). On
+    // Linux CI runners it always returns Libkrun. macOS contributor
+    // hosts get covered by the existing `vz_check_macos_reports_*`
+    // tests above; this Linux-only test pins the format of the new
+    // `builder backend` line so the doctor report stays readable for
+    // operators on the supported Linux path.
+    //
+    // The test serialises with itself by clearing `MVM_BUILDER_BACKEND`
+    // for the duration; other tests in this crate don't touch this
+    // env var so cross-test interference is bounded.
+    #[cfg(all(target_os = "linux", feature = "builder-vm"))]
+    #[test]
+    fn builder_backend_check_linux_reports_libkrun_auto_detected() {
+        // SAFETY: single-threaded test phase per crate; this env var
+        // isn't read elsewhere in this test binary.
+        let prev = std::env::var_os("MVM_BUILDER_BACKEND");
+        unsafe {
+            std::env::remove_var("MVM_BUILDER_BACKEND");
+        }
+
+        let c = builder_backend_check(Platform::LinuxNative);
+
+        // Restore before any assertion so a panic doesn't strand the
+        // env var.
+        unsafe {
+            if let Some(v) = prev {
+                std::env::set_var("MVM_BUILDER_BACKEND", v);
+            }
+        }
+
+        assert!(c.ok, "builder backend check must not fail informational");
+        assert_eq!(c.name, "builder backend");
+        assert_eq!(c.category, "platform");
+        // Format: `<backend> — <source> — <availability>`
+        assert!(
+            c.info.starts_with("libkrun — "),
+            "expected libkrun-resolved line; got: {}",
+            c.info
+        );
+        assert!(
+            c.info.contains("auto-detected"),
+            "expected `auto-detected` source label when env unset; got: {}",
+            c.info
+        );
+        assert!(
+            c.info.contains("libkrun available") || c.info.contains("libkrun NOT available"),
+            "expected per-VMM availability segment; got: {}",
+            c.info
+        );
+    }
+
+    #[cfg(all(target_os = "linux", feature = "builder-vm"))]
+    #[test]
+    fn builder_backend_check_linux_honors_env_override() {
+        let prev = std::env::var_os("MVM_BUILDER_BACKEND");
+        unsafe {
+            std::env::set_var("MVM_BUILDER_BACKEND", "vz");
+        }
+
+        let c = builder_backend_check(Platform::LinuxNative);
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MVM_BUILDER_BACKEND", v),
+                None => std::env::remove_var("MVM_BUILDER_BACKEND"),
+            }
+        }
+
+        assert!(c.ok);
+        // Env override flips the resolved backend even when
+        // `auto_detect_default()` would have picked libkrun.
+        assert!(
+            c.info.starts_with("vz — "),
+            "expected vz-resolved line under env override; got: {}",
+            c.info
+        );
+        assert!(
+            c.info.contains("override via"),
+            "expected `override via` source label; got: {}",
+            c.info
+        );
+        // On Linux Vz is never available; line must communicate that.
+        assert!(
+            c.info.contains("Vz NOT available"),
+            "expected `Vz NOT available` segment on Linux; got: {}",
+            c.info
+        );
+    }
+
+    #[cfg(not(feature = "builder-vm"))]
+    #[test]
+    fn builder_backend_check_stub_when_feature_off() {
+        let c = builder_backend_check(Platform::LinuxNative);
+        assert!(c.ok);
+        assert_eq!(c.name, "builder backend");
+        assert!(
+            c.info.contains("n/a"),
+            "stub should mention n/a; got: {}",
+            c.info
+        );
     }
 }

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1888,6 +1888,26 @@ code (vsock CID 3 / ports 5252, 10000+, 20000+ remain unchanged).
       audit-chain hashing of snapshot files remain follow-ups (needs
       CLI verb + different supervisor startup mode).
 
+### Plan 98 — finishing slices  [`plans/98-vz-builder-vm.md`](plans/98-vz-builder-vm.md)
+
+Vz builder one-shot driver (Phase 97 Phase C) shipped env-var-only.
+Plan 98 closes the remaining gaps: auto-detect, `--builder` CLI flag,
+`mvmctl doctor` reporting, Vz **persistent** parity with libkrun's
+`mvmctl dev`, Install E2E on Vz, CI floor (`macos-latest` lane only —
+no macos-26 self-hosted runner required), and docs (CLAUDE.md +
+ADR-046 extension with security-claim-parity language). Plan 99 PR-1
+(#448) is the Stage 0 audit/cache contract this builds on.
+
+- [ ] **Phase 1** — Selection user-surface (auto-detect + `--builder` flag + doctor + §0.x gap fixes). Single non-draft PR.
+  - `--builder vz` with `dev up/rebuild/shell` errors clearly via the §2.C1 grace guard until Phase 2 Slice 2B lands the Vz persistent dev driver. `--builder vz` already works for `mvmctl build` and `mvmctl up --prod`.
+- [ ] **Phase 2** — Vz persistent driver + Install E2E + security parity. Decomposed into four slices for review-sized PRs:
+  - **Slice 2A** — `VzPersistentBuilderVm` driver scaffold (§2.1-2.4, §2.10, §2.S1, §2.C2). No `mvmctl dev` rewire yet; §2.C1 guard stays.
+  - **Slice 2B** — Cross-backend coexistence dispatch (§2.5, §2.8, §2.C3) + remove §2.C1 guard + §2.S11 env-var regression test.
+  - **Slice 2C** — Install E2E byte-equivalence + audit chain + security parity batch (§2.6, §2.7, §2.S2-2.S10 + §2.S13) + ADR-046/002/047 updates.
+  - **Slice 2D** — In-repo flake invariant integration test (§2.11) + final regression gate (§2.9).
+- [ ] **Phase 3** — CI floor on `macos-latest` Vz construction smoke + Linux libkrun auto-detect assertion. `uv pip install` round-trip deferred to §3.6.
+- [ ] **Phase 4** — Docs: CLAUDE.md, ADR-046 extension landed in Slice 2C, ADR-056/055/041/057 cross-references, SPRINT.md close-out.
+
 ### Cross-cutting
 
 - [ ] Build / distribution / versioning (Swift toolchain in CI,

--- a/specs/plans/98-vz-builder-vm.md
+++ b/specs/plans/98-vz-builder-vm.md
@@ -1,0 +1,255 @@
+# Plan 98 — `VzBuilderVm` finishing slices (auto-detect, CLI flag, doctor, persistent, CI, docs)
+
+> **Status (2026-05-26):** Phase A/B/C of the original Plan 98 scope
+> shipped **as Plan 97 Phase C** while this plan was being brainstormed,
+> via PRs #434–#442 + #445. The seam (`VmBackendForBuilder`), shared
+> orchestration (`builder_vm_runtime`), `LibkrunBuilderVm` refactor,
+> `VzBuilderVm` driver, `builder_backend_select.rs` env-var dispatch,
+> and `is_macos_26_or_later()` predicate are all on `origin/main`.
+>
+> Plan 98 now scopes **only the finishing slices** the parallel sessions
+> did not pick up: auto-detect (macOS 26+ Apple Silicon → Vz default),
+> `--builder` CLI flag, `mvmctl doctor` builder-backend reporting,
+> **persistent variant for Vz that mirrors libkrun's `mvmctl dev`**,
+> Install E2E verification, CI lane updates, and docs.
+>
+> Plan 99 (Stage 0 audit/cache contract for Vz builder dirs, #448) is
+> the foundation Phase 2 builds on — cross-reference it, do not
+> duplicate its directory contract.
+>
+> Pick-up command for fresh sessions: read this file top to bottom,
+> then jump to the next unchecked item.
+
+## Selection policy (locked)
+
+- Default: **auto-detect** by host platform. macOS 26+ Apple Silicon → Vz; everywhere else (macOS 13-25, Linux) → libkrun.
+- Override priority: `--builder <libkrun|vz>` CLI flag > `MVM_BUILDER_BACKEND` env var > auto-detect.
+- Vz on macOS 13-25 is **opt-in only** via the override path.
+- Auto-detect must **refuse Vz when the entitlement / MDM probe fails**
+  (PR #445's `vz_check` semantics) and fall through to libkrun, rather
+  than fail mid-build.
+
+## Locked decisions (planning round 2026-05-26)
+
+1. **Rebase off `origin/main` before any commit** in the worktree.
+2. **No macos-26 self-hosted CI runner required.** Phase 3 ships the
+   floor that runs on `macos-latest` + Linux. Real `uv pip install`
+   smoke under Vz is a named deferred follow-up (§3.6), not blocking.
+3. **Extend ADR-046** (option a) rather than open a new ADR. Builder-VM
+   backend selection lives in one place.
+4. **Phase 1 PR opens as ready (non-draft) immediately.** Phase 3
+   (Vz CI lane) lands separately; main + libkrun lanes gate Phase 1.
+5. **Persistent drivers stay parallel** (`VzPersistentBuilderVm`
+   alongside `LibkrunPersistentBuilderVm`), mirroring the one-shot
+   driver pattern from Plan 97 Phase C.
+
+## Shipped (Phase A/B/C — by parallel sessions on origin/main)
+
+- [x] `is_macos_26_or_later()` in `crates/mvm-core/src/platform/platform.rs:189`
+- [x] `crates/mvm-build/src/builder_backend_select.rs` — `BuilderBackendChoice` enum, `MVM_BUILDER_BACKEND_ENV`, `resolve_choice()` (env-var only — no auto-detect yet)
+- [x] `resolve_builder_backend()` factory returning `Box<dyn BuilderVm>`
+- [x] Selection unit tests (10+ cases)
+- [x] `VmBackendForBuilder` seam in `crates/mvm-build/src/builder_vm.rs`
+- [x] `crates/mvm-build/src/builder_vm_runtime.rs` — shared `stage_job_dir`, `JobResult`, `finalize_flake_job`, `finalize_install_job`, `NixStoreImageLock`, `builder_vm_timeout`, stderr-tail formatters
+- [x] `crates/mvm-build/src/libkrun_builder.rs` — refactored against the seam, both `LibkrunBuilderVm` driver + `LibkrunBuilderBackend` impl
+- [x] `crates/mvm-build/src/vz_builder.rs` — `VzBuilderVm` driver + `VzBuilderBackend` impl (Plan 97 Phase C complete)
+- [x] `mvm-vz`: `VirtioFsShare.read_only` for builder mode (PR #440)
+- [x] Vz Phase E control socket: pause/resume/balloon/snapshot SAVE (PR #430)
+- [x] Doctor: `vz_check` entitlement + MDM-policy sub-probes for the **runtime** path (PR #445)
+- [x] Stage 0 audit/cache contract for Vz builder dirs (Plan 99 PR-1, #448)
+
+## Progress checklist — remaining slices
+
+### Phase 1 — Selection user-surface (auto-detect + CLI flag + doctor)
+
+User-facing knobs that the env-var-only shipping skipped. One PR.
+
+- [x] **1.1** `auto_detect_default_for(is_macos_26_apple_silicon: bool)` + `auto_detect_default()` in `builder_backend_select.rs`. Pure helper for testability.
+- [x] **1.2** `resolve_env_override()` returns `Option<BuilderBackendChoice>` (separates "unset/empty/unknown" from "explicit override"). Unknown values log a warning and fall through.
+- [x] **1.3** `resolve_choice_with_override(flag: Option<BuilderBackendChoice>)` applies CLI flag > env > auto-detect priority. `resolve_choice()` becomes `resolve_choice_with_override(None)`.
+- [x] **1.4** Added `--builder <libkrun|vz>` global flag to the Cli struct at `crates/mvm-cli/src/commands/mod.rs`. The flag is folded into `MVM_BUILDER_BACKEND` at startup so the existing env-var dispatch in `mvm_build::builder_backend_select` honours it transparently — no per-call-site plumbing needed.
+- [x] **1.5** `mvmctl doctor` (`crates/mvm-cli/src/doctor.rs`) reports the resolved backend, override source (flag/env if set), and per-VMM probe results via `builder_backend_check()`. Reuses existing `vz_check` + `has_libkrun()` predicates. Format: `<backend> — <source> — <availability>`. Stub variant for `not(feature = "builder-vm")` builds.
+- [x] **1.6** Selection unit tests extended: auto-detect path, override precedence (flag > env > auto), edge cases (empty env, unknown env).
+- [ ] **1.7** `cargo test --workspace` + `just lint` green.
+- [ ] **1.8** PR opened (non-draft per locked decision #4), review requested.
+
+### Phase 1 — gap-fix slice (this PR, §0.x — caught in 2026-05-26 planning round)
+
+Pre-ship gap review surfaced four items missing from the original
+§1.x scope. All four land in the same PR as Phase 1.
+
+- [x] **0.1** Extend §2.C1 grace guard to cover the `MVM_BUILDER_BACKEND` env-var path. The original predicate at `crates/mvm-cli/src/commands/env/dev.rs::run` checked `cli.builder.as_deref() == Some("vz")` only, so `MVM_BUILDER_BACKEND=vz mvmctl dev up` bypassed the guard and silently routed through `current_backend()` (libkrun) — a real bug. New `dev_action_blocked_by_vz_guard()` pure predicate covers both override paths, case-insensitive + whitespace-stripped to match `resolve_env_override`'s semantics. 16 hermetic unit tests in `dev.rs` cover the flag path, env path, case/whitespace variants, and unaffected verbs (`down`/`status`/`cache`).
+- [x] **0.2** `--builder` help-text + value-parser tests in `crates/mvm-cli/src/commands/tests.rs`. Asserts the flag surfaces in `mvmctl --help` output via `cli_command().render_help()`, accepts `libkrun`/`vz`, rejects unknown values via clap's `value_parser = [...]`, and is `None` by default. Subsumes §1.6a (doctor snapshot rolls into §0.3).
+- [x] **0.3** Doctor `builder backend` line unit-tested on Linux. New tests in `doctor.rs::tests` assert the format `<backend> — <source> — <availability>` for both the env-unset (auto-detected → libkrun) and env-override (`MVM_BUILDER_BACKEND=vz` → vz NOT available on Linux) cases. Stub-path test covers `cfg(not(feature = "builder-vm"))`. Tests cfg-gated to `target_os = "linux"` because `auto_detect_default()` queries the real host; macOS hosts get coverage via the existing `vz_check_macos_reports_*` tests.
+- [x] **0.4** CI apple-lane builds with `--features builder-vm`. Verified `mvm-cli/Cargo.toml` sets `default = ["builder-vm"]` (Plan 72 W5.B cutover), so every `cargo test` / `cargo build` invocation in the workflow exercises the new selection + doctor code. No workflow patch needed.
+
+### Phase 1 — deferred follow-ups (not blocking the Phase 1 PR)
+
+(§1.6a now subsumed into §0.3 — no remaining deferred items.)
+
+### Phase 2 — Vz persistent parity + Install E2E + coexistence
+
+The user-requested parity: `mvmctl dev up/down/shell/status` must work
+under Vz exactly as it does under libkrun.
+`crates/mvm-build/src/persistent_builder.rs` is backend-agnostic
+(supervisor owns a `UnixStream` to the running VM; driver owns the
+VM lifecycle). So the seam is "construct the right concrete driver";
+everything downstream of socket-connect is shared.
+
+- [ ] **2.1** Audit `crates/mvm-build/src/persistent_builder.rs` and `LibkrunPersistentBuilderVm` in `libkrun_builder.rs`. Snapshot the libkrun driver's API surface (start, dispatch socket path, PID file path, console log path, Drop semantics, audit emit).
+- [ ] **2.2** Write `VzPersistentBuilderVm` parallel to `LibkrunPersistentBuilderVm` in `crates/mvm-build/src/vz_builder.rs` (or sibling file if size warrants). Mirrors the libkrun API one-for-one. Wires to the **same** `PersistentBuilderSupervisor`.
+- [ ] **2.3** State dir layout (parity + isolation). Per Plan 99 PR-1 (#448), Vz builder state dirs live under `~/.cache/mvm/builder-vm/vms/mvm-builder-vz-<job_id>/` (subdirectory pattern; the orphan reaper at `apple_container.rs:3292` is prefix-agnostic and `VzBuilderVm` already writes `builder.pid`). For the persistent variant, pick a stable name (e.g. `mvm-builder-vz-persistent/` mirroring libkrun's `mvm-builder-vm-persistent/`) and confirm the same files (`dispatch.sock`, `builder.pid`, `console.log`, `audit.jsonl`, `lock`) participate in Stage 0 cleanup without code changes. Add a regression test mirroring Plan 99 PR-1's `reap_picks_up_orphaned_vz_builder_state_dir` for the persistent dir.
+- [ ] **2.4** `mvmctl dev shell` console parity. Vz uses `VZVirtioConsoleDevice` rather than libkrun's PTY-over-vsock. Confirm Plan 97 Phase C already exposes a console path; surface it through the same `dev shell` user verb.
+- [ ] **2.5** Cross-backend state coexistence. Per §2.3, both backends' persistent state dirs live under the same parent (`~/.cache/mvm/builder-vm/vms/`), distinguished by name prefix (`mvm-builder-vm-persistent/` vs `mvm-builder-vz-persistent/`). The dispatch must:
+  - `mvmctl dev down` enumerate the parent dir and stop whichever backend's persistent dir is currently active (matches the running PID).
+  - `mvmctl dev status` reports per-backend state (which prefix exists + which PID is alive).
+  - `mvmctl dev up` refuses (with a clear error) when the *other* backend's persistent dir has a live PID.
+  - Test: `MVM_BUILDER_BACKEND=libkrun mvmctl dev up && MVM_BUILDER_BACKEND=vz mvmctl dev up` exits nonzero with a helpful message naming the running backend + the `dev down` remedy.
+- [ ] **2.6** Install job E2E smoke on Vz. `MVM_BUILDER_BACKEND=vz mvmctl up --prod ./examples/python/hello-app-with-deps` produces a sealed volume identical to libkrun's. `mvmctl deps inspect --json` reports it.
+- [ ] **2.7** Byte-flip on `cve.json` makes `verify_sealed_volume()` refuse — same as libkrun.
+- [ ] **2.8** Doctor: running-persistent-VM indicator. Extend the Phase 1 doctor check to *also* report whether a persistent VM is currently running and which backend started it. Format suggestion: `Builder backend: vz (auto) — libkrun-vm-stopped, vz-vm-running PID 12345 since 2026-05-26T12:34`.
+- [ ] **2.9** Regression check. `mvmctl dev` under libkrun unchanged; `cargo test --workspace` + `just lint` green.
+- [ ] **2.10** Resource ceilings parity. Confirm Vz persistent uses the same RAM/CPU defaults the one-shot driver picked in Plan 97 Phase C (and that they honour the Plan 72 W5.D RAM cap). Document any divergence in ADR-046.
+- [ ] **2.11** Builder VM image flake path. Confirm `find_builder_vm_flake()` is the source for *both* drivers' VM image. No "Vz pulls a prebuilt" backdoor. Add an integration test that boots Vz against the in-repo flake (`nix/images/builder-vm/`) from a source checkout. This is the ADR-046 §"Source-checkout builds never depend on mvm-published artifacts" invariant applied to the second backend.
+
+### Phase 2 — security parity (Claims 1, 5, 7, 8, 9)
+
+The builder VM is the dev tier, *but* its Install arm is the prod-grade
+path that produces the sealed deps volumes Claim 9 covers, and every
+admission flows through the Claim 8 audit chain. So the security
+claims have to hold across both backends, not just libkrun.
+
+- [ ] **2.S1** State dir + dispatch socket permission parity (Claim 1, W1.2 / W1.5). Per §2.3 the Vz persistent state dir lives at `~/.cache/mvm/builder-vm/vms/mvm-builder-vz-persistent/`. Confirm mode `0700` (inherits from `~/.cache/mvm/builder-vm/` parent already enforced by Stage 0); confirm dispatch socket mode `0700`; confirm `audit.jsonl`, `builder.pid`, `console.log` files mode `0600`. Add a test that stats the dir + socket after a Vz persistent `dev up`. Cross-reference Plan 99 PR-1 — reuse, don't duplicate.
+- [ ] **2.S2** Cross-backend Install gate byte-equivalence (Claim 9). §2.6's hash equivalence test must compare *contents* of the sealed volume, not only the final sha256: `content/` tree byte-equal, `sbom.cdx.json` byte-equal, `fetch.log` byte-equal, `cve.json` byte-equal across libkrun and Vz on the same Install input. This prevents an attacker who controls one backend from shipping a divergent volume that the other backend's verifier trusts via cache hit.
+- [ ] **2.S3** Audit emit chain under Vz (Claim 8). Verify `mvmctl up --prod` under `MVM_BUILDER_BACKEND=vz` emits the same `plan.admitted` / `plan.launched` / `plan.failed` entries to `~/.mvm/audit/<tenant>.jsonl` as the libkrun path. Add a test that runs `mvmctl audit verify` after a Vz Install and asserts the chain is clean.
+- [ ] **2.S4** Vz entitlement / MDM probe applies to the builder path. Phase 1's doctor builder-backend line must surface the *same* probe results PR #445 brought for the runtime. Auto-detect must *refuse* Vz when the entitlement is missing on macOS 26+ — fall through to libkrun rather than fail mid-build. Add a test of the auto-detect fallback path (mock the probe).
+- [ ] **2.S5** `cargo deny` / `cargo audit` cover `crates/mvm-vz` (Claim 7). Confirm the CI `deny` + `audit` jobs in `ci.yml` exercise the Vz crate; add it explicitly to `deny.toml`'s scope if it's been excluded.
+- [ ] **2.S6** Vz host-side control-socket parser surface (Claim 5). PR #430's pause/resume/balloon/snapshot SAVE control socket is host-side untrusted-input surface. Default: add a `cargo-fuzz` target under `crates/mvm-vz/fuzz/` mirroring `crates/mvm-libkrun/fuzz/fuzz_supervisor_config.rs`. Fallback (document in ADR-046): host-process-local with `0700` parent dir inherits ADR-002 host-trust assumption.
+- [ ] **2.S7** Snapshot SAVE secret-leak protection. If Vz persistent uses Phase E's SAVE, the on-disk memory dump can contain build secrets. It must live inside `~/.cache/mvm/builder-vm/vms/mvm-builder-vz-persistent/` (0700 parent inherited from Stage 0), file mode `0600`, get cleaned up by `mvmctl cache prune` and on clean `dev down`. Test: stat the SAVE file after a save, assert mode + path; run `cache prune` and assert removal.
+
+#### New security items (2026-05-26 planning round — Slice 2C)
+
+- [ ] **2.S8** Virtiofs share parity (Claim 1). Vz and libkrun construct `VirtioFsShare` configs independently. If Vz mounts a path libkrun doesn't (or with a different r/w bit), Claim 1 ("no host-fs access from a guest beyond explicit shares") holds per-backend but breaks symmetry. Test: enumerate `VirtioFsShare` from both driver constructors for the same input; assert set equality on `(host_path, guest_path, read_only)` triples.
+- [ ] **2.S9** Builder VM kernel/rootfs parity for the Install arm (Claim 9). libkrun extracts its kernel from `libkrunfw`'s `.rodata`; Vz boots whatever its `VZLinuxBootLoader` is pointed at. If the kernels diverge, binaries produced from the same Nix derivation could too (libc/kernel-header drift), breaking §2.S2 byte-equivalence at the volume level. Per `feedback_dev_vm_vs_prod_security_tiers.md` the dev tier doesn't need dm-verity, but the Install arm IS the prod-grade path. Test: boot both backends with the same Install input; capture `/proc/version` + `uname -r` + kernel sha256 inside the guest; assert equality. If divergence is unavoidable, document in ADR-046 §"Why Install-arm kernels differ" with a justification paragraph for why §2.S2 still holds at the volume byte level.
+- [ ] **2.S10** Sealed-volume `meta.json` backend-neutrality (Claim 9). `meta.json` is hash-chained per CLAUDE.md. If the hash input embeds the backend name (e.g. `{"backend": "libkrun", ...}`), identical content yields different hashes per backend — supervisor refuses cross-backend cache hits AND an attacker could forge different-backend signatures on identical content. Test: (1) inspect the meta.json schema in `mvm_sdk::compile::deps_audit`; (2) decode meta.json from a libkrun-sealed and a Vz-sealed Install on the same input; (3) assert byte equality. If the backend name leaks in, normalise it out before hashing.
+- [ ] **2.S11** `MVM_BUILDER_BACKEND` env-var honor after §2.C1 guard removal (security-adjacent correctness, **Slice 2B**). When Slice 2B removes the §2.C1 grace guard, `commands/env/dev.rs` could regress to silently routing through `current_backend()` for `MVM_BUILDER_BACKEND=vz` without the flag. Test: after §2.5 dispatch lands and §2.C1 guard removed, integration test asserting `MVM_BUILDER_BACKEND=vz mvmctl dev up` actually boots the Vz persistent driver (not libkrun) and `dev status` reports `vz`. Mirrors §0.1's test on the opposite side.
+- [ ] **2.S13** Console-stream confidentiality. `mvmctl dev shell` opens a PTY into the builder VM where build-time env vars (`.env` contents, API keys for fetches, pip-index credentials) and source scroll across. The console log file is mode `0600` per §2.S1, but the LIVE PTY stream flows through the supervisor process. Test: (1) start a `dev shell` via the Vz driver; (2) `lsof -p <supervisor_pid>` and assert no fd is open against a path outside `~/.cache/mvm/builder-vm/vms/mvm-builder-vz-persistent/` AND mode > `0600`; (3) `mvmctl dev down` and assert `console.log` is mode `0600` (already in §2.S1).
+
+### Phase 2 — correctness parity
+
+- [ ] **2.C1** Phase 1 grace under partial implementation. With `--builder vz` available but Vz persistent not yet landed, `mvmctl --builder vz dev up` must error clearly: "Vz persistent mode arrives in Phase 2 (Plan 98); use `--builder libkrun` for `dev up`." Add this to Phase 1's CLI plumbing (`commands/build/persistent_builder.rs`) as a guard, then remove the guard in Phase 2 once the driver lands.
+- [ ] **2.C2** `mvmctl cache prune` honours the Vz lock. Per Plan 99 PR-1, the orphan reaper at `apple_container.rs:3292` is already prefix-agnostic and Stage 0 cleanup picks up `mvm-builder-vz-*` dirs automatically. Verify the persistent dir (`mvm-builder-vz-persistent/`) participates too — extend the existing `reap_picks_up_orphaned_vz_builder_state_dir` test or add a persistent variant.
+- [ ] **2.C3** Backend in structured logs + error messages. `tracing` spans in the build path carry a `backend=vz|libkrun` field. Error messages that mention state dirs reference the correct path. One grep test in CI catches the regression.
+
+### Phase 3 — CI lane updates (floor only, no macos-26 runner)
+
+Per locked decision #2, ship the floor that runs on `macos-latest` + Linux.
+
+- [ ] **3.1** Selection unit tests run everywhere. The 10+ tests in `builder_backend_select.rs` are hermetic; confirm they're exercised in the existing Ubuntu `test` lane and the `apple` lane.
+- [ ] **3.2** `macos-latest` Vz construction smoke. Extend (or add a step to) the existing `apple` lane in `.github/workflows/ci.yml`:
+  - `cargo test -p mvm-build vz_builder` — runs the Vz driver's unit tests on the macos-latest runner. Construction is pure; first I/O happens in `run_build`.
+  - `MVM_BUILDER_BACKEND=vz cargo test -p mvm-build builder_backend_select` — exercises the env-var path on macOS.
+- [ ] **3.3** `app-deps-audit` lane stays unchanged. Backend-agnostic verification path; cross-backend parity covered at the unit-test level by §2.S2.
+- [ ] **3.4** Linux `test` lane assertion: `auto_detect_default()` picks `Libkrun` on Linux. Already covered by `auto_detect_default_for_everything_else_picks_libkrun`; just confirm it runs.
+- [ ] **3.5** Architecture-invariants workflow re-check. Locate via `gh workflow list`; confirm no new `server-binding` patterns introduced by Phase 1/2.
+
+### Phase 3 — deferred follow-ups
+
+- [ ] **3.6** Real `uv pip install` + `pip-audit` round-trip under Vz on macos-26 self-hosted runner — gated on Plan 72 W4/W5 cutover; ADR-047 already names this deferred for libkrun too.
+
+### Phase 4 — Docs
+
+- [ ] **4.1** `CLAUDE.md`:
+  - Extend "Host dependencies" so macOS 26+ users know the libkrun Homebrew trio is optional when Vz is the default.
+  - Add "Builder backend selection" subsection under Architecture / Key Design Decisions documenting auto-detect, env, flag, priority order.
+  - Mention the state-dir layout: both backends live under `~/.cache/mvm/builder-vm/vms/`, distinguished by name prefix (`mvm-builder-vm-*` for libkrun, `mvm-builder-vz-*` for Vz) — the Stage 0 reaper handles both. Document the coexistence rules from §2.5.
+- [ ] **4.2** Extend `specs/adrs/046-builder-vm-via-libkrun.md` with a "Vz as a second builder backend" subsection under Decision **(Slice 2C — lands with the security tests so ADR text and evidence merge in one review)**:
+  - Selection policy (auto-detect rule, override priority).
+  - Parallel-driver choice (not generic).
+  - State-dir isolation + coexistence behaviour.
+  - Resource ceilings under Vz (any divergence from libkrun).
+  - Cross-reference Plan 99 for Stage 0 audit/cache contract.
+  - **Security claim parity** — explicit statement that Claims 1, 5, 7, 8, 9 hold under Vz with the same evidence: state-dir mode `0700` (§2.S1), virtiofs share parity (§2.S8), audit chain emission (§2.S3), `cargo deny`/`cargo audit` coverage (§2.S5), cross-backend Install volume byte-equivalence including kernel parity (§2.S2 + §2.S9), `meta.json` backend-neutrality (§2.S10), control-socket fuzz or host-trust justification (§2.S6), snapshot-SAVE secret protection (§2.S7), and console-stream confidentiality (§2.S13). Cross-reference ADR-002 for the threat model that Vz inherits unchanged.
+  - Discipline: per `feedback_adr_out_of_scope_discipline.md` ADR-046's "Security claim parity" subsection lists ONLY items in the same threat model as the parent claim. Adjacent surfaces (Sprint 56 Claim 10, networking observability) belong in their own ADRs, not here.
+- [ ] **4.2a** Update `specs/adrs/002-microvm-security-posture.md` (Slice 2C) — no claim change. Add per-claim sub-note under Claims 1, 5, 7, 8, 9: *"evidence applies to both libkrun and Vz builder paths — see ADR-046 §'Vz as a second builder backend' for backend-specific artifacts."* Otherwise the claim table reads libkrun-only.
+- [ ] **4.2b** Update `specs/adrs/047-app-deps-audit-pipeline.md` (Slice 2C) — add a "Backend symmetry" sub-paragraph to the Claim 9 evidence section citing §2.S2 (volume content byte-equivalence) and §2.S10 (`meta.json` hash-chain backend-neutrality). One short paragraph; proof lives in the tests.
+- [ ] **4.2c** Cross-references (Phase 4 docs slice — no scope change to the target ADRs):
+  - `specs/adrs/056-vz-backend.md` — add "Persistent builder variant" pointer paragraph to Plan 98 Slice 2A's `VzPersistentBuilderVm` (two sentences max; full design in ADR-046).
+  - `specs/adrs/055-passt-virtio-net.md` — one sentence on whether Vz networking diverges from libkrun's `krun_add_net_unixgram` path. If yes, name the attachment type and link to Plan 97 Phase A / Plan 98.
+  - `specs/adrs/041-signed-audited-execution-plans.md` — one-line backend-symmetry note to Claim 8 evidence citing §2.S3.
+  - `specs/adrs/057-symmetric-builder-vm.md` (Sprint 56) — bidirectional cross-link with Plan 98 (Vz builder narrows the asymmetric-trust gap on macOS that Sprint 56 fully closes; no scope change to ADR-057).
+- [ ] **4.3** `specs/SPRINT.md` final close-out — flip Phase 1/2/3/4 checkboxes in the Sprint 55 entry as each PR lands; this PR is the "all green" pass.
+
+### Phase 4 — deferred follow-ups
+
+- [ ] **4.4** ADR-055 cross-reference update if Vz network defaults diverge from gvproxy (likely out of scope; note explicitly). [Superseded by §4.2c above — leaving the placeholder for any post-2C deviation discovered.]
+- [ ] **4.5** §2.S12 — multi-binary same-host dispatch socket collision. Two `mvmctl` versions (system-install + dev worktree) racing on the same dispatch socket. Per ADR-002 the host is trusted; this is a robustness gap (panic, hang, stale state), not a security boundary violation. Track here rather than spending Slice 2C cycles on it. Likely fix: PID-file check before socket bind, refuse with clear "another mvmctl is running this dir" error.
+
+---
+
+## Verification (end-to-end)
+
+After Phase 1:
+- `cargo run -- --help` shows `--builder <libkrun|vz>` in the global flags.
+- `cargo run -- doctor` reports the auto-detected builder + per-VMM probes.
+- On macOS 26+ Apple Silicon: `cargo run -- build --flake .` defaults to Vz.
+- On Linux + macOS 13-25: defaults to libkrun.
+- `MVM_BUILDER_BACKEND=vz cargo run -- --builder libkrun build ...` — flag wins.
+- `mvmctl --builder vz dev up` exits nonzero with the §2.C1 grace-guard message until Phase 2 lands.
+- `cargo test --workspace` and `just lint` both green.
+
+After Phase 2:
+- `MVM_BUILDER_BACKEND=vz cargo run -- dev up && cargo run -- dev shell -- 'uname -a'` works on macOS 13+.
+- `MVM_BUILDER_BACKEND=vz cargo run -- dev down` stops cleanly.
+- `cargo run -- dev status` reports both backends' state.
+- Coexistence: `MVM_BUILDER_BACKEND=libkrun ... dev up && MVM_BUILDER_BACKEND=vz ... dev up` exits nonzero with a clear message.
+- `MVM_BUILDER_BACKEND=vz cargo run -- up --prod ./examples/python/hello-app-with-deps` produces sealed volume; `mvmctl deps inspect <hash> --json` reports it; byte-flip `cve.json` → `verify_sealed_volume` refuses.
+- Cross-backend hash equivalence test passes (§2.6) AND content/SBOM/fetch.log/cve.json byte-equivalence test passes (§2.S2).
+- `stat ~/.cache/mvm/builder-vm/vms/mvm-builder-vz-persistent` shows the dir inherits mode `0700` from `~/.cache/mvm/builder-vm/`; dispatch socket mode `0700`; `audit.jsonl` mode `0600`.
+- `mvmctl audit verify` is clean after a Vz Install (§2.S3).
+- `mvmctl doctor` reports `vz_check` entitlement probe on the builder line; auto-detect falls back to libkrun when the probe fails (§2.S4).
+- `cargo deny check` and `cargo audit` pass with `crates/mvm-vz` in scope (§2.S5).
+- Vz control-socket fuzz target exists under `crates/mvm-vz/fuzz/` *or* ADR-046 names the host-trust justification (§2.S6).
+- Snapshot SAVE (if used by persistent) lives at the expected path inside the 0700 dir, file mode `0600` (§2.S7).
+- §2.C1 grace guard removed in Phase 2's PR.
+
+After Phase 3:
+- `apple` lane in `ci.yml` runs Vz construction smoke green.
+- Linux `test` lane confirms libkrun auto-detect.
+
+After Phase 4:
+- `grep -n "Builder backend" CLAUDE.md` returns the new subsection.
+- `grep -n "Vz" specs/adrs/046-builder-vm-via-libkrun.md` shows the added subsection with security-claim-parity language.
+- All Plan 98 checkboxes flipped + Sprint 55 entry in `SPRINT.md` reflects close-out.
+
+## Files (remaining work)
+
+### Modified by Phase 1
+- `crates/mvm-build/src/builder_backend_select.rs` — auto-detect + override variant (shipped in worktree).
+- `crates/mvm-cli/src/commands/mod.rs` — `--builder` flag on Cli.
+- `crates/mvm-cli/src/commands/build/persistent_builder.rs` — consume flag + §2.C1 grace guard.
+- `crates/mvm-cli/src/commands/vm/up.rs` — consume flag (InstallDriver path).
+- `crates/mvm-cli/src/doctor.rs` — builder-backend reporting.
+- `specs/SPRINT.md` — Sprint 55 entry for Plan 98.
+
+### Modified by Phase 2
+- `crates/mvm-build/src/vz_builder.rs` — `VzPersistentBuilderVm` driver.
+- `crates/mvm-cli/src/commands/build/persistent_builder.rs` — coexistence dispatch (§2.5), remove §2.C1 guard.
+- `crates/mvm-cli/src/commands/dev/` (whichever module owns `dev up/down/shell/status`) — coexistence logic.
+- Tests: cross-backend volume-hash + content equivalence, permission-mode parity, audit-chain emit on Vz, entitlement-fallback auto-detect.
+- Possibly: `crates/mvm-vz/fuzz/` for §2.S6.
+
+### Modified by Phase 3
+- `.github/workflows/ci.yml` — `apple` lane Vz construction smoke step.
+
+### Modified by Phase 4
+- `CLAUDE.md` — Host dependencies + Builder backend selection + state dirs.
+- `specs/adrs/046-builder-vm-via-libkrun.md` — Vz subsection.
+- `specs/SPRINT.md` — final close-out bump.
+
+### Reused untouched
+- `crates/mvm-build/src/builder_vm.rs`, `builder_vm_runtime.rs`, `libkrun_builder.rs`, `vz_builder.rs` one-shot driver, `persistent_builder.rs` supervisor (all Phase A/B/C work, stable; backend-agnostic).
+- `crates/mvm-core/src/platform/platform.rs` — `is_macos_26_or_later()`.
+- `crates/mvm-vz/src/lib.rs` + supervisor.
+- `crates/mvm-build/src/app_deps_gate.rs` / `mvm_sdk::compile::deps_audit::verify_sealed_volume` — backend-agnostic.
+- Plan 99 PR-1 (#448) Stage 0 audit/cache contract — cross-reference, do not duplicate.


### PR DESCRIPTION
Closes Phase 1 of `specs/plans/98-vz-builder-vm.md` (§1.x) + the §0.x
gap-fix slice surfaced in the 2026-05-26 planning round.

## Summary

`mvm_build::builder_backend_select` shipped env-var-only (Plan 97
Phase C). This PR adds the user-facing surface:

- **Auto-detect**: macOS 26+ Apple Silicon → vz; everywhere else → libkrun.
- **`--builder <libkrun|vz>` global CLI flag**: highest priority, folded into the env var at startup so no per-call-site plumbing.
- **`mvmctl doctor` builder-backend line**: `<backend> — <source> — <availability>`.

## §0.x gap-fix slice

Caught in pre-ship review:

- **§0.1** `dev_action_blocked_by_vz_guard()` predicate extends the §2.C1 grace guard to cover `MVM_BUILDER_BACKEND=vz` (previously only `--builder vz` was guarded). 16 hermetic unit tests cover flag/env paths, case/whitespace variants, unaffected verbs.
- **§0.2** `--builder` help-text + value-parser tests in `commands/tests.rs`.
- **§0.3** Doctor `builder backend` line unit-tested on Linux (env-unset and env-override paths). Stub-path test for `cfg(not(feature = "builder-vm"))`.
- **§0.4** CI apple-lane already builds with `--features builder-vm` (default in `mvm-cli/Cargo.toml` since Plan 72 W5.B). No workflow patch needed.

## Test plan

- [x] `cargo test --features builder-vm -p mvm-build` — 16 selection-layer tests + auto-detect arms pass
- [x] `just lint` clean (fmt + clippy `-D warnings`)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)