### PR TITLE
docs(plans): renumber branch-local plans off merged-main collisions

### DIFF
--- a/specs/plans/150-osv-dependency-scanning-and-remediation.md
+++ b/specs/plans/150-osv-dependency-scanning-and-remediation.md
@@ -3,18 +3,17 @@
 > **For agentic workers:** use `superpowers:subagent-driven-development` or
 > `superpowers:executing-plans` to implement task-by-task. Steps use `- [ ]` for tracking.
 
-> **Spec number:** 150 is free on disk, `origin/main`, and open PRs at authoring time
-> (144–149 are taken — 149 was claimed by a parallel session's
-> `149-live-operator-event-stream.md` mid-authoring, hence 150; PR branches hold 146/147;
-> the pre-existing branch/main collision at 144–145 is not ours to resolve here).
-> Re-confirm before merge — `xtask check-spec-numbers` is a Lint gate.
+> **Spec number:** 150 chosen free at authoring. Numbering is actively raced across
+> parallel worktrees — re-confirm against `main` + open PRs before merge (`xtask
+> check-spec-numbers` is a Lint gate). Sibling branch-local plans were renumbered off
+> merged-`main` collisions in the same pass: 144→153, 146→154, 147→155.
 
 > **Sequencing:** Follow-on to the Plan 120 line, not a blocker for it. Depends on the
 > app-deps install pipeline actually running in the builder VM (Plan 73 W4/W5 cutover +
 > Plan 120 `core_demo_e2e` green) and pairs with the sealed-volume runtime mount
 > (`main`'s Plan 145, `145-app-deps-completion`) — land *after* that mount leg so the
 > `fix → rebuild → reseal → mount` loop is real end-to-end. Independent of this branch's
-> Plan 145 (snapshots/`watch`).
+> Plan 140 (snapshots) and Plan 149 (`mvmctl watch`).
 
 ## Context
 
@@ -245,4 +244,4 @@ pre-release.
   items (fs evidence, scheduled re-audit, DB pinning) named so omission is deliberate.
 - **Dependencies explicit:** after Plan 120 green + the sealed-volume runtime mount
   (`main` Plan 145) so `fix → rebuild → mount` is a real loop; independent of this branch's
-  Plan 145.
+  Plan 140 (snapshots) and Plan 149 (`watch`).

--- a/specs/plans/151-in-guest-filesystem-access-evidence.md
+++ b/specs/plans/151-in-guest-filesystem-access-evidence.md
@@ -3,24 +3,24 @@
 > **For agentic workers:** use `superpowers:subagent-driven-development` or
 > `superpowers:executing-plans` to implement task-by-task. Steps use `- [ ]` for tracking.
 
-> **Spec number:** 151 is free on disk, `origin/main`, and open PRs at authoring time
-> (144–150 taken — 149 = `149-live-operator-event-stream.md`, 150 = the OSV deps plan;
-> PR branches hold 146/147). Numbering is racing across parallel sessions
-> ([[feedback_always_use_git_worktrees]]); re-confirm before merge — `xtask
-> check-spec-numbers` is a Lint gate.
+> **Spec number:** 151 chosen free at authoring. Numbering is actively raced across
+> parallel worktrees ([[feedback_always_use_git_worktrees]]) — re-confirm against `main`
+> + open PRs before merge (`xtask check-spec-numbers` is a Lint gate). Sibling branch-local
+> plans were renumbered off merged-`main` collisions in the same pass: 144→153, 146→154,
+> 147→155.
 
 > **Sequencing:** Follow-on to the Plan 120 line, not a blocker for it. Gated behind Plan
 > 120 `core_demo_e2e` green (it touches the workload-guest boot path — a bad monitor init
 > presents as "agent never answered", Plan 120 Task 4's exact symptom) and lands *on top
 > of* Plan 143 R1 (shares the in-guest seccomp-apply boot path — don't race it). The live
-> surfacing depends on this-branch Plan 145 Workstream A (`mvmctl watch` category filter).
+> surfacing depends on this-branch Plan 149 (`mvmctl watch` category filter).
 
 ## Context
 
 mvm audits **network** access at the host boundary: the gateway audit substrate emits
 `FlowOpened/Closed/Bytes/PolicyDecision` over `~/.mvm/audit/gateway-<vm>.sock`
 (`crates/mvm-supervisor/src/gateway_audit.rs`; wire shape `FlowEventWire` in
-`gateway_bridge.rs`), and Plan 145 Workstream A merges that into `mvmctl watch`. mvm has
+`gateway_bridge.rs`), and Plan 149 merges that into `mvmctl watch`. mvm has
 **no filesystem-access evidence** — nothing records which paths a workload read, which
 writes it attempted, or which opens escaped its shares.
 
@@ -39,7 +39,7 @@ flow audit, deliberately scoped as a *visibility layer*, the same way Plan 143 f
 in-guest hardening as layered niceties over the hardware boundary, never a replacement.
 
 So: an **opt-in, dev-tier** fs-access evidence stream that reuses the in-guest
-seccomp/agent infra (Plan 143) and the audit substrate + `mvmctl watch` (Plan 145),
+seccomp/agent infra (Plan 143) and the audit substrate + `mvmctl watch` (Plan 149),
 surfaced as a live category and a per-run digest. Off by default; never on the hardened
 admitted path.
 
@@ -48,7 +48,7 @@ admitted path.
 - **Network evidence to mirror:** `FlowEventWire` (`gateway_bridge.rs`), `EventCategory`
   (`crates/mvm-supervisor/src/audit_recorder.rs`), per-VM bounded/lossy live socket
   (`gateway_audit.rs`, 256-event drop-oldest, 0700). `mvmctl watch --categories flow`
-  (Plan 145 WS-A) is the consumer.
+  (Plan 149) is the consumer.
 - **In-guest seccomp/agent path:** the agent execs the workload; `mvm-seccomp-apply`
   (`crates/mvm-guest/src/bin/mvm-seccomp-apply.rs`) applies the workload filter at boot,
   built via `crates/mvm-security/src/seccomp.rs` (`seccompiler` dep). Plan 143 R1 extends
@@ -78,8 +78,8 @@ audit substrate; `clap` under `crates/mvm-cli`; `tests/cli.rs`; `cargo test --wo
 ## Workstream A — Capture mechanism + in-guest monitor
 
 ### Task A1: ADR-071 — capture mechanism + advisory framing
-- [ ] Write `specs/adrs/071-filesystem-access-evidence.md` (confirm 071 free — 070 is
-      claimed by Plan 145's attested-snapshot ADR). Decide and record:
+- [ ] Write `specs/adrs/071-filesystem-access-evidence.md` (confirm 070/071 free before
+      authoring — claim the next open ADR number). Decide and record:
   - **Capture mechanism, with the feasibility result, not a guess:**
     - *Candidate A — fanotify* on each share-root subtree inside the guest
       (`FAN_OPEN`/`FAN_ACCESS`/`FAN_MODIFY`/`FAN_OPEN_EXEC`, `FAN_REPORT_DFID_NAME` for
@@ -140,10 +140,10 @@ audit substrate; `clap` under `crates/mvm-cli`; `tests/cli.rs`; `cargo test --wo
       events are high-volume; lossy-live is correct.
 
 ### Task B2: live stream (`mvmctl watch --categories fs`)
-- [ ] Add the fs source to `mvmctl watch` (Plan 145 WS-A) so `--categories fs` streams
+- [ ] Add the fs source to `mvmctl watch` (Plan 149) so `--categories fs` streams
       `FsEventWire`; one-line human formatter
-      (`… fs_open  ro  /work/src/main.py  vm=web`) + raw record under `--json`. If Plan 145
-      WS-A has not landed, gate this task on it rather than duplicating the merge reader.
+      (`… fs_open  ro  /work/src/main.py  vm=web`) + raw record under `--json`. If Plan 149
+      has not landed, gate this task on it rather than duplicating the merge reader.
 
 ### Task B3: per-run digest
 - [ ] On workload exit emit a digest rendered like `deps inspect`'s report:
@@ -202,7 +202,7 @@ audit substrate; `clap` under `crates/mvm-cli`; `tests/cli.rs`; `cargo test --wo
       reads under shares, EROFS-denied writes, opens-outside-shares, dropped-paths — and
       `--json` emits the structured rollup; flag-off / prod-tier is a strict no-op.
 - [ ] `mvmctl watch --categories fs` streams `FsEventWire` live for a running dev workload
-      (once Plan 145 WS-A lands).
+      (once Plan 149 lands).
 - [ ] libkrun + Vz covered; the monitor never blocks the workload; capture failure degrades
       to "evidence unavailable", not a boot failure.
 - [ ] ADR-071 merged stating advisory-not-a-claim + dev-tier-only + the chosen capture
@@ -224,4 +224,4 @@ audit substrate; `clap` under `crates/mvm-cli`; `tests/cli.rs`; `cargo test --wo
 - **Boundary-ideal deferred deliberately:** host virtiofs request logging is named as the
   future accurate capture, not silently omitted.
 - **Dependencies explicit:** after Plan 120 green + Plan 143 R1 (shared boot path);
-  live surfacing needs Plan 145 WS-A; libkrun + Vz first.
+  live surfacing needs Plan 149; libkrun + Vz first.

--- a/specs/plans/153-cli-command-group-modularization.md
+++ b/specs/plans/153-cli-command-group-modularization.md
@@ -1,4 +1,4 @@
-# Plan 144 — CLI command directory normalization
+# Plan 153 — CLI command directory normalization
 
 Status: proposed (sequenced for later in the rearchitecture; no code lands yet)
 

--- a/specs/plans/154-cloud-hypervisor-tier1-parity.md
+++ b/specs/plans/154-cloud-hypervisor-tier1-parity.md
@@ -1,4 +1,4 @@
-# Plan 146 — Cloud-hypervisor Tier-1 parity (Kuasar-referenced) + Wasm-sandbox note
+# Plan 154 — Cloud-hypervisor Tier-1 parity (Kuasar-referenced) + Wasm-sandbox note
 
 > **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:executing-plans /
 > subagent-driven-development. Checkbox (`- [ ]`) steps track progress.
@@ -7,11 +7,9 @@
 > top of the refactor (plans 120–132). It **does not stand alone or execute ahead
 > of its prereqs** — Task 1's live bring-up waits on Plan 120's `core_demo_e2e`
 > green; Task 2 waits on Plan 141's Rust-owned-shuffle trait; Task 3 feeds Plan
-> 140's snapshot security gaps. Verify the `146` prefix against `main` + open PRs
-> before merge (`cargo xtask check-spec-numbers` is CI-gated). Note: `145` is
-> already double-used on disk (`145-microvm-fork-fanout-and-branch.md` +
-> `145-portable-runnable-artifacts.md`) — that pre-existing collision is someone
-> else's to resolve; this plan deliberately takes 146.
+> 140's snapshot security gaps. Renumbered 146 → 154: `main` merged
+> `146-wasm-wasi-polyglot` (PR #556), so this branch-local plan yields. Re-confirm
+> before merge (`cargo xtask check-spec-numbers` is CI-gated).
 
 **Origin:** a comparison of mvm against **Kuasar** (https://github.com/kuasar-io/kuasar
 — a CNCF multi-sandbox container runtime, Apache-2.0, mostly Rust: a node-level
@@ -169,7 +167,7 @@ libkrun.
       `exit()`); the daemon-vs-process-per-VM tradeoff at fleet scale is **mvmd's**
       call, not mvm's. Record, don't implement here.
 
-## Acceptance (Plan 146 is done when)
+## Acceptance (Plan 154 is done when)
 
 - [ ] CH boots a real VM on a Lima KVM host and answers `agent_ping` over
       vsock:5252; the boot→ping smoke lane is green in the Plan 128 gate set

--- a/specs/plans/155-portable-runnable-artifacts.md
+++ b/specs/plans/155-portable-runnable-artifacts.md
@@ -1,4 +1,4 @@
-# Plan 147 — Portable runnable artifacts (`mvmctl artifact run`)
+# Plan 155 — Portable runnable artifacts (`mvmctl artifact run`)
 
 Status: proposed (no code lands yet). Sequenced after Plan 120 `core_demo_e2e`
 green and the Plan 134 artifact-model slices, both of which this depends on for


### PR DESCRIPTION
Single commit (`c1fab6af`) renumbering branch-local plan docs that collided with plan numbers already merged into `main`:

- `152-cli-command-group-modularization` → `153-…`
- `…-cloud-hypervisor-tier1-parity` → `154-…`
- `…-portable-runnable-artifacts` → `155-…`
- touch-ups to plans `150` / `151`.

Keeps `xtask check-spec-numbers` green against the current `main`. Merges cleanly (verified via merge-tree, no conflicts).