### PR TITLE
fix(gvproxy): free ssh-port + reap orphaned daemons on startup

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -60,8 +60,11 @@ jobs:
   #      local subscribers (`nc -U`). They do not accept control-plane
   #      commands or host multi-tenant orchestration state.
   #   5. Ephemeral port discovery — `TcpListener::bind("127.0.0.1:0")`
-  #      in `crates/mvm-cli/src/template_cmd.rs`. Binds to find a free
-  #      port; drops the listener immediately. Not a daemon.
+  #      in `crates/mvm-cli/src/template_cmd.rs` and
+  #      `crates/mvm-libkrun/src/gvproxy.rs` (`free_loopback_port`).
+  #      Binds to find a free port; drops the listener immediately so
+  #      the caller (here, gvproxy's mandatory ssh-forward listener)
+  #      can claim it. Not a daemon.
   #   6. Test-only mock guest-agent
   #      (`crates/mvm-backend/src/mock_guest_agent.rs`). Mirrors the
   #      in-guest vsock agent on the host side via Unix-domain socket
@@ -183,6 +186,7 @@ jobs:
               --glob '!crates/mvm-supervisor/src/gateway_bridge.rs' \
               --glob '!crates/mvm-supervisor/src/gateway_audit.rs' \
               --glob '!crates/mvm-cli/src/template_cmd.rs' \
+              --glob '!crates/mvm-libkrun/src/gvproxy.rs' \
               --glob '!crates/mvm-backend/src/mock_guest_agent.rs' \
               --glob '!crates/mvm-addon-vsock-bridge/**' \
               --glob '!crates/mvm-broker/src/bin/mvm-broker.rs' \

--- a/crates/mvm-backend/src/host_gvproxy.rs
+++ b/crates/mvm-backend/src/host_gvproxy.rs
@@ -98,15 +98,16 @@ pub fn spawn_detached(scratch_dir: &Path) -> Result<HostGvproxyInfo> {
     // gvproxy args (mirror mvm-libkrun::gvproxy::spawn):
     //   -listen-vfkit unixgram://<path>  — Vz connects here
     //   -log-file <path>                 — diagnostic log
-    //   -ssh-port <port>                 — per-scratch-dir derived
-    //                                      so concurrent gvproxies
-    //                                      don't collide on 2222
+    //   -ssh-port <port>                 — fresh OS-assigned free port
+    //                                      so concurrent gvproxies (and
+    //                                      leaked daemons) never collide
     let listen_url = {
         let mut s = OsString::from("unixgram://");
         s.push(socket_path.as_os_str());
         s
     };
-    let ssh_port = ssh_port_for(scratch_dir);
+    let ssh_port = mvm_libkrun::gvproxy::free_loopback_port()
+        .map_err(|e| anyhow!("reserve a free gvproxy ssh-forward port: {e}"))?;
 
     // NEVER inherit the parent's stderr. gvproxy is detached and
     // re-parented to init; an inherited stderr write end keeps the
@@ -272,20 +273,6 @@ pub fn derive_mac(vm_name: &str) -> String {
         .join(":")
 }
 
-/// Per-scratch-dir port derivation for gvproxy's SSH-forward
-/// listener. Mirrors the heuristic in `mvm_libkrun::gvproxy` so
-/// concurrent VMs (host + libkrun lane, multiple Vz lanes, etc.)
-/// don't collide on a single TCP port.
-fn ssh_port_for(scratch_dir: &Path) -> u16 {
-    let mut hasher = Sha256::new();
-    hasher.update(scratch_dir.as_os_str().as_encoded_bytes());
-    let digest = hasher.finalize();
-    // Range 22220..=29999 — wide enough that 4096 concurrent VMs
-    // is collision-improbable.
-    let n = u16::from(digest[0]) << 8 | u16::from(digest[1]);
-    22220 + (n % 7780)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,13 +306,13 @@ mod tests {
     }
 
     #[test]
-    fn ssh_port_in_range_and_stable() {
-        let p1 = ssh_port_for(Path::new("/tmp/x/vm-a"));
-        let p2 = ssh_port_for(Path::new("/tmp/x/vm-a"));
-        let p3 = ssh_port_for(Path::new("/tmp/x/vm-b"));
-        assert_eq!(p1, p2);
-        assert_ne!(p1, p3);
-        assert!((22220..30000).contains(&p1));
+    fn ssh_port_uses_a_free_os_assigned_port() {
+        // The Vz lane reserves its gvproxy ssh-forward port the same
+        // way the libkrun lane does — a fresh OS-assigned free port,
+        // never a deterministic scratch-dir hash that could collide
+        // with a leaked daemon.
+        let port = mvm_libkrun::gvproxy::free_loopback_port().expect("reserve a free port");
+        assert!(port >= 1024, "port {port} below gvproxy's 1024 floor");
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -2765,14 +2765,89 @@ pub(in crate::commands) struct ReapOutcome {
 /// of the prototype `/tmp/plan95/reap.sh`, which during validation
 /// nuked a live mvmctl's state dir.
 pub(in crate::commands) fn reap_orphaned_vm_helpers(dry_run: bool) -> Result<ReapOutcome> {
-    let vms_root =
-        std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("builder-vm/vms");
-    reap_orphaned_vm_helpers_at(&vms_root, dry_run)
+    reap_orphaned_vm_helpers_both_roots(/* remove_builder_dirs = */ true, dry_run)
 }
 
-/// Inner form taking an explicit `vms_root`. Exists for tests against
-/// a tempdir without mutating `MVM_CACHE_DIR`.
-fn reap_orphaned_vm_helpers_at(vms_root: &std::path::Path, dry_run: bool) -> Result<ReapOutcome> {
+/// Best-effort orphan-helper sweep run at the *start* of `mvmctl dev
+/// up` / `mvmctl up`. The next launch reaps the previous run's corpses
+/// — startup is the robust trigger because an abnormal exit (^C,
+/// SIGKILL, crash, the libkrun `krun_start_enter` `exit()` that skips
+/// `GvproxyHandle::Drop`) is exactly when mvmctl can't self-clean and
+/// reparents its helpers to launchd.
+///
+/// Kill-only: it signals provably-orphaned helpers but removes **no**
+/// directories (so it never deletes host bytes and carries no audit
+/// obligation — dir pruning stays the job of `mvmctl cache prune`).
+/// Quiet on the happy path; one line only when it actually reaped
+/// something. Swallows errors — a sweep failure must never block a
+/// launch. Since [`free_loopback_port`](mvm_libkrun::gvproxy::free_loopback_port)
+/// gives every gvproxy a fresh port, a missed leak is now harmless
+/// hygiene, not a boot blocker.
+pub(in crate::commands) fn sweep_orphaned_vm_helpers_on_startup() {
+    match reap_orphaned_vm_helpers_both_roots(/* remove_builder_dirs = */ false, false) {
+        Ok(o) if o.killed > 0 => crate::ui::info(&format!(
+            "Reaped {} orphaned VM helper(s) left by a prior run.",
+            o.killed
+        )),
+        Ok(_) => {}
+        Err(e) => {
+            tracing::debug!(error = %e, "startup orphan-helper sweep failed (non-fatal)")
+        }
+    }
+}
+
+/// Sidecar PID file names a *builder* VM dir carries (libkrun + Vz).
+const BUILDER_SIDECARS: &[&str] = &["builder.pid", "stage0.pid"];
+
+/// Sidecar PID file names a *workload* VM dir under `~/.mvm/vms/<name>/`
+/// carries: `libkrun.pid` (libkrun supervisor), `vz.pid` (Vz
+/// supervisor), and the gvproxy sidecars (`gvproxy.pid` libkrun lane /
+/// `host-gvproxy.pid` Vz lane). The argv scan backstops these, but
+/// reading the sidecar directly is cheaper and catches a detached Vz
+/// supervisor that the argv scan might miss.
+const WORKLOAD_SIDECARS: &[&str] = &["libkrun.pid", "vz.pid", "gvproxy.pid", "host-gvproxy.pid"];
+
+/// Scan both VM-state roots: the ephemeral builder cache
+/// (`~/.cache/mvm/builder-vm/vms/`) and the workload VM tree
+/// (`~/.mvm/vms/`). `remove_builder_dirs` deletes dead builder scratch
+/// dirs (cache-prune semantics); workload dirs are **never** removed —
+/// a stopped named VM's `~/.mvm/vms/<name>/` is persistent state the
+/// user may restart, so we only reap its leaked helpers.
+fn reap_orphaned_vm_helpers_both_roots(
+    remove_builder_dirs: bool,
+    dry_run: bool,
+) -> Result<ReapOutcome> {
+    let builder_root =
+        std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("builder-vm/vms");
+    let workload_root = std::path::PathBuf::from(mvm_core::config::mvm_data_dir()).join("vms");
+
+    let mut out = reap_orphaned_vm_helpers_at(
+        &builder_root,
+        BUILDER_SIDECARS,
+        remove_builder_dirs,
+        dry_run,
+    )?;
+    let workload = reap_orphaned_vm_helpers_at(
+        &workload_root,
+        WORKLOAD_SIDECARS,
+        /* remove_dead_dirs = */ false,
+        dry_run,
+    )?;
+    out.killed += workload.killed;
+    out.removed_dirs += workload.removed_dirs;
+    out.freed_bytes += workload.freed_bytes;
+    Ok(out)
+}
+
+/// Inner form taking an explicit `vms_root`, the sidecar names to look
+/// for in each dir, and whether dead dirs may be removed. Exists for
+/// tests against a tempdir without mutating `MVM_CACHE_DIR`.
+fn reap_orphaned_vm_helpers_at(
+    vms_root: &std::path::Path,
+    sidecars: &[&str],
+    remove_dead_dirs: bool,
+    dry_run: bool,
+) -> Result<ReapOutcome> {
     let mut outcome = ReapOutcome {
         killed: 0,
         removed_dirs: 0,
@@ -2792,9 +2867,11 @@ fn reap_orphaned_vm_helpers_at(vms_root: &std::path::Path, dry_run: bool) -> Res
         let mut killed_in_dir = 0u64;
         let mut seen_pids: std::collections::HashSet<i32> = std::collections::HashSet::new();
 
-        // Scan 1 — sidecar files. Steady-state builder VMs write
-        // `builder.pid`; Stage 0 writes `stage0.pid`.
-        for sidecar in ["builder.pid", "stage0.pid"] {
+        // Scan 1 — sidecar files. Builder dirs write `builder.pid` /
+        // `stage0.pid`; workload dirs write `libkrun.pid` / `vz.pid` /
+        // the gvproxy sidecars. `sidecars` is the per-root set; a
+        // missing file is skipped.
+        for sidecar in sidecars {
             let pid_file = dir.join(sidecar);
             let Some(pid) = read_pid_file(&pid_file) else {
                 continue;
@@ -2843,7 +2920,7 @@ fn reap_orphaned_vm_helpers_at(vms_root: &std::path::Path, dry_run: bool) -> Res
         }
 
         outcome.killed += killed_in_dir;
-        if dir_has_live_owner {
+        if dir_has_live_owner || !remove_dead_dirs {
             continue;
         }
 
@@ -4341,7 +4418,8 @@ mod reap_orphans_tests {
     fn missing_vms_root_is_empty_outcome() {
         let dir = tempfile::tempdir().expect("tempdir");
         let vms_root = dir.path().join("does-not-exist");
-        let out = reap_orphaned_vm_helpers_at(&vms_root, false).expect("reap");
+        let out =
+            reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, false).expect("reap");
         assert_eq!(out.killed, 0);
         assert_eq!(out.removed_dirs, 0);
         assert_eq!(out.freed_bytes, 0);
@@ -4363,7 +4441,8 @@ mod reap_orphans_tests {
         std::fs::write(vm.join("builder.pid"), "2147483646\n").expect("write pid");
         std::fs::write(vm.join("payload"), vec![0u8; 1024]).expect("write payload");
 
-        let out = reap_orphaned_vm_helpers_at(&vms_root, false).expect("reap");
+        let out =
+            reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, false).expect("reap");
         assert_eq!(out.killed, 0, "no live PID, so nothing to kill");
         assert_eq!(out.removed_dirs, 1, "dir should be removed");
         assert!(out.freed_bytes >= 1024, "payload size counted");
@@ -4383,10 +4462,38 @@ mod reap_orphans_tests {
         let my_pid = std::process::id() as i32;
         std::fs::write(vm.join("builder.pid"), format!("{my_pid}\n")).expect("write pid");
 
-        let out = reap_orphaned_vm_helpers_at(&vms_root, false).expect("reap");
+        let out =
+            reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, false).expect("reap");
         assert_eq!(out.killed, 0, "live owner should not be killed");
         assert_eq!(out.removed_dirs, 0, "dir preserved while owner alive");
         assert!(vm.exists(), "dir should still be on disk");
+    }
+
+    #[test]
+    fn workload_root_preserves_dir_with_dead_pid() {
+        // Workload VM dirs (`~/.mvm/vms/<name>/`) are persistent state —
+        // a stopped named VM the user may restart. The reaper must reap
+        // their leaked helpers but NEVER delete the dir, even when its
+        // supervisor PID is long dead. `remove_dead_dirs = false` is the
+        // contract; this pins it against a regression that would `rm -rf`
+        // a user's stopped-VM state.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let vms_root = dir.path().join("vms");
+        // Basename must not substring-match any live process — Scan 2
+        // argv-scans the whole host via `pgrep -f <basename>`, so a
+        // realistic VM name (e.g. "silly-experience") could match a real
+        // leaked daemon and pollute the count. Use an unmistakable one.
+        let vm = vms_root.join("mvm-workload-reaptest-7f3a9c-deadpid");
+        std::fs::create_dir_all(&vm).expect("mkdir");
+        std::fs::write(vm.join("libkrun.pid"), "2147483646\n").expect("write pid");
+        std::fs::write(vm.join("config"), vec![0u8; 512]).expect("write state");
+
+        let out = reap_orphaned_vm_helpers_at(&vms_root, WORKLOAD_SIDECARS, false, false)
+            .expect("reap workload root");
+        assert_eq!(out.killed, 0, "dead PID, nothing to kill");
+        assert_eq!(out.removed_dirs, 0, "workload dir must never be removed");
+        assert!(vm.exists(), "workload VM state dir must survive the sweep");
+        assert!(vm.join("config").exists(), "persistent state untouched");
     }
 
     #[test]
@@ -4398,7 +4505,8 @@ mod reap_orphans_tests {
         std::fs::write(vm.join("builder.pid"), "2147483646\n").expect("write pid");
         std::fs::write(vm.join("payload"), vec![0u8; 256]).expect("write payload");
 
-        let out = reap_orphaned_vm_helpers_at(&vms_root, true).expect("dry-run reap");
+        let out = reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, true)
+            .expect("dry-run reap");
         // Dry-run still *counts* what it would do, but doesn't mutate.
         assert_eq!(out.removed_dirs, 1);
         assert!(vm.exists(), "dry-run must not remove the dir");
@@ -4840,7 +4948,8 @@ mod builder_vm_bootstrap_tests {
         std::fs::write(vz_dir.join("builder.pid"), format!("{}\n", i32::MAX)).unwrap();
 
         let outcome =
-            reap_orphaned_vm_helpers_at(vms, /* dry_run = */ false).expect("reap should succeed");
+            reap_orphaned_vm_helpers_at(vms, BUILDER_SIDECARS, true, /* dry_run = */ false)
+                .expect("reap should succeed");
 
         assert_eq!(
             outcome.removed_dirs, 1,

--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -575,6 +575,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             };
             let open_shell = effective_up_shell(shell, no_shell);
 
+            // Reap helpers (gvproxy/supervisor) leaked by a prior killed
+            // run before booting a fresh builder VM. Kill-only, quiet,
+            // non-fatal — see `sweep_orphaned_vm_helpers_on_startup`.
+            apple_container::sweep_orphaned_vm_helpers_on_startup();
+
             match backend {
                 DevBackend::Libkrun => cmd_dev_libkrun(effective_cpus, effective_mem, open_shell),
                 DevBackend::Vz => cmd_dev_vz(effective_cpus, effective_mem, open_shell),

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -830,6 +830,11 @@ pub(in crate::commands) struct Args {
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
+    // Reap helpers (gvproxy/supervisor) leaked by a prior killed run
+    // before booting this workload's microVM. Kill-only, quiet,
+    // non-fatal — see `sweep_orphaned_vm_helpers_on_startup`.
+    super::super::env::apple_container::sweep_orphaned_vm_helpers_on_startup();
+
     // Plan 76 Phase 7 — surface the backend's isolation tier
     // when it isn't Tier 1, unless the operator explicitly
     // acknowledged the downgrade. This is observational today;

--- a/crates/mvm-libkrun/src/gvproxy.rs
+++ b/crates/mvm-libkrun/src/gvproxy.rs
@@ -143,26 +143,38 @@ pub fn locate_gvproxy() -> Option<PathBuf> {
     which::which("gvproxy").ok()
 }
 
-/// Pick a TCP port for gvproxy's mandatory SSH-forward listener,
-/// derived deterministically from the per-VM scratch dir. gvproxy's
-/// `-ssh-port` arg is *mandatory* (default 2222) and gvproxy binds
-/// it on every start — so a host running more than one gvproxy
-/// fails the second-and-later instances with `bind: address already
-/// in use`. Plan 88 W5 surfaced this when the supervisor unit tests
-/// collided with a live `mvmctl dev up` gvproxy instance.
+/// Reserve a free TCP port on loopback for gvproxy's mandatory
+/// SSH-forward listener by letting the OS assign one.
 ///
-/// Range: 49152..=65535 (IANA dynamic / private ports). The mapping
-/// is deterministic on the dir path so a given VM's gvproxy always
-/// picks the same port (helps log/debug reproducibility); collisions
-/// across simultaneous VMs are improbable in practice but not
-/// impossible — if they happen, the second gvproxy still exits with
-/// a clear bind error and the caller's `EarlyExit` path reports it.
-fn ssh_port_for(scratch_dir: &Path) -> u16 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    scratch_dir.hash(&mut hasher);
-    let dynamic_range: u32 = 65535 - 49152 + 1;
-    49152u16 + ((hasher.finish() as u32) % dynamic_range) as u16
+/// gvproxy's `-ssh-port` arg is *mandatory* (default 2222) and
+/// gvproxy binds it on every start. mvm never uses the SSH forward
+/// (no SSH in microVMs, ever) but gvproxy refuses to disable it
+/// (`-ssh-port` validates to 1024..=65535), so we have to hand it a
+/// port we don't care about.
+///
+/// We bind `127.0.0.1:0`, read back the ephemeral port the kernel
+/// picked, and immediately drop the listener so gvproxy can claim
+/// it. This is collision-proof in the way a deterministic
+/// scratch-dir hash is *not*: the OS never hands out a port already
+/// in `LISTEN`, so a leaked gvproxy from a prior run (libkrun's
+/// `krun_start_enter` `exit()`s on guest shutdown and skips
+/// `GvproxyHandle::Drop`, so daemons routinely outlive their VM) or
+/// a concurrent VM reusing the same scratch dir can't steal the
+/// port out from under us. Plan 88 W5's deterministic hash collided
+/// exactly this way — a re-run reusing `~/.mvm/vms/<name>/` derived
+/// the same port a still-bound leaked daemon already held, and
+/// gvproxy bailed with `bind: address already in use`.
+///
+/// The bind→read→close → gvproxy-bind window is a microsecond-scale
+/// TOCTOU that another process could in principle race, but a closed
+/// listener that never accepted a connection frees its port
+/// immediately (no `TIME_WAIT`), so in practice gvproxy reclaims it
+/// before anything else does.
+pub fn free_loopback_port() -> io::Result<u16> {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+    // Listener drops here, freeing the port for gvproxy to bind.
+    Ok(port)
 }
 
 /// Owning handle to a running gvproxy child process. `Drop` cleans up
@@ -229,9 +241,10 @@ pub fn spawn(scratch_dir: &Path) -> Result<GvproxyHandle, GvproxyError> {
     //                          (concurrent dev VMs, parallel tests,
     //                          debugging cycles), instance N+1 fails
     //                          to bind 2222 and exits immediately
-    //                          with `address already in use`. Derive
-    //                          a per-VM port from the scratch dir so
-    //                          concurrent instances don't collide.
+    //                          with `address already in use`. Hand it
+    //                          a fresh OS-assigned free port so no two
+    //                          instances — including leaked daemons —
+    //                          collide (see `free_loopback_port`).
     //   -debug               — verbose logging. Not set by default;
     //                          if a future MVM_GVPROXY_DEBUG=1 env
     //                          var trips this we'd flip it here.
@@ -245,7 +258,10 @@ pub fn spawn(scratch_dir: &Path) -> Result<GvproxyHandle, GvproxyError> {
         s.push(socket_path.as_os_str());
         s
     };
-    let ssh_port = ssh_port_for(scratch_dir);
+    let ssh_port = free_loopback_port().map_err(|e| GvproxyError::Io {
+        context: "reserving a free port for gvproxy's ssh-forward listener".to_string(),
+        source: e,
+    })?;
 
     // NEVER inherit the spawner's stdout/stderr. gvproxy is a long-lived
     // daemon; if it holds a write end of the parent's stdout/stderr pipe,
@@ -441,6 +457,20 @@ mod tests {
     #[test]
     fn locate_gvproxy_is_optional() {
         let _ = locate_gvproxy();
+    }
+
+    /// A reserved port is in gvproxy's accepted `-ssh-port` range
+    /// (1024..=65535) and is actually free — we can rebind it after
+    /// the reservation drops, which is exactly what gvproxy does.
+    #[test]
+    fn free_loopback_port_is_in_range_and_bindable() {
+        let port = free_loopback_port().expect("reserve a free port");
+        assert!(port >= 1024, "port {port} below gvproxy's 1024 floor");
+        // The reservation listener is already dropped, so this rebind
+        // models gvproxy claiming the port we handed it.
+        let rebound = std::net::TcpListener::bind(("127.0.0.1", port))
+            .expect("reserved port is free to bind");
+        drop(rebound);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`cargo test --workspace` (and live `mvmctl up` / `dev up`) intermittently failed with:

```
gvproxy exiting: cannot add network services: listen tcp 127.0.0.1:NNNNN: bind: address already in use
supervisor failed: supervisor I/O error: spawning gvproxy ...: gvproxy exited before its listener socket appeared
```

gvproxy's `-ssh-port` listener is **mandatory** (can't be disabled — it validates to 1024–65535), and both launch lanes derived the port **deterministically from the per-VM scratch dir**. Scratch dirs are reused (named VMs, the dev VM, re-runs), and libkrun's `krun_start_enter` calls `exit()` on guest shutdown — skipping `GvproxyHandle::Drop` — so gvproxy daemons leak and keep holding their port. The next run re-derives the *same* port and gvproxy fails to bind.

## Fix

- **`free_loopback_port()`** replaces the deterministic hash in both lanes (`mvm-libkrun::gvproxy`, shared by `mvm-backend::host_gvproxy`): bind `127.0.0.1:0`, read the kernel-assigned port, drop the listener so gvproxy claims it. The OS never assigns a port already in `LISTEN`, so leaked daemons and concurrent VMs can't collide.

## Also: close the leaks by default (don't just work around them)

- Broaden the orphan reaper to scan the **workload tree** (`~/.mvm/vms/`) in addition to the builder cache, with the right sidecars (`libkrun.pid` / `vz.pid` / `gvproxy.pid` / `host-gvproxy.pid`). Workload dirs are **never deleted** — a stopped named VM is persistent state; only leaked helpers are signalled.
- **Kill-only startup sweep** wired into `dev up` / `up`: the next launch reaps the previous run's corpses (an abnormal exit is exactly when mvmctl can't self-clean). Quiet, non-fatal, deletes no bytes. `cache prune --reap-orphans` now covers both roots too.
- The reaper's launchd-parent gate is unchanged, so a **live parallel session's VM is never touched**.

## Tests

- `free_loopback_port_is_in_range_and_bindable` (libkrun), `ssh_port_uses_a_free_os_assigned_port` (Vz lane).
- `workload_root_preserves_dir_with_dead_pid` pins the never-delete-workload-dirs contract; existing reaper tests updated for the new signature.
- Verified end-to-end on a real boot: gvproxy reached `waiting for clients...` with a free port and no bind collision; `cache prune --reap-orphans` reaped the accumulated leaks.

fmt (nightly) + clippy clean; `mvm-cli` lib suite (821) green.