### PR TITLE
Plan 98 §4.2a/b/c residual: ADR-002/041/047/055/057 backend-symmetry cross-refs

### DIFF
--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -138,6 +138,26 @@ by definition (see Threat model). L1 *enables* claim 3 (verified boot
 needs a hypervisor that respects the kernel cmdline). If the host is
 compromised, every layer falls; that case is explicitly out of scope.
 
+### Backend symmetry (Plan 98)
+
+Claims 1, 5, 7, 8, and 11 have **backend-symmetric evidence**: the
+gate holds under both the libkrun-backed builder VM and the
+Vz-backed builder VM (Plan 98). The libkrun-side evidence cited
+above is the canonical reference; the Vz-side parity claims hold
+with the same shape and are catalogued per-claim in **ADR-046 §"Vz
+as a second builder backend (Plan 98)" → "Security claim parity"**.
+Specifically:
+
+- **Claim 1** — VirtioFsShare set-equality test (Plan 98 §2.S8).
+- **Claim 5** — `crates/mvm-vz/fuzz/` parallels `crates/mvm-libkrun/fuzz/fuzz_supervisor_config.rs` (Plan 98 §2.S6).
+- **Claim 7** — `crates/mvm-vz` participates in `deny` + `audit` like every workspace member (Plan 98 §2.S5).
+- **Claim 8** — `mvmctl audit verify` after a Vz-driven `mvmctl up --prod` asserts chain cleanliness (Plan 98 §2.S3).
+- **Claim 11** — cross-backend byte-equivalence of sealed deps volume `(content/, sbom.cdx.json, fetch.log, cve.json)` (Plan 98 §2.S2) + `meta.json` backend-neutrality (Plan 98 §2.S10) + Install-arm kernel parity (Plan 98 §2.S9).
+
+Claims 2, 3, 4, 6, 9, 10 are guest-side or end-user-runtime concerns
+that don't depend on which host VMM booted the builder, so the
+existing libkrun-side evidence applies unchanged.
+
 ### Framework references
 
 Each claim is named here in MITRE vocabulary. Adversary technique = the

--- a/specs/adrs/041-signed-audited-execution-plans.md
+++ b/specs/adrs/041-signed-audited-execution-plans.md
@@ -123,6 +123,8 @@ Three event types today:
 
 Audit emission failures `tracing::warn` and continue — a flaky audit fs cannot block a VM that already booted. W6's follow-up tightens this to "audit failure fails the boot" once the chain is reliably reachable on every supported host.
 
+**Backend symmetry (Plan 98).** The `labels.backend` field accepts either `libkrun` or `vz` (and `firecracker` on Linux) — the chain itself is hypervisor-agnostic. `mvmctl up --prod` driven by `MVM_BUILDER_BACKEND=vz` emits the same `plan.admitted` / `plan.launched` / `plan.failed` sequence as the libkrun path, and `mvmctl audit verify` round-trips cleanly across both. Plan 98 §2.S3 ships the cross-backend audit-chain integrity test.
+
 ### Operator-facing surface
 
 - `mvmctl up` (existing, instrumented): every invocation admits + audits. `--no-supervisor` is a one-release escape hatch that prints a deprecation warning and skips both.

--- a/specs/adrs/047-app-deps-audit-pipeline.md
+++ b/specs/adrs/047-app-deps-audit-pipeline.md
@@ -122,6 +122,21 @@ critical findings.
 > the workload's audit chain. A tampered volume — content, SBOM,
 > fetch log, CVE result, or manifest — fails admission closed.
 
+### Backend symmetry (Plan 98)
+
+The Install pipeline above is backend-agnostic on the host side and
+entirely guest-side internal. The blanket `InstallDriver` impl over
+any `BuilderVm` (`crates/mvm-build/src/app_deps.rs:304-321`) means
+the same sealed volume — same `content/`, `sbom.cdx.json`,
+`fetch.log`, `cve.json`, hash-chained `meta.json` — flows out of
+both libkrun-driven and Vz-driven Install jobs. Cross-backend
+parity is enforced by Plan 98 §2.S2 (sealed volume content
+byte-equivalence on the same Install input) + §2.S10 (`meta.json`
+hash-chain backend-neutrality — identical content yields identical
+volume_hash regardless of which VMM booted the builder). Full
+backend-parity discussion lives in **ADR-046 §"Vz as a second
+builder backend (Plan 98)" → "Security claim parity"**.
+
 ## Status of the implementation
 
 | Component | State |

--- a/specs/adrs/055-passt-virtio-net.md
+++ b/specs/adrs/055-passt-virtio-net.md
@@ -238,6 +238,15 @@ binary doesn't exist), but the user gets a clear error rather than a
 silent regression — `mvmctl doctor` flags the missing dep with the
 right install hint per platform.
 
+**Vz backend (Plan 98).** The Apple Virtualization.framework builder
+also wires gvproxy on macOS — `mvm_vz::NetworkConfig::Gvproxy { socket_path, mac }`
+piped through `mvm-vz-supervisor`'s `Network.swift` attaches a
+`VZFileHandleNetworkDeviceAttachment` to the same gvproxy listener
+libkrun uses via `krun_add_net_unixgram`. The host-side gateway
+(gvproxy) is one process per dev session; the Vz and libkrun paths
+just attach to its socket differently. Full Plan 98 selection-policy
+context lives in **ADR-046 §"Vz as a second builder backend"**.
+
 Both backends share the same threat model: a userspace process
 running as the contributor's user, no privileged sockets, no host-fs
 visibility into the guest. The libkrun-end of the virtio-net frame

--- a/specs/adrs/057-symmetric-builder-vm.md
+++ b/specs/adrs/057-symmetric-builder-vm.md
@@ -42,8 +42,18 @@ The signing identity is established inside the builder VM on both hosts. The hos
 - Builder VM cold-start latency on Linux CI runners. Plan 100 W0 measures this against the current Firecracker-direct baseline.
 - Nested KVM availability on cloud Linux hosts. Some cloud hypervisors disable nested virt by default (or expose it via per-VM capabilities). Doctor probe + clear failure mode required.
 
+## Relationship to Plan 98 (Vz builder backend)
+
+Plan 98 ships a second builder-VMM impl (Apple Virtualization.framework / Vz) on macOS 26+ Apple Silicon, parallel to libkrun. That work is **complementary** to this ADR's symmetric-builder uplift:
+
+- **Plan 98** picks which host VMM runs the macOS builder VM (libkrun or Vz). It does not change which OSes have a builder VM at all.
+- **This ADR (Plan 100)** adds a builder VM to Linux too, so workload microVMs always run nested.
+
+Plan 98's macOS work narrows the asymmetric-trust gap *on macOS* (it stops requiring the third-party `slp/krun` Homebrew trio when Vz is the default), but Linux still runs Firecracker directly until Plan 100 W2 lands the nested libkrun-on-Linux path. The two efforts ship independently; their selection layers compose via `mvm_build::builder_backend_select::resolve_choice` (Plan 98 introduced) which already has a third arm reserved for future Linux-builder dispatch (Plan 100 W2 will populate it). Builder-backend parity discussion lives in **ADR-046 §"Vz as a second builder backend (Plan 98)"**.
+
 ## References
 
 - [ADR-001](001-firecracker-only.md) — Firecracker-only execution (needs update for nested model)
 - [ADR-002](002-microvm-security-posture.md) — microVM security posture (claim 1 reworded by Plan 100 W8)
+- [ADR-046](046-builder-vm-via-libkrun.md) — builder VM via libkrun + Plan 98 Vz extension
 - [Plan 100](../plans/100-symmetric-builder-vm-rollout.md) — implementation rollout


### PR DESCRIPTION
Closes Plan 98 §4.2a/b/c residual. Pure prose, no code.

## What this PR adds

| ADR | Change | Plan §|
|---|---|---|
| ADR-002 | "Backend symmetry (Plan 98)" subsection — Claims 1, 5, 7, 8, 11 hold under both backends; Claims 2, 3, 4, 6, 9, 10 are guest-side | §4.2a |
| ADR-041 | One-line backend-symmetry note to the audit-chain-shape section | §4.2c |
| ADR-047 | "Backend symmetry (Plan 98)" subsection after the Claim 9 statement | §4.2b |
| ADR-055 | "Vz backend (Plan 98)" paragraph noting Vz attaches to the same gvproxy listener libkrun uses | §4.2c |
| ADR-057 | "Relationship to Plan 98" subsection + ADR-046 added to References | §4.2c |

All cross-refs point at **ADR-046 §"Vz as a second builder backend (Plan 98)"** as the single canonical place for backend-parity discussion. No claim changes; no scope creep into adjacent surfaces (Sprint 56 Claim 10, Plan 101 gateway audit).

## Test plan

- [x] Markdown renders cleanly (visual scan).
- [x] No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)