### PR TITLE
docs: lead quickstart + README with five-line Sandbox.exec (closes Plan 120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@
 > [`MIGRATING-FROM-V1.md`](MIGRATING-FROM-V1.md) and
 > [`CHANGELOG.md`](CHANGELOG.md) for the upgrade path and what changed.
 
+## Quick start
+
+Boot a transient dev-tier microVM, run a command, get its output back — five
+lines with the Python SDK:
+
+```python
+import mvm
+
+with mvm.Sandbox.create(image="python-3.12") as sb:
+    result = sb.exec("python", "-c", "print(2 + 2)")
+    print(result.stdout.strip())   # -> 4
+```
+
+Run it against a real local microVM with `mvmctl run --mode live ./quickstart.py`.
+`exec` is dev-tier (live mode); it refuses prod templates with `SandboxDevOnly`.
+See the [Python quickstart](public/src/content/docs/getting-started/python-quickstart.md)
+for the imperative-lifecycle and static-declaration paths, and the build/derive
+flow (`mvmctl compile` / `up --flake`) below.
+
 ## Backends
 
 `mvmctl` picks a backend per `AnyBackend::auto_select()` (see ADR-013).

--- a/public/src/content/docs/getting-started/python-quickstart.md
+++ b/public/src/content/docs/getting-started/python-quickstart.md
@@ -3,9 +3,23 @@ title: Python quickstart
 description: Use the current Python SDK runtime surface and the static decorator compiler safely.
 ---
 
-This page shows the two Python paths: imperative sandbox lifecycle and static workload declaration.
+This page shows the three Python paths: the one-shot `exec` (the quickest), the imperative sandbox lifecycle, and static workload declaration.
 
-> **Status:** The Python package in `sdks/python` has `Sandbox.create(...)`, `commands.start(...)`, `files.write(...)`, record mode, live mode, and context-manager cleanup. Higher-level helpers such as `commands.run(...)`, file read/list/remove, ports, logs, and cold-mode methods are parity work.
+> **Status:** The Python package in `sdks/python` has `Sandbox.create(...)`, `Sandbox.exec(...)`, `commands.start(...)`, `files.write(...)`, record mode, live mode, and context-manager cleanup. Higher-level helpers such as `commands.run(...)`, file read/list/remove, ports, logs, and cold-mode methods are parity work.
+
+## Run a command (five lines)
+
+Boot a transient dev-tier microVM, run one command, get its output back:
+
+```python
+import mvm
+
+with mvm.Sandbox.create(image="python-3.12") as sb:
+    result = sb.exec("python", "-c", "print(2 + 2)")
+    print(result.stdout.strip())   # -> 4
+```
+
+`exec(*argv) -> ExecResult` is a one-shot over `commands.start` (start → wait → collect `stdout`/`stderr`/`exit_code`). `image=` is the friendly alias for the positional template. It is **live-mode only** (dev tier) — run the script with `mvmctl run --mode live ./quickstart.py`; against a prod template it refuses with `SandboxDevOnly` (no silent fallback — ADR-002 claim 4). The `with` block kills the sandbox on exit.
 
 ## Imperative runtime
 

--- a/specs/plans/120-core-demo.md
+++ b/specs/plans/120-core-demo.md
@@ -227,7 +227,7 @@ The spine is *believed* complete (fresh build → `overlay_aware: true` → admi
 
 ## Task 5: the one-call live-exec ergonomic — `Sandbox` (the DX headline)
 
-> **✅ `exec` API LANDED (commit `c989fac7`).** `Sandbox.exec(*argv, timeout, cwd, env) -> ExecResult` is in `sdks/python/mvm/_sandbox.py` with the `SandboxDevOnly`/`SandboxModeError` guards; `sdks/python/tests/test_sandbox_exec.py` exists (gated). **Remaining: §4 — lead the quickstart/README with it (still shows the build/derive path).**
+> **✅ `exec` API LANDED (commit `c989fac7`).** `Sandbox.exec(*argv, timeout, cwd, env) -> ExecResult` is in `sdks/python/mvm/_sandbox.py` with the `SandboxDevOnly`/`SandboxModeError` guards; `sdks/python/tests/test_sandbox_exec.py` exists (gated). **§4 done (2026-06-03): `README.md` "Quick start" + `getting-started/python-quickstart.md` lead with the five-line `Sandbox.exec` snippet. Task 5 (and the plan's acceptance section) complete.**
 
 The gap analysis (`specs/research/embeddable-sandbox-sdk-dx-gap-analysis.md`) put the parity gap in one place: the imperative "boot a sandbox, exec against it" experience. mvm **already has the class** — `sdks/python/mvm/_sandbox.py` (`Sandbox.create(...)`, `sb.commands.start(...)`) with two modes (record → prod plan, live → dev) and the dev-tier guard `SandboxDevOnly` already in place. This task adds the dead-simple one-shot ergonomic on top and makes it the demo headline. **Extend `Sandbox`; do not add a new class** (and never name it `Box` — that's a competitor's term). Typed helpers / async / Node are plan 125.
 
@@ -248,9 +248,9 @@ The gap analysis (`specs/research/embeddable-sandbox-sdk-dx-gap-analysis.md`) pu
       finally:
           sb.shutdown()
   ```
-- [ ] **Step 2: Add `Sandbox.exec(*argv, timeout=None, cwd=None, env=None) -> ExecResult`** as a one-shot over the existing `commands.start` (start → wait → collect stdout/stderr/exit). Keep the existing `SandboxDevOnly` refusal for prod-tier — no silent fallback (ADR-053). Reuse the `_live_sandbox` one-process invariant already in `_sandbox.py`.
-- [ ] **Step 3: Run gated** (`MVM_E2E_SMOKE=1`) on a libkrun host → PASS; ungated → skip. Commit.
-- [ ] **Step 4: Lead the quickstart with it** — README / `mvmctl` quickstart shows the five-line `Sandbox` example, not the build/derive path.
+- [x] **Step 2: Add `Sandbox.exec(*argv, timeout=None, cwd=None, env=None) -> ExecResult`** as a one-shot over the existing `commands.start` (start → wait → collect stdout/stderr/exit). Keep the existing `SandboxDevOnly` refusal for prod-tier — no silent fallback (ADR-053). Reuse the `_live_sandbox` one-process invariant already in `_sandbox.py`. **(landed, commit `c989fac7`; `image=` keyword alias added for the snippet.)**
+- [ ] **Step 3: Run gated** (`MVM_E2E_SMOKE=1`) on a libkrun host → PASS; ungated → skip. Commit. *(`sdks/python/tests/test_sandbox_exec.py` exists, gated; a green host run is not yet recorded — left open intentionally.)*
+- [x] **Step 4: Lead the quickstart with it** — README / `mvmctl` quickstart shows the five-line `Sandbox` example, not the build/derive path. **(2026-06-03 — `README.md` + `python-quickstart.md`.)**
 
 ## Acceptance (this plan is done when)
 
@@ -259,7 +259,7 @@ The gap analysis (`specs/research/embeddable-sandbox-sdk-dx-gap-analysis.md`) pu
 - [x] `crates/mvm-cli/tests/core_demo_e2e.rs` exists, is `MVM_E2E_SMOKE`-gated (test + `ci.yml::core-demo-e2e` lane + `development.md` docs), and is **hardened against freezing** (Workstream A: watchdog + bounded subprocess, commit `898b8507`).
 - [x] `core_demo_e2e` is **green on a macOS/libkrun host** end-to-end (`dev up` → `compile` → `up` with the agent reachable) — Task 4. **(2026-06-02: 1 passed, 114s.)**
 - [x] The one-shot `Sandbox.exec(...)` returns stdout on a dev-tier sandbox and raises `SandboxDevOnly` in prod (API landed, commit `c989fac7`).
-- [ ] The quickstart/README leads with the five-line `Sandbox.exec` example (Task 5 §4).
+- [x] The quickstart/README leads with the five-line `Sandbox.exec` example (Task 5 §4). **(2026-06-03 — `README.md` "Quick start" + `getting-started/python-quickstart.md` "Run a command (five lines)" both lead with `mvm.Sandbox.create(image=…)` → `sb.exec(...)` → `result.stdout`.)**
 - [x] The proven §4 acceptance boxes are ticked in the brief (2026-06-02 — 4 of 5; cross-platform/encryption/Noise box deferred to its plans).
 
 ### deferred follow-ups


### PR DESCRIPTION
Closes the last open **Plan 120** acceptance box — Task 5 §4: "the quickstart/README leads with the five-line `Sandbox.exec` example, not the build/derive path."

- **README.md** gains a "Quick start" section (ahead of the build/derive flow) with the five-line snippet.
- **getting-started/python-quickstart.md** now leads with "Run a command (five lines)" before the imperative-lifecycle and static-declaration paths.
- Both use the **real API** — `mvm.Sandbox.create(image="python-3.12")` (the `image=` alias is real), `sb.exec(*argv) -> ExecResult`, `result.stdout`, context-manager cleanup — not the plan's red-step sketch (which had `shutdown()`/`python:slim`).
- **Plan 120**: the §4 acceptance box is ticked; all 7 acceptance boxes are now `[x]` → the plan is formally complete. (Task 5 Step 3 — a recorded green run of the gated `test_sandbox_exec.py` on a libkrun host — is left honestly unchecked; it's a sub-step, not an acceptance criterion.)

Docs-only; no code touched.