### PR TITLE
Centralize ~/.mvm path management in mvm-core::config + fix dev up / core-demo (#582)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -104,7 +104,9 @@ test-cargo:
 #      gvproxy-orphan hang.
 e2e-core-demo:
     cargo build --bin mvmctl
-    cargo build -p mvm-libkrun-supervisor --features libkrun-sys
+    # Plan 121 D2 folded the supervisor bin into mvm-vm-host; build the
+    # cfg-gated [[bin]] by crate + bin name (it is no longer its own crate).
+    cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys
     MVM_E2E_SMOKE=1 MVM_BUILDER_BACKEND=libkrun cargo test -p mvm-cli --test core_demo_e2e -- --nocapture
 
 # ── Lint & Format ────────────────────────────────────────────────────────

--- a/crates/mvm-backend/src/apple_container.rs
+++ b/crates/mvm-backend/src/apple_container.rs
@@ -283,21 +283,7 @@ impl VmBackend for AppleContainerBackend {
 /// lives here. Each running Apple Container VM owns its own copy so VZ
 /// can attach it writable without conflicting with sibling instances.
 fn instance_rootfs_path(vm_name: &str) -> Result<std::path::PathBuf> {
-    let home = std::env::var("HOME").unwrap_or_default();
-    if home.is_empty() {
-        anyhow::bail!("HOME is not set; cannot resolve instance rootfs path");
-    }
-    Ok(instance_rootfs_path_at(
-        std::path::Path::new(&home),
-        vm_name,
-    ))
-}
-
-fn instance_rootfs_path_at(base: &std::path::Path, vm_name: &str) -> std::path::PathBuf {
-    base.join(".mvm")
-        .join("vms")
-        .join(vm_name)
-        .join("rootfs.ext4")
+    Ok(mvm_core::config::vm_state_dir(vm_name).join("rootfs.ext4"))
 }
 
 /// Materialize the per-instance rootfs for an Apple Container VM and
@@ -345,8 +331,7 @@ fn prepare_instance_rootfs_inner(
 
 /// Read persisted port mappings from the VM state directory.
 fn read_vm_ports(vm_name: &str) -> Vec<mvm_core::vm_backend::VmPortMapping> {
-    let home = std::env::var("HOME").unwrap_or_default();
-    let path = format!("{home}/.mvm/vms/{vm_name}/ports");
+    let path = mvm_core::config::vm_state_dir(vm_name).join("ports");
     let Ok(content) = std::fs::read_to_string(&path) else {
         return Vec::new();
     };
@@ -395,12 +380,26 @@ mod tests {
     }
 
     #[test]
-    fn instance_rootfs_path_at_layout() {
-        let p = instance_rootfs_path_at(std::path::Path::new("/var/home/user"), "vm-1");
+    fn instance_rootfs_path_layout_honors_data_dir() {
+        // MVM_DATA_DIR is process-global; HOME_TEST_LOCK serializes us with
+        // every other test that mutates env-derived path roots.
+        let _guard = crate::base::runtime_meta::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let saved = std::env::var_os("MVM_DATA_DIR");
+        // SAFETY: guarded by HOME_TEST_LOCK.
+        unsafe { std::env::set_var("MVM_DATA_DIR", "/var/home/user/.mvm") };
+        let p = instance_rootfs_path("vm-1").expect("resolve rootfs path");
         assert_eq!(
             p,
             std::path::PathBuf::from("/var/home/user/.mvm/vms/vm-1/rootfs.ext4")
         );
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("MVM_DATA_DIR", v),
+                None => std::env::remove_var("MVM_DATA_DIR"),
+            }
+        }
     }
 
     #[test]

--- a/crates/mvm-backend/src/base/runtime_meta.rs
+++ b/crates/mvm-backend/src/base/runtime_meta.rs
@@ -86,19 +86,8 @@ impl From<StartModeKind> for StartMode {
     }
 }
 
-#[cfg(unix)]
-fn home_dir() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(PathBuf::from)
-}
-
-#[cfg(not(unix))]
-fn home_dir() -> Option<PathBuf> {
-    std::env::var_os("USERPROFILE").map(PathBuf::from)
-}
-
 fn meta_path(name: &str) -> Result<PathBuf> {
-    let home = home_dir().context("$HOME unset; cannot locate ~/.mvm/vms/<name>/mode.json")?;
-    Ok(home.join(".mvm").join("vms").join(name).join("mode.json"))
+    Ok(mvm_core::config::vm_state_dir(name).join("mode.json"))
 }
 
 /// Write the metadata file.
@@ -209,15 +198,25 @@ mod tests {
         let _guard = HOME_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().expect("tempdir");
         let prev = std::env::var_os("HOME");
-        // SAFETY: tests only; HOME is process-global but the
-        // HOME_TEST_LOCK serializes us with everything else that
-        // reads it.
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        // `meta_path` resolves via `vm_state_dir`, which prefers MVM_DATA_DIR
+        // over $HOME — clear it so these $HOME-rooted assertions hold even if
+        // a sibling test (under the same lock) leaked the override.
+        let prev_data = std::env::var_os("MVM_DATA_DIR");
+        // SAFETY: tests only; HOME/MVM_DATA_DIR are process-global but the
+        // HOME_TEST_LOCK serializes us with everything else that reads them.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::remove_var("MVM_DATA_DIR");
+        }
         f(tmp.path());
         unsafe {
             match prev {
                 Some(v) => std::env::set_var("HOME", v),
                 None => std::env::remove_var("HOME"),
+            }
+            match prev_data {
+                Some(v) => std::env::set_var("MVM_DATA_DIR", v),
+                None => std::env::remove_var("MVM_DATA_DIR"),
             }
         }
     }

--- a/crates/mvm-backend/src/docker.rs
+++ b/crates/mvm-backend/src/docker.rs
@@ -172,11 +172,10 @@ impl VmBackend for DockerBackend {
 
         // Config files — write to temp dir and mount
         if !config.config_files.is_empty() {
-            let config_dir = format!(
-                "{}/.mvm/vms/{}/config",
-                std::env::var("HOME").unwrap_or_default(),
-                config.name
-            );
+            let config_dir = mvm_core::config::vm_state_dir(&config.name)
+                .join("config")
+                .to_string_lossy()
+                .into_owned();
             std::fs::create_dir_all(&config_dir)?;
             for f in &config.config_files {
                 std::fs::write(format!("{}/{}", config_dir, f.name), &f.content)?;
@@ -360,9 +359,12 @@ impl VmBackend for DockerBackend {
     }
 
     fn guest_channel_info(&self, id: &VmId) -> Result<GuestChannelInfo> {
-        let home = std::env::var("HOME").unwrap_or_default();
         Ok(GuestChannelInfo::UnixSocket {
-            path: std::path::PathBuf::from(format!("{home}/.mvm/vms/{}/agent/agent.sock", id.0)),
+            // No dedicated helper for the agent socket; build it on the per-VM
+            // state dir so it honors MVM_DATA_DIR like every other backend.
+            path: mvm_core::config::vm_state_dir(&id.0)
+                .join("agent")
+                .join("agent.sock"),
         })
     }
 

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -43,6 +43,12 @@ pub struct LibkrunBackend;
 /// How long [`LibkrunBackend::start`] waits for the supervisor to
 /// write its PID file before giving up and killing the child.
 const PID_FILE_TIMEOUT: Duration = Duration::from_secs(5);
+/// After the PID file appears the supervisor still has to bind the
+/// per-port vsock listener socket; callers (the console attach,
+/// `shell_exec` via `connect_with_auto_start`) race that window and
+/// wrongly see the VM as "not running" (#582). `start` waits for the
+/// agent socket before returning so "ready" actually means reachable.
+const VSOCK_SOCKET_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// How long [`LibkrunBackend::stop`] waits after `SIGTERM` before
 /// escalating to `SIGKILL`. Tight because libkrun's signal handling
@@ -303,6 +309,36 @@ impl VmBackend for LibkrunBackend {
                     "supervisor did not write {} within {:?}; killed",
                     pid_file.display(),
                     PID_FILE_TIMEOUT
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // The PID file means the supervisor process is up, but it binds the
+        // per-port vsock listener a beat later. Wait for the agent socket so
+        // the console attach / shell_exec that immediately follow don't race
+        // a not-yet-bound socket and report the VM "not running" (#582).
+        let agent_sock = mvm_core::config::vm_vsock_port_socket(
+            &config.name,
+            mvm_guest::vsock::GUEST_AGENT_PORT,
+        );
+        let sock_deadline = Instant::now() + VSOCK_SOCKET_TIMEOUT;
+        while !agent_sock.exists() {
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|e| anyhow!("poll supervisor child: {e}"))?
+            {
+                bail!(
+                    "supervisor exited before binding vsock socket {} (status: {status})",
+                    agent_sock.display()
+                );
+            }
+            if Instant::now() >= sock_deadline {
+                let _ = child.kill();
+                bail!(
+                    "supervisor did not bind vsock socket {} within {:?}; killed",
+                    agent_sock.display(),
+                    VSOCK_SOCKET_TIMEOUT
                 );
             }
             std::thread::sleep(Duration::from_millis(50));

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -31,6 +31,7 @@ use mvm_core::vm_backend::{
 
 use crate::base::ui;
 use libkrun_sys::{KrunContext, SupervisorConfig};
+use mvm_core::config::{mvm_data_dir, vm_console_log, vm_libkrun_pid, vm_state_dir};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -263,7 +264,7 @@ impl VmBackend for LibkrunBackend {
         // per-VM log so a boot failure / kernel panic is diagnosable
         // (mirrors firecracker.log). Best-effort: fall back to null if
         // the file can't be created.
-        let console_log = std::fs::File::create(state_dir.join("console.log"))
+        let console_log = std::fs::File::create(vm_console_log(&config.name))
             .map(Stdio::from)
             .unwrap_or_else(|_| Stdio::null());
         let mut child = Command::new(&supervisor_path)
@@ -316,7 +317,7 @@ impl VmBackend for LibkrunBackend {
     }
 
     fn stop(&self, id: &VmId) -> Result<()> {
-        let pid_path = vm_state_dir(&id.0).join("libkrun.pid");
+        let pid_path = vm_libkrun_pid(&id.0);
         let pid = match read_pid(&pid_path) {
             Some(p) => p,
             None => {
@@ -393,7 +394,7 @@ impl VmBackend for LibkrunBackend {
     }
 
     fn status(&self, id: &VmId) -> Result<VmStatus> {
-        let pid_path = vm_state_dir(&id.0).join("libkrun.pid");
+        let pid_path = vm_libkrun_pid(&id.0);
         match read_pid(&pid_path) {
             Some(pid) if pid_alive(pid) => Ok(VmStatus::Running),
             _ => Ok(VmStatus::Stopped),
@@ -401,7 +402,7 @@ impl VmBackend for LibkrunBackend {
     }
 
     fn list(&self) -> Result<Vec<VmInfo>> {
-        let root = vms_root();
+        let root = PathBuf::from(mvm_data_dir()).join("vms");
         let entries = match std::fs::read_dir(&root) {
             Ok(it) => it,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -513,15 +514,6 @@ impl VmBackend for LibkrunBackend {
 }
 
 // ─── helpers ───────────────────────────────────────────────────────
-
-fn vms_root() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".mvm/vms")
-}
-
-fn vm_state_dir(name: &str) -> PathBuf {
-    vms_root().join(name)
-}
 
 /// Resolve the absolute path to the `mvm-libkrun-supervisor` binary,
 /// checking three sources in order:

--- a/crates/mvm-backend/src/providers/apple_container/macos.rs
+++ b/crates/mvm-backend/src/providers/apple_container/macos.rs
@@ -25,15 +25,16 @@ const START_TIMEOUT: Duration = Duration::from_secs(30);
 static VMS: std::sync::LazyLock<Mutex<HashMap<String, usize>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Directory for persisted VM state (PID files + metadata).
-fn vm_state_dir() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    std::path::PathBuf::from(format!("{home}/.mvm/vms"))
+/// Root of per-VM persisted state (`<mvm_data_dir>/vms/`); callers join the
+/// VM id. Shares `mvm_core::config`'s data-dir resolution so MVM_DATA_DIR is
+/// honored and the per-VM layout matches every other backend.
+fn vms_root() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_core::config::mvm_data_dir()).join("vms")
 }
 
 /// Write VM state to disk so other processes can see it.
 fn persist_vm_state(id: &str) {
-    let dir = vm_state_dir().join(id);
+    let dir = vms_root().join(id);
     tracing::info!("Persisting VM state to {}", dir.display());
     if let Err(e) = std::fs::create_dir_all(&dir) {
         tracing::warn!("Failed to create VM state dir {}: {e}", dir.display());
@@ -44,9 +45,12 @@ fn persist_vm_state(id: &str) {
     let _ = std::fs::write(dir.join("backend"), "apple-virtualization");
 }
 
-/// Path to the cross-process vsock proxy Unix socket for VM `id`.
+/// Path to the cross-process vsock proxy Unix socket for VM `id`. Both the
+/// listener (`start_vsock_proxy_listener`) and the connector resolve through
+/// this, and it must equal what `mvm_core::config` hands the rest of mvm —
+/// the single source of truth that keeps the two ends from drifting (#582).
 fn vsock_proxy_socket_path(id: &str) -> std::path::PathBuf {
-    vm_state_dir().join(id).join("vsock.sock")
+    mvm_core::config::vm_vsock_proxy_socket(id)
 }
 
 /// Listen on the per-VM Unix socket and forward each connection to a vsock
@@ -172,7 +176,7 @@ fn proxy_accept_loop(listener: std::os::unix::net::UnixListener, id: String) {
 /// Remove VM state from disk and unload launchd agent.
 fn remove_vm_state(id: &str) {
     unload_launchd_agent(id);
-    let dir = vm_state_dir().join(id);
+    let dir = vms_root().join(id);
     let _ = std::fs::remove_dir_all(dir);
 }
 
@@ -207,7 +211,7 @@ pub fn install_launchd_direct(
     let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
     let label = launchd_label(id);
     let plist_path = launchd_plist_path(id);
-    let log_dir = vm_state_dir().join(id);
+    let log_dir = vms_root().join(id);
     std::fs::create_dir_all(&log_dir).map_err(|e| format!("mkdir: {e}"))?;
 
     // The plist runs mvmctl with --hypervisor apple-container and
@@ -295,7 +299,7 @@ fn unload_launchd_agent(id: &str) {
 
 /// Read all VM IDs from disk, filtering out dead PIDs.
 fn read_persisted_vm_ids() -> Vec<String> {
-    let dir = vm_state_dir();
+    let dir = vms_root();
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
         Err(_) => return vec![],
@@ -511,7 +515,7 @@ pub fn start_vm(
 
     // Copy rootfs to a writable location — the Nix store copy is read-only
     // but Virtualization.framework needs read-write access for the disk.
-    let vm_dir = vm_state_dir().join(id);
+    let vm_dir = vms_root().join(id);
     std::fs::create_dir_all(&vm_dir).map_err(|e| format!("create vm dir: {e}"))?;
     let writable_rootfs = vm_dir.join("rootfs.ext4");
     // Always create a fresh copy — previous runs may have left a locked file
@@ -900,7 +904,7 @@ pub fn start_vm(
                         // and tear down the just-persisted state, but
                         // leave any launchd plist alone so the agent that
                         // spawned us isn't cleaned up mid-execution.
-                        let _ = std::fs::remove_dir_all(vm_state_dir().join(id));
+                        let _ = std::fs::remove_dir_all(vms_root().join(id));
                         return Err(format!("start vsock proxy listener: {e}"));
                     }
                     return Ok(());
@@ -1043,13 +1047,25 @@ mod tests {
         let temp = std::path::PathBuf::from(format!("/tmp/mvmac-{}", unique_id()));
         std::fs::create_dir_all(&temp).expect("create temp HOME");
         let saved = std::env::var("HOME").ok();
+        // The proxy path now resolves via `mvm_core::config`, which prefers
+        // MVM_DATA_DIR over $HOME. Clear it so the $HOME-rooted, SUN_LEN-safe
+        // socket path these tests rely on holds even if a sibling test leaked
+        // a long override (which would overflow `sockaddr_un`).
+        let saved_data = std::env::var("MVM_DATA_DIR").ok();
         // SAFETY: serialised by HOME_LOCK above.
-        unsafe { std::env::set_var("HOME", &temp) };
+        unsafe {
+            std::env::set_var("HOME", &temp);
+            std::env::remove_var("MVM_DATA_DIR");
+        }
         body(&temp);
         unsafe {
             match saved {
                 Some(v) => std::env::set_var("HOME", v),
                 None => std::env::remove_var("HOME"),
+            }
+            match saved_data {
+                Some(v) => std::env::set_var("MVM_DATA_DIR", v),
+                None => std::env::remove_var("MVM_DATA_DIR"),
             }
         }
         let _ = std::fs::remove_dir_all(&temp);

--- a/crates/mvm-backend/src/providers/apple_container/mod.rs
+++ b/crates/mvm-backend/src/providers/apple_container/mod.rs
@@ -211,9 +211,10 @@ pub fn vsock_connect_any(id: &str, port: u32) -> Result<std::os::unix::net::Unix
     //    so we connect directly — no port handshake. Without this branch a
     //    healthy libkrun dev VM is misreported as "not running" (#582), which
     //    is exactly what broke `dev up`'s console attach on macOS+libkrun.
-    //    Mirrors `mvm::vsock_transport::LibkrunTransport::socket_path`; the two
-    //    resolvers live in different crate layers, so keep them in lockstep.
-    let libkrun = libkrun_vsock_path(id, port);
+    //    Path comes from `mvm_core::config` — the single source of truth the
+    //    console transport (`mvm::vsock_transport::LibkrunTransport`) shares,
+    //    so the two resolvers can no longer drift (the #582 root cause).
+    let libkrun = mvm_core::config::vm_vsock_port_socket(id, port);
     if libkrun.exists() {
         return std::os::unix::net::UnixStream::connect(&libkrun)
             .map_err(|e| format!("connect libkrun vsock {}: {e}", libkrun.display()));
@@ -223,18 +224,6 @@ pub fn vsock_connect_any(id: &str, port: u32) -> Result<std::os::unix::net::Unix
         proxy.display(),
         libkrun.display(),
     ))
-}
-
-/// Host path of a libkrun dev VM's per-port vsock socket. Mirrors
-/// `mvm::vsock_transport::LibkrunTransport::socket_path` and the
-/// `vsock-<port>.sock` convention libkrun's supervisor writes (Plan 57),
-/// duplicated here because this provider sits below the `mvm` crate.
-fn libkrun_vsock_path(id: &str, port: u32) -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    std::path::PathBuf::from(home)
-        .join(".mvm/vms")
-        .join(id)
-        .join(format!("vsock-{port}.sock"))
 }
 
 /// Guest agent vsock port.
@@ -299,21 +288,6 @@ mod tests {
         assert!(err.contains(id), "got: {err}");
         assert!(err.contains("not running"), "got: {err}");
         assert!(err.contains("vsock.sock"), "got: {err}");
-    }
-
-    #[test]
-    fn libkrun_vsock_path_matches_convention() {
-        // #582: libkrun dev VMs expose a per-port socket; the resolver must
-        // build `~/.mvm/vms/<id>/vsock-<port>.sock` (mirrors LibkrunTransport).
-        let path = libkrun_vsock_path("some-vm", GUEST_AGENT_PORT);
-        let suffix =
-            std::path::PathBuf::from(format!(".mvm/vms/some-vm/vsock-{GUEST_AGENT_PORT}.sock"));
-        assert!(
-            path.ends_with(&suffix),
-            "expected path to end with {} but got {}",
-            suffix.display(),
-            path.display(),
-        );
     }
 
     #[test]

--- a/crates/mvm-backend/src/providers/apple_container/mod.rs
+++ b/crates/mvm-backend/src/providers/apple_container/mod.rs
@@ -189,23 +189,52 @@ pub fn vsock_proxy_path(id: &str) -> std::path::PathBuf {
 /// Returns a clear error when neither is reachable so callers can decide
 /// whether to surface the message or auto-start the dev daemon.
 pub fn vsock_connect_any(id: &str, port: u32) -> Result<std::os::unix::net::UnixStream, String> {
+    // 1. In-process Virtualization.framework reference.
     if let Ok(stream) = vsock_connect(id, port) {
         return Ok(stream);
     }
+    // 2. Apple-Container cross-process proxy socket. The proxy multiplexes
+    //    every port over one socket, so the client writes the target port as
+    //    a 4-byte LE prefix before talking the guest protocol.
     let proxy = vsock_proxy_path(id);
-    if !proxy.exists() {
-        return Err(format!(
-            "dev VM '{id}' is not running (no in-process VM and no proxy socket at {})",
-            proxy.display(),
-        ));
+    if proxy.exists() {
+        use std::io::Write as _;
+        let mut stream = std::os::unix::net::UnixStream::connect(&proxy)
+            .map_err(|e| format!("connect proxy {}: {e}", proxy.display()))?;
+        stream
+            .write_all(&port.to_le_bytes())
+            .map_err(|e| format!("write proxy port: {e}"))?;
+        return Ok(stream);
     }
-    use std::io::Write as _;
-    let mut stream = std::os::unix::net::UnixStream::connect(&proxy)
-        .map_err(|e| format!("connect proxy {}: {e}", proxy.display()))?;
-    stream
-        .write_all(&port.to_le_bytes())
-        .map_err(|e| format!("write proxy port: {e}"))?;
-    Ok(stream)
+    // 3. libkrun per-port socket. A dev VM booted via the libkrun backend
+    //    exposes one socket *per port* at `~/.mvm/vms/<id>/vsock-<port>.sock`,
+    //    so we connect directly — no port handshake. Without this branch a
+    //    healthy libkrun dev VM is misreported as "not running" (#582), which
+    //    is exactly what broke `dev up`'s console attach on macOS+libkrun.
+    //    Mirrors `mvm::vsock_transport::LibkrunTransport::socket_path`; the two
+    //    resolvers live in different crate layers, so keep them in lockstep.
+    let libkrun = libkrun_vsock_path(id, port);
+    if libkrun.exists() {
+        return std::os::unix::net::UnixStream::connect(&libkrun)
+            .map_err(|e| format!("connect libkrun vsock {}: {e}", libkrun.display()));
+    }
+    Err(format!(
+        "dev VM '{id}' is not running (no in-process VM, no proxy socket at {}, no libkrun socket at {})",
+        proxy.display(),
+        libkrun.display(),
+    ))
+}
+
+/// Host path of a libkrun dev VM's per-port vsock socket. Mirrors
+/// `mvm::vsock_transport::LibkrunTransport::socket_path` and the
+/// `vsock-<port>.sock` convention libkrun's supervisor writes (Plan 57),
+/// duplicated here because this provider sits below the `mvm` crate.
+fn libkrun_vsock_path(id: &str, port: u32) -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(home)
+        .join(".mvm/vms")
+        .join(id)
+        .join(format!("vsock-{port}.sock"))
 }
 
 /// Guest agent vsock port.
@@ -270,5 +299,33 @@ mod tests {
         assert!(err.contains(id), "got: {err}");
         assert!(err.contains("not running"), "got: {err}");
         assert!(err.contains("vsock.sock"), "got: {err}");
+    }
+
+    #[test]
+    fn libkrun_vsock_path_matches_convention() {
+        // #582: libkrun dev VMs expose a per-port socket; the resolver must
+        // build `~/.mvm/vms/<id>/vsock-<port>.sock` (mirrors LibkrunTransport).
+        let path = libkrun_vsock_path("some-vm", GUEST_AGENT_PORT);
+        let suffix =
+            std::path::PathBuf::from(format!(".mvm/vms/some-vm/vsock-{GUEST_AGENT_PORT}.sock"));
+        assert!(
+            path.ends_with(&suffix),
+            "expected path to end with {} but got {}",
+            suffix.display(),
+            path.display(),
+        );
+    }
+
+    #[test]
+    fn vsock_connect_any_consults_libkrun_socket() {
+        // #582 regression: a libkrun dev VM's per-port socket must be part of
+        // the resolution chain, so the "not running" error names it (a real
+        // socket is connected — exercised end-to-end by core_demo_e2e).
+        let err = vsock_connect_any("never-existed-vm-582", GUEST_AGENT_PORT)
+            .expect_err("no VM, no sockets → error");
+        assert!(
+            err.contains("libkrun socket"),
+            "error must name the libkrun socket: {err}"
+        );
     }
 }

--- a/crates/mvm-backend/src/providers/apple_container/mod.rs
+++ b/crates/mvm-backend/src/providers/apple_container/mod.rs
@@ -172,8 +172,7 @@ pub fn vsock_proxy_path(id: &str) -> std::path::PathBuf {
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-        std::path::PathBuf::from(format!("{home}/.mvm/vms/{id}/vsock.sock"))
+        mvm_core::config::vm_vsock_proxy_socket(id)
     }
 }
 
@@ -263,16 +262,17 @@ mod tests {
     }
 
     #[test]
-    fn test_vsock_proxy_path_under_home() {
-        // Whatever HOME points at, the path must resolve below it and end
-        // with the conventional segment used by the dev daemon.
+    fn test_vsock_proxy_path_matches_core_helper() {
+        // The proxy path is the single source of truth in mvm-core::config;
+        // both this provider and the connector must resolve to it identically
+        // (the #582 drift class). Assert equality rather than a $HOME-shaped
+        // suffix so the test honors MVM_DATA_DIR like production does.
         let path = vsock_proxy_path("some-vm");
-        let suffix = std::path::Path::new(".mvm/vms/some-vm/vsock.sock");
+        assert_eq!(path, mvm_core::config::vm_vsock_proxy_socket("some-vm"));
         assert!(
-            path.ends_with(suffix),
-            "expected path to end with {} but got {}",
-            suffix.display(),
-            path.display(),
+            path.ends_with("vms/some-vm/vsock.sock"),
+            "got {}",
+            path.display()
         );
     }
 

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -462,7 +462,7 @@ impl VmBackend for VzBackend {
     }
 
     fn list(&self) -> Result<Vec<VmInfo>> {
-        let root = vms_root();
+        let root = PathBuf::from(mvm_core::config::mvm_data_dir()).join("vms");
         let entries = match std::fs::read_dir(&root) {
             Ok(it) => it,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -511,7 +511,7 @@ impl VmBackend for VzBackend {
         // logs", which today is empty — the supervisor inherits stderr
         // from the parent `mvmctl`, so its logs are already on the
         // user's terminal. Surface the console capture in both cases.
-        let log = vm_state_dir(&id.0).join("console.log");
+        let log = mvm_core::config::vm_console_log(&id.0);
         let contents = std::fs::read_to_string(&log)
             .map_err(|e| anyhow!("read console log {}: {e}", log.display()))?;
         if lines == 0 {
@@ -857,11 +857,6 @@ fn persist_supervisor_config(path: &Path, json: &str) -> Result<()> {
 
 // ─── helpers ───────────────────────────────────────────────────────
 
-fn vms_root() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".mvm/vms")
-}
-
 /// Plan 97 Phase E gate: snapshot save/restore lands in macOS 14
 /// (`VZVirtualMachine.saveMachineStateTo` / `restoreMachineStateFrom`).
 /// Reported as the *backend* capability rather than the live host's
@@ -898,7 +893,7 @@ fn macos_major_version() -> u32 {
 }
 
 fn vm_state_dir(name: &str) -> PathBuf {
-    vms_root().join(name)
+    mvm_core::config::vm_state_dir(name)
 }
 
 /// Plan 102 W6.A.5 — per-VM Vz events-ingest socket path. The Swift

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1483,9 +1483,8 @@ pub fn spawn_vsock_response_listener(
     use crate::builder_protocol::{HostVmResponseRead, read_host_vm_response};
 
     let (tx, rx) = mpsc::channel();
-    let socket_path = vm_state_dir.join(format!(
-        "vsock-{}.sock",
-        mvm_guest::builder_agent::BUILDER_DISPATCH_PORT
+    let socket_path = vm_state_dir.join(mvm_core::config::vsock_socket_filename(
+        mvm_guest::builder_agent::BUILDER_DISPATCH_PORT,
     ));
 
     std::thread::Builder::new()
@@ -2084,10 +2083,10 @@ impl PersistentVmHandle {
     /// inside the guest. The W3 part 1
     /// `PersistentBuilderSupervisor::new` takes this directly.
     pub fn dispatch_socket_path(&self) -> PathBuf {
-        self.vm_state_dir.join(format!(
-            "vsock-{}.sock",
-            mvm_guest::builder_agent::BUILDER_DISPATCH_PORT
-        ))
+        self.vm_state_dir
+            .join(mvm_core::config::vsock_socket_filename(
+                mvm_guest::builder_agent::BUILDER_DISPATCH_PORT,
+            ))
     }
 
     /// Per-VM job directory bound at `/job` inside the guest.

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -626,9 +626,8 @@ fn read_next_response(
 /// `libkrun_sys::KrunContext` uses when
 /// `add_vsock_port(BUILDER_DISPATCH_PORT)` is configured.
 pub fn dispatch_socket_path(vm_state_dir: &Path) -> PathBuf {
-    vm_state_dir.join(format!(
-        "vsock-{}.sock",
-        mvm_guest::builder_agent::BUILDER_DISPATCH_PORT
+    vm_state_dir.join(mvm_core::config::vsock_socket_filename(
+        mvm_guest::builder_agent::BUILDER_DISPATCH_PORT,
     ))
 }
 

--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -1271,10 +1271,11 @@ impl VzPersistentVmHandle {
     /// guest. The W3 part 1 `PersistentBuilderSupervisor::new` takes
     /// this directly.
     pub fn dispatch_socket_path(&self) -> PathBuf {
-        self.vm_state_dir.join("vsock").join(format!(
-            "vsock-{}.sock",
-            mvm_guest::builder_agent::BUILDER_DISPATCH_PORT
-        ))
+        self.vm_state_dir
+            .join("vsock")
+            .join(mvm_core::config::vsock_socket_filename(
+                mvm_guest::builder_agent::BUILDER_DISPATCH_PORT,
+            ))
     }
 
     /// Per-VM job directory bound at `/job` (and `/out`) inside the

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -3083,45 +3083,44 @@ fn stage0_dir_size_bytes(path: &std::path::Path) -> u64 {
 /// builder-VM rootfs.
 ///
 /// The builder-VM rootfs is built by `nix/images/builder-vm/flake.nix`
-/// from three categories of source input:
+/// from these categories of source input:
 ///
 /// 1. The flake itself (`flake.nix` + `flake.lock`) — controls
 ///    which `nixpkgs` rev, which `mkGuest` shape, which `microvm.nix`,
 ///    which packages get installed.
-/// 2. The workspace `Cargo.lock` — `rustPlatform.buildRustPackage`
-///    consumes it for the dep closure of every Rust binary baked
-///    into the rootfs (`mvm-host-vm-init`, `mvm-egress-proxy`).
-/// 3. The Rust sources of the in-VM binaries (`crates/mvm-host-vm-init/`,
-///    `crates/mvm-egress-proxy/`) — these are the actual PID-1 +
-///    egress-proxy binaries the rootfs runs.
+/// 2. The workspace `Cargo.lock` — the dep closure of every Rust
+///    binary baked into the rootfs.
+/// 3. The embedded host-binary bytes — `build.rs` cross-compiles the
+///    in-VM PID-1 + egress-proxy binaries (`cargo build -p mvm-build
+///    --bin <name>`) and embeds the bytes in mvmctl; injected into the
+///    rootfs at boot. The byte hash captures the bin source, the
+///    `mvm-build` lib, its deps, AND the cross-compile toolchain in one
+///    shot — strictly more than the per-crate `src/` hash this replaced
+///    (which also broke when Plan 121 folded the two former top-level
+///    `crates/<name>/` crates into `crates/mvm-build/src/bin/`).
+/// 4. The shared Nix library (`nix/lib`) the flake imports.
 ///
-/// Pre-2026-05 this function only hashed (1), with the result that
-/// contributor edits to `crates/mvm-host-vm-init/src/main.rs` (or
-/// any other Rust source baked into the rootfs) silently reused the
-/// cached `rootfs.ext4`. The bug burned the PR #420 dev-loop
-/// repeatedly: every test required manually `rm -rf
-/// ~/.cache/mvm/builder-vm/aarch64/` to force a Stage 0 rebuild.
-/// This version closes that hole.
+/// Pre-2026-05 this function only hashed (1), so contributor edits to
+/// the in-VM binaries silently reused the cached `rootfs.ext4`,
+/// burning the dev loop. This version closes that hole — now via the
+/// embedded-byte hash rather than a per-crate source walk.
 ///
 /// ## Scope and tradeoffs
 ///
 /// We don't hash the entire workspace. A change to `mvm-cli` doesn't
-/// affect the rootfs and shouldn't invalidate the cache. The two
-/// crates listed match the `rustPlatform.buildRustPackage` calls in
-/// `nix/images/builder-vm/flake.nix` (`mvmBuilderInitFor` +
-/// `mvmEgressProxyFor`); a future flake change that bakes a third
-/// Rust binary into the rootfs needs to add that crate to the list
-/// here.
+/// affect the rootfs and shouldn't invalidate the cache; only the
+/// embedded binaries' bytes carry the in-VM binary identity.
 ///
 /// ## Hash discipline
 ///
-/// Same shape as the original flake-only hash:
+/// File layers use the original flake-only shape:
 /// `{name}\0{u64-length-LE}\0{contents}\0`, repeated for each input.
 /// The `name` is the relative path keyed off the workspace, so
-/// renaming a file or moving it across crates changes the fingerprint.
-/// Files within a directory are visited in lexicographic order
-/// regardless of filesystem read order so the hash is deterministic
-/// across HFS+, APFS, and ext4.
+/// renaming a file changes the fingerprint. Files within a directory
+/// are visited in lexicographic order regardless of filesystem read
+/// order so the hash is deterministic across HFS+, APFS, and ext4.
+/// The embedded-binary layer folds `(name, sha256_hex)` under a
+/// `host-bin\0` domain tag (see `fold_embedded_binary_identity`).
 fn builder_vm_source_fingerprint(builder_flake_dir: &str) -> Result<String> {
     let flake_dir = std::path::Path::new(builder_flake_dir);
     let workspace_root = workspace_root_for_builder_flake(flake_dir)?;
@@ -3152,58 +3151,20 @@ fn builder_vm_source_fingerprint(builder_flake_dir: &str) -> Result<String> {
     }
     hash_named_file(&mut hasher, "Cargo.lock", &cargo_lock)?;
 
-    // Layer 3: in-VM binary sources. Each crate listed here
-    // corresponds to a `rustPlatform.buildRustPackage` call in
-    // `nix/images/builder-vm/flake.nix`. Add to this list when a
-    // new Rust binary gets baked into the rootfs.
-    //
-    // Only `Cargo.toml` and the recursive `src/` tree enter the
-    // closure `rustc` actually sees. `README.md`, `CHANGELOG.md`,
-    // and other crate-root files don't influence the baked binary,
-    // so they don't bust the Stage 0 cache (Plan 93 Phase 0).
-    for crate_name in ["mvm-host-vm-init", "mvm-egress-proxy"] {
-        let crate_dir = workspace_root.join("crates").join(crate_name);
-        if !crate_dir.is_dir() {
-            anyhow::bail!(
-                "builder VM source fingerprint missing crate dir {}",
-                crate_dir.display()
-            );
-        }
-
-        let cargo_toml = crate_dir.join("Cargo.toml");
-        if !cargo_toml.is_file() {
-            anyhow::bail!(
-                "builder VM source fingerprint missing {}",
-                cargo_toml.display()
-            );
-        }
-        hash_named_file(
-            &mut hasher,
-            &format!("crates/{crate_name}/Cargo.toml"),
-            &cargo_toml,
-        )?;
-
-        let src_dir = crate_dir.join("src");
-        if !src_dir.is_dir() {
-            anyhow::bail!(
-                "builder VM source fingerprint missing crate src dir {}",
-                src_dir.display()
-            );
-        }
-        hash_dir_recursive(&mut hasher, &format!("crates/{crate_name}/src"), &src_dir)?;
-    }
-
-    // Layer 4: the embedded host-binary identity. These bytes are what
-    // actually get baked into the rootfs, so their SHA captures anything
-    // the crate-src hash above can miss — chiefly the cross-compile
-    // toolchain (a gnu→musl target switch produces different binaries
-    // from identical source). Without this a toolchain change would
-    // silently reuse a stale cached image.
+    // Layer 3: the embedded host-binary identity — the authoritative
+    // fingerprint of the in-VM Rust binaries (`mvm-host-vm-init`,
+    // `mvm-egress-proxy`). `build.rs` cross-compiles them with
+    // `cargo build -p mvm-build --bin <name>` and embeds the bytes in
+    // mvmctl; they are injected into the rootfs at boot
+    // (`host_binaries::extract`), NOT built by the flake (which forbids
+    // `rustPlatform.buildRustPackage`). Hashing the bytes captures the bin
+    // source, the `mvm-build` lib, its deps, AND the cross-compile
+    // toolchain (a gnu→musl switch yields different bytes from identical
+    // source) in one shot — strictly more than the per-crate `src/` hash
+    // this replaced, which also broke when Plan 121 folded the two former
+    // top-level `crates/<name>/` crates into `crates/mvm-build/src/bin/`.
     for bin in crate::host_binaries::embedded::EMBEDDED.iter() {
-        hasher.update(b"host-bin\0");
-        hasher.update(bin.name.as_bytes());
-        hasher.update(b"\0");
-        hasher.update(bin.sha256_hex.as_bytes());
+        fold_embedded_binary_identity(&mut hasher, bin.name, bin.sha256_hex);
     }
 
     // Layer 5: the shared Nix library the flake imports. The builder-vm
@@ -3217,6 +3178,19 @@ fn builder_vm_source_fingerprint(builder_flake_dir: &str) -> Result<String> {
     }
 
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Fold one embedded host-binary's identity into the fingerprint.
+/// Keyed on `(name, sha256_hex)` so a rebuilt binary's byte change —
+/// the authoritative signal that the in-VM PID-1 / egress-proxy source
+/// or toolchain shifted — busts the Stage 0 cache key. The `host-bin\0`
+/// domain tag keeps these entries from colliding with the file-hash
+/// layers above.
+fn fold_embedded_binary_identity(hasher: &mut Sha256, name: &str, sha256_hex: &str) {
+    hasher.update(b"host-bin\0");
+    hasher.update(name.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(sha256_hex.as_bytes());
 }
 
 /// Resolve the workspace root from the builder-VM flake dir.
@@ -4223,12 +4197,12 @@ mod dev_status_image_tests {
     }
 
     /// Stage the workspace prerequisites that `builder_vm_source_fingerprint`
-    /// (post-PR #422) reads in addition to the flake dir itself:
-    /// `Cargo.lock` at the workspace root + stub `mvm-host-vm-init` and
-    /// `mvm-egress-proxy` crate dirs. Without this, any test that calls
-    /// the fingerprint helper against a fresh tempdir-rooted flake at
-    /// `<tmp>/nix/images/builder-vm` blows up with
-    /// `builder VM source fingerprint missing <tmp>/Cargo.lock`.
+    /// reads beyond the flake dir: a `Cargo.lock` at the workspace root.
+    /// Without it, a test calling the fingerprint helper against a fresh
+    /// tempdir-rooted flake at `<tmp>/nix/images/builder-vm` blows up with
+    /// `builder VM source fingerprint missing <tmp>/Cargo.lock`. (The
+    /// in-VM binary identity comes from the embedded host-binary bytes,
+    /// not on-disk crate dirs, so no crate stubs are needed.)
     ///
     /// Matches `builder_vm_bootstrap_tests::write_builder_vm_workspace`
     /// in shape; lives here as well because the two test mods are
@@ -4237,16 +4211,6 @@ mod dev_status_image_tests {
     fn write_builder_vm_workspace_prereqs(workspace_root: &std::path::Path) {
         std::fs::write(workspace_root.join("Cargo.lock"), "# stub Cargo.lock\n")
             .expect("write Cargo.lock");
-        for crate_name in ["mvm-host-vm-init", "mvm-egress-proxy"] {
-            let src = workspace_root.join("crates").join(crate_name).join("src");
-            std::fs::create_dir_all(&src).expect("mkdir crate src");
-            std::fs::write(
-                src.parent().unwrap().join("Cargo.toml"),
-                format!("[package]\nname = \"{crate_name}\"\nversion = \"0.0.0\"\n"),
-            )
-            .expect("write Cargo.toml");
-            std::fs::write(src.join("main.rs"), "fn main() {}\n").expect("write main.rs");
-        }
     }
 
     #[test]
@@ -5227,32 +5191,29 @@ mod builder_vm_bootstrap_tests {
     }
 
     /// Lay out a synthetic mvm workspace under `tmp` that the
-    /// expanded `builder_vm_source_fingerprint` will accept:
+    /// `builder_vm_source_fingerprint` will accept:
     ///
     /// ```text
     /// tmp/
     ///   Cargo.lock
-    ///   crates/
-    ///     mvm-host-vm-init/{Cargo.toml,src/main.rs}
-    ///     mvm-egress-proxy/{Cargo.toml,src/main.rs}
+    ///   nix/lib/mkguest.nix
     ///   nix/images/builder-vm/{flake.nix,flake.lock}
     /// ```
+    ///
+    /// In-VM binary identity now rides on the embedded host-binary
+    /// bytes (see `fold_embedded_binary_identity`), so the old per-crate
+    /// `crates/<name>/{Cargo.toml,src}` stubs are gone. `nix/lib` is
+    /// present because the flake imports it (Layer 5) and the dir-walker
+    /// skip tests exercise it.
     ///
     /// Returns the path of the `nix/images/builder-vm/` dir — the
     /// argument the fingerprint function expects.
     fn write_builder_vm_workspace(tmp: &std::path::Path) -> std::path::PathBuf {
         std::fs::write(tmp.join("Cargo.lock"), "# stub Cargo.lock\n").expect("write Cargo.lock");
 
-        for crate_name in ["mvm-host-vm-init", "mvm-egress-proxy"] {
-            let src = tmp.join("crates").join(crate_name).join("src");
-            std::fs::create_dir_all(&src).expect("mkdir crate src");
-            std::fs::write(
-                src.parent().unwrap().join("Cargo.toml"),
-                format!("[package]\nname = \"{crate_name}\"\nversion = \"0.0.0\"\n"),
-            )
-            .expect("write Cargo.toml");
-            std::fs::write(src.join("main.rs"), "fn main() {}\n").expect("write main.rs");
-        }
+        let nix_lib = tmp.join("nix/lib");
+        std::fs::create_dir_all(&nix_lib).expect("mkdir nix/lib");
+        std::fs::write(nix_lib.join("mkguest.nix"), "{ }\n").expect("write nix/lib");
 
         let flake = tmp.join("nix/images/builder-vm");
         write_builder_vm_flake(&flake, "{ outputs = _: {}; }", Some("{\"nodes\":{}}"));
@@ -5298,135 +5259,43 @@ mod builder_vm_bootstrap_tests {
     }
 
     #[test]
-    fn builder_vm_source_fingerprint_changes_with_mvm_host_vm_init_source() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let flake = write_builder_vm_workspace(tmp.path());
-        let first = builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("fingerprint");
-
-        // The bug this whole expansion fixes: a contributor edits
-        // the PID-1 binary source and `mvmctl dev up` silently
-        // serves the stale cached rootfs.
-        std::fs::write(
-            tmp.path().join("crates/mvm-host-vm-init/src/main.rs"),
-            "fn main() { println!(\"hello from edited builder-init\"); }\n",
-        )
-        .expect("rewrite main.rs");
-        let second = builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("fingerprint");
-
-        assert_ne!(
-            first, second,
-            "edit to mvm-host-vm-init source must invalidate the builder-vm cache key"
-        );
-    }
-
-    #[test]
-    fn builder_vm_source_fingerprint_changes_with_mvm_egress_proxy_source() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let flake = write_builder_vm_workspace(tmp.path());
-        let first = builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("fingerprint");
-
-        std::fs::write(
-            tmp.path().join("crates/mvm-egress-proxy/src/main.rs"),
-            "fn main() { println!(\"updated proxy\"); }\n",
-        )
-        .expect("rewrite main.rs");
-        let second = builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("fingerprint");
+    fn fold_embedded_binary_identity_distinguishes_inputs() {
+        // The new contract: in-VM binary identity rides on the embedded
+        // bytes, not a per-crate source walk. A rebuilt binary (changed
+        // name OR changed sha256) must fold to a different digest so the
+        // Stage 0 cache key busts.
+        let base = {
+            let mut h = Sha256::new();
+            fold_embedded_binary_identity(&mut h, "mvm-host-vm-init", "aa");
+            format!("{:x}", h.finalize())
+        };
+        let changed_hash = {
+            let mut h = Sha256::new();
+            fold_embedded_binary_identity(&mut h, "mvm-host-vm-init", "bb");
+            format!("{:x}", h.finalize())
+        };
+        let changed_name = {
+            let mut h = Sha256::new();
+            fold_embedded_binary_identity(&mut h, "mvm-egress-proxy", "aa");
+            format!("{:x}", h.finalize())
+        };
 
         assert_ne!(
-            first, second,
-            "edit to mvm-egress-proxy source must invalidate the builder-vm cache key"
+            base, changed_hash,
+            "a rebuilt binary (new sha256) must bust the cache key"
         );
-    }
-
-    #[test]
-    fn builder_vm_source_fingerprint_does_not_change_with_readme_edit() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let flake = write_builder_vm_workspace(tmp.path());
-        let baseline =
-            builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("baseline fingerprint");
-
-        // Plan 93 Phase 0: only `Cargo.toml` + `src/**` enter the
-        // closure rustc sees. README, CHANGELOG, LICENSE, and other
-        // crate-root files don't influence the baked binary, so they
-        // must NOT bust the Stage 0 cache — a contributor tweaking
-        // docs shouldn't eat a 10-30 minute rebuild.
-        std::fs::write(
-            tmp.path().join("crates/mvm-host-vm-init/README.md"),
-            "# mvm-host-vm-init\n\nAdded docs.\n",
-        )
-        .expect("write README");
-        std::fs::write(
-            tmp.path().join("crates/mvm-egress-proxy/CHANGELOG.md"),
-            "# changelog\n",
-        )
-        .expect("write CHANGELOG");
-
-        let after =
-            builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("after fingerprint");
-
-        assert_eq!(
-            baseline, after,
-            "non-src crate-root files must not affect the builder-vm cache key"
-        );
-    }
-
-    #[test]
-    fn builder_vm_source_fingerprint_changes_with_cargo_toml_edit() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let flake = write_builder_vm_workspace(tmp.path());
-        let first = builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("fingerprint");
-
-        // A dep bump or a feature-flag change in Cargo.toml shifts
-        // what rustPlatform.buildRustPackage produces, so the
-        // fingerprint must pick it up.
-        std::fs::write(
-            tmp.path().join("crates/mvm-host-vm-init/Cargo.toml"),
-            "[package]\nname = \"mvm-host-vm-init\"\nversion = \"0.0.1\"\n",
-        )
-        .expect("rewrite Cargo.toml");
-        let second = builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("fingerprint");
-
         assert_ne!(
-            first, second,
-            "Cargo.toml edit must invalidate the builder-vm cache key"
+            base, changed_name,
+            "a renamed embedded binary must bust the cache key"
         );
-    }
-
-    #[test]
-    fn builder_vm_source_fingerprint_errors_when_cargo_toml_missing() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let flake = write_builder_vm_workspace(tmp.path());
-        std::fs::remove_file(tmp.path().join("crates/mvm-host-vm-init/Cargo.toml"))
-            .expect("rm Cargo.toml");
-
-        let err = builder_vm_source_fingerprint(flake.to_str().unwrap())
-            .expect_err("missing Cargo.toml must be a hard error");
-        assert!(
-            err.to_string().contains("Cargo.toml"),
-            "error must name the missing path: {err}"
-        );
-    }
-
-    #[test]
-    fn builder_vm_source_fingerprint_changes_when_new_file_added_to_crate() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let flake = write_builder_vm_workspace(tmp.path());
-        let first = builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("fingerprint");
-
-        // A `git add` of a new module file under the crate also
-        // changes the closure rustc sees, so the fingerprint must
-        // reflect new files, not just modifications of existing ones.
-        std::fs::write(
-            tmp.path().join("crates/mvm-host-vm-init/src/new_module.rs"),
-            "pub fn whatever() {}\n",
-        )
-        .expect("write new_module.rs");
-        let second = builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("fingerprint");
-
-        assert_ne!(
-            first, second,
-            "new file in mvm-host-vm-init must invalidate the builder-vm cache key"
-        );
+        // The `\0` separator prevents (name+hash) concatenation
+        // collisions, e.g. ("ab","") vs ("a","b").
+        let glued = {
+            let mut h = Sha256::new();
+            fold_embedded_binary_identity(&mut h, "mvm-host-vm-initaa", "");
+            format!("{:x}", h.finalize())
+        };
+        assert_ne!(base, glued, "name/hash boundary must be unambiguous");
     }
 
     #[test]
@@ -5455,20 +5324,12 @@ mod builder_vm_bootstrap_tests {
         let baseline =
             builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("baseline fingerprint");
 
-        // cargo build artifacts under `target/` are not flake inputs.
-        // Adding multi-MB junk there must not change the fingerprint
-        // (otherwise every `cargo build` would invalidate the cache).
-        // Place a `target/` both at the crate root (outside the
-        // narrowed walk) and inside `src/` (inside the walk, exercising
-        // the explicit skip).
-        let crate_target = tmp.path().join("crates/mvm-host-vm-init/target/debug");
-        std::fs::create_dir_all(&crate_target).expect("mkdir crate target");
-        std::fs::write(crate_target.join("garbage.rlib"), vec![0u8; 4096])
-            .expect("write crate target garbage");
-        let src_target = tmp.path().join("crates/mvm-host-vm-init/src/target/debug");
-        std::fs::create_dir_all(&src_target).expect("mkdir src/target");
-        std::fs::write(src_target.join("junk.rlib"), vec![0u8; 4096])
-            .expect("write src/target garbage");
+        // The `nix/lib` walk (Layer 5) skips `target/`. Drop junk in a
+        // `target/` under the walked dir; the fingerprint must ignore it.
+        let lib_target = tmp.path().join("nix/lib/target/debug");
+        std::fs::create_dir_all(&lib_target).expect("mkdir nix/lib/target");
+        std::fs::write(lib_target.join("junk.rlib"), vec![0u8; 4096])
+            .expect("write target garbage");
 
         let after =
             builder_vm_source_fingerprint(flake.to_str().unwrap()).expect("after fingerprint");
@@ -5488,14 +5349,12 @@ mod builder_vm_bootstrap_tests {
 
         // `.git/HEAD`, editor swap files (`.swp`, `foo.rs.swp`),
         // `.DS_Store`, etc. — none are flake inputs and editing them
-        // shouldn't bust the cache. Place each both at the crate root
-        // (outside the narrowed walk) and inside `src/` (inside the
-        // walk, exercising the explicit skip).
+        // shouldn't bust the cache. Drop each inside the walked `nix/lib`
+        // dir, exercising the explicit skip in `walk_source_dir_sorted`.
         for path in [
-            "crates/mvm-host-vm-init/.swp",
-            "crates/mvm-host-vm-init/.DS_Store",
-            "crates/mvm-host-vm-init/src/.DS_Store",
-            "crates/mvm-host-vm-init/src/main.rs.swp",
+            "nix/lib/.DS_Store",
+            "nix/lib/.swp",
+            "nix/lib/mkguest.nix.swp",
         ] {
             std::fs::write(tmp.path().join(path), b"junk").expect("write hidden");
         }
@@ -5520,20 +5379,6 @@ mod builder_vm_bootstrap_tests {
         assert!(
             err.to_string().contains("Cargo.lock"),
             "error must name the missing path: {err}"
-        );
-    }
-
-    #[test]
-    fn builder_vm_source_fingerprint_errors_when_in_vm_crate_missing() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let flake = write_builder_vm_workspace(tmp.path());
-        std::fs::remove_dir_all(tmp.path().join("crates/mvm-host-vm-init")).expect("rm crate dir");
-
-        let err = builder_vm_source_fingerprint(flake.to_str().unwrap())
-            .expect_err("missing in-VM crate dir must be a hard error");
-        assert!(
-            err.to_string().contains("mvm-host-vm-init"),
-            "error must name the missing crate: {err}"
         );
     }
 

--- a/crates/mvm-cli/src/commands/env/dev.rs
+++ b/crates/mvm-cli/src/commands/env/dev.rs
@@ -631,7 +631,19 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
             } else {
                 memory
             };
-            let open_shell = effective_up_shell(shell, no_shell);
+            // The interactive shell bridges the guest console over a PTY,
+            // which needs a real terminal. Without one (CI, scripts, the
+            // core_demo test — stdin is redirected) `console_interactive`'s
+            // openpty() fails. Boot the VM and return instead; `dev shell`
+            // attaches later once a TTY is present. (#582)
+            let want_shell = effective_up_shell(shell, no_shell);
+            let open_shell = want_shell && std::io::IsTerminal::is_terminal(&std::io::stdin());
+            if want_shell && !open_shell {
+                ui::info(
+                    "No interactive terminal detected; dev VM is up — run \
+                     `mvmctl dev shell` to attach.",
+                );
+            }
             let dev_volumes = resolve_dev_volumes(&volume)?;
 
             // Reap helpers (gvproxy/supervisor) leaked by a prior killed

--- a/crates/mvm-cli/src/commands/ops/audit_posture.rs
+++ b/crates/mvm-cli/src/commands/ops/audit_posture.rs
@@ -127,14 +127,14 @@ fn render_human(report: &PostureReport) {
 // ──────────────────────────────────────────────────────────────
 
 fn check_host_signer(home: Option<&std::path::Path>) -> PostureCheck {
-    let Some(home) = home else {
+    if home.is_none() {
         return PostureCheck {
             name: "host_signer",
             status: PostureStatus::Fail,
             detail: "$HOME unset — cannot locate ~/.mvm/keys/host-signer.ed25519".into(),
         };
-    };
-    let path = home.join(".mvm").join("keys").join("host-signer.ed25519");
+    }
+    let path = mvm_core::config::mvm_keys_dir().join("host-signer.ed25519");
     if !path.exists() {
         return PostureCheck {
             name: "host_signer",
@@ -182,14 +182,14 @@ fn check_host_signer(home: Option<&std::path::Path>) -> PostureCheck {
 }
 
 fn check_audit_chain(home: Option<&std::path::Path>) -> PostureCheck {
-    let Some(home) = home else {
+    if home.is_none() {
         return PostureCheck {
             name: "audit_chain",
             status: PostureStatus::Fail,
             detail: "$HOME unset — cannot locate ~/.mvm/audit/local.jsonl".into(),
         };
-    };
-    let path = home.join(".mvm").join("audit").join("local.jsonl");
+    }
+    let path = mvm_core::config::mvm_audit_dir().join("local.jsonl");
     if !path.exists() {
         return PostureCheck {
             name: "audit_chain",
@@ -202,7 +202,7 @@ fn check_audit_chain(home: Option<&std::path::Path>) -> PostureCheck {
     }
     // Verifying the chain requires the host signer's verifying
     // key. Load it lazily — if it fails, surface that.
-    let keys_dir = home.join(".mvm").join("keys");
+    let keys_dir = mvm_core::config::mvm_keys_dir();
     match crate::commands::vm::host_signer::load_or_init_at(&keys_dir) {
         Ok(signer) => match mvm_hostd::supervisor::verify_audit_chain(&path, &signer.verifying) {
             Ok(count) => PostureCheck {
@@ -326,7 +326,9 @@ fn check_tool_staging_dir(home: Option<&std::path::Path>) -> PostureCheck {
     let path = match std::env::var_os(mvm_hostd::supervisor::tools::staging::STAGING_DIR_ENV_VAR) {
         Some(p) => std::path::PathBuf::from(p),
         None => match home {
-            Some(h) => h.join(".mvm").join("tool-staging"),
+            Some(_) => {
+                std::path::PathBuf::from(mvm_core::config::mvm_data_dir()).join("tool-staging")
+            }
             None => {
                 return PostureCheck {
                     name: "tool_staging_dir",
@@ -350,14 +352,14 @@ fn check_tool_staging_dir(home: Option<&std::path::Path>) -> PostureCheck {
 }
 
 fn check_overlay_root(home: Option<&std::path::Path>) -> PostureCheck {
-    let Some(home) = home else {
+    if home.is_none() {
         return PostureCheck {
             name: "overlay_root",
             status: PostureStatus::Fail,
             detail: "$HOME unset".into(),
         };
-    };
-    let path = home.join(".mvm").join("overlays");
+    }
+    let path = mvm_core::config::mvm_overlays_dir();
     if !path.exists() {
         return PostureCheck {
             name: "overlay_root",
@@ -381,14 +383,14 @@ fn check_overlay_root(home: Option<&std::path::Path>) -> PostureCheck {
 }
 
 fn check_secret_store(home: Option<&std::path::Path>) -> PostureCheck {
-    let Some(home) = home else {
+    if home.is_none() {
         return PostureCheck {
             name: "secret_store",
             status: PostureStatus::Fail,
             detail: "$HOME unset".into(),
         };
-    };
-    let path = home.join(".mvm").join("secrets");
+    }
+    let path = mvm_core::config::mvm_secrets_dir();
     if !path.exists() {
         return PostureCheck {
             name: "secret_store",
@@ -479,6 +481,40 @@ mod tests {
         dir
     }
 
+    // Production paths now resolve via mvm_core::config::mvm_data_dir()
+    // (MVM_DATA_DIR first, then $HOME). Point MVM_DATA_DIR at the test's
+    // `<temp>/.mvm` so the helper-built paths land in the temp tree the
+    // test populates. Serialized via a static lock; restored on drop.
+    static DATA_DIR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct DataDirGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl DataDirGuard {
+        fn new(home: &std::path::Path) -> Self {
+            let guard = DATA_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var_os("MVM_DATA_DIR");
+            unsafe { std::env::set_var("MVM_DATA_DIR", home.join(".mvm")) };
+            Self {
+                _guard: guard,
+                prev,
+            }
+        }
+    }
+
+    impl Drop for DataDirGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var("MVM_DATA_DIR", v),
+                    None => std::env::remove_var("MVM_DATA_DIR"),
+                }
+            }
+        }
+    }
+
     fn write_mode(path: &std::path::Path, content: &[u8], mode: u32) {
         std::fs::write(path, content).unwrap();
         #[cfg(unix)]
@@ -495,6 +531,7 @@ mod tests {
     #[test]
     fn host_signer_check_fails_when_missing() {
         let dir = build_fake_home();
+        let _g = DataDirGuard::new(dir.path());
         let check = check_host_signer(Some(dir.path()));
         assert_eq!(check.status, PostureStatus::Fail);
         assert!(check.detail.contains("not present"), "{}", check.detail);
@@ -504,6 +541,7 @@ mod tests {
     #[test]
     fn host_signer_check_fails_when_mode_loose() {
         let dir = build_fake_home();
+        let _g = DataDirGuard::new(dir.path());
         let signer = dir
             .path()
             .join(".mvm")
@@ -519,6 +557,7 @@ mod tests {
     #[test]
     fn host_signer_check_passes_at_0600() {
         let dir = build_fake_home();
+        let _g = DataDirGuard::new(dir.path());
         let signer = dir
             .path()
             .join(".mvm")
@@ -536,6 +575,7 @@ mod tests {
     #[test]
     fn overlay_root_check_warns_when_missing() {
         let dir = build_fake_home();
+        let _g = DataDirGuard::new(dir.path());
         let check = check_overlay_root(Some(dir.path()));
         assert_eq!(check.status, PostureStatus::Warn);
     }
@@ -544,6 +584,7 @@ mod tests {
     #[test]
     fn overlay_root_check_passes_at_0700_with_tenant_count() {
         let dir = build_fake_home();
+        let _g = DataDirGuard::new(dir.path());
         let overlay = dir.path().join(".mvm").join("overlays");
         std::fs::create_dir_all(&overlay).unwrap();
         std::fs::create_dir_all(overlay.join("acme")).unwrap();
@@ -559,6 +600,7 @@ mod tests {
     #[test]
     fn overlay_root_check_fails_at_0755() {
         let dir = build_fake_home();
+        let _g = DataDirGuard::new(dir.path());
         let overlay = dir.path().join(".mvm").join("overlays");
         std::fs::create_dir_all(&overlay).unwrap();
         use std::os::unix::fs::PermissionsExt;
@@ -619,6 +661,7 @@ mod tests {
     #[test]
     fn build_report_emits_all_checks() {
         let dir = build_fake_home();
+        let _g = DataDirGuard::new(dir.path());
         let report = build_report(Some(dir.path()));
         // The list of check names is stable; pin the count so a
         // future addition is a deliberate update.
@@ -641,6 +684,7 @@ mod tests {
     #[test]
     fn report_serializes_to_stable_json_keys() {
         let dir = build_fake_home();
+        let _g = DataDirGuard::new(dir.path());
         let report = build_report(Some(dir.path()));
         let json = serde_json::to_string(&report).unwrap();
         // The check names + the lowercase status enum are part of

--- a/crates/mvm-cli/src/commands/ops/secret.rs
+++ b/crates/mvm-cli/src/commands/ops/secret.rs
@@ -247,16 +247,15 @@ pub(crate) struct AuditLog {
 
 impl AuditLog {
     pub(crate) fn default() -> Result<Self> {
-        let home = match std::env::var_os("HOME") {
-            Some(h) => h,
-            None => {
-                return Ok(Self {
-                    path: None,
-                    recorder: None,
-                });
-            }
-        };
-        let dir = PathBuf::from(home).join(".mvm").join("audit");
+        // No `$HOME` → no-op log (CI sandboxes, daemons without a home
+        // dir). MVM_DATA_DIR is honored by mvm_audit_dir when set.
+        if std::env::var_os("HOME").is_none() && std::env::var_os("MVM_DATA_DIR").is_none() {
+            return Ok(Self {
+                path: None,
+                recorder: None,
+            });
+        }
+        let dir = mvm_core::config::mvm_audit_dir();
         std::fs::create_dir_all(&dir)
             .with_context(|| format!("creating audit dir {}", dir.display()))?;
         #[cfg(unix)]

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -368,6 +368,34 @@ pub fn vm_console_log(name: &str) -> std::path::PathBuf {
     vm_state_dir(name).join("console.log")
 }
 
+// ============================================================================
+// Sensitive ~/.mvm subdirectories
+// ============================================================================
+//
+// Build these ONLY through the helpers below so they honor MVM_DATA_DIR and
+// stay consistent across the diagnostics, signer, and audit paths. The
+// inline `$HOME/.mvm/<sub>` derivations these replace ignored MVM_DATA_DIR.
+
+/// Host signing keys (e.g. `host-signer.ed25519`): `<mvm_data_dir>/keys/`.
+pub fn mvm_keys_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_data_dir()).join("keys")
+}
+
+/// Chain-signed audit logs: `<mvm_data_dir>/audit/`.
+pub fn mvm_audit_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_data_dir()).join("audit")
+}
+
+/// Overlay receipts / destruction certificates: `<mvm_data_dir>/overlays/`.
+pub fn mvm_overlays_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_data_dir()).join("overlays")
+}
+
+/// Secret-material staging: `<mvm_data_dir>/secrets/`.
+pub fn mvm_secrets_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_data_dir()).join("secrets")
+}
+
 /// Check if running in production mode (MVM_PRODUCTION=1).
 pub fn is_production_mode() -> bool {
     std::env::var("MVM_PRODUCTION")

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -312,6 +312,62 @@ pub fn deps_volume_dir(volume_hash: &str) -> std::path::PathBuf {
     std::path::PathBuf::from(mvm_deps_volumes_dir()).join(volume_hash)
 }
 
+// ============================================================================
+// Per-VM host-side state paths
+// ============================================================================
+//
+// Every per-VM artifact mvm writes on the host lives under
+// `<mvm_data_dir>/vms/<name>/`. Build these paths ONLY through the helpers
+// below: a single source of truth for the layout, and `MVM_DATA_DIR` is
+// honored everywhere. The inline `$HOME/.mvm/vms/...` derivations these
+// replace duplicated the convention — which let the libkrun vsock socket
+// name drift between two resolvers (the #582 regression) — and silently
+// ignored `MVM_DATA_DIR`, so parallel sessions collided despite setting it.
+
+/// Per-VM state directory: `<mvm_data_dir>/vms/<name>/`. Holds the
+/// libkrun pid file, console log, vsock listener socket(s), runtime
+/// `mode.json`, `rootfs.ref` / `kernel.ref`, and the `ports` file.
+pub fn vm_state_dir(name: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_data_dir())
+        .join("vms")
+        .join(name)
+}
+
+/// Filename of libkrun's per-port vsock listener socket: `vsock-<port>.sock`.
+/// The single source of truth for the name. Callers that already hold the
+/// per-VM dir (e.g. a `VsockTransport` constructed from an explicit dir)
+/// join this; callers that hold the VM name use [`vm_vsock_port_socket`].
+pub fn vsock_socket_filename(port: u32) -> String {
+    format!("vsock-{port}.sock")
+}
+
+/// libkrun's per-port vsock listener socket: `<vm_state_dir>/vsock-<port>.sock`.
+/// libkrun's supervisor binds one socket per forwarded port, so a client
+/// connects directly with no port handshake. This + [`vsock_socket_filename`]
+/// are the single source of truth for the convention — every host-side
+/// resolver (the console transport, the dev-VM connect path) must use them
+/// so they cannot drift, which is exactly what broke in #582.
+pub fn vm_vsock_port_socket(name: &str, port: u32) -> std::path::PathBuf {
+    vm_state_dir(name).join(vsock_socket_filename(port))
+}
+
+/// The Apple-Container cross-process vsock proxy socket:
+/// `<vm_state_dir>/vsock.sock`. The dev daemon listens here and
+/// multiplexes ports via a 4-byte little-endian port prefix.
+pub fn vm_vsock_proxy_socket(name: &str) -> std::path::PathBuf {
+    vm_state_dir(name).join("vsock.sock")
+}
+
+/// libkrun supervisor pid file: `<vm_state_dir>/libkrun.pid`.
+pub fn vm_libkrun_pid(name: &str) -> std::path::PathBuf {
+    vm_state_dir(name).join("libkrun.pid")
+}
+
+/// Guest console capture log: `<vm_state_dir>/console.log`.
+pub fn vm_console_log(name: &str) -> std::path::PathBuf {
+    vm_state_dir(name).join("console.log")
+}
+
 /// Check if running in production mode (MVM_PRODUCTION=1).
 pub fn is_production_mode() -> bool {
     std::env::var("MVM_PRODUCTION")
@@ -579,5 +635,36 @@ mod tests {
         assert_eq!(mode, 0o700, "expected 0700, got 0{:o}", mode);
 
         let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn vm_state_paths_honor_data_dir_and_share_one_source() {
+        let _g = env_lock();
+        unsafe { std::env::set_var("MVM_DATA_DIR", "/custom/data") };
+
+        // Per-VM dir + sockets derive from MVM_DATA_DIR; the inline
+        // `$HOME/.mvm/vms/...` derivations this centralizes silently ignored
+        // it, so parallel sessions collided despite setting it.
+        assert_eq!(
+            vm_state_dir("foo"),
+            std::path::PathBuf::from("/custom/data/vms/foo")
+        );
+        assert_eq!(
+            vm_vsock_port_socket("foo", 5252),
+            std::path::PathBuf::from("/custom/data/vms/foo/vsock-5252.sock")
+        );
+        assert_eq!(
+            vm_vsock_proxy_socket("foo"),
+            std::path::PathBuf::from("/custom/data/vms/foo/vsock.sock")
+        );
+        // The dev-VM connect resolver (mvm-backend) and the console transport
+        // (mvm) both build the libkrun socket as state-dir + shared filename,
+        // so they cannot drift again (#582).
+        assert_eq!(
+            vm_state_dir("foo").join(vsock_socket_filename(5252)),
+            vm_vsock_port_socket("foo", 5252)
+        );
+
+        unsafe { std::env::remove_var("MVM_DATA_DIR") };
     }
 }

--- a/crates/mvm/src/vsock_transport.rs
+++ b/crates/mvm/src/vsock_transport.rs
@@ -88,12 +88,16 @@ impl LibkrunTransport {
     }
 
     pub fn for_vm(vm_name: &str) -> Self {
-        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-        Self::new(PathBuf::from(home).join(".mvm/vms").join(vm_name))
+        // Single source of truth for the per-VM dir (honors MVM_DATA_DIR).
+        // for_vm(name).socket_path(port) now equals
+        // mvm_core::config::vm_vsock_port_socket(name, port) — the same path
+        // the dev-VM connect resolver uses, so they can't drift (#582).
+        Self::new(mvm_core::config::vm_state_dir(vm_name))
     }
 
     fn socket_path(&self, port: u32) -> PathBuf {
-        self.socket_dir.join(format!("vsock-{port}.sock"))
+        self.socket_dir
+            .join(mvm_core::config::vsock_socket_filename(port))
     }
 }
 


### PR DESCRIPTION
## What

Centralize **all** `~/.mvm` path construction in `mvm-core::config` (the foundation crate every other crate already depends on), and fix the chain of bugs that had `mvmctl dev up` / the core-demo broken on `main`. Closes #582.

The two are linked: the **root cause** of #582 was that the libkrun per-VM vsock socket convention (`~/.mvm/vms/<name>/vsock-<port>.sock`) was duplicated across crate layers and the copies **drifted** — one resolver knew the path, the other didn't. Centralizing the layout removes that whole class of bug.

## Centralization (the directory-management refactor)

New single-source-of-truth helpers in `mvm-core::config`, all built on `mvm_data_dir()` so they **honor `MVM_DATA_DIR`**:

- Per-VM: `vm_state_dir`, `vm_vsock_port_socket`, `vm_vsock_proxy_socket`, `vm_libkrun_pid`, `vm_console_log`, `vsock_socket_filename`
- Subdirs: `mvm_keys_dir`, `mvm_audit_dir`, `mvm_overlays_dir`, `mvm_secrets_dir`

Every inline `$HOME/.mvm/...` construction across `mvm-backend` (libkrun, vz, apple_container, docker, runtime_meta, the macOS vsock proxy — listener **and** connector now resolve identically), `mvm-build` (builder vsock sockets), and `mvm-cli` (audit-posture + secret diagnostics) now routes through these. This also fixes a **latent isolation bug**: the inline derivations ignored `MVM_DATA_DIR`, so parallel sessions collided despite setting it.

## The #582 chain (each found by driving `core_demo_e2e` one step further)

1. **Console resolver missing the libkrun branch** — `vsock_connect_any` knew the in-process Vz ref and the Apple-Container `vsock.sock` proxy but not libkrun's per-port socket, so a healthy libkrun dev VM was reported "not running."
2. **Stage 0 fingerprint bailed on consolidation-moved crates** — `builder_vm_source_fingerprint` hashed `crates/mvm-host-vm-init` / `crates/mvm-egress-proxy`, which Plan 121 folded into `crates/mvm-build/src/bin/`; `dev up` bailed before the builder VM could boot. Their identity is already captured by the embedded-binary-bytes hash, so the redundant (and now-wrong) source hash was dropped.
3. **Startup race** — `LibkrunBackend::start` returned on the PID file, before the supervisor bound the vsock socket; the console/`shell_exec` that follow raced that window. `start` now waits for the agent socket so "ready" means reachable.
4. **`openpty()` in non-TTY context** — `dev up` unconditionally opened an interactive PTY console; in CI/scripts/the test (stdin redirected) `openpty()` fails. The shell is now gated on `stdin().is_terminal()` — boot + return otherwise (`dev shell` attaches later). Makes `dev up` scriptable.
5. **Stale `just e2e-core-demo` recipe** — built `-p mvm-libkrun-supervisor` (no longer a crate; it's a `mvm-vm-host` bin). This is *why* the regression went uncaught — the guard itself didn't build.

## Verification

- **`core_demo_e2e` is GREEN** end-to-end on macOS/libkrun: `dev up → compile (Python hello-app) → up (build + admit signed plan + boot + guest-agent ping) → teardown` (1 passed, ~580s).
- `cargo clippy --workspace` clean; `nightly cargo fmt --all --check` clean; `xtask check-spec-numbers` + `check-claim-catalog` (14 claims / 33 witnesses) pass.
- New unit tests: `vm_state_paths_honor_data_dir_and_share_one_source` (both resolvers derive one path, MVM_DATA_DIR honored), `vsock_connect_any_consults_libkrun_socket`, `fold_embedded_binary_identity_distinguishes_inputs`; fingerprint tests retargeted to the new contract; audit-posture tests pin `MVM_DATA_DIR`.

## Notes

- `deps/libkrun-sys` stays parameterized (caller supplies the dir) — the leaf FFI crate gains no dependency.
