### PR TITLE
[codex] Fix landing header width

### DIFF
--- a/public/src/overrides/Header.astro
+++ b/public/src/overrides/Header.astro
@@ -85,7 +85,8 @@ const navLinks = [
     position: sticky;
     top: 0;
     z-index: 100;
-    width: 100%;
+    width: 100vw;
+    margin-inline: calc(50% - 50vw);
     border-bottom: 1px solid var(--sl-color-hairline);
     background: var(--sl-color-bg);
     backdrop-filter: blur(12px);


### PR DESCRIPTION
## Summary

- Make the custom landing header span the full viewport width instead of stopping at Starlight's content wrapper.
- Keep the header nav content centered inside the existing max-width rail.

## Validation

- npm run build from public/ passes.