### PR TITLE
Fix landing terminal theme toggle

### DIFF
--- a/public/src/components/landing/Hero.tsx
+++ b/public/src/components/landing/Hero.tsx
@@ -26,12 +26,12 @@ function TerminalAnimation() {
   }, []);
 
   return (
-    <div className="w-full overflow-hidden rounded-xl border border-edge/60 bg-[#0a0e14] shadow-2xl shadow-black/40">
-      <div className="flex items-center gap-2 border-b border-edge/40 px-4 py-3">
-        <span className="h-3 w-3 rounded-full bg-[#ff5f57]/80" />
-        <span className="h-3 w-3 rounded-full bg-[#febc2e]/80" />
-        <span className="h-3 w-3 rounded-full bg-[#28c840]/80" />
-        <span className="ml-3 text-xs text-label/60">terminal</span>
+    <div className="w-full overflow-hidden rounded-xl border border-code-border bg-code-canvas shadow-2xl shadow-black/30">
+      <div className="flex items-center gap-2 border-b border-code-border bg-code-header px-4 py-3">
+        <span className="h-3 w-3 rounded-full bg-dot-close/80" />
+        <span className="h-3 w-3 rounded-full bg-dot-minimize/80" />
+        <span className="h-3 w-3 rounded-full bg-dot-expand/80" />
+        <span className="ml-3 text-xs text-code-text/55">terminal</span>
       </div>
       <div className="p-5 font-mono text-[13px] leading-relaxed sm:p-6">
         {lines.slice(0, visibleLines).map((line, i) => (
@@ -39,10 +39,10 @@ function TerminalAnimation() {
             key={i}
             className={`${
               line.accent
-                ? "text-green"
+                ? "text-code-success"
                 : line.dim
-                  ? "text-label/60"
-                  : "text-heading"
+                  ? "text-code-text/55"
+                  : "text-code-text"
             } ${line.text === "" ? "h-3" : ""}`}
           >
             {line.text}

--- a/public/src/overrides/Header.astro
+++ b/public/src/overrides/Header.astro
@@ -30,6 +30,22 @@ const navLinks = [
         ))}
       </nav>
       <div class="landing-nav-right">
+        <button class="landing-theme-toggle" type="button" aria-label="Toggle color theme" title="Toggle color theme">
+          <svg class="theme-icon theme-icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2" />
+            <path d="M12 20v2" />
+            <path d="m4.93 4.93 1.41 1.41" />
+            <path d="m17.66 17.66 1.41 1.41" />
+            <path d="M2 12h2" />
+            <path d="M20 12h2" />
+            <path d="m6.34 17.66-1.41 1.41" />
+            <path d="m19.07 4.93-1.41 1.41" />
+          </svg>
+          <svg class="theme-icon theme-icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M20.99 12.79A9 9 0 1 1 11.21 3.01 7 7 0 0 0 20.99 12.79Z" />
+          </svg>
+        </button>
         <a href="https://github.com/tinylabscom/mvm" target="_blank" rel="noopener" class="landing-github-link" aria-label="GitHub">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 .3a12 12 0 0 0-3.8 23.38c.6.12.83-.26.83-.57L9 21.07c-3.34.72-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.08-.74.09-.73.09-.73 1.2.09 1.83 1.24 1.83 1.24 1.08 1.83 2.81 1.3 3.5 1 .1-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.64 1.66.24 2.88.12 3.18a4.65 4.65 0 0 1 1.23 3.22c0 4.61-2.8 5.63-5.48 5.92.42.36.81 1.1.81 2.22l-.01 3.29c0 .31.2.69.82.57A12 12 0 0 0 12 .3Z"/>
@@ -62,22 +78,71 @@ const navLinks = [
 )}
 
 <script>
-  const btn = document.querySelector('.landing-hamburger');
-  const menu = document.querySelector('.landing-mobile-nav');
-  if (btn && menu) {
-    btn.addEventListener('click', () => {
-      const open = menu.classList.toggle('is-open');
-      btn.classList.toggle('is-open', open);
-      btn.setAttribute('aria-expanded', String(open));
-    });
-    menu.querySelectorAll('a').forEach(link => {
-      link.addEventListener('click', () => {
-        menu.classList.remove('is-open');
-        btn.classList.remove('is-open');
-        btn.setAttribute('aria-expanded', 'false');
-      });
-    });
-  }
+  (() => {
+    function initLandingHeader() {
+      const storageKey = 'starlight-theme';
+      const themeToggle = document.querySelector('.landing-theme-toggle');
+
+      function currentTheme() {
+        return document.documentElement.dataset.theme === 'light' ? 'light' : 'dark';
+      }
+
+      function setTheme(theme) {
+        document.documentElement.dataset.theme = theme;
+        if (typeof localStorage !== 'undefined') {
+          localStorage.setItem(storageKey, theme);
+        }
+        if (window.StarlightThemeProvider) {
+          window.StarlightThemeProvider.updatePickers(theme);
+        }
+        updateThemeToggle();
+      }
+
+      function updateThemeToggle() {
+        if (!themeToggle) return;
+        const isLight = currentTheme() === 'light';
+        themeToggle.classList.toggle('is-light', isLight);
+        themeToggle.setAttribute(
+          'aria-label',
+          isLight ? 'Switch to dark mode' : 'Switch to light mode'
+        );
+        themeToggle.setAttribute(
+          'title',
+          isLight ? 'Switch to dark mode' : 'Switch to light mode'
+        );
+      }
+
+      if (themeToggle) {
+        updateThemeToggle();
+        themeToggle.addEventListener('click', () => {
+          setTheme(currentTheme() === 'light' ? 'dark' : 'light');
+        });
+      }
+
+      const btn = document.querySelector('.landing-hamburger');
+      const menu = document.querySelector('.landing-mobile-nav');
+      if (btn && menu) {
+        btn.addEventListener('click', () => {
+          const open = menu.classList.toggle('is-open');
+          btn.classList.toggle('is-open', open);
+          btn.setAttribute('aria-expanded', String(open));
+        });
+        menu.querySelectorAll('a').forEach(link => {
+          link.addEventListener('click', () => {
+            menu.classList.remove('is-open');
+            btn.classList.remove('is-open');
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      }
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initLandingHeader, { once: true });
+    } else {
+      initLandingHeader();
+    }
+  })();
 </script>
 
 <style>
@@ -85,8 +150,7 @@ const navLinks = [
     position: sticky;
     top: 0;
     z-index: 100;
-    width: 100vw;
-    margin-inline: calc(50% - 50vw);
+    width: 100%;
     border-bottom: 1px solid var(--sl-color-hairline);
     background: var(--sl-color-bg);
     backdrop-filter: blur(12px);
@@ -151,18 +215,61 @@ const navLinks = [
   .landing-nav-right {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.5rem;
+  }
+
+  .landing-theme-toggle,
+  .landing-github-link {
+    border-radius: 0.375rem;
+  }
+
+  .landing-theme-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border: none;
+    background: transparent;
+    color: var(--sl-color-gray-2);
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .landing-theme-toggle:hover {
+    color: var(--sl-color-text);
+    background: var(--sl-color-bg-inline-code);
+  }
+
+  .landing-theme-toggle .theme-icon {
+    display: block;
+  }
+
+  .landing-theme-toggle .theme-icon-sun {
+    display: none;
+  }
+
+  .landing-theme-toggle.is-light .theme-icon-sun {
+    display: block;
+  }
+
+  .landing-theme-toggle.is-light .theme-icon-moon {
+    display: none;
   }
 
   .landing-github-link {
     display: flex;
     align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
     color: var(--sl-color-gray-2);
-    transition: color 0.15s;
+    transition: color 0.15s, background 0.15s;
   }
 
   .landing-github-link:hover {
     color: var(--sl-color-text);
+    background: var(--sl-color-bg-inline-code);
   }
 
   /* Hamburger button — visible on mobile only */

--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -50,6 +50,7 @@
   --color-code-header: #21262d;
   --color-code-border: #30363d;
   --color-code-text: #e6edf3;
+  --color-code-success: var(--color-green);
 }
 
 @theme inline {
@@ -105,6 +106,7 @@
     --color-code-header: #21262d;
     --color-code-border: #30363d;
     --color-code-text: #e6edf3;
+    --color-code-success: #3fb950;
   }
 
   /* Auto mode + OS prefers light → use the light palette. The
@@ -134,6 +136,7 @@
       --color-code-header: #21262d;
       --color-code-border: #30363d;
       --color-code-text: #e6edf3;
+      --color-code-success: #3fb950;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add a compact light/dark theme toggle to the landing header.
- Move the landing terminal colors onto theme tokens so the terminal remains visible in light mode.
- Scope the landing header script and initialize it after DOM readiness so it does not interfere with React hydration for the terminal animation.

## Validation

- npm run build from public/
- Served-page verification with headless Chrome showed the landing terminal animating through Booted in 1.2s. Health: OK.