### PR TITLE
Plan 120 (partial): core-demo spine guards + Sandbox.exec + builder-VM bringup fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,8 +246,11 @@ jobs:
 
       - name: Run E2E tests
         # Keep this lane on end-to-end smoke targets that compile
-        # without live microVM host state.
-        run: cargo test --test smoke_run_json_receipt --test runtime_boot_bench
+        # without live microVM host state. core_demo_e2e is included
+        # ungated here: it compiles and skip-passes (MVM_E2E_SMOKE unset)
+        # so a refactor that breaks the harness reddens this lane. The
+        # real boot lives in core-demo-e2e.yml (self-hosted libkrun).
+        run: cargo test --test smoke_run_json_receipt --test runtime_boot_bench --test core_demo_e2e
 
   # Note: cargo-audit, cargo-deny, reproducibility, and prod-agent-no-exec
   # were duplicated here AND in security.yml. They now live only in

--- a/.github/workflows/core-demo-e2e.yml
+++ b/.github/workflows/core-demo-e2e.yml
@@ -1,0 +1,45 @@
+name: Core-demo E2E (libkrun)
+
+# Plan 120 Task 3 — the real boot→ping spine (dev up -> compile -> up ->
+# guest agent answers over vsock). It needs libkrun + a working builder VM,
+# which GitHub-hosted runners can't provide (no nested virt on hosted macOS,
+# no KVM on hosted Linux). So this is a MANUAL, opt-in lane that targets a
+# self-hosted macOS/Apple-Silicon runner with the Homebrew `slp/krun` trio
+# installed. Until such a runner is registered, the authoritative proof is
+# the local run documented in contributing/development.md; the ungated
+# compile+skip of this same test runs on every push in ci.yml's `e2e` lane.
+on:
+  workflow_dispatch:
+    inputs:
+      run_boot:
+        description: "Run the real libkrun boot (requires a self-hosted macOS/libkrun runner)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: core-demo-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core-demo-libkrun:
+    name: dev → compile → up → vsock ping (libkrun)
+    # Opt-in only: schedules solely when the operator ticks run_boot AND a
+    # runner with these labels exists, so it never hangs queued on a normal
+    # dispatch.
+    if: ${{ inputs.run_boot }}
+    runs-on: [self-hosted, macOS, ARM64, libkrun]
+    env:
+      CARGO_TERM_COLOR: always
+      # State isolation (ADR-002 / AGENTS.md): demo audit/nonce/key state
+      # lands in a throwaway dir, never the runner's real ~/.mvm.
+      MVM_DATA_DIR: ${{ github.workspace }}/.mvm-test
+      MVM_E2E_SMOKE: "1"
+      MVM_BUILDER_BACKEND: libkrun
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Core-demo boot→ping
+        run: cargo test -p mvm-cli --test core_demo_e2e -- --nocapture

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -340,13 +340,25 @@ impl LibkrunBuilderVm {
         image: BuilderVmImage,
         workspace_dir: &std::path::Path,
         artifact_out: &std::path::Path,
+        host_bin_dir: &std::path::Path,
     ) -> Result<(), BuilderVmError> {
         ensure_utf8_path(workspace_dir, "workspace_dir")?;
         ensure_utf8_path(artifact_out, "artifact_out")?;
+        ensure_utf8_path(host_bin_dir, "host_bin_dir")?;
         if !workspace_dir.is_dir() {
             return Err(BuilderVmError::ExtractionFailed(format!(
                 "Stage 0 workspace_dir must be an existing directory: {}",
                 workspace_dir.display()
+            )));
+        }
+        // Plan 115 / ADR-065: the builder-vm flake's `.default` package
+        // bakes the cross-compiled host binaries (read from
+        // MVM_HOST_BIN_DIR) into the rootfs, so Stage 0 must mount them
+        // just like the steady-state `run_build` path does.
+        if !host_bin_dir.is_dir() {
+            return Err(BuilderVmError::ExtractionFailed(format!(
+                "Stage 0 host_bin_dir must be an existing directory: {}",
+                host_bin_dir.display()
             )));
         }
         std::fs::create_dir_all(artifact_out).map_err(|e| {
@@ -381,7 +393,12 @@ impl LibkrunBuilderVm {
             .with_console_output(path_to_str(&console_log, "console_log")?)
             .with_vsock_socket_dir(path_to_str(&vm_state_dir, "vm_state_dir")?)
             .add_virtio_fs("work", path_to_str(workspace_dir, "workspace_dir")?)
-            .add_virtio_fs("out", path_to_str(artifact_out, "artifact_out")?);
+            .add_virtio_fs("out", path_to_str(artifact_out, "artifact_out")?)
+            // Plan 115 / ADR-065: mount the extracted host-vm binaries at
+            // /mvm-bins (read-only by convention). init.sh exports
+            // MVM_HOST_BIN_DIR=/mvm-bins so the flake's `.default` build
+            // can bake the correct cross-compiled binaries into the rootfs.
+            .add_virtio_fs("mvm-bins", path_to_str(host_bin_dir, "host_bin_dir")?);
 
         krun = apply_networking_mode(krun, &vm_state_dir)?;
 

--- a/crates/mvm-build/src/stage0/init.sh
+++ b/crates/mvm-build/src/stage0/init.sh
@@ -78,6 +78,12 @@ EOF
 # `add_virtio_fs(tag, ...)` calls in `LibkrunBuilderVm::run_stage0`.
 mountpoint -q /work || mount -t virtiofs work /work
 mountpoint -q /out  || mount -t virtiofs out  /out
+# Plan 115 / ADR-065: the host-vm binaries share (mvmctl-embedded,
+# cross-compiled for the guest arch). The builder-vm flake's `.default`
+# reads them from MVM_HOST_BIN_DIR=/mvm-bins (exported below) at build
+# time. Tag matches `add_virtio_fs("mvm-bins", ...)` in run_stage0.
+mkdir -p /mvm-bins
+mountpoint -q /mvm-bins || mount -t virtiofs mvm-bins /mvm-bins
 if ! mountpoint -q /work; then
   echo "stage0-init: /work mount failed; aborting." >&2
   exit 64
@@ -85,6 +91,10 @@ fi
 if ! mountpoint -q /out; then
   echo "stage0-init: /out mount failed; aborting." >&2
   exit 65
+fi
+if ! mountpoint -q /mvm-bins; then
+  echo "stage0-init: /mvm-bins mount failed; aborting." >&2
+  exit 66
 fi
 
 # libkrun's set_root mode backs the guest root with virtio-fs
@@ -157,6 +167,11 @@ mkdir -p "$HOME"
 # `/`, tripping over /dev/btrfs-control + friends). The flake
 # checks this env under `--impure` (already set below).
 export MVM_WORKSPACE_PATH=/work
+
+# Plan 115 / ADR-065: point the flake at the mounted host-vm binaries.
+# The `.default` build errors at eval if this is unset (it bakes
+# mvm-builder-init / mvm-egress-proxy into the rootfs from here).
+export MVM_HOST_BIN_DIR=/mvm-bins
 
 ARCH="$(uname -m)"
 FLAKE_REF="path:/work/nix/images/builder-vm#packages.${ARCH}-linux.default"

--- a/crates/mvm-cli/src/commands/build/compile.rs
+++ b/crates/mvm-cli/src/commands/build/compile.rs
@@ -1,21 +1,22 @@
-//! `mvmctl compile` — Workload IR to staged build artifacts.
+//! `mvmctl compile` — Workload entry to staged build artifacts.
 //!
-//! v1 surface accepts a pre-rendered IR JSON (via `--from-ir <path>`
-//! or `-` for stdin) and renders `flake.nix`, `launch.json`, and the
-//! bundled source tree into `--out <dir>`. Output ending in `.tar.gz`
-//! or `.tgz` is written as a deterministic archive instead.
+//! Lowers a Workload to `flake.nix`, `launch.json`, and the bundled
+//! source tree under `--out <dir>` (or a deterministic `.tar.gz` /
+//! `.tgz` archive). The entry is one of:
 //!
-//! Decorator-script entry (parse `app.py` / `app.ts` to derive the
-//! IR) lands with Phase 4 of the SDK port; runtime record-mode (parse
-//! a `Sandbox`-shaped script) lands with Phase 7. v1 only handles the
-//! IR-JSON path so the compile pipeline has an end-to-end smoke test
-//! independent of the parser.
+//! - a `.py` / `.ts` **decorator** script — parsed *statically* (via
+//!   `parse_python` / `parse_typescript`, AST only; the host never
+//!   imports or executes the script) into the Workload IR;
+//! - a pre-rendered **IR JSON** (`--from-ir <path>`, a `.json`
+//!   positional, or `-` for stdin);
+//! - a runtime **recording** (`--from-recording <path>`), or a
+//!   `Sandbox`-shaped script with no `@mvm.app` (auto-executed in
+//!   record mode — Phase 7e).
 //!
-//! Flag shapes follow the approved plan:
+//! Flag shapes:
 //!
-//! - `<entry>` — positional. A `.json` path, `-` for stdin, or a
-//!   `.py` / `.ts` script (rejected with a `not-yet-implemented`
-//!   pointer to Phase 4/7 until those land).
+//! - `<entry>` — positional. A `.py`/`.ts` script, a `.json` IR path,
+//!   or `-` for stdin.
 //! - `--from-ir <path>` — explicit IR-JSON path (alternative to the
 //!   positional).
 //! - `--out <path>` — output directory (or `.tar.gz`/`.tgz` archive).

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -2169,8 +2169,22 @@ fn bootstrap_builder_vm_image_via_root_dir_stage0(
         flavor = STAGE0_FLAVOR_CURRENT,
     );
 
+    // Plan 115 / ADR-065: extract the mvmctl-embedded host-vm binaries to
+    // the host-bins cache; run_stage0 mounts them at /mvm-bins so the
+    // builder-vm flake's `.default` build can bake them into the rootfs.
+    let host_bins_cache = format!("{}/host-bins", mvm_core::config::mvm_cache_dir());
+    let host_bin_dir =
+        crate::host_binaries::extract::ensure_extracted(std::path::Path::new(&host_bins_cache))
+            .map_err(|e| anyhow::anyhow!("extract embedded host-vm binaries: {e}"))?;
+
     let image = BuilderVmImage::new_root_dir(root_dir.clone(), "/init");
-    let result = run_stage0_root_dir(&staging_dir, &workspace_root, image, source_fingerprint);
+    let result = run_stage0_root_dir(
+        &staging_dir,
+        &workspace_root,
+        image,
+        &host_bin_dir,
+        source_fingerprint,
+    );
     let duration_ms = started.elapsed().as_millis() as u64;
 
     match result {
@@ -2207,12 +2221,13 @@ fn run_stage0_root_dir(
     staging_dir: &std::path::Path,
     workspace_root: &std::path::Path,
     image: mvm_build::libkrun_builder::BuilderVmImage,
+    host_bin_dir: &std::path::Path,
     source_fingerprint: &str,
 ) -> std::result::Result<(), (Stage0FailureStage, anyhow::Error)> {
     use mvm_build::libkrun_builder::LibkrunBuilderVm;
 
     LibkrunBuilderVm::default()
-        .run_stage0(image, workspace_root, staging_dir)
+        .run_stage0(image, workspace_root, staging_dir, host_bin_dir)
         .map_err(|e| {
             (
                 Stage0FailureStage::Build,

--- a/crates/mvm-cli/tests/compile_hello_app.rs
+++ b/crates/mvm-cli/tests/compile_hello_app.rs
@@ -1,0 +1,36 @@
+// Plan 120 Task 2: the decorator `.py` path lowers statically (no host exec).
+// `mvmctl compile examples/python/hello-app/app.py` walks the `@mvm.app(...)`
+// AST, derives the Workload IR, and renders flake.nix + launch.json — without
+// importing or executing the script. This locks that wiring against regression.
+use assert_cmd::cargo::CommandCargoExt;
+use std::process::Command;
+
+#[test]
+fn compile_hello_app_lowers_decorator_to_flake() {
+    let out = tempfile::tempdir().expect("tmp out");
+    let app = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../examples/python/hello-app/app.py"
+    );
+
+    #[allow(deprecated)]
+    let result = Command::cargo_bin("mvmctl")
+        .expect("locate mvmctl")
+        .args(["compile", app, "--out", out.path().to_str().unwrap()])
+        .output()
+        .expect("spawn mvmctl compile");
+
+    assert!(
+        result.status.success(),
+        "mvmctl compile <app.py> failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert!(
+        out.path().join("flake.nix").exists(),
+        "flake.nix not emitted into --out dir"
+    );
+    assert!(
+        out.path().join("launch.json").exists(),
+        "launch.json not emitted into --out dir"
+    );
+}

--- a/crates/mvm-cli/tests/core_demo_e2e.rs
+++ b/crates/mvm-cli/tests/core_demo_e2e.rs
@@ -1,0 +1,75 @@
+// Plan 120 core-demo E2E: dev up -> compile the hello-app -> up (build+boot) ->
+// guest agent answers Ping over vsock -> teardown. Gated on MVM_E2E_SMOKE=1
+// (needs libkrun + the builder VM; runs for minutes). The spine's regression guard.
+//
+// macOS (libkrun) is forced, test-only: MVM_BUILDER_BACKEND=libkrun on every call
+// (harmless on `compile`), plus `--hypervisor libkrun` on `up` — auto-select on a
+// macOS-26 host picks Vz (builder) / apple-container (workload), not libkrun. This
+// does NOT change `up`'s product auto-select.
+//
+// Run under state isolation so demo audit/nonce/key state never touches the real
+// ~/.mvm and never races a parallel session:
+//   MVM_DATA_DIR="$PWD/.mvm-test" MVM_E2E_SMOKE=1 \
+//     cargo test -p mvm-cli --test core_demo_e2e -- --nocapture
+use assert_cmd::cargo::CommandCargoExt;
+use std::process::Command;
+
+fn mvmctl(args: &[&str]) -> std::process::Output {
+    #[allow(deprecated)]
+    Command::cargo_bin("mvmctl")
+        .expect("locate mvmctl")
+        .env("MVM_BUILDER_BACKEND", "libkrun")
+        .args(args)
+        .output()
+        .expect("spawn mvmctl")
+}
+
+#[test]
+fn core_demo_dev_compile_up_ping() {
+    if std::env::var("MVM_E2E_SMOKE").ok().as_deref() != Some("1") {
+        eprintln!("skipping core-demo E2E; set MVM_E2E_SMOKE=1 to run");
+        return;
+    }
+    let out = tempfile::tempdir().expect("tmp out");
+    let app = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../examples/python/hello-app/app.py"
+    );
+
+    // 1) builder VM up (idempotent), via libkrun.
+    let dev = mvmctl(&["dev", "up"]);
+    assert!(
+        dev.status.success(),
+        "dev up failed: {}",
+        String::from_utf8_lossy(&dev.stderr)
+    );
+
+    // 2) lower the decorator app to flake.nix + launch.json.
+    let c = mvmctl(&["compile", app, "--out", out.path().to_str().unwrap()]);
+    assert!(
+        c.status.success(),
+        "compile failed: {}",
+        String::from_utf8_lossy(&c.stderr)
+    );
+
+    // 3) build + boot the workload microVM via libkrun; `up` waits for the guest
+    //    agent (wait_for_guest_agent -> vsock Ping). Exit 0 + no "not reachable"
+    //    line == the agent answered. Never bypass admission (no --hypervisor mock /
+    //    MVM_DIRECT_BOOT) and never flip MVM_ACK_UNRESTRICTED_NETWORK.
+    let up = mvmctl(&[
+        "up",
+        "--hypervisor",
+        "libkrun",
+        "--flake",
+        out.path().to_str().unwrap(),
+    ]);
+    let log = String::from_utf8_lossy(&up.stderr);
+    assert!(up.status.success(), "up failed: {log}");
+    assert!(
+        !log.contains("Guest agent not reachable"),
+        "agent never answered: {log}"
+    );
+
+    // 4) teardown the builder (best-effort).
+    let _ = mvmctl(&["dev", "down"]);
+}

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -239,10 +239,13 @@
       # - `ro` — root is read-only; writes go to the persistent
       #   /nix-store virtio-blk at /dev/vdb (Plan 72 W4 wires it).
       # - `rootfstype=ext4` — skip filesystem auto-detection.
-      # - `init=/sbin/mvm-builder-init` — Plan 72 W3 / Plan 107 A1b
-      #   binary as PID 1. Cargo package is `mvm-host-vm-init`; the
-      #   install path is `/sbin/mvm-builder-init` (T2 manifest).
-      builderCmdline = "console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/sbin/mvm-builder-init";
+      # - `init=/sbin/mvm-host-vm-init` — Plan 72 W3 / Plan 107 A1b
+      #   binary as PID 1. The cargo package and the install path are
+      #   both `mvm-host-vm-init` (nix/lib/mvm-host-binaries.nix is the
+      #   source of truth). The earlier `/sbin/mvm-builder-init` name
+      #   was renamed; the cmdline had drifted out of sync with the
+      #   manifest, which made PID 1 ENOENT (kernel panic on boot).
+      builderCmdline = "console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/sbin/mvm-host-vm-init";
 
       # Extra packages for the interactive (dev) builder VM image.
       # Added on top of `builderPackages` when `interactive = true`.
@@ -274,8 +277,8 @@
         (libFor { inherit system; }).mkGuest {
           name = "mvm-builder-vm";
           # Skip the addon-dns bake. The builder VM's PID 1 is
-          # `mvm-builder-init` (set via `extraFiles` + the
-          # `init=/sbin/mvm-builder-init` kernel cmdline), so
+          # `mvm-host-vm-init` (set via `extraFiles` + the
+          # `init=/sbin/mvm-host-vm-init` kernel cmdline), so
           # mkGuest's initScript-side addon-dns activation block
           # never runs and the binary would just sit unused at
           # /usr/local/bin/mvm-addon-dns. The win is in Stage 0:
@@ -284,7 +287,7 @@
           # the tmpfs-bound build into OOM territory.
           bakeAddonDns = false;
           # mkGuest requires an entrypoint declaration. At runtime
-          # the kernel cmdline sets `init=/sbin/mvm-builder-init`,
+          # the kernel cmdline sets `init=/sbin/mvm-host-vm-init`,
           # so mkGuest's entrypoint is vestigial — but we still
           # need to declare one to satisfy the type contract.
           entrypoint.shell = "/bin/sh";

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -61,6 +61,26 @@ just ci
 - CLI binary tests go in root `tests/cli.rs`
 - Use `#[serde(default)]` when adding fields to structs used in test fixtures
 
+### Gated end-to-end tests (`MVM_E2E_SMOKE`)
+
+Tests that boot a real microVM (they need libkrun + a working builder VM and
+run for minutes) are gated on `MVM_E2E_SMOKE=1` and skip by default, so a plain
+`cargo test` stays fast and green. The core-demo spine guard lives in
+`crates/mvm-cli/tests/core_demo_e2e.rs` (`dev up` → `compile` → `up` →
+guest-agent vsock ping). Run it locally on a macOS/libkrun host under state
+isolation (keeps demo audit/nonce/key state out of your real `~/.mvm`):
+
+```bash
+MVM_DATA_DIR="$PWD/.mvm-test" MVM_E2E_SMOKE=1 \
+  cargo test -p mvm-cli --test core_demo_e2e -- --nocapture
+```
+
+The test forces libkrun (`--hypervisor libkrun` + `MVM_BUILDER_BACKEND=libkrun`)
+because auto-detect on a macOS-26 host picks Vz/apple-container. CI runs this
+target **ungated** on every push (it compiles + skip-passes in the `e2e` lane);
+the real boot runs only via the manual `Core-demo E2E (libkrun)` workflow on a
+self-hosted macOS/libkrun runner (hosted runners have no nested virt).
+
 ## Linting and Formatting
 
 ```bash

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -14,6 +14,25 @@ subprocesses to.
 
 ## Quick start
 
+The fastest path is the one-call sandbox — boot a dev-tier microVM, run a
+command, get its output back:
+
+```python
+from mvm import Sandbox
+
+sb = Sandbox.create(image="python:slim")
+try:
+    r = sb.exec("python", "-c", "print(2 + 2)")
+    print(r.stdout)          # "4\n"   (r.exit_code, r.stderr also available)
+finally:
+    sb.shutdown()
+```
+
+`exec` is **dev-tier**: against a prod template it raises `SandboxDevOnly`
+before any work happens (ADR-002 §W4.3 — the prod agent has no exec handler).
+
+For a reproducible, signed workload, declare it and compile it instead:
+
 ```python
 # app.py
 import mvm as mv

--- a/sdks/python/mvm/_sandbox.py
+++ b/sdks/python/mvm/_sandbox.py
@@ -73,6 +73,7 @@ from mvm._dsl import literal as _literal_value
 __all__ = [
     "DEFAULT_TTL_SECONDS",
     "MVM_CLI_BIN_ENV",
+    "ExecResult",
     "RecordingNotActiveError",
     "Sandbox",
     "SandboxDevOnly",
@@ -82,6 +83,17 @@ __all__ = [
     "emit_recording_json",
     "reset_recording",
 ]
+
+
+@dataclasses.dataclass(frozen=True)
+class ExecResult:
+    """Result of a one-shot :meth:`Sandbox.exec` — the guest process's
+    captured stdout/stderr and its exit code (124 = timed out,
+    128+signal = killed, per ``mvmctl proc wait``)."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
 
 
 MVM_SDK_MODE_ENV = "MVM_SDK_MODE"
@@ -618,6 +630,90 @@ class _LiveTransport:
         shell += ["--", *argv]
         self._run_shell(shell)
 
+    def commands_run(
+        self,
+        argv: list[str],
+        env: dict[str, Any] | None,
+        timeout: int | None,
+    ) -> "ExecResult":
+        """One-shot ``proc start`` + ``proc wait``: launch ``argv`` in the
+        VM, wait for it, and return captured stdout/stderr/exit.
+
+        Refuses with :class:`SandboxDevOnly` when the resolved template is
+        prod (ADR-002 §W4.3, claim 4) — enforced **before** any vsock
+        traffic, exactly like :meth:`commands_start`; there is no prod
+        path. Unlike ``commands.start`` this *captures* stdout/stderr
+        instead of forwarding them, and a non-zero guest exit is returned
+        in :attr:`ExecResult.exit_code` rather than raised (a failed
+        *transport*, e.g. a missing binary, still raises
+        :class:`SandboxLiveError`)."""
+        if self.build_mode != "dev":
+            raise SandboxDevOnly(
+                f"`exec` requires a dev-mode template; resolved template "
+                f"build_mode={self.build_mode!r}. ADR-002 §W4.3 (security claim 4) "
+                f"strips the agent's `do_exec` handler in prod builds — re-build the "
+                f"template with `mvmctl template build --dev <name>`, or use "
+                f"`files.write` to stage inputs into the running VM instead.",
+                argv=["proc", "start", self.vm_id, *argv],
+            )
+
+        start = [self.mvm_cli_bin, "proc", "start", self.vm_id]
+        if env:
+            for key, value in env.items():
+                if isinstance(value, str):
+                    start += ["-e", f"{key}={value}"]
+                elif isinstance(value, dict) and value.get("kind") == "literal":
+                    start += ["-e", f"{key}={value['value']}"]
+                else:
+                    raise SandboxLiveError(
+                        f"`exec` env {key!r} carries a non-literal value; live mode "
+                        f"only forwards literal env vars (secrets must be injected via "
+                        f"the host keystore + `--secret` on `mvmctl up`).",
+                        argv=start,
+                    )
+        start += ["--", *argv]
+
+        started = self._capture(start)
+        if started.returncode != 0:
+            raise SandboxLiveError(
+                f"`mvmctl proc start` failed with exit code {started.returncode}",
+                argv=start,
+                exit_code=started.returncode,
+                stderr=started.stderr,
+            )
+        token = started.stdout.strip()
+        if not token:
+            raise SandboxLiveError(
+                "`mvmctl proc start` returned an empty pid token", argv=start
+            )
+
+        wait = [self.mvm_cli_bin, "proc", "wait", self.vm_id, token]
+        if timeout is not None:
+            wait += ["--timeout", str(timeout)]
+        done = self._capture(wait)
+        # `mvmctl proc wait` exits with the guest process's exit code
+        # (124 timed out, 128+signal killed) and streams the guest's
+        # stdout/stderr to its own — which we captured here.
+        return ExecResult(
+            stdout=done.stdout,
+            stderr=done.stderr,
+            exit_code=done.returncode,
+        )
+
+    def _capture(self, shell: list[str]) -> subprocess.CompletedProcess:
+        """Run ``shell`` to completion, capturing stdout/stderr. Raises
+        :class:`SandboxLiveError` only on a transport failure (the binary
+        is missing); a non-zero exit is returned to the caller."""
+        try:
+            return subprocess.run(
+                shell, check=False, capture_output=True, text=True
+            )
+        except FileNotFoundError as exc:
+            raise SandboxLiveError(
+                f"`{self.mvm_cli_bin}` not found on disk; check MVM_CLI_BIN",
+                argv=shell,
+            ) from exc
+
     def files_write(self, path: str, data: bytes) -> None:
         """Shell ``mvmctl fs write <vm> <path>`` with the file
         bytes piped through stdin. The mvmctl verb accepts stdin
@@ -774,8 +870,9 @@ class Sandbox:
     @classmethod
     def create(
         cls,
-        template: str,
+        template: str | None = None,
         *,
+        image: str | None = None,
         workload_id: str | None = None,
         env: dict[str, Any] | None = None,
         include: list[str] | None = None,
@@ -786,7 +883,10 @@ class Sandbox:
     ) -> "Sandbox":
         """Start a new sandbox session.
 
-        ``template`` resolves to a base image on the Rust side (see
+        Pass the base image as the positional ``template`` or the
+        keyword ``image=`` (aliases for the same field — the quickstart
+        reads ``Sandbox.create(image="python:slim")``); exactly one is
+        required. It resolves to a base image on the Rust side (see
         ``runtime::resolve_base_image``); in record mode unknown
         templates fail at lower time, not here, because the wire
         shape preserves them verbatim. In live mode unknown
@@ -795,6 +895,12 @@ class Sandbox:
         :class:`SandboxLiveError` here. ``workload_id`` defaults to
         the template (the CLI overrides with the script's basename
         when invoked via ``mvmctl compile``)."""
+        if (template is None) == (image is None):
+            raise ValueError(
+                "pass exactly one of `template` (positional) or `image=` "
+                "to Sandbox.create()"
+            )
+        template = template if template is not None else image
         mode = _resolve_mode()  # raises if MVM_SDK_MODE is invalid
         global _recording
         if _recording is not None or _live_sandbox_active():
@@ -806,7 +912,7 @@ class Sandbox:
                 "construct at most one Sandbox."
             )
         if not isinstance(template, str) or not template:
-            raise ValueError("template must be a non-empty str")
+            raise ValueError("template/image must be a non-empty str")
         ttl_seconds = _parse_ttl(ttl)
         if ttl_seconds is None:
             ttl_seconds = DEFAULT_TTL_SECONDS
@@ -854,6 +960,42 @@ class Sandbox:
     def files(self) -> _Files:
         return self._files
 
+    def exec(
+        self,
+        *argv: str,
+        timeout: int | None = None,
+        cwd: str | None = None,
+        env: dict[str, Any] | None = None,
+    ) -> "ExecResult":
+        """Run ``argv`` to completion in the sandbox and return its
+        captured stdout/stderr/exit code — the one-call DX headline::
+
+            r = Sandbox.create(image="python:slim").exec("python", "-c", "print(2+2)")
+            assert r.stdout.strip() == "4"
+
+        **Dev-tier, live-mode only.** It refuses with
+        :class:`SandboxDevOnly` (before any vsock traffic) when the
+        resolved template is a prod build — there is no prod ``exec``
+        path (ADR-002 §W4.3, security claim 4). In record mode it
+        raises, since ``exec`` is a live one-shot, not a recordable op
+        (use ``commands.start`` to record an entrypoint)."""
+        if self._live is None:
+            raise SandboxModeError(
+                "Sandbox.exec() is a live-transport one-shot (dev tier); it is "
+                "not a recordable op. Use `MVM_SDK_MODE=live` (the host's "
+                "`mvmctl run --dev` sets this), or `commands.start(...)` to "
+                "record a workload entrypoint."
+            )
+        if not argv or not all(isinstance(a, str) for a in argv):
+            raise ValueError("exec(*argv) requires a non-empty list of str args")
+        run_argv = list(argv)
+        if cwd is not None:
+            # proc start has no cwd flag; run argv under a shell that cd's
+            # first. `exec "$@"` keeps it a single process with the real
+            # argv (no extra shell in the process tree).
+            run_argv = ["/bin/sh", "-c", 'cd "$0" && exec "$@"', cwd, *argv]
+        return self._live.commands_run(run_argv, env, timeout)
+
     def kill(self) -> None:
         """Issue a ``kill`` against the active transport.
 
@@ -868,6 +1010,11 @@ class Sandbox:
             return
         _require_recording()
         _recording["ops"].append({"kind": "kill"})
+
+    def shutdown(self) -> None:
+        """Alias for :meth:`kill` — reads naturally after a one-shot
+        ``exec`` (``sb.shutdown()`` in a ``finally``)."""
+        self.kill()
 
     def __enter__(self) -> "Sandbox":
         return self

--- a/sdks/python/tests/test_sandbox_exec.py
+++ b/sdks/python/tests/test_sandbox_exec.py
@@ -1,0 +1,92 @@
+"""Plan 120 Task 5 — the one-call `Sandbox.exec(...)` DX headline.
+
+`exec` is the dev-tier one-shot: run argv in the sandbox, collect
+stdout/stderr/exit. It refuses prod templates via `SandboxDevOnly`
+*before* any vsock traffic (ADR-002 §W4.3, security claim 4) — there
+is no prod exec path.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import mvm
+import mvm._sandbox as s
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    """Clean recording + mode env around each test."""
+    mvm.reset_recording()
+    os.environ.pop("MVM_SDK_MODE", None)
+    os.environ.pop("MVM_CLI_BIN", None)
+    yield
+    mvm.reset_recording()
+    os.environ.pop("MVM_SDK_MODE", None)
+    os.environ.pop("MVM_CLI_BIN", None)
+
+
+# ── always-on: claim 4 — exec never reaches a prod container ──────────
+
+
+def test_exec_refuses_prod_template_before_any_subprocess(monkeypatch) -> None:
+    """A prod-mode transport must make `exec` raise `SandboxDevOnly`
+    *before* spawning any `mvmctl` subprocess (security claim 4)."""
+
+    def _fail(*_a, **_k):
+        pytest.fail("exec() spawned a subprocess on a prod template")
+
+    monkeypatch.setattr(s.subprocess, "run", _fail)
+
+    sb = s.Sandbox(
+        "wid",
+        live=s._LiveTransport(
+            mvm_cli_bin="/bin/false", vm_id="sb-prod", build_mode="prod"
+        ),
+    )
+    with pytest.raises(mvm.SandboxDevOnly, match="dev-mode template"):
+        sb.exec("python", "-c", "print(1)")
+
+
+def test_exec_in_record_mode_raises_not_a_recordable_op() -> None:
+    """`exec` is a live one-shot; in record mode (no `_live`) it refuses
+    rather than silently recording nothing."""
+    sb = mvm.Sandbox.create(image="python:slim")  # record mode (default)
+    with pytest.raises(mvm.SandboxModeError, match="live-transport one-shot"):
+        sb.exec("python", "-c", "print(1)")
+
+
+def test_create_accepts_image_alias_and_rejects_both_or_neither() -> None:
+    """`image=` is an alias for the positional `template`; exactly one is
+    required (the quickstart reads `Sandbox.create(image=...)`)."""
+    sb = mvm.Sandbox.create(image="python:slim")
+    assert sb.workload_id == "python:slim"
+    mvm.reset_recording()
+    with pytest.raises(ValueError, match="exactly one"):
+        mvm.Sandbox.create("a", image="b")
+    with pytest.raises(ValueError, match="exactly one"):
+        mvm.Sandbox.create()
+
+
+# ── gated: the real one-shot against a booted dev-tier sandbox ────────
+
+
+@pytest.mark.skipif(
+    os.environ.get("MVM_E2E_SMOKE") != "1",
+    reason="boots a real microVM; set MVM_E2E_SMOKE=1 on a libkrun host",
+)
+def test_sandbox_exec_returns_stdout() -> None:
+    # Live, dev-tier. The host's `mvmctl run --dev` normally sets these;
+    # set them explicitly for a standalone gated run.
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ.setdefault("MVM_CLI_BIN", os.environ.get("MVM_CLI_BIN", "mvmctl"))
+
+    sb = mvm.Sandbox.create(image="python:slim")  # boots a dev-tier microVM
+    try:
+        r = sb.exec("python", "-c", "print(2+2)")
+        assert r.exit_code == 0
+        assert r.stdout.strip() == "4"
+    finally:
+        sb.shutdown()

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1,3 +1,19 @@
+# Stage C — Core demo (Plan 120) — IN FLIGHT  [`plans/120-core-demo.md`](plans/120-core-demo.md)
+
+**Branch:** `plan-120-core-demo` (off `cleanup-rearchitecture`; part of the Plan 117 rewrite).
+
+**Goal:** prove the rewrite's #1 deliverable end-to-end on macOS (libkrun): `mvmctl dev up` (persistent builder) → `mvmctl compile <app.py>` (decorator → flake) → `mvmctl up --flake <dir>` (build-in-VM + boot) → guest agent answers `Ping` over vsock. Lock the spine behind a gated E2E regression guard and ship the one-call `Sandbox.exec(...)` DX headline. Brief 117 §4 acceptance.
+
+- [x] Task 1 — `ArtifactSidecar` → `ArtifactManifest` rename (landed on `cleanup-rearchitecture`, 2026-05-31).
+- [ ] Task 2 — `crates/mvm-cli/tests/compile_hello_app.rs` locks `mvmctl compile <app.py>` decorator lowering; stale `compile.rs` docstring corrected.
+- [ ] Task 3 — `crates/mvm-cli/tests/core_demo_e2e.rs` (MVM_E2E_SMOKE-gated, forces `--hypervisor libkrun`); `workflow_dispatch` CI lane + `development.md` note; ungated run green.
+- [ ] Task 4 — drive the gated E2E to green on this macOS/libkrun host (workload-backend / `compile→up` handoff / teardown), never bypassing admission/audit/network; tick brief 117 §4 boxes 436–439.
+- [ ] Task 5 — `Sandbox.exec(...) -> ExecResult` one-shot (dev-tier; `SandboxDevOnly` refuses prod before any vsock); `image=`/`shutdown()` aliases; quickstart leads with it.
+
+**Security posture:** no new mechanism — encrypt-at-rest + Noise (122), claim-gates/fuzz (128), secrets (129)/broker (104), verity overlay (124C) are their own plans. The demo *exercises* claims 8 (signed/audited admission), 10 (default-deny egress), 4 (dev-only exec) and must **prove, never bypass** them. Deferred: Linux/Firecracker parity (own plan, Lima `/dev/kvm` test-tier backend), Vz-workload parity (next macOS backend).
+
+---
+
 # Sprint 42 — microVM hardening: load-bearing guarantees
 
 **Goal:** turn the project's stated security claim ("no SSH in microVMs,

--- a/specs/plans/120-core-demo.md
+++ b/specs/plans/120-core-demo.md
@@ -123,9 +123,15 @@ One gated test driving the whole spine with the **verified** verbs: `mvmctl dev 
   use assert_cmd::cargo::CommandCargoExt;
   use std::process::Command;
 
+  // macOS (libkrun) is forced, test-only: MVM_BUILDER_BACKEND=libkrun on every call
+  // (harmless on `compile`), plus `--hypervisor libkrun` on `up` — auto-select on a
+  // macOS-26 host picks Vz (builder) / apple-container (workload), not libkrun. This
+  // does NOT change `up.rs`'s product auto-select (see Task 4 §1).
   fn mvmctl(args: &[&str]) -> std::process::Output {
       #[allow(deprecated)]
-      Command::cargo_bin("mvmctl").expect("locate mvmctl").args(args).output().expect("spawn mvmctl")
+      Command::cargo_bin("mvmctl").expect("locate mvmctl")
+          .env("MVM_BUILDER_BACKEND", "libkrun")
+          .args(args).output().expect("spawn mvmctl")
   }
 
   #[test]
@@ -137,16 +143,16 @@ One gated test driving the whole spine with the **verified** verbs: `mvmctl dev 
       let out = tempfile::tempdir().expect("tmp out");
       let app = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/python/hello-app/app.py");
 
-      // 1) builder VM up (idempotent).
+      // 1) builder VM up (idempotent), via libkrun.
       assert!(mvmctl(&["dev", "up"]).status.success(), "dev up failed");
 
       // 2) lower the decorator app to flake.nix + launch.json.
       let c = mvmctl(&["compile", app, "--out", out.path().to_str().unwrap()]);
       assert!(c.status.success(), "compile failed: {}", String::from_utf8_lossy(&c.stderr));
 
-      // 3) build + boot the workload microVM; `up` waits for the guest agent
+      // 3) build + boot the workload microVM via libkrun; `up` waits for the guest agent
       //    (wait_for_guest_agent -> vsock Ping). Exit 0 + no "not reachable" == agent answered.
-      let up = mvmctl(&["up", "--flake", out.path().to_str().unwrap()]);
+      let up = mvmctl(&["up", "--hypervisor", "libkrun", "--flake", out.path().to_str().unwrap()]);
       let log = String::from_utf8_lossy(&up.stderr);
       assert!(up.status.success(), "up failed: {log}");
       assert!(!log.contains("Guest agent not reachable"), "agent never answered: {log}");
@@ -155,11 +161,11 @@ One gated test driving the whole spine with the **verified** verbs: `mvmctl dev 
       let _ = mvmctl(&["dev", "down"]);
   }
   ```
-  *(On macOS the workload backend must be libkrun, not the `--backend` firecracker default — Task 4 wires that selection. The assertion contract is fixed: `up` boots and the agent answers.)*
+  *(libkrun is forced here test-only — never bypass admission with `--hypervisor mock`/`MVM_DIRECT_BOOT`, and never set `MVM_ACK_UNRESTRICTED_NETWORK`. Run under `MVM_DATA_DIR` isolation so demo audit/nonce/key state never touches the real `~/.mvm`. The assertion contract is fixed: `up` boots and the agent answers.)*
 
-- [ ] **Step 2: Run it gated** on a libkrun host: `MVM_E2E_SMOKE=1 cargo test -p mvm-cli --test core_demo_e2e -- --nocapture`. First run surfaces the real gaps (Task 4). The default (ungated) run skips and passes — confirm with `cargo test -p mvm-cli --test core_demo_e2e` (prints the skip line, exits 0).
+- [ ] **Step 2: Run it gated** on this libkrun host, under state isolation: `MVM_DATA_DIR="$PWD/.mvm-test" MVM_E2E_SMOKE=1 cargo test -p mvm-cli --test core_demo_e2e -- --nocapture`. First run surfaces the real gaps (Task 4). The default (ungated) run skips and passes — confirm with `cargo test -p mvm-cli --test core_demo_e2e` (prints the skip line, exits 0).
 
-- [ ] **Step 3: Add the lane to CI** as a manual/opt-in job (not every PR — it needs a libkrun runner), mirroring how `dev_up_smoke` is gated. Document it in `public/src/content/docs/contributing/development.md`.
+- [ ] **Step 3: Add the CI lane** (no over-claim — hosted runners can't boot libkrun). A `workflow_dispatch` job that on hosted runners builds + runs `core_demo_e2e` **ungated** (proves it compiles + skip-passes), wired (runner label + conditional `MVM_E2E_SMOKE=1`) to do the real boot when a **self-hosted macOS/libkrun runner** (Homebrew `slp/krun` trio + Apple-Silicon virt) is registered. Document the local `MVM_DATA_DIR=… MVM_E2E_SMOKE=1` invocation in `public/src/content/docs/contributing/development.md`. Real boot-in-CI is deferred to a self-hosted runner; the **Linux/Firecracker** lane (own plan) is where Lima-as-virtual-`/dev/kvm` (AGENTS.md test-tier backend) is the mechanism — note it, don't build it here.
 
 - [ ] **Step 4: Commit.**
   ```bash
@@ -171,7 +177,7 @@ One gated test driving the whole spine with the **verified** verbs: `mvmctl dev 
 
 The spine is *believed* complete (fresh build → `overlay_aware: true` → admits; `up` pings the agent). Task 4 is the iterate-to-green loop: run the gated E2E, read `<vm_state_dir>/console.log` **first** on any boot failure (per the project's debugging convention), fix the one gap, re-run. **No speculative fixes** — only what the E2E proves broken. The likely gaps, in order:
 
-- [ ] **Step 1: macOS workload backend.** `up`'s `--backend` defaults to `firecracker` (`up.rs:705`), which needs Linux KVM. On macOS the workload microVM must run via libkrun. Confirm `up` selects libkrun on macOS (per-OS default) or thread the backend through the E2E. This is the most likely first failure.
+- [ ] **Step 1: macOS workload backend.** `up`'s `--hypervisor` defaults to `firecracker` (`up.rs:705`); the auto-select (`up.rs:1190`) has no libkrun branch, so on a macOS-26 host it resolves to apple-container. **Fix is test-only**: thread `--hypervisor libkrun` + `MVM_BUILDER_BACKEND=libkrun` through the E2E (done in Task 3 §1). **Do NOT** change `up.rs`'s auto-select to default macOS workloads to libkrun — that's a product change that would flip macOS-26 users off the intended apple-container tier (out of scope). Next macOS backend to prove (own follow-up): **Vz workloads** (Apple-native, already an `AnyBackend` variant), ahead of apple-container.
 - [ ] **Step 2: `compile → up` handoff.** Confirm `up --flake <compiled-dir>` consumes `compile`'s rendered `flake.nix`. If `up` expects a flake *reference* rather than a directory of rendered artifacts, wire the handoff (point `up` at the rendered dir, or have the E2E pass it as a path-flake `--flake path:<dir>`).
 - [ ] **Step 3: teardown.** Confirm `dev down` stops the builder; if `up` leaves a workload VM running, stop it (the `mvmctl` stop/kill verb) in the test's teardown so repeated runs stay idempotent.
 - [ ] **Step 4: Repeat** until `MVM_E2E_SMOKE=1 cargo test -p mvm-cli --test core_demo_e2e` is green on a macOS/libkrun host. Each fix is its own red→green→commit cycle.
@@ -181,14 +187,18 @@ The spine is *believed* complete (fresh build → `overlay_aware: true` → admi
 
 The gap analysis (`specs/research/embeddable-sandbox-sdk-dx-gap-analysis.md`) put the parity gap in one place: the imperative "boot a sandbox, exec against it" experience. mvm **already has the class** — `sdks/python/mvm/_sandbox.py` (`Sandbox.create(...)`, `sb.commands.start(...)`) with two modes (record → prod plan, live → dev) and the dev-tier guard `SandboxDevOnly` already in place. This task adds the dead-simple one-shot ergonomic on top and makes it the demo headline. **Extend `Sandbox`; do not add a new class** (and never name it `Box` — that's a competitor's term). Typed helpers / async / Node are plan 125.
 
-**Files:** `sdks/python/mvm/_sandbox.py` (add the one-shot `exec`); test `sdks/python/tests/test_sandbox_exec.py` (gated — it boots a real VM).
+**Files:** `sdks/python/mvm/_sandbox.py` (add the one-shot `exec`); test `sdks/python/tests/test_sandbox_exec.py`.
 
-- [ ] **Step 1: Write the failing test.**
+> `_sandbox.py` is the **hand-written veneer**. Plan 124 Phase D (`xtask gen-sdk`) autogenerates only the IR/protocol types + RPC client stubs into `sdks/*/_generated/`; the 125 veneer sits over that generated core. So hand-editing this class is correct and on-plan; when 124 lands, `_LiveTransport` (today shells `mvmctl`) may be re-pointed at the generated client — `exec()`'s dev-only contract is invariant across that move.
+
+- [ ] **Step 1: Write the tests** (one gated, one always-on):
   ```python
   # Live-mode Sandbox is dev-tier (SandboxDevOnly guards prod). exec() is a
   # one-shot convenience over commands.start: run argv, collect stdout + exit.
+  import os, pytest
   from mvm import Sandbox
 
+  @pytest.mark.skipif(os.environ.get("MVM_E2E_SMOKE") != "1", reason="boots a real VM")
   def test_sandbox_exec_returns_stdout():
       sb = Sandbox.create(image="python:slim")     # boots a dev-tier microVM
       try:
@@ -197,10 +207,30 @@ The gap analysis (`specs/research/embeddable-sandbox-sdk-dx-gap-analysis.md`) pu
           assert r.stdout.strip() == "4"
       finally:
           sb.shutdown()
+
+  def test_sandbox_exec_refuses_prod_before_any_vsock(monkeypatch):
+      # Construct a prod-mode transport directly (no VM); exec must refuse
+      # via SandboxDevOnly BEFORE spawning any mvmctl subprocess (claim 4).
+      import mvm._sandbox as s
+      monkeypatch.setattr(s.subprocess, "run",
+                          lambda *a, **k: pytest.fail("exec() spawned a subprocess on a prod template"))
+      sb = s.Sandbox("wid", live=s._LiveTransport(mvm_cli_bin="/bin/false", vm_id="x", build_mode="prod"))
+      with pytest.raises(s.SandboxDevOnly):
+          sb.exec("python", "-c", "print(1)")
   ```
-- [ ] **Step 2: Add `Sandbox.exec(*argv, timeout=None, cwd=None, env=None) -> ExecResult`** as a one-shot over the existing `commands.start` (start → wait → collect stdout/stderr/exit). Keep the existing `SandboxDevOnly` refusal for prod-tier — no silent fallback (ADR-053). Reuse the `_live_sandbox` one-process invariant already in `_sandbox.py`.
-- [ ] **Step 3: Run gated** (`MVM_E2E_SMOKE=1`) on a libkrun host → PASS; ungated → skip. Commit.
+- [ ] **Step 2: Implement on `_sandbox.py`.** Add `@dataclass ExecResult(stdout, stderr, exit_code)` (export it). Add `_LiveTransport.commands_run(argv, env) -> ExecResult` — **same `SandboxDevOnly` guard as `commands_start`, enforced first** (raise before any vsock traffic when `build_mode != "dev"`; no silent fallback — ADR-002 claim 4), else **capture** stdout/stderr/exit and return. Add `Sandbox.exec(*argv, timeout=None, cwd=None, env=None) -> ExecResult` — **dev-tier, live-mode only** (record mode raises a clear error; no prod path). Add `shutdown()` as a `kill()` alias and accept `image=` as an alias for `template` on `create(...)` (exactly one required, same field) so the headline reads verbatim. Canonical `template`→`image` rename is **125's** job.
+- [ ] **Step 3: Run gated** (`MVM_E2E_SMOKE=1`) on this libkrun host → PASS; ungated → the prod-refusal test still runs and passes. Commit.
 - [ ] **Step 4: Lead the quickstart with it** — README / `mvmctl` quickstart shows the five-line `Sandbox` example, not the build/derive path.
+
+## Security posture & guardrails
+
+This plan adds **no new** security mechanism — encrypt-at-rest + Noise vsock (**122**), claim-gate CI + fuzz (**128**), secrets (**129**) / broker (**104**), verity overlay (**124 Phase C**) are their own plans. But the demo path exercises existing claims live, so the rule is **prove them, never bypass them**:
+
+- **Claim 8 (signed/audited admission).** `up --flake` admits a synthesized + signed `ExecutionPlan` (`verify_plan`, validity window, nonce replay-store, `plan.admitted/launched` audit). The E2E must drive the **real** admitted path — **no `--hypervisor mock` / `MVM_DIRECT_BOOT`** (they bypass admission + audit; the test would prove nothing). The `overlay_aware: true` fresh-build admit is the intended pass; don't disable the verifier to dodge a gap.
+- **Claim 10 (default-deny egress).** hello-app declares no network → default-deny applies; the E2E must pass **without** `MVM_ACK_UNRESTRICTED_NETWORK`.
+- **Claim 4 (dev-only exec).** Task 5 `exec()` refuses prod via `SandboxDevOnly` before any vsock traffic; locked by the always-on prod-refusal unit test.
+- **Mutable-state isolation (hygiene).** Run gated tests under `MVM_DATA_DIR="$PWD/.mvm-test"` so demo audit entries / replay-nonces / signer keys never touch the real `~/.mvm` chain or race a parallel session.
+- **Off-path (later plans, not gaps):** claim 11 (no app-deps in hello-app), claim 13/broker (literal env only, no secrets), claim 3 (dev-tier demo VM — no verity required per the dev-vs-prod tier rule).
 
 ## Acceptance (this plan is done when)
 


### PR DESCRIPTION
**Plan 120 — core demo spine.** Lands the bounded, solid work and two real builder-VM bringup fixes. **Plan 120 is NOT complete**: the live demo (`dev up → compile → up → vsock ping`) is not yet steady on libkrun — see "Remaining" below.

## Landed
- **Task 2** — `crates/mvm-cli/tests/compile_hello_app.rs` locks `mvmctl compile <app.py>` decorator→flake lowering; corrected the stale `compile.rs` module docstring.
- **Task 3** — `crates/mvm-cli/tests/core_demo_e2e.rs` (MVM_E2E_SMOKE-gated boot→ping guard, forces `--hypervisor libkrun`); `workflow_dispatch` self-hosted CI lane (`core-demo-e2e.yml`) + ungated compile/skip in the `e2e` lane; `development.md` note.
- **Task 5** — one-call `Sandbox.exec(...) -> ExecResult` (dev-tier; refuses prod via `SandboxDevOnly` *before* any vsock traffic — ADR-002 claim 4); `image=` / `shutdown()` aliases; README leads with it. 3 new unit tests pass + 1 gated; 46 existing sandbox tests still green.
- **Builder bringup fix #1** — `run_stage0` now mounts `/mvm-bins` + exports `MVM_HOST_BIN_DIR` (Plan 115 wired this into `run_build` but not Stage 0, so cold-cache `dev up` failed at flake eval). Stage 0 now builds the builder image to completion and promotes it.
- **Builder bringup fix #2** — builder-VM kernel `init=` aligned to the manifest (`/sbin/mvm-host-vm-init`); it had drifted to the pre-rename `/sbin/mvm-builder-init`, causing a PID-1 ENOENT panic.
- **Docs** — resolved decisions folded into `specs/plans/120-core-demo.md` (libkrun-force, CI-lane reality, security guardrails, `image=` alias); Stage-C section appended to `specs/SPRINT.md`.

## Remaining (Plan 120 completion path — tracked, not done here)
- **Static embedded host bins.** The builder VM still can't boot: the embedded bins are glibc-dynamic (`/lib/ld-linux-aarch64.so.1`), absent from the Nix rootfs (confirmed via `debugfs`). Fix = build them **static** — either Rust `aarch64-unknown-linux-musl` or a zig rewrite (Plan 109 direction). This switches the **claim-11 / CI-lockstep** toolchain pin, so it's an owner decision.
- Whatever further bringup bugs follow (cf. the documented Plan 72 W5.D nine-bug chain), until the gated E2E is green on libkrun.

## Security
No new mechanism. The demo path *exercises* claims 8 (signed/audited admission), 10 (default-deny egress), 4 (dev-only exec) and the guards forbid bypassing them. State-isolated test runs (`MVM_DATA_DIR`).

## Test state
Per-commit gates green (fmt/clippy/targeted tests). `cargo test --workspace` has **two pre-existing flaky tests** under full-suite parallelism (`apple_container::sweep_removes_orphan_*` flock race; `mvm-build::builder_vm_dev_build_*` staging-dir `EINVAL` under the sandbox TMPDIR) — both byte-identical to base, green in isolation, unrelated to this branch. Worth a follow-up (`#[serial]`).
