### PR TITLE
compile: warn when Node package.json deps won't be baked (Plan 145 WS-B/WS-C)

### DIFF
--- a/crates/mvm-cli/src/commands/build/compile.rs
+++ b/crates/mvm-cli/src/commands/build/compile.rs
@@ -34,7 +34,7 @@ use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, ValueEnum};
 
 use mvm_core::user_config::MvmConfig;
-use mvm_ir::Workload;
+use mvm_ir::{Entrypoint, Workload};
 use mvm_sdk::compile::{compile, compile_archive, is_archive_output};
 use mvm_sdk::decorator::{ParseError, parse_python, parse_typescript};
 
@@ -126,7 +126,48 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             .with_context(|| format!("compile to directory {}", args.out.display()))?;
         eprintln!("compiled directory: {}", args.out.display());
     }
+    warn_node_deps(&workload, &manifest_dir);
     Ok(())
+}
+
+/// Warn at compile time when a Node workload ships a `package.json` whose
+/// dependencies the build won't install. The build-time bake is npm-only
+/// (nixpkgs `importNpmLock`, which reads `package-lock.json` integrity
+/// hashes — the only hash-free path); pnpm/yarn need a precomputed FOD hash
+/// the host-side compile can't produce, so they route through the
+/// sealed-volume builder path (Plan 145 WS-A, not yet wired). Either gap is
+/// silent today — the bundle just copies the source with no `node_modules` —
+/// so a missing dep only surfaces as a runtime import failure. Make it loud.
+fn warn_node_deps(workload: &Workload, manifest_dir: &Path) {
+    let is_node = workload.apps.iter().any(|app| {
+        app.entrypoints
+            .iter()
+            .any(|ep| matches!(ep, Entrypoint::Function { language, .. } if language == "node"))
+    });
+    if !is_node || !manifest_dir.join("package.json").is_file() {
+        return;
+    }
+    // npm lockfile → the nix-native bake handles it; nothing to warn.
+    if manifest_dir.join("package-lock.json").is_file() {
+        return;
+    }
+    if let Some(lock) = ["pnpm-lock.yaml", "yarn.lock"]
+        .into_iter()
+        .find(|f| manifest_dir.join(f).is_file())
+    {
+        eprintln!(
+            "[mvm] warning: {lock} detected, but the build-time bake is npm-only \
+             (nixpkgs importNpmLock). pnpm/yarn dependencies are NOT baked into the image \
+             — install them via the sealed-volume builder path (Plan 145 WS-A, not yet \
+             wired). For a build-time bake today, use npm + package-lock.json."
+        );
+        return;
+    }
+    eprintln!(
+        "[mvm] warning: package.json has no lockfile — dependencies will NOT be installed \
+         and `node_modules` will be absent at runtime. Run `npm install` to generate \
+         package-lock.json so the build bakes the dependency tree into the image."
+    );
 }
 
 fn resolve_mode(args: &Args) -> Result<Mode> {

--- a/crates/mvm-cli/tests/compile_node_deps_warnings.rs
+++ b/crates/mvm-cli/tests/compile_node_deps_warnings.rs
@@ -1,0 +1,81 @@
+//! `mvmctl compile` warns when a Node workload's `package.json` deps won't be
+//! installed: no lockfile at all, or a pnpm/yarn lockfile the npm-only
+//! build-time bake can't consume. Without these the gap is silent — the
+//! bundle copies the source with no `node_modules` and the miss only shows up
+//! as a runtime import failure. Plan 145 WS-B/WS-C.
+
+use assert_cmd::cargo::CommandCargoExt;
+use std::process::Command;
+
+const APP_TS: &str = r#"import * as mvm from "mvm-sdk";
+export const greet = mvm.app({
+  image: mvm.node_image({ node: "22" }),
+})((name: string): string => `hi ${name}`);
+"#;
+
+const PACKAGE_JSON: &str =
+    r#"{"name":"warn-fixture","type":"module","dependencies":{"is-number":"^7.0.0"}}"#;
+
+/// Compile `app.ts` plus the given sibling files (name → contents) and return
+/// (success, stderr). The temp dir is the manifest dir, so lockfile detection
+/// scans exactly these files.
+fn compile_with(files: &[(&str, &str)]) -> (bool, String) {
+    let dir = tempfile::tempdir().expect("tmp dir");
+    std::fs::write(dir.path().join("app.ts"), APP_TS).unwrap();
+    for (name, body) in files {
+        std::fs::write(dir.path().join(name), body).unwrap();
+    }
+    let out = tempfile::tempdir().expect("tmp out");
+    #[allow(deprecated)]
+    let output = Command::cargo_bin("mvmctl")
+        .expect("locate mvmctl")
+        .args([
+            "compile",
+            dir.path().join("app.ts").to_str().unwrap(),
+            "--out",
+            out.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn mvmctl compile");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn warns_when_package_json_has_no_lockfile() {
+    let (ok, stderr) = compile_with(&[("package.json", PACKAGE_JSON)]);
+    assert!(ok, "compile should still succeed; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("no lockfile") && stderr.contains("npm install"),
+        "expected a no-lockfile warning, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn warns_that_pnpm_lockfile_is_not_baked() {
+    let (ok, stderr) = compile_with(&[
+        ("package.json", PACKAGE_JSON),
+        ("pnpm-lock.yaml", "lockfileVersion: '9.0'\n"),
+    ]);
+    assert!(ok, "compile should still succeed; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("pnpm-lock.yaml") && stderr.contains("npm-only"),
+        "expected an npm-only warning for pnpm, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn no_warning_when_npm_lockfile_present() {
+    // package-lock.json → the nix-native bake handles it; stay quiet.
+    let (ok, stderr) = compile_with(&[
+        ("package.json", PACKAGE_JSON),
+        ("package-lock.json", r#"{"lockfileVersion":3}"#),
+    ]);
+    assert!(ok, "compile should succeed; stderr:\n{stderr}");
+    assert!(
+        !stderr.contains("warning:"),
+        "npm lockfile must not warn, got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Fast-follow to the v0.15.2 TypeScript/Node work — closes Plan 145 WS-B + WS-C.

The build-time deps bake is **npm-only**: nixpkgs `importNpmLock` is the only hash-free path (it reads `package-lock.json` integrity hashes). pnpm (`pnpm.fetchDeps`) and yarn (`fetchYarnBerryDeps`) both require a precomputed FOD `hash` that the host-side `compile` can't produce — so they belong on the sealed-volume builder path (Plan 145 WS-A, which already runs `pnpm install --frozen-lockfile`), not the nix-native bake.

Previously both gaps were **silent** — the bundle copied the source with no `node_modules`, and a missing dep only surfaced as a runtime import failure. Now `mvmctl compile` warns:
- **WS-C** — `package.json` with no lockfile → "dependencies will NOT be installed; run `npm install`".
- **WS-B** — `pnpm-lock.yaml`/`yarn.lock` → "npm-only bake; not baked — use npm + package-lock.json, or the sealed-volume path".
- `package-lock.json` present → stays quiet (the bake handles it).

Tests: `compile_node_deps_warnings` (no-lockfile warns, pnpm warns, npm quiet). No version bump — release/tag is a separate call.

Note: this scopes WS-B to honest detection/routing; actual pnpm/yarn *install* rides WS-A (sealed volume). Plan 145 updated accordingly.