### PR TITLE
perf(test): faster workspace test runs (nextest gate + embed-skip fast path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,10 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace --all-targets
 
+      - name: Run doctests
+        # nextest does not run doctests; gate them separately.
+        run: cargo test --workspace --doc
+
       - name: Assert auto-detect on Linux picks libkrun
         run: |
           cargo test -p mvm-build --features builder-vm --lib \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,9 +353,24 @@ No task is done without tests. Before marking any feature complete:
 
 ```bash
 cargo fmt --all -- --check           # workspace-wide fmt; --all matters
-cargo test --workspace               # all tests must pass
+cargo nextest run --workspace        # all tests must pass (process-parallel)
+cargo test --workspace --doc         # doctests — nextest does NOT run these
 cargo clippy --workspace -- -D warnings  # zero warnings
 ```
+
+`cargo nextest run --workspace` (what `just test` and CI run) is the named
+test gate — it's process-parallel and faster than `cargo test` on this
+~4,350-test suite. The one gap: **nextest skips doctests**, so the
+`cargo test --workspace --doc` line above (wrapped as `just test-doc`, and
+folded into `just ci`) keeps doc-fence coverage gated. `cargo test
+--workspace` still works as a fallback if nextest isn't installed.
+
+For fast inner-loop iteration or a freshly-created worktree, `just
+test-fast` (`MVM_SKIP_EMBED_BINARIES=1`) skips the embedded host-vm binary
+cross-compile in `crates/mvm-cli/build.rs` — safe for everything except a
+builder-VM boot (which fails closed with a clear message under a stub
+build). `just test-cached` wraps rustc in sccache to share compilation
+across worktrees/branches (needs `cargo install sccache`).
 
 **Always pass `--all` to `cargo fmt`.** Without it, fmt only checks the
 manifest crate (whichever one the manifest points at), silently missing
@@ -366,8 +381,8 @@ fmt --all` and re-stages — `just install-hooks` wires
 `core.hooksPath` to `.githooks/` so it fires on every commit.
 
 The Justfile recipes wrap this correctly: `just fmt-check`, `just
-clippy`, `just lint` (both), `just ci` (lint + test). Prefer those over
-raw cargo invocations.
+clippy`, `just lint` (both), `just ci` (lint + test + doctests). Prefer
+those over raw cargo invocations.
 
 Every new module, type, or function needs test coverage:
 - Types: serde roundtrip, default values

--- a/Justfile
+++ b/Justfile
@@ -54,6 +54,28 @@ dev-check:
 test:
     cargo nextest run --workspace
 
+# Fast inner-loop / fresh-worktree run: skips the embedded host-vm binary
+# cross-compile (cargo zigbuild --release) in mvm-cli/build.rs. Safe for
+# everything except builder-VM boot — the env-gated E2E tests need the
+# real binaries and the `e2e-core-demo` recipe never sets this var.
+test-fast:
+    MVM_SKIP_EMBED_BINARIES=1 cargo nextest run --workspace
+
+# Doctests. nextest does NOT run doctests, so `just test` skips them;
+# this is the companion that keeps doc-fence coverage gated.
+test-doc:
+    cargo test --workspace --doc
+
+# Run tests with sccache wrapping rustc — caches compilation across
+# worktrees/branches (a content cache, not a build lock, so parallel
+# sessions don't serialize on it). Incremental is OFF because sccache and
+# incremental compilation are mutually exclusive: this trades inner-loop
+# incremental for cross-worktree cache hits. Needs `cargo install sccache`.
+test-cached:
+    @command -v sccache >/dev/null || { echo "sccache not found — install with: cargo install sccache"; exit 1; }
+    RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0 cargo nextest run --workspace
+    @sccache --show-stats
+
 # Test a single crate
 test-crate CRATE:
     cargo nextest run -p {{CRATE}}
@@ -104,8 +126,8 @@ lint: fmt-check clippy
 
 # ── CI Gate ──────────────────────────────────────────────────────────────
 
-# Full CI gate: lint + test
-ci: lint test
+# Full CI gate: lint + test + doctests (nextest skips doctests).
+ci: lint test test-doc
 
 # Alias for ci
 preflight: ci

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -27,9 +27,32 @@ fn main() {
     let host_triple = std::env::var("HOST").unwrap();
     let native = host_triple.contains("linux") && host_triple.contains(strip_glibc(&pin.target));
 
+    // Fast path for local test/dev iteration: skip the nested
+    // `cargo zigbuild --release` cross-compile of the host-vm binaries and
+    // bake zero-byte stubs instead. Cuts the dominant cold-build tax on
+    // macOS (and any fresh worktree) for everyone who isn't exercising a
+    // builder-VM boot. The only consumers that read the *bytes* are the
+    // env-gated boot/E2E tests (`MVM_E2E_SMOKE`, libkrun lifecycle), which
+    // are skipped in a default `cargo test`/`nextest` run — and the
+    // `e2e-core-demo` recipe never sets this var, so a stub build can't
+    // masquerade as a passing E2E. NEVER set this in CI release builds:
+    // the shipped mvmctl must embed the real reproducible binaries
+    // (Plan 115 / ADR-065 claim 11).
+    let skip_embed = std::env::var("MVM_SKIP_EMBED_BINARIES").as_deref() == Ok("1");
+    println!("cargo:rerun-if-env-changed=MVM_SKIP_EMBED_BINARIES");
+    if skip_embed {
+        println!(
+            "cargo:warning=MVM_SKIP_EMBED_BINARIES=1: embedding zero-byte host-vm \
+             stubs; builder-VM boot is unavailable in this build"
+        );
+    }
+
     for name in manifest.iter() {
         let out_file = bins_out.join(name);
-        if native {
+        if skip_embed {
+            std::fs::write(&out_file, b"")
+                .unwrap_or_else(|e| panic!("write stub {}: {e}", out_file.display()));
+        } else if native {
             run_cargo_build(&workspace_root, name, &pin.target, &out_file);
         } else {
             run_cargo_zigbuild(&workspace_root, name, &pin.target, &out_file);

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1995,9 +1995,10 @@ fn bootstrap_builder_vm_image_via_root_dir_stage0(
     // build can install them from /mvm-bins instead of building them with
     // the guest's nix. Same cache dir the steady-state job path uses.
     let host_bins_cache = format!("{}/host-bins", mvm_core::config::mvm_cache_dir());
-    let host_bin_dir =
-        crate::host_binaries::extract::ensure_extracted(std::path::Path::new(&host_bins_cache))
-            .map_err(|e| anyhow::anyhow!("extract embedded host-vm binaries: {e}"))?;
+    let host_bin_dir = crate::host_binaries::extract::ensure_extracted_for_boot(
+        std::path::Path::new(&host_bins_cache),
+    )
+    .map_err(|e| anyhow::anyhow!("extract embedded host-vm binaries: {e}"))?;
 
     // Kernel acquisition override (MVM_KERNEL_SOURCE / --kernel-source).
     // `download` (and `auto` when a publish exists) boots the builder VM
@@ -2305,9 +2306,10 @@ pub(crate) fn build_kernel_via_stage0(
     // ADR-065: the Stage 0 nix build installs the embedded host-vm
     // binaries from /mvm-bins rather than building them in-guest.
     let host_bins_cache = format!("{}/host-bins", mvm_core::config::mvm_cache_dir());
-    let host_bin_dir =
-        crate::host_binaries::extract::ensure_extracted(std::path::Path::new(&host_bins_cache))
-            .map_err(|e| anyhow::anyhow!("extract embedded host-vm binaries: {e}"))?;
+    let host_bin_dir = crate::host_binaries::extract::ensure_extracted_for_boot(
+        std::path::Path::new(&host_bins_cache),
+    )
+    .map_err(|e| anyhow::anyhow!("extract embedded host-vm binaries: {e}"))?;
 
     ui::info(&format!(
         "Compiling {} kernel ({arch}) via Stage 0 — first build is slow \
@@ -3658,9 +3660,10 @@ fn build_image_via_libkrun(out_dir: &str) -> Result<(String, String)> {
     // The builder-vm flake's cmd.sh reads MVM_HOST_BIN_DIR=/mvm-bins to
     // install the correct cross-compiled binaries into the rootfs.
     let host_bins_cache = format!("{}/host-bins", mvm_core::config::mvm_cache_dir());
-    let host_bin_dir =
-        crate::host_binaries::extract::ensure_extracted(std::path::Path::new(&host_bins_cache))
-            .map_err(|e| anyhow::anyhow!("extract embedded host-vm binaries: {e}"))?;
+    let host_bin_dir = crate::host_binaries::extract::ensure_extracted_for_boot(
+        std::path::Path::new(&host_bins_cache),
+    )
+    .map_err(|e| anyhow::anyhow!("extract embedded host-vm binaries: {e}"))?;
 
     let job = BuilderJob::Flake {
         flake_ref: "path:/work/nix/images/builder-vm".to_string(),

--- a/crates/mvm-cli/src/host_binaries/extract.rs
+++ b/crates/mvm-cli/src/host_binaries/extract.rs
@@ -35,6 +35,29 @@ pub fn ensure_extracted(cache_root: &Path) -> std::io::Result<PathBuf> {
     Ok(target)
 }
 
+/// Like [`ensure_extracted`], but refuses a stub build — the zero-byte
+/// binaries baked when mvmctl is compiled with `MVM_SKIP_EMBED_BINARIES=1`
+/// (the fast local test/dev path). Call this from any path that actually
+/// boots a VM from the embedded binaries so a fast-test build fails fast
+/// with a clear message instead of an opaque builder-VM boot failure.
+pub fn ensure_extracted_for_boot(cache_root: &Path) -> std::io::Result<PathBuf> {
+    let dir = ensure_extracted(cache_root)?;
+    for bin in EMBEDDED.iter() {
+        if bin.bytes.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "embedded host-vm binary `{}` is a zero-byte stub — this mvmctl was \
+                     built with MVM_SKIP_EMBED_BINARIES=1 (fast test build) and cannot boot \
+                     a builder VM; rebuild without that env var",
+                    bin.name
+                ),
+            ));
+        }
+    }
+    Ok(dir)
+}
+
 fn combined_hash_hex() -> String {
     use sha2::{Digest, Sha256};
     let mut h = Sha256::new();

--- a/crates/mvm-cli/tests/host_binaries_extract.rs
+++ b/crates/mvm-cli/tests/host_binaries_extract.rs
@@ -28,3 +28,21 @@ fn ensure_extracted_is_idempotent() {
     let dir2 = ensure_extracted(tmp.path()).unwrap();
     assert_eq!(dir1, dir2);
 }
+
+// The boot guard must reject a stub build (MVM_SKIP_EMBED_BINARIES=1) and
+// admit a real one. The expected verdict is whatever this binary was
+// compiled with, so the test is valid in both modes.
+#[test]
+fn ensure_extracted_for_boot_matches_build_mode() {
+    use mvm_cli::host_binaries::embedded::EMBEDDED;
+    use mvm_cli::host_binaries::extract::ensure_extracted_for_boot;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let res = ensure_extracted_for_boot(tmp.path());
+    let is_stub_build = EMBEDDED.iter().any(|b| b.bytes.is_empty());
+    if is_stub_build {
+        assert!(res.is_err(), "stub build must be refused for VM boot");
+    } else {
+        assert!(res.is_ok(), "real build must extract for VM boot");
+    }
+}


### PR DESCRIPTION
## Context

`cargo test --workspace` is slow, and the workflow that dominates here is **parallel git worktrees on macOS Apple Silicon** — every fresh worktree pays a full cold compile. This adds three independent levers to cut that, without weakening any gate.

What was *already* tuned (left alone): `[profile.test]` (opt 0, line-tables, codegen-units 256, incremental), per-package opt-level overrides, `lld` on Linux, nextest in CI + `just test`. The heavy E2E tests are already env-gated.

## Changes

**Lever 1 — make nextest the named gate**
- `CLAUDE.md` Testing block now names `cargo nextest run --workspace` + `cargo test --workspace --doc`.
- nextest **skips doctests**, so doctests get an explicit step: new `just test-doc`, folded into `just ci`, and a `Run doctests` step in `ci.yml` (CI previously ran nextest only and silently dropped ~150 doc-fences).

**Lever 2 — skip the embedded-binary cross-compile (headline win)**
- `MVM_SKIP_EMBED_BINARIES=1` makes `mvm-cli/build.rs` bake zero-byte host-vm stubs instead of running the nested `cargo zigbuild --release`. Wired as `just test-fast`.
- Safe by construction: `rerun-if-env-changed` forces a rebuild when the var flips, the `e2e-core-demo` recipe never sets it, and a new `ensure_extracted_for_boot()` guard (routed through the 3 builder-VM boot sites) fails closed with a clear message if a stub build ever reaches a boot path.

**Lever 3 — opt-in sccache** (`just test-cached`) for cross-worktree/branch caching (content cache, not a build lock; `CARGO_INCREMENTAL=0` since the two are exclusive). Errors helpfully if sccache isn't installed.

cargo-hakari (workspace-hack) considered and deferred — only worth it if these don't suffice.

## Measured (cold `mvm-cli` build; shared recompile cancels out)

| | wall | CPU (user) |
|---|---|---|
| Real embed build | **31.0s** | 157s |
| `MVM_SKIP_EMBED_BINARIES=1` | **7.4s** | 9.7s |

~24s wall / ~147s CPU removed per cold build — a floor, since a fully-cold worktree also rebuilds the whole dep graph for the `aarch64-unknown-linux-musl` triple that the fast path skips.

## Verification

- Nightly `cargo fmt --all -- --check` clean; `cargo clippy -p mvm-cli --all-targets -- -D warnings` clean.
- `host_binaries_extract` tests green in **both** stub and real builds; new `ensure_extracted_for_boot_matches_build_mode` test asserts the guard rejects a stub build and admits a real one (verdict adapts to the build mode, so it's valid either way).

## Notes

- `scripts/dev-env.sh` is referenced by the `dev-test`/`dev-clippy`/`dev-check` recipes but doesn't exist in-tree (pre-existing; out of scope). I put the sccache toggle in a self-contained `test-cached` recipe rather than create that file blind.
- `MVM_SKIP_EMBED_BINARIES` must **never** be set in release/CI artifact builds — the shipped mvmctl must embed the real reproducible binaries (Plan 115 / ADR-065 claim 11). The build.rs comment says so.