### PR TITLE
ci: stop publish-crates from auto-running on release

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,8 +1,11 @@
 name: Publish to crates.io
 
 on:
-  release:
-    types: [published]
+  # The `release: published` auto-trigger is intentionally disabled: crates.io
+  # publishing of this workspace isn't wired yet (scripts/deploy-guard.sh is
+  # absent and not every workspace crate is publish-ready), so a release tag
+  # would fail this workflow on every cut. Publish manually via workflow_dispatch
+  # once the deploy guard + dependency-ordered publish are built out.
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
`publish-crates.yml` calls `scripts/deploy-guard.sh`, which has **never existed** in the repo (checked full git history). The job fails at the guard step on every release tag — crates.io publishing of this workspace has never actually worked, and it's independent of the PyPI/npm SDK publishes.

This disables the `release: published` auto-trigger and keeps `workflow_dispatch`, so cutting a release tag stops producing a spurious red ❌. The real crates.io rollout (write the deploy guard, confirm every workspace crate is publishable, publish in dependency order) is deferred to a dedicated change.

No effect on `publish-pypi.yml` / `publish-npm.yml`.