### PR TITLE
Plan 158 — dual dev/prod default microVM image (design refinement)

### DIFF
--- a/nix/images/default-tenant/flake.lock
+++ b/nix/images/default-tenant/flake.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "microvm": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "spectrum": "spectrum"
+      },
+      "locked": {
+        "lastModified": 1778669912,
+        "narHash": "sha256-WT2iimtOBZM/6AcZeBoJU2EgUSaywtlItsEgNkZBda0=",
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "rev": "a7a7009064cec75d9da652c6723412ce27b9bc44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "microvm": "microvm",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "spectrum": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772189877,
+        "narHash": "sha256-i1p90Rgssb//aNiTDFq46ZG/fk3LmyRLChtp/9lddyA=",
+        "ref": "refs/heads/main",
+        "rev": "fe39e122d898f66e89ffa17d4f4209989ccb5358",
+        "revCount": 1255,
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/images/default-tenant/flake.nix
+++ b/nix/images/default-tenant/flake.nix
@@ -1,0 +1,174 @@
+{
+  description =
+    "mvm bundled default microVM image (Plan 158). Two variants: a dev image "
+    + "(accessible, exec-able, unsealed) built locally in dev mode, and a prod "
+    + "image (sealed, rootless, dm-verity-sealed rootfs) shipped as the "
+    + "default-microvm-* release assets. Booted by `mvmctl up`/`exec` when no "
+    + "--flake/--template/--image is given.";
+
+  # DRAFT (Plan 158 Task 1). Authored against the grounded patterns but NOT yet
+  # validated by a `nix build` (the author's host has no nix). A nix/Linux
+  # session must: generate/repair flake.lock, `nix flake check`, and `nix build`
+  # both variants. See specs/plans/158-restore-default-microvm-image.md and the
+  # handoff prompt. Verify-points are marked `# VERIFY:`.
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    microvm = {
+      url = "github:microvm-nix/microvm.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { self, nixpkgs, microvm, ... }:
+    let
+      systems = [ "aarch64-linux" "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      # Same impure workspace-path override the sibling image flakes use.
+      workspaceRoot =
+        let envPath = builtins.getEnv "MVM_WORKSPACE_PATH";
+        in if envPath != "" then /. + envPath else ../../..;
+
+      # Filtered workspace (mirrors builder-vm/runtime-overlay) for mkGuest.
+      workspace =
+        (import (workspaceRoot + "/nix/lib/workspace-filter.nix") {
+          inherit (nixpkgs) lib;
+        })
+        { inherit workspaceRoot; };
+
+      libFor = system:
+        (import (workspace + "/nix/lib") {
+          inherit nixpkgs microvm;
+          mvmSrc = workspace;
+        }) { inherit system; };
+
+      # Workload kernel base — built-in DM_VERITY (no module tree), matching
+      # builder-vm's `workload-kernel` (nix/images/builder-vm/flake.nix:480-486).
+      # VERIFY: importing the base through the RAW workspaceRoot (not the
+      # filtered `workspace`) mirrors builder-vm's relative `./kernel/base.nix`
+      # import so `nix flake check --no-build` doesn't force realisation.
+      kernelBaseFor = pkgs:
+        import (workspaceRoot + "/nix/images/builder-vm/kernel/base.nix")
+          { inherit pkgs; };
+      workloadKernelEnables = [ "MD" "BLK_DEV_DM" "DM_VERITY" ];
+      mkWorkloadKernel = pkgs:
+        (kernelBaseFor pkgs).mkKernel { extraEnables = workloadKernelEnables; };
+
+      # Verity determinism — copied verbatim from runtime-overlay
+      # (nix/images/runtime-overlay/flake.nix:180-203). MUST stay in lockstep
+      # with `mvm_build::oci_to_rootfs::verity::VeritysetupOptions::default` and
+      # `mvm-verity-init`'s DATA_BLOCK_SIZE.
+      verityDataBlockSize = 1024;
+      verityHashBlockSize = 4096;
+      veritySalt = "0000000000000000000000000000000000000000000000000000000000000000";
+      verityHashAlgorithm = "sha256";
+      pinnedCryptsetupVersion = "2.8.6";
+      pinnedCryptsetupSrcHash = "sha256-gAQmX9mTiF0I97Yz2+BWhR3hohAwdhOk693HQ/zO/lo=";
+      pinnedCryptsetupFor = pkgs:
+        pkgs.cryptsetup.overrideAttrs (_old: {
+          version = pinnedCryptsetupVersion;
+          src = pkgs.fetchurl {
+            url =
+              "mirror://kernel/linux/utils/cryptsetup/v${pkgs.lib.versions.majorMinor pinnedCryptsetupVersion}/"
+              + "cryptsetup-${pinnedCryptsetupVersion}.tar.xz";
+            hash = pinnedCryptsetupSrcHash;
+          };
+        });
+
+      # Serialize mkGuest's `passthru.mvm` into the GuestSidecar wire shape
+      # (crates/mvm-base/src/runtime_meta.rs, #[serde(rename_all="camelCase")]).
+      sidecarJson = mvm:
+        builtins.toJSON {
+          inherit (mvm)
+            name accessible sealed entrypointKind initSystem
+            expectedBootMs agentBinary rootlessEntrypoint hypervisor overlayAware;
+        };
+
+      # One variant. `sealed = true` → prod (verity-sealed, rootless, no
+      # do_exec); `sealed = false` → dev (accessible, exec-able).
+      mkVariant = { system, sealed }:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          lib = libFor system;
+          kernelPkg = mkWorkloadKernel pkgs;
+          kernelFile = if pkgs.stdenv.hostPlatform.isAarch64 then "Image" else "bzImage";
+          imageName = if sealed then "mvm-default-microvm" else "mvm-default-microvm-dev";
+          rootfsPkg = lib.mkGuest {
+            name = imageName;
+            # command form → sealed/prod; shell form → dev/accessible.
+            entrypoint =
+              if sealed
+              then { command = [ "/bin/sleep" "infinity" ]; }
+              else { shell = "/bin/sh"; };
+            packages = [ pkgs.busybox ];
+            # VERIFY: mkGuest's `kernel` arg drives the in-rootfs module tree.
+            # The workload kernel is module-free (DM_VERITY built-in), so this
+            # may be omittable; pass it for parity with a real workload image.
+            kernel = kernelPkg;
+          };
+          meta = rootfsPkg.passthru.mvm;
+        in
+        pkgs.runCommand imageName
+          {
+            nativeBuildInputs = [ pkgs.e2fsprogs (pinnedCryptsetupFor pkgs) pkgs.coreutils ];
+            passthru = { inherit rootfsPkg meta; kernel = kernelPkg; };
+          }
+          (''
+            set -euo pipefail
+            mkdir -p $out
+
+            # Kernel → vmlinux (same probe order as builder-vm).
+            if   [ -f ${kernelPkg}/${kernelFile} ]; then cp ${kernelPkg}/${kernelFile} $out/vmlinux
+            elif [ -f ${kernelPkg}/Image ];        then cp ${kernelPkg}/Image        $out/vmlinux
+            elif [ -f ${kernelPkg}/bzImage ];      then cp ${kernelPkg}/bzImage      $out/vmlinux
+            else echo "kernel ${kernelPkg} produced no Image/bzImage" >&2; ls -la ${kernelPkg} >&2; exit 1
+            fi
+
+            # Rootfs → rootfs.ext4 (mkGuest emits a single ext4).
+            if [ -f ${rootfsPkg} ]; then
+              cp ${rootfsPkg} $out/rootfs.ext4
+            else
+              img=$(find ${rootfsPkg} -maxdepth 1 \( -name '*.img' -o -name '*.ext4' \) | head -1)
+              [ -n "$img" ] || { echo "mkGuest output ${rootfsPkg} has no .img/.ext4" >&2; ls -la ${rootfsPkg} >&2; exit 1; }
+              cp "$img" $out/rootfs.ext4
+            fi
+
+            # Overlay-aware sidecar so `admit_overlay_aware` passes.
+            cat > $out/mvm-meta.json <<'META'
+            ${sidecarJson meta}
+            META
+
+            chmod 0644 $out/vmlinux $out/rootfs.ext4 $out/mvm-meta.json
+          ''
+          + nixpkgs.lib.optionalString sealed ''
+
+            # dm-verity seal (prod only) — runtime-overlay recipe verbatim.
+            touch $out/rootfs.verity
+            veritysetup_out=$(
+              veritysetup format \
+                --data-block-size=${toString verityDataBlockSize} \
+                --hash-block-size=${toString verityHashBlockSize} \
+                --salt=${veritySalt} \
+                --hash=${verityHashAlgorithm} \
+                $out/rootfs.ext4 \
+                $out/rootfs.verity
+            )
+            echo "$veritysetup_out" \
+              | grep -i '^Root hash:' \
+              | sed 's/^[Rr]oot [Hh]ash:[[:space:]]*//' \
+              | tr 'A-F' 'a-f' \
+              > $out/rootfs.roothash
+            chmod 0644 $out/rootfs.verity $out/rootfs.roothash
+          '');
+
+    in
+    {
+      packages = forAllSystems (system: {
+        # `default` = prod (the variant the release job ships).
+        default = mkVariant { inherit system; sealed = true; };
+        prod = mkVariant { inherit system; sealed = true; };
+        dev = mkVariant { inherit system; sealed = false; };
+      });
+    };
+}

--- a/specs/plans/158-restore-default-microvm-image.md
+++ b/specs/plans/158-restore-default-microvm-image.md
@@ -6,7 +6,34 @@
 
 ## Goal
 
-Restore the bundled **default production microVM image** so that `mvmctl up` / `mvmctl run` / `mvmctl exec` with **no** `--flake` / `--template` / `--image` boots a real, admittable, verity-sealed image — and so claim 3's CI witness has a representative bundled prod image again. The standalone image flake (`nix/images/default-tenant`) was removed during the Plan 115 image consolidation; the host still tries to download + boot it.
+Restore the bundled **default microVM image** so that `mvmctl up` / `mvmctl run` /
+`mvmctl exec` with **no** `--flake` / `--template` / `--image` boots a real,
+admittable image. The standalone flake (`nix/images/default-tenant`) was removed
+in the Plan 115 consolidation; the host still tries to download + boot it.
+
+**Dual image, keyed on `BuildMode` (decided 2026-06-04).** The flake produces
+**two** variants, matching mvm's existing dev/prod tiers (`mvm_build::pipeline::
+BuildMode`, `--dev`/`--prod`, default `--prod` — `up.rs:781`):
+
+| Variant | `mkGuest` form | Tier | Verity | `exec`/console | Distribution |
+|---|---|---|---|---|---|
+| **dev** | `entrypoint.shell` (`isDev`) | dev | no (ADR-002 dev-VM exemption) | **yes** (agent ships `do_exec`, entrypoint uid 0) | built **locally** in dev mode; not shipped |
+| **prod** | `entrypoint.command` (sealed) | prod | **yes** (rootfs.verity + roothash) | no | **shipped** as the `default-microvm-*` release assets |
+
+Rationale: a single image can't be both interactive *and* sealed (sealed refuses
+`exec`/console by design). The dev variant is the interactive scratch default; the
+prod variant is the hardened image that ships for hosting. This is the documented
+dev/prod split, not a new posture.
+
+**Security posture (verified against `mk-guest.nix` + ADR-002).** The microVM
+isolation boundary (hypervisor, seccomp-jailed VMM, no host-fs beyond shares,
+default-deny egress, proxy 0700 + port allowlist) holds identically for **both**
+variants — the host is protected either way. The **dev** variant relaxes
+*in-guest* defense-in-depth only: entrypoint uid 0 (`defaultEntrypointUid = if
+isDev then 0 else 1000`), `do_exec` compiled in (`withDevShell = isDev`), no
+rootfs verity — exactly the dev tier ADR-002 §"Verified boot is mandatory for
+production microVMs" explicitly exempts. **Untrusted/production workloads must run
+in the prod variant (or a sealed user flake), never the dev default.**
 
 ## Why it's currently broken (grounded findings)
 
@@ -57,76 +84,97 @@ Restore the bundled **default production microVM image** so that `mvmctl up` / `
 
 ## Design decisions (recommendations)
 
-**D1 — Image build: a new `nix/images/default-tenant/` flake calling current
-`mkGuest`.** Recommended. The historical flake (`nix/default-microvm/flake.nix`
-at commit `20a789d7`) is stale (input path `../guest-lib` → `../lib`, no explicit
-`entrypoint`). Author fresh against the current API rather than resurrect.
-Entrypoint: a minimal **sealed/prod** default — `entrypoint.command` running a
-busybox shell-less idle/echo so the image is sealed (uid 1000, no `do_exec`).
-This both fixes admission (mkGuest bakes `/mvm/runtime` + emits the overlay-aware
-sidecar metadata) and gives claim 3 a representative prod image.
+**D1 — A new `nix/images/default-tenant/` flake with TWO `mkGuest` variants.**
+Author fresh against the current API (the historical `nix/default-microvm/flake.nix`
+at `20a789d7` is stale — input `../guest-lib`→`../lib`, no explicit entrypoint).
+- `packages.<sys>.dev` — `mkGuest { entrypoint.shell = "/bin/sh"; … }` →
+  accessible, `do_exec`, uid 0. Built locally in dev mode; **not** verity-sealed.
+- `packages.<sys>.default` (= prod) — `mkGuest { entrypoint.command = [ … minimal
+  idle … ]; … }` → sealed, rootless uid 1000, no `do_exec`; **verity-sealed**
+  (D2). This is what ships.
+Both use the **workload kernel** (`builder-vm`'s `workload-kernel` attr, which
+enables `MD BLK_DEV_DM DM_VERITY` — `nix/images/builder-vm/flake.nix:480, 506`)
+and both emit the overlay-aware `mvm-meta.json` (D3) so admission passes.
 
-**D2 — Verity: Option (a), seal inside the Nix build.** Recommended over the
-host-side `seal_with_verity` (test-only, breaks Nix purity, Linux-only) and over
-"overlay-only, don't seal the rootfs" (fails sealed-prod / claim 3). Emit
-`rootfs.verity` + `rootfs.roothash` from the flake by reusing runtime-overlay's
-exact `veritysetup format` recipe (same pinned cryptsetup, block sizes, salt,
-determinism). This keeps verity in the Nix dep graph and matches the shipped
-overlay pattern.
+**D2 — Verity (prod variant only): seal inside the Nix build.** Reuse
+runtime-overlay's exact `veritysetup format` recipe (pinned cryptsetup 2.8.6,
+data-block 1024, hash-block 4096, zero salt, sha256 — `runtime-overlay/flake.nix:
+180-203, 288-312`) over the prod variant's `rootfs.ext4`, emitting `rootfs.verity`
++ `rootfs.roothash`. The dev variant is not sealed (ADR-002 dev-VM exemption). The
+backend probes these siblings + builds the `mvm.roothash=` cmdline host-side
+(`microvm.rs:1589-1632`), so the flake only emits artifacts — no baked cmdline.
 
-**D3 — Sidecar: emit `mvm-meta.json` next to the rootfs from `passthru.mvm`.**
-The flake (or the release job) writes the `GuestSidecar` JSON
-(`overlay_aware: true`, name, sealed, init_system, agent_binary, …) so
-`admit_overlay_aware` passes. Confirm the exact serialization shape against
-`GuestSidecar` (`crates/mvm-build/src/builder_vm.rs:207-245`) and reuse the same
-writer the normal build pipeline uses if one exists (W6.2 emit site — locate
-during Task 1).
+**D3 — Sidecar: emit `mvm-meta.json` via `builtins.toJSON` from `passthru.mvm`.**
+The `GuestSidecar` struct (`crates/mvm-base/src/runtime_meta.rs`, written by
+`GuestSidecar::write_to_dir` / `SIDECAR_FILENAME`; mirror at `builder_vm.rs:207-245`)
+is `#[serde(rename_all="camelCase")]` with fields `name, accessible, sealed,
+entrypointKind, initSystem, expectedBootMs, agentBinary, rootlessEntrypoint,
+hypervisor, overlayAware`. mkGuest's `passthru.mvm` carries all of these, so the
+flake emits the file with `builtins.toJSON` of an attrset using those exact
+camelCase keys — no hand-formatting, guaranteed to parse. Both variants set
+`overlayAware = true`; dev sets `sealed=false/accessible=true`, prod the inverse.
 
-**D4 — Keep the download contract, extend the asset set.** Keep
-`~/.cache/mvm/default-microvm/` + the `default-microvm-*` asset names; add the
-new siblings (`rootfs.verity`, `rootfs.roothash`, `mvm-meta.json`) so the backend
-verity probe + admit gate are satisfied from a pure download.
+**D4 — Resolution keyed on `BuildMode`; only prod ships.**
+`ensure_default_microvm_image()` (`apple_container.rs:3815`) takes the resolved
+`BuildMode`:
+- **Prod** → download the shipped `default-microvm-*` assets (now incl.
+  `rootfs.verity`, `rootfs.roothash`, `mvm-meta.json`) into
+  `~/.cache/mvm/default-microvm/prod/`, SHA-256-verified.
+- **Dev** → build the `dev` variant **locally** from the in-repo flake (source
+  checkout) — dev images are never published (matches the
+  source-checkout-builds-locally invariant); cache at `…/default-microvm/dev/`.
+Callers (`up.rs:1543`, `exec.rs`, `bench_probe.rs`) pass the mode they already
+resolve (`BuildMode`, default Prod — `up.rs:781`).
 
 **D5 — Leave the security.yml lanes on the runtime overlay (Plan-568 state).**
-Once this image exists, the `verified-boot-artifacts` lane *could* point back at
-it, but the overlay witness already exercises the identical seal; revisit only if
-we want the bundled-image rootfs specifically witnessed. Out of scope here.
+Once the prod variant exists, `verified-boot-artifacts` *could* witness it too,
+but the overlay already exercises the identical seal; out of scope here.
 
 ## Workstreams
 
-### Task 1 — Author `nix/images/default-tenant/flake.nix`
-- [ ] Locate the W6.2 `mvm-meta.json` emit site (grep `GuestSidecar` writer /
-      `mvm-meta.json` in `crates/mvm-build`) and the runtime-overlay verity
-      recipe (`nix/images/runtime-overlay/flake.nix:288-312`).
-- [ ] Write the flake: `mkGuest { name = "mvm-default-microvm"; entrypoint.command
-      = [ … minimal sealed idle … ]; packages = [ pkgs.busybox ]; }`, then a
-      `veritysetup format` derivation phase (mirroring runtime-overlay) producing
-      `$out/{vmlinux, rootfs.ext4, rootfs.verity, rootfs.roothash, mvm-meta.json}`.
-      `mvm-meta.json` serialized from `passthru.mvm` with `overlay_aware = true`.
-- [ ] `nix flake lock` committed (`flake.lock`).
-- [ ] Add an eval smoke test under `nix/tests/` (mirror `nix/tests/mk-guest-eval.nix`)
-      asserting the package evaluates and the sidecar carries `overlay_aware: true`.
-- [ ] **Cannot be built on a macOS dev host** — validated by CI (the
+### Task 1 — Author `nix/images/default-tenant/flake.nix` (two variants)
+- [ ] `packages.<sys>.dev` = `mkGuest { name = "mvm-default-microvm-dev";
+      entrypoint.shell = "/bin/sh"; packages = [ pkgs.busybox ]; kernel = <workload>; }`
+      → assemble `$out/{vmlinux, rootfs.ext4, mvm-meta.json}` (no verity).
+- [ ] `packages.<sys>.default` (prod) = `mkGuest { name = "mvm-default-microvm";
+      entrypoint.command = [ "/bin/sleep" "infinity" ]; packages = [ pkgs.busybox ];
+      kernel = <workload>; }` → assemble `$out/{vmlinux, rootfs.ext4, rootfs.verity,
+      rootfs.roothash, mvm-meta.json}`, sealing the rootfs with the runtime-overlay
+      `veritysetup format` recipe (D2).
+- [ ] Source the **workload kernel** (`workload-kernel` attr — `builder-vm/flake.nix:
+      480-506`): either add `builder-vm` as a flake input and use its output, or
+      replicate `mkWorkloadKernel` (`extraEnables = ["MD" "BLK_DEV_DM" "DM_VERITY"]`).
+      Decide during impl; prefer the flake-input form to avoid recipe drift.
+- [ ] `mvm-meta.json` via `builtins.toJSON` of `passthru.mvm` (D3).
+- [ ] **`flake.lock` must be generated in a nix env** (cannot be produced on a
+      macOS host) — seed from a sibling flake's lock if inputs match, else
+      `nix flake lock` in CI/Linux.
+- [ ] Eval smoke test under `nix/tests/` (mirror `nix/tests/mk-guest-eval.nix`):
+      both variants evaluate; dev sidecar `sealed:false`, prod `sealed:true`, both
+      `overlayAware:true`.
+- [ ] **Cannot be built/locked on a macOS dev host** — validated by CI (the
       `Nix flake check (Linux eval)` lane + the release/security `nix build` lanes).
 
-### Task 2 — Re-add the `default-microvm` release job
+### Task 2 — Re-add the `default-microvm` release job (PROD variant only)
 - [ ] In `.github/workflows/release.yml`, re-add a `default-microvm` matrix job
       (aarch64 + x86_64) that `nix build ./nix/images/default-tenant#…default`
-      and uploads `default-microvm-{vmlinux,rootfs.ext4,rootfs.verity,
-      rootfs.roothash,mvm-meta.json}-<arch>` + `default-microvm-<arch>-checksums-sha256.txt`.
-- [ ] Add `default-microvm` back to the `release` job `needs:` and the nullglob
-      asset list (the slots PR #567 removed). It stays best-effort under the
-      #566 `if: !cancelled() && needs.build.result == 'success'` gate — an
-      image failure still won't block the binary download.
+      (the **prod** variant) and uploads `default-microvm-{vmlinux,rootfs.ext4,
+      rootfs.verity,rootfs.roothash,mvm-meta.json}-<arch>` +
+      `default-microvm-<arch>-checksums-sha256.txt`. The dev variant is **not**
+      shipped.
+- [ ] Add `default-microvm` back to the `release` job `needs:` + the nullglob
+      asset list (the slots PR #567 removed). Best-effort under the #566
+      `if: !cancelled() && needs.build.result=='success'` gate.
 
-### Task 3 — Extend `download_default_microvm_image`
-- [ ] In `crates/mvm-cli/src/commands/env/apple_container.rs:3832`, fetch the new
-      siblings (`rootfs.verity`, `rootfs.roothash`, `mvm-meta.json`) into
-      `~/.cache/mvm/default-microvm/` alongside `vmlinux` + `rootfs.ext4`, and
-      extend SHA-256 verification to cover them (same checksums manifest).
-- [ ] `ensure_default_microvm_image()` (`:3815`) returns the dir; confirm the
-      backend's verity probe (`microvm.rs:1589`) and `admit_overlay_aware`
-      (`builder_vm.rs:850`) both resolve their files from that dir layout.
+### Task 3 — Make `ensure_default_microvm_image` `BuildMode`-aware
+- [ ] In `crates/mvm-cli/src/commands/env/apple_container.rs:3815`, take the
+      resolved `BuildMode`. **Prod:** `download_default_microvm_image` fetches the
+      five prod assets into `…/default-microvm/prod/`, extending SHA-256
+      verification to all five. **Dev:** build the `dev` variant locally from the
+      in-repo flake into `…/default-microvm/dev/` (no download).
+- [ ] Thread the mode from callers (`up.rs:1543`, `exec.rs`, `bench_probe.rs`).
+- [ ] Confirm the prod dir layout satisfies the backend verity probe
+      (`microvm.rs:1589`) and `admit_overlay_aware` (`builder_vm.rs:850`).
 
 ### Task 4 — Tests
 - [ ] Rust unit test: `download_default_microvm_image` places all five files +


### PR DESCRIPTION
Refines Plan 158 (merged in #570) to the **dual-image** design we settled on, and is the contract the flake + resolver implementation will follow.

## The model

The `nix/images/default-tenant` flake produces **two** variants, keyed on the existing `mvm_build::pipeline::BuildMode` (`--dev`/`--prod`, default prod):

| Variant | mkGuest | Tier | Verity | exec/console | Ships? |
|---|---|---|---|---|---|
| **dev** | `entrypoint.shell` | dev | no | **yes** | no — built locally in dev mode |
| **prod** | `entrypoint.command` | prod | **yes** | no | **yes** — the `default-microvm-*` release assets |

A single image can't be both interactive and sealed, so dev = the scratch image you `exec` into; prod = the hardened image that ships for hosting.

## Security posture (verified, not asserted)

The microVM **isolation boundary holds for both** variants (hypervisor, seccomp-jailed VMM, no host-fs beyond shares, default-deny egress) — the host is protected either way. The **dev** variant relaxes only *in-guest* defense-in-depth (entrypoint uid 0 via `defaultEntrypointUid`, `do_exec` via `withDevShell`, no rootfs verity) — exactly the dev tier ADR-002 explicitly exempts from verified boot. Untrusted/prod workloads must run in the prod variant or a sealed user flake.

## Honest status of the implementation

This PR is the **design/plan only**. The flake itself (Task 1) genuinely needs a **nix/Linux environment** — I can't generate a valid `flake.lock` or eval/build Nix from a macOS host, so that piece is CI/nix-loop work. The grounded facts to write it are all captured (workload kernel w/ `DM_VERITY`, the runtime-overlay `veritysetup` recipe, `mvm-meta.json` via `builtins.toJSON`). The `BuildMode`-aware resolver (Task 3) + release job (Task 2) are locally validatable and follow once the flake's asset contract is fixed.