### PR TITLE
Plan 158 — bundled default microVM image (dual dev/prod)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,8 +241,62 @@ jobs:
             staging/runtime-overlay-${{ matrix.arch }}.VERSION
             staging/runtime-overlay-${{ matrix.arch }}-checksums-sha256.txt
 
+  # Plan 158: the bundled default microVM image `mvmctl up`/`exec` boots when
+  # no --flake/--template/--image is given. Ships the PROD variant only
+  # (sealed + verity-sealed rootfs); the dev variant is built locally in dev
+  # mode, never published. `download_default_microvm_image` fetches these five
+  # assets + the checksums.
+  default-microvm:
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+          - arch: x86_64
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build default microVM image (prod variant)
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          SYSTEM="${ARCH}-linux"
+          nix build "./nix/images/default-tenant#packages.${SYSTEM}.default" \
+            --impure --no-link --print-out-paths > /tmp/store-path.txt
+          STORE_PATH=$(head -1 /tmp/store-path.txt)
+          mkdir -p staging
+          cp -L "$STORE_PATH/vmlinux"         "staging/default-microvm-vmlinux-${ARCH}"
+          cp -L "$STORE_PATH/rootfs.ext4"     "staging/default-microvm-rootfs-${ARCH}.ext4"
+          cp -L "$STORE_PATH/rootfs.verity"   "staging/default-microvm-rootfs-${ARCH}.verity"
+          cp -L "$STORE_PATH/rootfs.roothash" "staging/default-microvm-rootfs-${ARCH}.roothash"
+          cp -L "$STORE_PATH/mvm-meta.json"   "staging/default-microvm-meta-${ARCH}.json"
+          cd staging
+          sha256sum "default-microvm-vmlinux-${ARCH}" \
+                    "default-microvm-rootfs-${ARCH}.ext4" \
+                    "default-microvm-rootfs-${ARCH}.verity" \
+                    "default-microvm-rootfs-${ARCH}.roothash" \
+                    "default-microvm-meta-${ARCH}.json" \
+            > "default-microvm-${ARCH}-checksums-sha256.txt"
+
+      - name: Upload default microVM image artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: default-microvm-${{ matrix.arch }}
+          path: |
+            staging/default-microvm-vmlinux-${{ matrix.arch }}
+            staging/default-microvm-rootfs-${{ matrix.arch }}.ext4
+            staging/default-microvm-rootfs-${{ matrix.arch }}.verity
+            staging/default-microvm-rootfs-${{ matrix.arch }}.roothash
+            staging/default-microvm-meta-${{ matrix.arch }}.json
+            staging/default-microvm-${{ matrix.arch }}-checksums-sha256.txt
+
   release:
-    needs: [build, builder-vm-image, runtime-overlay-image]
+    needs: [build, builder-vm-image, runtime-overlay-image, default-microvm]
     # Gate the published release on the mvmctl binary build ONLY. The Nix
     # image jobs still run and their artifacts are attached when present,
     # but an image-build failure must not block the binary download
@@ -353,6 +407,10 @@ jobs:
             artifacts/runtime-overlay-*.roothash
             artifacts/runtime-overlay-*.VERSION
             artifacts/runtime-overlay-*-checksums-sha256.txt
+            artifacts/default-microvm-vmlinux-*
+            artifacts/default-microvm-rootfs-*
+            artifacts/default-microvm-meta-*
+            artifacts/default-microvm-*-checksums-sha256.txt
             sbom.cdx.json
             sbom.cdx.json.bundle
           )

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -3805,37 +3805,159 @@ mod builder_backend_attempt_order_tests {
     }
 }
 
-/// Ensure the bundled default microVM image (kernel + rootfs) is in the cache.
+/// Ensure the bundled default microVM image (kernel + rootfs) is in the cache,
+/// keyed on `BuildMode` (Plan 158). Used by any image-taking command when no
+/// `--flake`/`--template`/`--image` was supplied. Returns `(kernel, rootfs)`;
+/// the verity + `mvm-meta.json` sidecars land alongside the rootfs.
 ///
-/// Used by any image-taking command when no `--flake` or `--manifest` was
-/// supplied. Returns `(kernel_path, rootfs_path)`.
-///
-/// Downloads a pre-built image from the matching GitHub release when
-/// the local cache is empty.
-pub(crate) fn ensure_default_microvm_image() -> Result<(String, String)> {
-    let cache_dir = format!("{}/default-microvm", mvm_core::config::mvm_cache_dir());
-    std::fs::create_dir_all(&cache_dir)?;
+/// - **Prod** downloads the published, verity-sealed prod image (the
+///   `default-microvm-*` release assets), hash-verified.
+/// - **Dev** builds the accessible dev variant locally from the in-repo flake
+///   via the builder VM — dev images are never published.
+pub(crate) fn ensure_default_microvm_image(
+    mode: mvm_build::pipeline::BuildMode,
+) -> Result<(String, String)> {
+    use mvm_build::pipeline::BuildMode;
+    let base = format!("{}/default-microvm", mvm_core::config::mvm_cache_dir());
+    match mode {
+        BuildMode::Prod => {
+            let cache_dir = format!("{base}/prod");
+            std::fs::create_dir_all(&cache_dir)?;
+            let kernel_path = format!("{cache_dir}/vmlinux");
+            let rootfs_path = format!("{cache_dir}/rootfs.ext4");
+            // All five must be present before skipping the download — a cache
+            // that predates Plan 158 has only vmlinux + rootfs.ext4 and would
+            // fail admission (no overlay-aware sidecar, no verity).
+            let required = [
+                kernel_path.clone(),
+                rootfs_path.clone(),
+                format!("{cache_dir}/mvm-meta.json"),
+                format!("{cache_dir}/rootfs.verity"),
+                format!("{cache_dir}/rootfs.roothash"),
+            ];
+            if required.iter().all(|p| std::path::Path::new(p).exists()) {
+                return Ok((kernel_path, rootfs_path));
+            }
+            download_default_microvm_image(&cache_dir, &kernel_path, &rootfs_path)
+        }
+        BuildMode::Dev => ensure_default_microvm_dev_image(&format!("{base}/dev")),
+    }
+}
 
+/// Dev-mode default image: build the accessible `dev` variant locally from the
+/// in-repo `nix/images/default-tenant` flake via the builder VM (not published).
+#[cfg(feature = "builder-vm")]
+fn ensure_default_microvm_dev_image(cache_dir: &str) -> Result<(String, String)> {
+    std::fs::create_dir_all(cache_dir)?;
     let kernel_path = format!("{cache_dir}/vmlinux");
     let rootfs_path = format!("{cache_dir}/rootfs.ext4");
-    // Sidecars the boot path needs as siblings of the rootfs: the dm-verity
-    // Merkle tree + roothash (probed by `microvm.rs::probe_verity_sidecar`)
-    // and the overlay-aware `mvm-meta.json` (read by `admit_overlay_aware`).
-    // All five must be present before we skip the download — a cache that
-    // predates Plan 158 has only vmlinux + rootfs.ext4 and would fail
-    // admission.
-    let required = [
-        kernel_path.clone(),
-        rootfs_path.clone(),
-        format!("{cache_dir}/mvm-meta.json"),
-        format!("{cache_dir}/rootfs.verity"),
-        format!("{cache_dir}/rootfs.roothash"),
-    ];
-    if required.iter().all(|p| std::path::Path::new(p).exists()) {
+    let meta_path = format!("{cache_dir}/mvm-meta.json");
+    if [&kernel_path, &rootfs_path, &meta_path]
+        .iter()
+        .all(|p| std::path::Path::new(p).exists())
+    {
         return Ok((kernel_path, rootfs_path));
     }
+    ui::info("Building the dev default microVM image locally (dev mode)...");
+    build_default_microvm_dev_via_libkrun(cache_dir)
+}
 
-    download_default_microvm_image(&cache_dir, &kernel_path, &rootfs_path)
+#[cfg(not(feature = "builder-vm"))]
+fn ensure_default_microvm_dev_image(_cache_dir: &str) -> Result<(String, String)> {
+    anyhow::bail!(
+        "dev mode builds the default image locally via the builder VM, but this \
+         mvmctl was built without the `builder-vm` feature. Use `--prod` (downloads \
+         the published image), or pass a `--flake`."
+    )
+}
+
+/// Build the bundled **dev** default microVM image via the libkrun builder VM:
+/// `nix build nix/images/default-tenant#packages.<sys>.dev` inside the guest,
+/// extracting `vmlinux` + `rootfs.ext4` + `mvm-meta.json` to `out_dir`. Mirrors
+/// [`build_image_via_libkrun`] but targets the default-tenant flake. Plan 158.
+#[cfg(feature = "builder-vm")]
+fn build_default_microvm_dev_via_libkrun(out_dir: &str) -> Result<(String, String)> {
+    use mvm_build::builder_backend_select::{
+        resolve_builder_backend_with_override, resolve_choice, resolve_env_override,
+    };
+    use mvm_build::builder_vm::{BuilderJob, BuilderMounts, host_system_linux};
+
+    bootstrap_builder_vm_image()
+        .context("Stage 0 builder-VM image bootstrap (precondition for libkrun dispatch)")?;
+
+    // The default-tenant flake reads the workspace via the `/work` mount the
+    // builder VM sets (`MVM_WORKSPACE_PATH=/work`), same as the builder-vm flake.
+    let builder_flake = find_builder_vm_flake().context(
+        "builder-vm flake missing at nix/images/builder-vm/flake.nix; libkrun dispatch needs it",
+    )?;
+    let workspace_root = std::path::Path::new(&builder_flake)
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .ok_or_else(|| anyhow::anyhow!("Cannot derive workspace root from {builder_flake}"))?
+        .to_path_buf();
+
+    let host_bins_cache = format!("{}/host-bins", mvm_core::config::mvm_cache_dir());
+    let host_bin_dir =
+        crate::host_binaries::extract::ensure_extracted(std::path::Path::new(&host_bins_cache))
+            .map_err(|e| anyhow::anyhow!("extract embedded host-vm binaries: {e}"))?;
+
+    std::fs::create_dir_all(out_dir)
+        .with_context(|| format!("creating default-microvm dev out dir {out_dir}"))?;
+
+    let job = BuilderJob::Flake {
+        flake_ref: "path:/work/nix/images/default-tenant".to_string(),
+        attr_path: format!("packages.{}.dev", host_system_linux()),
+    };
+    let mounts = BuilderMounts {
+        flake_src: workspace_root,
+        host_nix_store: None,
+        artifact_out: std::path::PathBuf::from(out_dir),
+        host_bin_dir,
+        staged_user_flake: None,
+    };
+
+    let selected = resolve_choice();
+    let explicit_override = resolve_env_override().is_some();
+    let attempt_order = builder_backend_attempt_order(selected, explicit_override);
+    let mut last_error = None;
+    for (idx, choice) in attempt_order.iter().copied().enumerate() {
+        let backend = resolve_builder_backend_with_override(Some(choice));
+        match backend.run_build(&job, &mounts) {
+            Ok(_) => {
+                last_error = None;
+                break;
+            }
+            Err(err) => {
+                if idx + 1 < attempt_order.len() {
+                    ui::warn(&format!(
+                        "Auto-selected {} builder failed ({}); retrying with {}.",
+                        choice.name(),
+                        err,
+                        attempt_order[idx + 1].name(),
+                    ));
+                }
+                last_error = Some(anyhow::anyhow!("{} builder VM: {err}", choice.name()));
+            }
+        }
+    }
+    if let Some(err) = last_error {
+        return Err(err);
+    }
+
+    let kernel = format!("{out_dir}/vmlinux");
+    let rootfs = format!("{out_dir}/rootfs.ext4");
+    let meta = format!("{out_dir}/mvm-meta.json");
+    for (label, p) in [
+        ("vmlinux", &kernel),
+        ("rootfs.ext4", &rootfs),
+        ("mvm-meta.json", &meta),
+    ] {
+        if !std::path::Path::new(p).exists() {
+            anyhow::bail!("builder VM exited cleanly but did not produce {label} at {p}");
+        }
+    }
+    Ok((kernel, rootfs))
 }
 
 /// The (release asset name, local destination) contract for the prod default

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -3818,18 +3818,98 @@ pub(crate) fn ensure_default_microvm_image() -> Result<(String, String)> {
 
     let kernel_path = format!("{cache_dir}/vmlinux");
     let rootfs_path = format!("{cache_dir}/rootfs.ext4");
-
-    if std::path::Path::new(&kernel_path).exists() && std::path::Path::new(&rootfs_path).exists() {
+    // Sidecars the boot path needs as siblings of the rootfs: the dm-verity
+    // Merkle tree + roothash (probed by `microvm.rs::probe_verity_sidecar`)
+    // and the overlay-aware `mvm-meta.json` (read by `admit_overlay_aware`).
+    // All five must be present before we skip the download — a cache that
+    // predates Plan 158 has only vmlinux + rootfs.ext4 and would fail
+    // admission.
+    let required = [
+        kernel_path.clone(),
+        rootfs_path.clone(),
+        format!("{cache_dir}/mvm-meta.json"),
+        format!("{cache_dir}/rootfs.verity"),
+        format!("{cache_dir}/rootfs.roothash"),
+    ];
+    if required.iter().all(|p| std::path::Path::new(p).exists()) {
         return Ok((kernel_path, rootfs_path));
     }
 
-    download_default_microvm_image(&kernel_path, &rootfs_path)
+    download_default_microvm_image(&cache_dir, &kernel_path, &rootfs_path)
 }
 
-/// Download a pre-built default microVM image (kernel + rootfs) from the
-/// matching GitHub release. Mirrors `download_dev_image`, including the
-/// ADR-002 §W5.1 hash-verify path.
+/// The (release asset name, local destination) contract for the prod default
+/// microVM image. Release names match the `default-microvm` job in
+/// `release.yml`; local names are the rootfs siblings the backend verity probe
+/// (`microvm.rs::probe_verity_sidecar`) and `admit_overlay_aware` expect. Pure
+/// — pinned by `default_microvm_assets_pins_the_five_asset_contract`.
+fn default_microvm_assets(cache_dir: &str, arch: &str) -> [(String, String); 5] {
+    [
+        (
+            format!("default-microvm-vmlinux-{arch}"),
+            format!("{cache_dir}/vmlinux"),
+        ),
+        (
+            format!("default-microvm-rootfs-{arch}.ext4"),
+            format!("{cache_dir}/rootfs.ext4"),
+        ),
+        (
+            format!("default-microvm-rootfs-{arch}.verity"),
+            format!("{cache_dir}/rootfs.verity"),
+        ),
+        (
+            format!("default-microvm-rootfs-{arch}.roothash"),
+            format!("{cache_dir}/rootfs.roothash"),
+        ),
+        (
+            format!("default-microvm-meta-{arch}.json"),
+            format!("{cache_dir}/mvm-meta.json"),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod default_microvm_tests {
+    use super::default_microvm_assets;
+
+    #[test]
+    fn default_microvm_assets_pins_the_five_asset_contract() {
+        let a = default_microvm_assets("/cache/dm", "aarch64");
+        let names: Vec<&str> = a.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "default-microvm-vmlinux-aarch64",
+                "default-microvm-rootfs-aarch64.ext4",
+                "default-microvm-rootfs-aarch64.verity",
+                "default-microvm-rootfs-aarch64.roothash",
+                "default-microvm-meta-aarch64.json",
+            ],
+            "release asset names must match the default-microvm release job",
+        );
+        let dests: Vec<&str> = a.iter().map(|(_, d)| d.as_str()).collect();
+        assert_eq!(
+            dests,
+            vec![
+                "/cache/dm/vmlinux",
+                "/cache/dm/rootfs.ext4",
+                "/cache/dm/rootfs.verity",
+                "/cache/dm/rootfs.roothash",
+                "/cache/dm/mvm-meta.json",
+            ],
+            "local dests must be the rootfs siblings the backend + admit gate expect",
+        );
+    }
+}
+
+/// Download the pre-built **prod** default microVM image from the matching
+/// GitHub release: kernel + verity-sealed rootfs + the `rootfs.verity` /
+/// `rootfs.roothash` sidecars + the overlay-aware `mvm-meta.json`. Every file
+/// is SHA-256-verified against the release checksums manifest (ADR-002 §W5.1).
+/// The sidecars land alongside the rootfs so the backend verity probe +
+/// `admit_overlay_aware` resolve them by path convention. Plan 158.
 fn download_default_microvm_image(
+    cache_dir: &str,
     kernel_path: &str,
     rootfs_path: &str,
 ) -> Result<(String, String)> {
@@ -3840,36 +3920,24 @@ fn download_default_microvm_image(
     } else {
         "x86_64"
     };
-    let kernel_name = format!("default-microvm-vmlinux-{arch}");
-    let rootfs_name = format!("default-microvm-rootfs-{arch}.ext4");
+
+    let assets = default_microvm_assets(cache_dir, arch);
     let checksums_name = format!("default-microvm-{arch}-checksums-sha256.txt");
-    let kernel_url = format!("{base_url}/{kernel_name}");
-    let rootfs_url = format!("{base_url}/{rootfs_name}");
     let checksums_url = format!("{base_url}/{checksums_name}");
 
     ui::info(&format!(
         "Downloading default microVM image (v{version})..."
     ));
 
-    let expected = fetch_expected_hashes(&checksums_url, &[&kernel_name, &rootfs_name])?;
+    let asset_names: Vec<&str> = assets.iter().map(|(n, _)| n.as_str()).collect();
+    let expected = fetch_expected_hashes(&checksums_url, &asset_names)?;
 
-    ui::info("  Fetching kernel...");
-    download_file(&kernel_url, kernel_path)
-        .with_context(|| format!("Failed to download kernel from {kernel_url}"))?;
-    verify_artifact_hash(
-        kernel_path,
-        &kernel_name,
-        expected.get(kernel_name.as_str()),
-    )?;
-
-    ui::info("  Fetching rootfs...");
-    download_file(&rootfs_url, rootfs_path)
-        .with_context(|| format!("Failed to download rootfs from {rootfs_url}"))?;
-    verify_artifact_hash(
-        rootfs_path,
-        &rootfs_name,
-        expected.get(rootfs_name.as_str()),
-    )?;
+    for (name, dest) in &assets {
+        ui::info(&format!("  Fetching {name}..."));
+        let url = format!("{base_url}/{name}");
+        download_file(&url, dest).with_context(|| format!("Failed to download {url}"))?;
+        verify_artifact_hash(dest, name, expected.get(name.as_str()))?;
+    }
 
     ui::success("Default microVM image downloaded, hash-verified, and cached.");
     Ok((kernel_path.to_string(), rootfs_path.to_string()))

--- a/crates/mvm-cli/src/commands/ops/bench_probe.rs
+++ b/crates/mvm-cli/src/commands/ops/bench_probe.rs
@@ -30,8 +30,9 @@ pub struct ProbeImage {
 /// target (a `HostDescriptor`-comparable baseline).
 #[allow(dead_code)]
 pub fn resolve_probe_image() -> Result<ProbeImage> {
-    let (kernel, rootfs) =
-        ensure_default_microvm_image().context("resolving default-microvm bench image")?;
+    // Bench baseline boots the published, admitted prod default image.
+    let (kernel, rootfs) = ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Prod)
+        .context("resolving default-microvm bench image")?;
     Ok(ProbeImage { kernel, rootfs })
 }
 

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -470,7 +470,10 @@ fn build_exec_request(
                     auth_source
                 );
             }
-            let (kernel_path, _default_rootfs_path) = ensure_default_microvm_image()?;
+            // `exec` is interactive (dev): a sealed prod image refuses
+            // console/exec, so the default image must be the dev variant.
+            let (kernel_path, _default_rootfs_path) =
+                ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Dev)?;
             crate::exec::ImageSource::Prebuilt {
                 kernel_path,
                 rootfs_path: cached.rootfs_path.display().to_string(),
@@ -480,7 +483,8 @@ fn build_exec_request(
         }
         (None, None) => {
             ui::info("No --manifest specified; using bundled default microVM image.");
-            let (kernel_path, rootfs_path) = ensure_default_microvm_image()?;
+            let (kernel_path, rootfs_path) =
+                ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Dev)?;
             crate::exec::ImageSource::Prebuilt {
                 kernel_path,
                 rootfs_path,

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1540,7 +1540,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 vm_name
             ),
         );
-        let (kernel, rootfs) = ensure_default_microvm_image()?;
+        let (kernel, rootfs) = ensure_default_microvm_image(build_mode)?;
         (
             kernel,
             None,

--- a/nix/images/default-tenant/flake.lock
+++ b/nix/images/default-tenant/flake.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "microvm": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "spectrum": "spectrum"
+      },
+      "locked": {
+        "lastModified": 1778669912,
+        "narHash": "sha256-WT2iimtOBZM/6AcZeBoJU2EgUSaywtlItsEgNkZBda0=",
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "rev": "a7a7009064cec75d9da652c6723412ce27b9bc44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "microvm": "microvm",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "spectrum": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772189877,
+        "narHash": "sha256-i1p90Rgssb//aNiTDFq46ZG/fk3LmyRLChtp/9lddyA=",
+        "ref": "refs/heads/main",
+        "rev": "fe39e122d898f66e89ffa17d4f4209989ccb5358",
+        "revCount": 1255,
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/images/default-tenant/flake.nix
+++ b/nix/images/default-tenant/flake.nix
@@ -1,0 +1,174 @@
+{
+  description =
+    "mvm bundled default microVM image (Plan 158). Two variants: a dev image "
+    + "(accessible, exec-able, unsealed) built locally in dev mode, and a prod "
+    + "image (sealed, rootless, dm-verity-sealed rootfs) shipped as the "
+    + "default-microvm-* release assets. Booted by `mvmctl up`/`exec` when no "
+    + "--flake/--template/--image is given.";
+
+  # DRAFT (Plan 158 Task 1). Authored against the grounded patterns but NOT yet
+  # validated by a `nix build` (the author's host has no nix). A nix/Linux
+  # session must: generate/repair flake.lock, `nix flake check`, and `nix build`
+  # both variants. See specs/plans/158-restore-default-microvm-image.md and the
+  # handoff prompt. Verify-points are marked `# VERIFY:`.
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    microvm = {
+      url = "github:microvm-nix/microvm.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { self, nixpkgs, microvm, ... }:
+    let
+      systems = [ "aarch64-linux" "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      # Same impure workspace-path override the sibling image flakes use.
+      workspaceRoot =
+        let envPath = builtins.getEnv "MVM_WORKSPACE_PATH";
+        in if envPath != "" then /. + envPath else ../../..;
+
+      # Filtered workspace (mirrors builder-vm/runtime-overlay) for mkGuest.
+      workspace =
+        (import (workspaceRoot + "/nix/lib/workspace-filter.nix") {
+          inherit (nixpkgs) lib;
+        })
+        { inherit workspaceRoot; };
+
+      libFor = system:
+        (import (workspace + "/nix/lib") {
+          inherit nixpkgs microvm;
+          mvmSrc = workspace;
+        }) { inherit system; };
+
+      # Workload kernel base — built-in DM_VERITY (no module tree), matching
+      # builder-vm's `workload-kernel` (nix/images/builder-vm/flake.nix:480-486).
+      # VERIFY: importing the base through the RAW workspaceRoot (not the
+      # filtered `workspace`) mirrors builder-vm's relative `./kernel/base.nix`
+      # import so `nix flake check --no-build` doesn't force realisation.
+      kernelBaseFor = pkgs:
+        import (workspaceRoot + "/nix/images/builder-vm/kernel/base.nix")
+          { inherit pkgs; };
+      workloadKernelEnables = [ "MD" "BLK_DEV_DM" "DM_VERITY" ];
+      mkWorkloadKernel = pkgs:
+        (kernelBaseFor pkgs).mkKernel { extraEnables = workloadKernelEnables; };
+
+      # Verity determinism — copied verbatim from runtime-overlay
+      # (nix/images/runtime-overlay/flake.nix:180-203). MUST stay in lockstep
+      # with `mvm_build::oci_to_rootfs::verity::VeritysetupOptions::default` and
+      # `mvm-verity-init`'s DATA_BLOCK_SIZE.
+      verityDataBlockSize = 1024;
+      verityHashBlockSize = 4096;
+      veritySalt = "0000000000000000000000000000000000000000000000000000000000000000";
+      verityHashAlgorithm = "sha256";
+      pinnedCryptsetupVersion = "2.8.6";
+      pinnedCryptsetupSrcHash = "sha256-gAQmX9mTiF0I97Yz2+BWhR3hohAwdhOk693HQ/zO/lo=";
+      pinnedCryptsetupFor = pkgs:
+        pkgs.cryptsetup.overrideAttrs (_old: {
+          version = pinnedCryptsetupVersion;
+          src = pkgs.fetchurl {
+            url =
+              "mirror://kernel/linux/utils/cryptsetup/v${pkgs.lib.versions.majorMinor pinnedCryptsetupVersion}/"
+              + "cryptsetup-${pinnedCryptsetupVersion}.tar.xz";
+            hash = pinnedCryptsetupSrcHash;
+          };
+        });
+
+      # Serialize mkGuest's `passthru.mvm` into the GuestSidecar wire shape
+      # (crates/mvm-base/src/runtime_meta.rs, #[serde(rename_all="camelCase")]).
+      sidecarJson = mvm:
+        builtins.toJSON {
+          inherit (mvm)
+            name accessible sealed entrypointKind initSystem
+            expectedBootMs agentBinary rootlessEntrypoint hypervisor overlayAware;
+        };
+
+      # One variant. `sealed = true` → prod (verity-sealed, rootless, no
+      # do_exec); `sealed = false` → dev (accessible, exec-able).
+      mkVariant = { system, sealed }:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          lib = libFor system;
+          kernelPkg = mkWorkloadKernel pkgs;
+          kernelFile = if pkgs.stdenv.hostPlatform.isAarch64 then "Image" else "bzImage";
+          imageName = if sealed then "mvm-default-microvm" else "mvm-default-microvm-dev";
+          rootfsPkg = lib.mkGuest {
+            name = imageName;
+            # command form → sealed/prod; shell form → dev/accessible.
+            entrypoint =
+              if sealed
+              then { command = [ "/bin/sleep" "infinity" ]; }
+              else { shell = "/bin/sh"; };
+            packages = [ pkgs.busybox ];
+            # VERIFY: mkGuest's `kernel` arg drives the in-rootfs module tree.
+            # The workload kernel is module-free (DM_VERITY built-in), so this
+            # may be omittable; pass it for parity with a real workload image.
+            kernel = kernelPkg;
+          };
+          meta = rootfsPkg.passthru.mvm;
+        in
+        pkgs.runCommand imageName
+          {
+            nativeBuildInputs = [ pkgs.e2fsprogs (pinnedCryptsetupFor pkgs) pkgs.coreutils ];
+            passthru = { inherit rootfsPkg meta; kernel = kernelPkg; };
+          }
+          (''
+            set -euo pipefail
+            mkdir -p $out
+
+            # Kernel → vmlinux (same probe order as builder-vm).
+            if   [ -f ${kernelPkg}/${kernelFile} ]; then cp ${kernelPkg}/${kernelFile} $out/vmlinux
+            elif [ -f ${kernelPkg}/Image ];        then cp ${kernelPkg}/Image        $out/vmlinux
+            elif [ -f ${kernelPkg}/bzImage ];      then cp ${kernelPkg}/bzImage      $out/vmlinux
+            else echo "kernel ${kernelPkg} produced no Image/bzImage" >&2; ls -la ${kernelPkg} >&2; exit 1
+            fi
+
+            # Rootfs → rootfs.ext4 (mkGuest emits a single ext4).
+            if [ -f ${rootfsPkg} ]; then
+              cp ${rootfsPkg} $out/rootfs.ext4
+            else
+              img=$(find ${rootfsPkg} -maxdepth 1 \( -name '*.img' -o -name '*.ext4' \) | head -1)
+              [ -n "$img" ] || { echo "mkGuest output ${rootfsPkg} has no .img/.ext4" >&2; ls -la ${rootfsPkg} >&2; exit 1; }
+              cp "$img" $out/rootfs.ext4
+            fi
+
+            # Overlay-aware sidecar so `admit_overlay_aware` passes.
+            cat > $out/mvm-meta.json <<'META'
+            ${sidecarJson meta}
+            META
+
+            chmod 0644 $out/vmlinux $out/rootfs.ext4 $out/mvm-meta.json
+          ''
+          + nixpkgs.lib.optionalString sealed ''
+
+            # dm-verity seal (prod only) — runtime-overlay recipe verbatim.
+            touch $out/rootfs.verity
+            veritysetup_out=$(
+              veritysetup format \
+                --data-block-size=${toString verityDataBlockSize} \
+                --hash-block-size=${toString verityHashBlockSize} \
+                --salt=${veritySalt} \
+                --hash=${verityHashAlgorithm} \
+                $out/rootfs.ext4 \
+                $out/rootfs.verity
+            )
+            echo "$veritysetup_out" \
+              | grep -i '^Root hash:' \
+              | sed 's/^[Rr]oot [Hh]ash:[[:space:]]*//' \
+              | tr 'A-F' 'a-f' \
+              > $out/rootfs.roothash
+            chmod 0644 $out/rootfs.verity $out/rootfs.roothash
+          '');
+
+    in
+    {
+      packages = forAllSystems (system: {
+        # `default` = prod (the variant the release job ships).
+        default = mkVariant { inherit system; sealed = true; };
+        prod = mkVariant { inherit system; sealed = true; };
+        dev = mkVariant { inherit system; sealed = false; };
+      });
+    };
+}

--- a/nix/images/default-tenant/flake.nix
+++ b/nix/images/default-tenant/flake.nix
@@ -109,7 +109,12 @@
         pkgs.runCommand imageName
           {
             nativeBuildInputs = [ pkgs.e2fsprogs (pinnedCryptsetupFor pkgs) pkgs.coreutils ];
-            passthru = { inherit rootfsPkg meta; kernel = kernelPkg; };
+            # Expose the inner mkGuest rootfs as `passthru.rootfs` (the
+            # convention builder-vm uses): the builder VM's nix-build cmd.sh
+            # emits mvm-meta.json by eval'ing `<attr>.passthru.rootfs.passthru.mvm`
+            # for runCommand-wrapped images (builder_vm_runtime.rs). Without
+            # this the dev-build path would produce an image admission refuses.
+            passthru = { rootfs = rootfsPkg; kernel = kernelPkg; };
           }
           (''
             set -euo pipefail

--- a/nix/images/default-tenant/flake.nix
+++ b/nix/images/default-tenant/flake.nix
@@ -1,16 +1,13 @@
 {
-  description =
-    "mvm bundled default microVM image (Plan 158). Two variants: a dev image "
-    + "(accessible, exec-able, unsealed) built locally in dev mode, and a prod "
-    + "image (sealed, rootless, dm-verity-sealed rootfs) shipped as the "
-    + "default-microvm-* release assets. Booted by `mvmctl up`/`exec` when no "
-    + "--flake/--template/--image is given.";
+  description = "mvm bundled default microVM image (Plan 158) — dev + prod (verity-sealed) variants";
 
-  # DRAFT (Plan 158 Task 1). Authored against the grounded patterns but NOT yet
-  # validated by a `nix build` (the author's host has no nix). A nix/Linux
-  # session must: generate/repair flake.lock, `nix flake check`, and `nix build`
-  # both variants. See specs/plans/158-restore-default-microvm-image.md and the
-  # handoff prompt. Verify-points are marked `# VERIFY:`.
+  # Plan 158 Task 1. Both variants (`default`/`prod`, `dev`) eval-validated via
+  # nix-in-docker on the authoring host (eval covers the `*-linux` derivations
+  # cross-platform — imports, the mkGuest call, passthru.mvm/toJSON, the verity
+  # recipe attrs). A full `nix build` (kernel compile + rootfs + veritysetup)
+  # validates the runtime; it runs in the release/security Nix lanes. Remaining
+  # build-time checks are marked `# VERIFY:`. See
+  # specs/plans/158-restore-default-microvm-image.md.
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     microvm = {

--- a/nix/images/default-tenant/flake.nix
+++ b/nix/images/default-tenant/flake.nix
@@ -1,13 +1,14 @@
 {
   description = "mvm bundled default microVM image (Plan 158) — dev + prod (verity-sealed) variants";
 
-  # Plan 158 Task 1. Both variants (`default`/`prod`, `dev`) eval-validated via
-  # nix-in-docker on the authoring host (eval covers the `*-linux` derivations
-  # cross-platform — imports, the mkGuest call, passthru.mvm/toJSON, the verity
-  # recipe attrs). A full `nix build` (kernel compile + rootfs + veritysetup)
-  # validates the runtime; it runs in the release/security Nix lanes. Remaining
-  # build-time checks are marked `# VERIFY:`. See
-  # specs/plans/158-restore-default-microvm-image.md.
+  # Plan 158 Task 1. Both variants build-validated (aarch64-linux) via
+  # nix-in-docker on the authoring host: `default`/`prod` emits
+  # {vmlinux, rootfs.ext4, rootfs.verity, rootfs.roothash, mvm-meta.json} with a
+  # valid 64-hex verity roothash and a `sealed:true, accessible:false,
+  # overlayAware:true, rootlessEntrypoint:true` sidecar; `dev` emits
+  # {vmlinux, rootfs.ext4, mvm-meta.json} with `sealed:false, accessible:true`.
+  # The x86_64-linux build + the actual VM boot run in CI / on a runtime host.
+  # See specs/plans/158-restore-default-microvm-image.md.
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     microvm = {
@@ -42,9 +43,8 @@
 
       # Workload kernel base — built-in DM_VERITY (no module tree), matching
       # builder-vm's `workload-kernel` (nix/images/builder-vm/flake.nix:480-486).
-      # VERIFY: importing the base through the RAW workspaceRoot (not the
-      # filtered `workspace`) mirrors builder-vm's relative `./kernel/base.nix`
-      # import so `nix flake check --no-build` doesn't force realisation.
+      # Imports the base through the raw workspaceRoot (not the filtered
+      # `workspace`), mirroring builder-vm's relative `./kernel/base.nix` import.
       kernelBaseFor = pkgs:
         import (workspaceRoot + "/nix/images/builder-vm/kernel/base.nix")
           { inherit pkgs; };
@@ -99,9 +99,9 @@
               then { command = [ "/bin/sleep" "infinity" ]; }
               else { shell = "/bin/sh"; };
             packages = [ pkgs.busybox ];
-            # VERIFY: mkGuest's `kernel` arg drives the in-rootfs module tree.
-            # The workload kernel is module-free (DM_VERITY built-in), so this
-            # may be omittable; pass it for parity with a real workload image.
+            # mkGuest's `kernel` arg supplies the in-rootfs module tree; the
+            # workload kernel is module-free (DM_VERITY built-in), passed for
+            # parity with a real workload image.
             kernel = kernelPkg;
           };
           meta = rootfsPkg.passthru.mvm;

--- a/specs/plans/158-restore-default-microvm-image.md
+++ b/specs/plans/158-restore-default-microvm-image.md
@@ -6,7 +6,34 @@
 
 ## Goal
 
-Restore the bundled **default production microVM image** so that `mvmctl up` / `mvmctl run` / `mvmctl exec` with **no** `--flake` / `--template` / `--image` boots a real, admittable, verity-sealed image — and so claim 3's CI witness has a representative bundled prod image again. The standalone image flake (`nix/images/default-tenant`) was removed during the Plan 115 image consolidation; the host still tries to download + boot it.
+Restore the bundled **default microVM image** so that `mvmctl up` / `mvmctl run` /
+`mvmctl exec` with **no** `--flake` / `--template` / `--image` boots a real,
+admittable image. The standalone flake (`nix/images/default-tenant`) was removed
+in the Plan 115 consolidation; the host still tries to download + boot it.
+
+**Dual image, keyed on `BuildMode` (decided 2026-06-04).** The flake produces
+**two** variants, matching mvm's existing dev/prod tiers (`mvm_build::pipeline::
+BuildMode`, `--dev`/`--prod`, default `--prod` — `up.rs:781`):
+
+| Variant | `mkGuest` form | Tier | Verity | `exec`/console | Distribution |
+|---|---|---|---|---|---|
+| **dev** | `entrypoint.shell` (`isDev`) | dev | no (ADR-002 dev-VM exemption) | **yes** (agent ships `do_exec`, entrypoint uid 0) | built **locally** in dev mode; not shipped |
+| **prod** | `entrypoint.command` (sealed) | prod | **yes** (rootfs.verity + roothash) | no | **shipped** as the `default-microvm-*` release assets |
+
+Rationale: a single image can't be both interactive *and* sealed (sealed refuses
+`exec`/console by design). The dev variant is the interactive scratch default; the
+prod variant is the hardened image that ships for hosting. This is the documented
+dev/prod split, not a new posture.
+
+**Security posture (verified against `mk-guest.nix` + ADR-002).** The microVM
+isolation boundary (hypervisor, seccomp-jailed VMM, no host-fs beyond shares,
+default-deny egress, proxy 0700 + port allowlist) holds identically for **both**
+variants — the host is protected either way. The **dev** variant relaxes
+*in-guest* defense-in-depth only: entrypoint uid 0 (`defaultEntrypointUid = if
+isDev then 0 else 1000`), `do_exec` compiled in (`withDevShell = isDev`), no
+rootfs verity — exactly the dev tier ADR-002 §"Verified boot is mandatory for
+production microVMs" explicitly exempts. **Untrusted/production workloads must run
+in the prod variant (or a sealed user flake), never the dev default.**
 
 ## Why it's currently broken (grounded findings)
 
@@ -57,76 +84,97 @@ Restore the bundled **default production microVM image** so that `mvmctl up` / `
 
 ## Design decisions (recommendations)
 
-**D1 — Image build: a new `nix/images/default-tenant/` flake calling current
-`mkGuest`.** Recommended. The historical flake (`nix/default-microvm/flake.nix`
-at commit `20a789d7`) is stale (input path `../guest-lib` → `../lib`, no explicit
-`entrypoint`). Author fresh against the current API rather than resurrect.
-Entrypoint: a minimal **sealed/prod** default — `entrypoint.command` running a
-busybox shell-less idle/echo so the image is sealed (uid 1000, no `do_exec`).
-This both fixes admission (mkGuest bakes `/mvm/runtime` + emits the overlay-aware
-sidecar metadata) and gives claim 3 a representative prod image.
+**D1 — A new `nix/images/default-tenant/` flake with TWO `mkGuest` variants.**
+Author fresh against the current API (the historical `nix/default-microvm/flake.nix`
+at `20a789d7` is stale — input `../guest-lib`→`../lib`, no explicit entrypoint).
+- `packages.<sys>.dev` — `mkGuest { entrypoint.shell = "/bin/sh"; … }` →
+  accessible, `do_exec`, uid 0. Built locally in dev mode; **not** verity-sealed.
+- `packages.<sys>.default` (= prod) — `mkGuest { entrypoint.command = [ … minimal
+  idle … ]; … }` → sealed, rootless uid 1000, no `do_exec`; **verity-sealed**
+  (D2). This is what ships.
+Both use the **workload kernel** (`builder-vm`'s `workload-kernel` attr, which
+enables `MD BLK_DEV_DM DM_VERITY` — `nix/images/builder-vm/flake.nix:480, 506`)
+and both emit the overlay-aware `mvm-meta.json` (D3) so admission passes.
 
-**D2 — Verity: Option (a), seal inside the Nix build.** Recommended over the
-host-side `seal_with_verity` (test-only, breaks Nix purity, Linux-only) and over
-"overlay-only, don't seal the rootfs" (fails sealed-prod / claim 3). Emit
-`rootfs.verity` + `rootfs.roothash` from the flake by reusing runtime-overlay's
-exact `veritysetup format` recipe (same pinned cryptsetup, block sizes, salt,
-determinism). This keeps verity in the Nix dep graph and matches the shipped
-overlay pattern.
+**D2 — Verity (prod variant only): seal inside the Nix build.** Reuse
+runtime-overlay's exact `veritysetup format` recipe (pinned cryptsetup 2.8.6,
+data-block 1024, hash-block 4096, zero salt, sha256 — `runtime-overlay/flake.nix:
+180-203, 288-312`) over the prod variant's `rootfs.ext4`, emitting `rootfs.verity`
++ `rootfs.roothash`. The dev variant is not sealed (ADR-002 dev-VM exemption). The
+backend probes these siblings + builds the `mvm.roothash=` cmdline host-side
+(`microvm.rs:1589-1632`), so the flake only emits artifacts — no baked cmdline.
 
-**D3 — Sidecar: emit `mvm-meta.json` next to the rootfs from `passthru.mvm`.**
-The flake (or the release job) writes the `GuestSidecar` JSON
-(`overlay_aware: true`, name, sealed, init_system, agent_binary, …) so
-`admit_overlay_aware` passes. Confirm the exact serialization shape against
-`GuestSidecar` (`crates/mvm-build/src/builder_vm.rs:207-245`) and reuse the same
-writer the normal build pipeline uses if one exists (W6.2 emit site — locate
-during Task 1).
+**D3 — Sidecar: emit `mvm-meta.json` via `builtins.toJSON` from `passthru.mvm`.**
+The `GuestSidecar` struct (`crates/mvm-base/src/runtime_meta.rs`, written by
+`GuestSidecar::write_to_dir` / `SIDECAR_FILENAME`; mirror at `builder_vm.rs:207-245`)
+is `#[serde(rename_all="camelCase")]` with fields `name, accessible, sealed,
+entrypointKind, initSystem, expectedBootMs, agentBinary, rootlessEntrypoint,
+hypervisor, overlayAware`. mkGuest's `passthru.mvm` carries all of these, so the
+flake emits the file with `builtins.toJSON` of an attrset using those exact
+camelCase keys — no hand-formatting, guaranteed to parse. Both variants set
+`overlayAware = true`; dev sets `sealed=false/accessible=true`, prod the inverse.
 
-**D4 — Keep the download contract, extend the asset set.** Keep
-`~/.cache/mvm/default-microvm/` + the `default-microvm-*` asset names; add the
-new siblings (`rootfs.verity`, `rootfs.roothash`, `mvm-meta.json`) so the backend
-verity probe + admit gate are satisfied from a pure download.
+**D4 — Resolution keyed on `BuildMode`; only prod ships.**
+`ensure_default_microvm_image()` (`apple_container.rs:3815`) takes the resolved
+`BuildMode`:
+- **Prod** → download the shipped `default-microvm-*` assets (now incl.
+  `rootfs.verity`, `rootfs.roothash`, `mvm-meta.json`) into
+  `~/.cache/mvm/default-microvm/prod/`, SHA-256-verified.
+- **Dev** → build the `dev` variant **locally** from the in-repo flake (source
+  checkout) — dev images are never published (matches the
+  source-checkout-builds-locally invariant); cache at `…/default-microvm/dev/`.
+Callers (`up.rs:1543`, `exec.rs`, `bench_probe.rs`) pass the mode they already
+resolve (`BuildMode`, default Prod — `up.rs:781`).
 
 **D5 — Leave the security.yml lanes on the runtime overlay (Plan-568 state).**
-Once this image exists, the `verified-boot-artifacts` lane *could* point back at
-it, but the overlay witness already exercises the identical seal; revisit only if
-we want the bundled-image rootfs specifically witnessed. Out of scope here.
+Once the prod variant exists, `verified-boot-artifacts` *could* witness it too,
+but the overlay already exercises the identical seal; out of scope here.
 
 ## Workstreams
 
-### Task 1 — Author `nix/images/default-tenant/flake.nix`
-- [ ] Locate the W6.2 `mvm-meta.json` emit site (grep `GuestSidecar` writer /
-      `mvm-meta.json` in `crates/mvm-build`) and the runtime-overlay verity
-      recipe (`nix/images/runtime-overlay/flake.nix:288-312`).
-- [ ] Write the flake: `mkGuest { name = "mvm-default-microvm"; entrypoint.command
-      = [ … minimal sealed idle … ]; packages = [ pkgs.busybox ]; }`, then a
-      `veritysetup format` derivation phase (mirroring runtime-overlay) producing
-      `$out/{vmlinux, rootfs.ext4, rootfs.verity, rootfs.roothash, mvm-meta.json}`.
-      `mvm-meta.json` serialized from `passthru.mvm` with `overlay_aware = true`.
-- [ ] `nix flake lock` committed (`flake.lock`).
-- [ ] Add an eval smoke test under `nix/tests/` (mirror `nix/tests/mk-guest-eval.nix`)
-      asserting the package evaluates and the sidecar carries `overlay_aware: true`.
-- [ ] **Cannot be built on a macOS dev host** — validated by CI (the
+### Task 1 — Author `nix/images/default-tenant/flake.nix` (two variants)
+- [ ] `packages.<sys>.dev` = `mkGuest { name = "mvm-default-microvm-dev";
+      entrypoint.shell = "/bin/sh"; packages = [ pkgs.busybox ]; kernel = <workload>; }`
+      → assemble `$out/{vmlinux, rootfs.ext4, mvm-meta.json}` (no verity).
+- [ ] `packages.<sys>.default` (prod) = `mkGuest { name = "mvm-default-microvm";
+      entrypoint.command = [ "/bin/sleep" "infinity" ]; packages = [ pkgs.busybox ];
+      kernel = <workload>; }` → assemble `$out/{vmlinux, rootfs.ext4, rootfs.verity,
+      rootfs.roothash, mvm-meta.json}`, sealing the rootfs with the runtime-overlay
+      `veritysetup format` recipe (D2).
+- [ ] Source the **workload kernel** (`workload-kernel` attr — `builder-vm/flake.nix:
+      480-506`): either add `builder-vm` as a flake input and use its output, or
+      replicate `mkWorkloadKernel` (`extraEnables = ["MD" "BLK_DEV_DM" "DM_VERITY"]`).
+      Decide during impl; prefer the flake-input form to avoid recipe drift.
+- [ ] `mvm-meta.json` via `builtins.toJSON` of `passthru.mvm` (D3).
+- [ ] **`flake.lock` must be generated in a nix env** (cannot be produced on a
+      macOS host) — seed from a sibling flake's lock if inputs match, else
+      `nix flake lock` in CI/Linux.
+- [ ] Eval smoke test under `nix/tests/` (mirror `nix/tests/mk-guest-eval.nix`):
+      both variants evaluate; dev sidecar `sealed:false`, prod `sealed:true`, both
+      `overlayAware:true`.
+- [ ] **Cannot be built/locked on a macOS dev host** — validated by CI (the
       `Nix flake check (Linux eval)` lane + the release/security `nix build` lanes).
 
-### Task 2 — Re-add the `default-microvm` release job
+### Task 2 — Re-add the `default-microvm` release job (PROD variant only)
 - [ ] In `.github/workflows/release.yml`, re-add a `default-microvm` matrix job
       (aarch64 + x86_64) that `nix build ./nix/images/default-tenant#…default`
-      and uploads `default-microvm-{vmlinux,rootfs.ext4,rootfs.verity,
-      rootfs.roothash,mvm-meta.json}-<arch>` + `default-microvm-<arch>-checksums-sha256.txt`.
-- [ ] Add `default-microvm` back to the `release` job `needs:` and the nullglob
-      asset list (the slots PR #567 removed). It stays best-effort under the
-      #566 `if: !cancelled() && needs.build.result == 'success'` gate — an
-      image failure still won't block the binary download.
+      (the **prod** variant) and uploads `default-microvm-{vmlinux,rootfs.ext4,
+      rootfs.verity,rootfs.roothash,mvm-meta.json}-<arch>` +
+      `default-microvm-<arch>-checksums-sha256.txt`. The dev variant is **not**
+      shipped.
+- [ ] Add `default-microvm` back to the `release` job `needs:` + the nullglob
+      asset list (the slots PR #567 removed). Best-effort under the #566
+      `if: !cancelled() && needs.build.result=='success'` gate.
 
-### Task 3 — Extend `download_default_microvm_image`
-- [ ] In `crates/mvm-cli/src/commands/env/apple_container.rs:3832`, fetch the new
-      siblings (`rootfs.verity`, `rootfs.roothash`, `mvm-meta.json`) into
-      `~/.cache/mvm/default-microvm/` alongside `vmlinux` + `rootfs.ext4`, and
-      extend SHA-256 verification to cover them (same checksums manifest).
-- [ ] `ensure_default_microvm_image()` (`:3815`) returns the dir; confirm the
-      backend's verity probe (`microvm.rs:1589`) and `admit_overlay_aware`
-      (`builder_vm.rs:850`) both resolve their files from that dir layout.
+### Task 3 — Make `ensure_default_microvm_image` `BuildMode`-aware
+- [ ] In `crates/mvm-cli/src/commands/env/apple_container.rs:3815`, take the
+      resolved `BuildMode`. **Prod:** `download_default_microvm_image` fetches the
+      five prod assets into `…/default-microvm/prod/`, extending SHA-256
+      verification to all five. **Dev:** build the `dev` variant locally from the
+      in-repo flake into `…/default-microvm/dev/` (no download).
+- [ ] Thread the mode from callers (`up.rs:1543`, `exec.rs`, `bench_probe.rs`).
+- [ ] Confirm the prod dir layout satisfies the backend verity probe
+      (`microvm.rs:1589`) and `admit_overlay_aware` (`builder_vm.rs:850`).
 
 ### Task 4 — Tests
 - [ ] Rust unit test: `download_default_microvm_image` places all five files +


### PR DESCRIPTION
Full Plan 158 feature stack. **Draft** — the flake (Task 1) still needs a nix/Linux session to validate (see below). Supersedes the plan-only #574.

## What's in here

- **Plan 158** refined to the dual dev/prod design (keyed on `BuildMode`).
- **Task 1 (flake) — DRAFT, unvalidated:** `nix/images/default-tenant/flake.nix` with `dev` (accessible) + `default`/`prod` (sealed + in-Nix dm-verity) variants, workload kernel, `mvm-meta.json` via `builtins.toJSON`. `flake.lock` seeded from builder-vm. **Needs a nix env to flake-check + build + repair the `# VERIFY:` points.**
- **Task 2 (release):** re-added the `default-microvm` job (prod variant only) → uploads the 5 assets + checksums; added to `release.needs` + the nullglob asset list.
- **Task 3 (prod download):** `download_default_microvm_image` now fetches the full 5-asset contract (vmlinux + rootfs.ext4 + rootfs.verity + rootfs.roothash + mvm-meta.json), each SHA-256-verified, landing as rootfs siblings so the backend verity probe + `admit_overlay_aware` resolve them. `ensure_default_microvm_image` requires all five before skipping.
- **Task 4 (test):** `default_microvm_assets` pure helper pins the release-name ↔ local-sibling contract (unit-tested). ✅ passes; clippy clean (default + `builder-vm`); fmt clean.

## Remaining

1. **Validate the flake** (Task 1) in a nix/Linux env — `nix flake check` + `nix build` both variants on both arches; repair the lock + VERIFY points. The host-side wiring is complete against the asset contract.
2. **Task 3b — dev-mode-local-build:** make `ensure_default_microvm_image` `BuildMode`-aware so dev mode builds the `dev` variant locally instead of downloading the prod image. (Bigger mechanism — builder-VM nix build of the in-repo dev variant.)

Must NOT merge until the flake is validated — the release job builds it.