### PR TITLE
docs(specs): Plan 143 deferred follow-up — widen Landlock envelope to host-side helpers

### DIFF
--- a/specs/plans/143-in-guest-syscall-and-path-hardening.md
+++ b/specs/plans/143-in-guest-syscall-and-path-hardening.md
@@ -158,6 +158,18 @@ positioning goes in §Threat model).
 | Network firewall / pledge-style categories | **Already convergent** — default-deny egress + mandatory-deny ranges (`crates/mvm-core/src/policy/network_policy.rs:466`) + tiered seccomp categories. |
 | `--bounding-set=-all` cap drop | **Verify, not learn** — documented (`crates/mvm-guest/src/fs_rpc.rs:12`) but not visible in the `setpriv` call (`nix/lib/mk-guest.nix:193`); confirm it's actually applied. Independent of the comparison. |
 
+## Deferred follow-up (candidate, not yet scoped)
+
+- [ ] **Widen the per-process Landlock + seccomp envelope to host-side helpers.**
+  Distinct from the rejected "Landlock for workloads" row above: today
+  `crates/mvm-jailer-lite/` confines only the Firecracker bridge sidecar
+  (`src/landlock.rs` ABI v2 + `src/seccomp.rs` `BRIDGE_SYSCALLS`). The host-side
+  egress proxy (`crates/mvm-egress-proxy/src/proxy.rs`) parses guest-supplied
+  CONNECT bytes with no Landlock; the supervisor is similarly unconfined. Assess
+  reusing `mvm-jailer-lite` as a library (path-set + syscall-set inputs) to wrap
+  those processes. Lowest-ROI item from the comparison — promote only if there's
+  appetite; Linux/Firecracker-tier only (macOS helpers differ).
+
 ## Self-review
 
 - Real symbols only: every file:line above was read during research (seccomp


### PR DESCRIPTION
Records the one net-new idea from the in-guest-hardening comparison that wasn't already a Plan 143 Task or a rejected-features row: extending the `mvm-jailer-lite` Landlock+seccomp envelope from the Firecracker bridge sidecar to the host-side egress proxy / supervisor. Marked lowest-ROI, Linux/Firecracker-tier only. Docs-only.