### PR TITLE
docs(ADR-002): document the verified-boot verity surface post-consolidation

### DIFF
--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -144,6 +144,19 @@ by definition (see Threat model). L1 *enables* claim 3 (verified boot
 needs a hypervisor that respects the kernel cmdline). If the host is
 compromised, every layer falls; that case is explicitly out of scope.
 
+**Verified-boot verity surface (claim 3, current architecture).** The
+dm-verity seal is produced by `mvm_build::oci_to_rootfs::verity`
+(`veritysetup format` + a 64-hex roothash) and covers two read-only
+images: the workload **rootfs** — sealed-prod `.mvm` artifacts carry
+`rootfs.verity` + `roothash`, which the backend wires as a dm-verity
+device on the kernel cmdline (`mvm-backend/src/microvm.rs`) and
+`mvm-verity-init` mounts — and the **runtime overlay** attached to
+every microVM (ADR-051, "sealed the same way it seals rootfs"). The
+`verified-boot-artifacts` CI lane witnesses the seal end-to-end via the
+runtime-overlay build (the standalone bundled prod image it formerly
+built was retired by Plan 115); the live-KVM tamper test exercises the
+boot-time panic on a flipped data block.
+
 ### Backend symmetry (Plan 98)
 
 Claims 1, 5, 7, 8, and 11 have **backend-symmetric evidence**: the


### PR DESCRIPTION
Follow-up A from the security.yml repoint (#568).

## What

ADR-002's claim-3 description named only **rootfs** dm-verity and never mentioned that the always-attached **runtime overlay** is verity-sealed too (ADR-051). Adds a short, factual note clarifying the current verified-boot surface:

- the dm-verity seal is produced by `mvm_build::oci_to_rootfs::verity` (`veritysetup format` + 64-hex roothash);
- it covers the **workload rootfs** (sealed-prod `.mvm` artifacts carry `rootfs.verity` + `roothash`, wired as a dm-verity device by `mvm-backend/src/microvm.rs` + `mvm-verity-init`) **and** the **runtime overlay** (ADR-051);
- `verified-boot-artifacts` now witnesses the seal via the runtime-overlay build (the bundled prod image it once built was retired by Plan 115); the live-KVM tamper test exercises the boot-time panic.

**No change to claim 3's status or guarantee** — this only aligns the prose with where the seal is produced and witnessed today.

## Gates

`check-doc-claims`, `check-no-overclaim`, `check-claim-catalog` pass. `check-adr-coverage` reports 1 broken ADR ref, but it's **pre-existing** (unrelated to this change — ADR-002 and ADR-051 both resolve) and that lane is informational/`continue-on-error` in CI. Worth a separate tiny cleanup.