### PR TITLE
feat(crypto): one AEAD entry point — crypto::aead (plan 122 A1)

### DIFF
--- a/crates/mvm-core/src/crypto/aead.rs
+++ b/crates/mvm-core/src/crypto/aead.rs
@@ -1,0 +1,175 @@
+//! One AES-256-GCM entry point for every at-rest call site.
+//!
+//! `snapshot_crypto` (single-shot byte slices) and `snapshot_encryption`
+//! (chunked files) both used to reach for `Aes256Gcm` directly, each
+//! generating its own nonce. They now funnel through [`seal`] / [`open`]
+//! so the wire format and — the part that actually matters — the nonce
+//! discipline live in exactly one place.
+//!
+//! Wire: `nonce (12) ‖ ciphertext ‖ tag (16)`.
+
+use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::{AeadCore, Aes256Gcm, Nonce};
+use zeroize::Zeroize;
+
+/// Nonce size for AES-256-GCM: 96 bits / 12 bytes.
+pub const NONCE_SIZE: usize = 12;
+
+/// Authentication tag size: 128 bits / 16 bytes.
+pub const TAG_SIZE: usize = 16;
+
+/// Required key size: 256 bits / 32 bytes.
+pub const KEY_SIZE: usize = 32;
+
+/// Errors surfaced by [`open`] and [`Key::from_slice`].
+#[derive(Debug, thiserror::Error)]
+pub enum AeadError {
+    /// A key slice was not exactly [`KEY_SIZE`] bytes.
+    #[error("AES-256-GCM key must be {KEY_SIZE} bytes, got {0}")]
+    KeySize(usize),
+    /// Framed input was shorter than a bare nonce + tag — can't possibly
+    /// be a valid AEAD frame.
+    #[error("AEAD input too short: {got} bytes (minimum {} for nonce+tag)", NONCE_SIZE + TAG_SIZE)]
+    TooShort { got: usize },
+    /// GCM tag did not verify: wrong key, or the ciphertext/nonce/tag was
+    /// tampered with. The single failure mode a caller must fail closed on.
+    #[error("authentication tag mismatch — wrong key or tampered ciphertext")]
+    Auth,
+}
+
+/// An AES-256-GCM key.
+///
+/// A newtype rather than a bare `[u8; 32]` so a key can't be passed where
+/// a signing key or arbitrary buffer is wanted, and so the zeroize-on-drop
+/// lives in one spot instead of at every call site.
+pub struct Key([u8; KEY_SIZE]);
+
+impl Key {
+    /// Wrap an owned 32-byte key.
+    pub fn from_bytes(bytes: [u8; KEY_SIZE]) -> Self {
+        Key(bytes)
+    }
+
+    /// Build from a slice; errors unless it is exactly [`KEY_SIZE`] bytes.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, AeadError> {
+        let arr: [u8; KEY_SIZE] = bytes
+            .try_into()
+            .map_err(|_| AeadError::KeySize(bytes.len()))?;
+        Ok(Key(arr))
+    }
+
+    /// Fresh random key drawn from the OS CSPRNG.
+    pub fn random() -> Self {
+        let generic = Aes256Gcm::generate_key(&mut OsRng);
+        let mut bytes = [0u8; KEY_SIZE];
+        bytes.copy_from_slice(&generic);
+        Key(bytes)
+    }
+}
+
+impl Drop for Key {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+/// Seal `plaintext` under `key`, returning `nonce ‖ ciphertext ‖ tag`.
+///
+/// The nonce is drawn fresh from the OS CSPRNG on every call and is never
+/// caller-supplied: nonce reuse under one key is catastrophic for GCM
+/// (it leaks the XOR of two plaintexts and the authentication key), so the
+/// only safe API is one that owns nonce generation.
+///
+/// Infallible: AES-GCM encryption of an in-memory buffer cannot fail for
+/// any plaintext small enough to hold in a `Vec` — the lone documented
+/// error is exceeding GCM's ~64 GiB message ceiling, which would OOM first.
+pub fn seal(key: &Key, plaintext: &[u8]) -> Vec<u8> {
+    let cipher = Aes256Gcm::new(&key.0.into());
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext)
+        .expect("AES-256-GCM seal of an in-memory buffer cannot fail");
+
+    let mut out = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
+    out.extend_from_slice(&nonce);
+    out.extend_from_slice(&ciphertext);
+    out
+}
+
+/// Open a `nonce ‖ ciphertext ‖ tag` frame produced by [`seal`].
+///
+/// Returns [`AeadError::Auth`] on any tag mismatch (wrong key, tampered
+/// bytes) and [`AeadError::TooShort`] when the frame can't hold a nonce
+/// and tag.
+pub fn open(key: &Key, framed: &[u8]) -> Result<Vec<u8>, AeadError> {
+    if framed.len() < NONCE_SIZE + TAG_SIZE {
+        return Err(AeadError::TooShort { got: framed.len() });
+    }
+    let (nonce_bytes, ciphertext) = framed.split_at(NONCE_SIZE);
+    let nonce = Nonce::from_slice(nonce_bytes);
+    let cipher = Aes256Gcm::new(&key.0.into());
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| AeadError::Auth)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seal_open_roundtrip_and_reject_tamper() {
+        let k = Key::random();
+        let mut ct = seal(&k, b"snapshot bytes");
+        assert_eq!(open(&k, &ct).unwrap(), b"snapshot bytes");
+        ct[20] ^= 1; // flip one ciphertext byte
+        assert!(matches!(open(&k, &ct), Err(AeadError::Auth)));
+    }
+
+    #[test]
+    fn roundtrip_empty_plaintext() {
+        let k = Key::random();
+        let ct = seal(&k, b"");
+        assert_eq!(ct.len(), NONCE_SIZE + TAG_SIZE); // nonce + tag, no body
+        assert_eq!(open(&k, &ct).unwrap(), b"");
+    }
+
+    #[test]
+    fn wrong_key_fails_auth() {
+        let k1 = Key::random();
+        let k2 = Key::random();
+        let ct = seal(&k1, b"secret");
+        assert!(matches!(open(&k2, &ct), Err(AeadError::Auth)));
+    }
+
+    #[test]
+    fn fresh_nonce_per_seal() {
+        let k = Key::random();
+        let a = seal(&k, b"same");
+        let b = seal(&k, b"same");
+        assert_ne!(a, b, "each seal must draw a fresh nonce");
+    }
+
+    #[test]
+    fn open_rejects_short_frame() {
+        let k = Key::random();
+        let err = open(&k, &[0u8; NONCE_SIZE + TAG_SIZE - 1]).unwrap_err();
+        assert!(matches!(err, AeadError::TooShort { .. }));
+    }
+
+    #[test]
+    fn from_slice_rejects_wrong_length() {
+        assert!(matches!(
+            Key::from_slice(&[0u8; 16]),
+            Err(AeadError::KeySize(16))
+        ));
+        assert!(Key::from_slice(&[0u8; KEY_SIZE]).is_ok());
+    }
+
+    #[test]
+    fn output_size_is_nonce_plus_plaintext_plus_tag() {
+        let k = Key::random();
+        let ct = seal(&k, b"test");
+        assert_eq!(ct.len(), NONCE_SIZE + 4 + TAG_SIZE);
+    }
+}

--- a/crates/mvm-core/src/crypto/mod.rs
+++ b/crates/mvm-core/src/crypto/mod.rs
@@ -1,3 +1,4 @@
+pub mod aead;
 pub mod attestation;
 pub mod command_gate;
 pub mod image_verify;

--- a/crates/mvm-core/src/crypto/snapshot_crypto.rs
+++ b/crates/mvm-core/src/crypto/snapshot_crypto.rs
@@ -7,72 +7,33 @@
 //! Phase 2 proper so they can sit on `mvm-storage::VolumeBackend`
 //! (Sprint 49 / plan 45) rather than re-deriving an earlier shape.
 
-use aes_gcm::aead::{Aead, KeyInit, OsRng};
-use aes_gcm::{AeadCore, Aes256Gcm, Nonce};
+use crate::crypto::aead;
 use anyhow::Result;
 
-/// Nonce size for AES-256-GCM: 96 bits / 12 bytes.
-pub const NONCE_SIZE: usize = 12;
-
-/// Authentication tag size: 128 bits / 16 bytes.
-pub const TAG_SIZE: usize = 16;
-
-/// Required key size: 256 bits / 32 bytes.
-pub const KEY_SIZE: usize = 32;
+// The wire format and nonce discipline now live in `crypto::aead`; these
+// re-exports keep the long-standing `snapshot_crypto::{KEY_SIZE,…}` paths
+// working for downstream callers.
+pub use crate::crypto::aead::{KEY_SIZE, NONCE_SIZE, TAG_SIZE};
 
 /// Encrypt `plaintext` under `key`.
 ///
 /// Returns `[12-byte nonce || ciphertext || 16-byte tag]`. The nonce
-/// is freshly generated from `OsRng` for every call; never reuse a
-/// nonce under the same key.
+/// is freshly generated for every call; never reuse a nonce under the
+/// same key. Thin `anyhow` shim over [`aead::seal`].
 pub fn encrypt(plaintext: &[u8], key: &[u8]) -> Result<Vec<u8>> {
-    if key.len() != KEY_SIZE {
-        anyhow::bail!(
-            "AES-256-GCM key must be {KEY_SIZE} bytes, got {}",
-            key.len()
-        );
-    }
-
-    let cipher = Aes256Gcm::new_from_slice(key)
-        .map_err(|e| anyhow::anyhow!("Failed to create cipher: {}", e))?;
-    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
-    let ciphertext = cipher
-        .encrypt(&nonce, plaintext)
-        .map_err(|e| anyhow::anyhow!("Encryption failed: {}", e))?;
-
-    let mut out = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
-    out.extend_from_slice(&nonce);
-    out.extend_from_slice(&ciphertext);
-    Ok(out)
+    let key = aead::Key::from_slice(key).map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(aead::seal(&key, plaintext))
 }
 
 /// Decrypt `encrypted` under `key`.
 ///
 /// `encrypted` must be `[12-byte nonce || ciphertext || 16-byte tag]`.
 /// Authentication failure (wrong key, tampered ciphertext, truncated
-/// tag) returns an error; success returns the recovered plaintext.
+/// tag) returns an error; success returns the recovered plaintext. Thin
+/// `anyhow` shim over [`aead::open`].
 pub fn decrypt(encrypted: &[u8], key: &[u8]) -> Result<Vec<u8>> {
-    if key.len() != KEY_SIZE {
-        anyhow::bail!(
-            "AES-256-GCM key must be {KEY_SIZE} bytes, got {}",
-            key.len()
-        );
-    }
-    if encrypted.len() < NONCE_SIZE + TAG_SIZE {
-        anyhow::bail!(
-            "Encrypted payload too short: {} bytes (minimum {})",
-            encrypted.len(),
-            NONCE_SIZE + TAG_SIZE
-        );
-    }
-
-    let (nonce_bytes, ciphertext) = encrypted.split_at(NONCE_SIZE);
-    let nonce = Nonce::from_slice(nonce_bytes);
-    let cipher = Aes256Gcm::new_from_slice(key)
-        .map_err(|e| anyhow::anyhow!("Failed to create cipher: {}", e))?;
-    cipher
-        .decrypt(nonce, ciphertext)
-        .map_err(|_| anyhow::anyhow!("Decryption failed: authentication tag mismatch"))
+    let key = aead::Key::from_slice(key).map_err(|e| anyhow::anyhow!("{e}"))?;
+    aead::open(&key, encrypted).map_err(|e| anyhow::anyhow!("Decryption failed: {e}"))
 }
 
 #[cfg(test)]

--- a/crates/mvm-core/src/crypto/snapshot_encryption.rs
+++ b/crates/mvm-core/src/crypto/snapshot_encryption.rs
@@ -54,23 +54,16 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 
-use aes_gcm::aead::{Aead, KeyInit};
-use aes_gcm::{Aes256Gcm, Nonce};
+use crate::crypto::aead;
 use anyhow::{Context, Result};
-use rand::RngCore;
 
 /// Default plaintext chunk size: 1 MiB. Each on-disk encrypted
 /// chunk is `chunk_size + 28` bytes (12 nonce + 16 tag).
 pub const DEFAULT_CHUNK_SIZE: usize = 1024 * 1024;
 
-/// 12-byte nonce per AES-256-GCM convention.
-pub const NONCE_SIZE: usize = 12;
-
-/// 16-byte AES-GCM authentication tag.
-pub const TAG_SIZE: usize = 16;
-
-/// 32-byte AES-256 key.
-pub const KEY_SIZE: usize = 32;
+// The AEAD sizes live in `crypto::aead`; re-export so the
+// `snapshot_encryption::{NONCE_SIZE,…}` paths downstream keep working.
+pub use crate::crypto::aead::{KEY_SIZE, NONCE_SIZE, TAG_SIZE};
 
 /// File header magic; lets the resume path probe for "is this file
 /// encrypted?" cheaply.
@@ -104,12 +97,7 @@ pub fn encrypt_file_in_place_with_chunk_size(
     key: &[u8],
     chunk_size: usize,
 ) -> Result<()> {
-    if key.len() != KEY_SIZE {
-        anyhow::bail!(
-            "snapshot encryption key must be {KEY_SIZE} bytes, got {}",
-            key.len()
-        );
-    }
+    let key = aead::Key::from_slice(key).map_err(|e| anyhow::anyhow!("snapshot encryption {e}"))?;
     if chunk_size == 0 || chunk_size > u32::MAX as usize {
         anyhow::bail!("chunk_size must be in 1..=u32::MAX, got {chunk_size}");
     }
@@ -119,8 +107,6 @@ pub fn encrypt_file_in_place_with_chunk_size(
     let pt_size = plaintext_meta.len();
 
     let tmp_path = path.with_extension("enc.tmp");
-    let cipher = Aes256Gcm::new_from_slice(key)
-        .map_err(|e| anyhow::anyhow!("constructing AES-256-GCM cipher: {e}"))?;
 
     // Wrap the write in a closure so we can clean up on any error.
     let result: Result<()> = (|| {
@@ -150,24 +136,18 @@ pub fn encrypt_file_in_place_with_chunk_size(
 
         // Chunks.
         let mut buf = vec![0u8; chunk_size];
-        let mut nonce_bytes = [0u8; NONCE_SIZE];
         let mut written_pt: u64 = 0;
         loop {
             let n = read_exact_up_to(&mut reader, &mut buf)?;
             if n == 0 {
                 break;
             }
-            rand::thread_rng().fill_bytes(&mut nonce_bytes);
-            let nonce = Nonce::from_slice(&nonce_bytes);
-            let ct = cipher
-                .encrypt(nonce, &buf[..n])
-                .map_err(|e| anyhow::anyhow!("AES-256-GCM encrypt chunk: {e}"))?;
+            // `seal` prepends a fresh nonce, so a sealed chunk is exactly
+            // the `nonce ‖ ct ‖ tag` the decoder reads back below.
+            let chunk = aead::seal(&key, &buf[..n]);
             writer
-                .write_all(&nonce_bytes)
-                .with_context(|| format!("writing chunk nonce to {}", tmp_path.display()))?;
-            writer
-                .write_all(&ct)
-                .with_context(|| format!("writing chunk ciphertext to {}", tmp_path.display()))?;
+                .write_all(&chunk)
+                .with_context(|| format!("writing encrypted chunk to {}", tmp_path.display()))?;
             written_pt += n as u64;
             if n < chunk_size {
                 break;
@@ -227,16 +207,9 @@ fn read_exact_up_to<R: Read>(reader: &mut R, buf: &mut [u8]) -> Result<usize> {
 /// Validates the magic, schema version, and stitched plaintext
 /// size against the header.
 pub fn decrypt_file_in_place(path: &Path, key: &[u8]) -> Result<()> {
-    if key.len() != KEY_SIZE {
-        anyhow::bail!(
-            "snapshot encryption key must be {KEY_SIZE} bytes, got {}",
-            key.len()
-        );
-    }
+    let key = aead::Key::from_slice(key).map_err(|e| anyhow::anyhow!("snapshot encryption {e}"))?;
     let header = read_header(path)?;
     let tmp_path = path.with_extension("dec.tmp");
-    let cipher = Aes256Gcm::new_from_slice(key)
-        .map_err(|e| anyhow::anyhow!("constructing AES-256-GCM cipher: {e}"))?;
 
     let result: Result<()> = (|| {
         let ct_file =
@@ -256,27 +229,24 @@ pub fn decrypt_file_in_place(path: &Path, key: &[u8]) -> Result<()> {
             .with_context(|| format!("creating tmp {}", tmp_path.display()))?;
         let mut writer = BufWriter::new(tmp_file);
 
-        let chunk_input_size = header.chunk_size as usize + TAG_SIZE;
-        let mut nonce_bytes = [0u8; NONCE_SIZE];
-        let mut ct_buf = vec![0u8; chunk_input_size];
+        // Each on-disk chunk is `nonce ‖ ct ‖ tag`; read the whole frame
+        // and hand it to `aead::open`.
+        let framed_chunk_size = NONCE_SIZE + header.chunk_size as usize + TAG_SIZE;
+        let mut framed = vec![0u8; framed_chunk_size];
         let mut written_pt: u64 = 0;
         loop {
-            match reader.read_exact(&mut nonce_bytes) {
-                Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                Err(e) => {
-                    return Err(anyhow::anyhow!("reading chunk nonce: {e}"));
-                }
+            let n = read_exact_up_to(&mut reader, &mut framed)?;
+            if n == 0 {
+                break; // clean EOF on a chunk boundary
             }
-            let n = read_exact_up_to(&mut reader, &mut ct_buf)?;
-            if n < TAG_SIZE {
+            if n < NONCE_SIZE + TAG_SIZE {
                 anyhow::bail!(
-                    "ciphertext chunk truncated: got {n} bytes after nonce \
-                     (minimum {TAG_SIZE} for AEAD tag)"
+                    "ciphertext chunk truncated: got {n} bytes \
+                     (minimum {} for nonce+tag)",
+                    NONCE_SIZE + TAG_SIZE
                 );
             }
-            let nonce = Nonce::from_slice(&nonce_bytes);
-            let pt = cipher.decrypt(nonce, &ct_buf[..n]).map_err(|_| {
+            let pt = aead::open(&key, &framed[..n]).map_err(|_| {
                 anyhow::anyhow!(
                     "AES-256-GCM authentication failure — wrong key or tampered ciphertext"
                 )

--- a/specs/plans/122-encryption-key-lifecycle.md
+++ b/specs/plans/122-encryption-key-lifecycle.md
@@ -48,6 +48,13 @@ Gaps this plan fills: macOS volume-at-rest, 90-day rotation timer, per-rebuild D
 
 ### Task A0: pluggable channel layering (the encryption seam)
 
+> **DEFERRED (2026-06-04).** Skipped for now: A0 ships only an `Identity`
+> no-op and would rewrite a claims-8/12/13 fuzzed wire format for an
+> untrusted in-mvm channel that does not exist yet. Deferred until a real
+> untrusted in-mvm channel appears (the same conditional work descoped from
+> plan 121 B4). If `framing` later moves to `mvm-hostd`, coordinate with
+> plan 126 B5 — whichever crate owns `framing` then hosts the seam.
+
 **Reconciled with what plan 121 actually shipped — folds in 121 B4 "Option B".** Plan 121 (#581) shipped `core::framing` as the *simple* `read_json_frame` / `write_json_frame` (4-byte length prefix + serde body, cap-before-alloc) — **not** the `FramedMessage<T>` + pluggable-`AuthStage` structure this task originally assumed. Genericizing the host↔guest Ed25519 `AuthenticatedFrame` onto `FramedMessage<T>` was **descoped** from 121 as zero-dedup churn on a claims-8/12/13 fuzzed wire format, and parked as a 121 follow-up. It lands **here**, as the prerequisite half of this seam, because 122 is the first plan that actually needs the pluggable stage. So A0 is two stages: (1) build the `FramedMessage<T>` auth seam (the retrofit descoped from 121), then (2) add the optional encryption transform.
 
 **Gate carried from the 121 descope (do NOT skip):** the auth retrofit rewrites a claims-8/12/13 fuzzed wire format — land it only behind a dedicated cargo-fuzz pass on the unified frame parser **and** a live host↔guest boot round-trip (`examples/agent_ping`) proving the authed path is byte-for-byte unchanged. Never a pure refactor commit.
@@ -75,7 +82,7 @@ Then add the encryption transform — an optional second pluggable stage so a No
 
 **Files:** `crates/mvm-core/src/crypto/aead.rs` (new, post-121); the two existing modules become callers.
 
-- [ ] **Step 1:** Write `aead.rs` with a typed key and the existing wire format. The `Key` newtype exists so a 32-byte buffer can't be passed where a signing key is wanted, and to carry the zeroize impl in one spot.
+- [x] **Step 1:** Write `aead.rs` with a typed key and the existing wire format. The `Key` newtype exists so a 32-byte buffer can't be passed where a signing key is wanted, and to carry the zeroize impl in one spot.
   ```rust
   /// AES-256-GCM with a random 96-bit nonce per call. Wire: nonce ‖ ct ‖ tag.
   /// Nonce reuse under one key is catastrophic for GCM, so we never accept a
@@ -85,7 +92,7 @@ Then add the encryption transform — an optional second pluggable stage so a No
   pub fn seal(key: &Key, plaintext: &[u8]) -> Vec<u8>;
   pub fn open(key: &Key, framed: &[u8]) -> Result<Vec<u8>, AeadError>; // AeadError on tag mismatch / short input
   ```
-- [ ] **Step 2:** Failing test — roundtrip and tamper.
+- [x] **Step 2:** Failing test — roundtrip and tamper.
   ```rust
   #[test]
   fn seal_open_roundtrip_and_reject_tamper() {
@@ -96,9 +103,9 @@ Then add the encryption transform — an optional second pluggable stage so a No
       assert!(open(&k, &ct).is_err()); // GCM tag must catch it
   }
   ```
-- [ ] **Step 3:** Implement over `aes-gcm` (already a dep), nonce from `getrandom`.
-- [ ] **Step 4:** Re-point `snapshot_crypto::{encrypt,decrypt}` and `snapshot_encryption` at `aead::{seal,open}`; keep their public signatures so callers don't churn. `cargo test -p mvm-core aead snapshot` green.
-- [ ] **Step 5:** Commit.
+- [x] **Step 3:** Implement over `aes-gcm` (already a dep), nonce from `getrandom`.
+- [x] **Step 4:** Re-point `snapshot_crypto::{encrypt,decrypt}` and `snapshot_encryption` at `aead::{seal,open}`; keep their public signatures so callers don't churn. `cargo test -p mvm-core aead snapshot` green.
+- [x] **Step 5:** Commit.
 
 ### Task A2: macOS volume-at-rest path
 


### PR DESCRIPTION
## Plan 122 — Task A1: collapse the AEAD call sites into `mvm_core::crypto::aead`

First slice of [plan 122](specs/plans/122-encryption-key-lifecycle.md) (encryption + key lifecycle). Foundational and low-risk: it unifies the two existing AES-256-GCM call sites behind one typed entry point so later tasks (volume-at-rest, DEK binding, signed snapshots) build on a single primitive.

### What changed
- **New `crypto::aead`** — a `Key` newtype (zeroize-on-drop; can't be passed where a signing key is wanted) plus `seal`/`open` over the existing `nonce ‖ ct ‖ tag` wire format. `seal` owns nonce generation from the OS CSPRNG; there is deliberately **no caller-supplied-nonce path**, because nonce reuse under one key is catastrophic for GCM.
- **`snapshot_crypto::{encrypt,decrypt}`** are now thin `anyhow` shims over `aead`. Public signatures and the wire format are unchanged.
- **`snapshot_encryption`** seals/opens each chunk via `aead`, dropping its direct `aes-gcm`/`rand` use. The on-disk `MVSE` format is **byte-identical** — a sealed chunk is exactly the `nonce ‖ ct ‖ tag` it wrote before — so existing snapshots still decrypt.

### Why it's safe
The existing behavioural tests in both modules pass unchanged, which is the proof the re-point preserves observable behaviour (roundtrip, tamper rejection, wrong-key rejection, multi-chunk distinct-nonce, exact-boundary, truncation). New focused tests cover `aead` directly.

### Acceptance
- **No new dependency** — `aes-gcm`/`zeroize` were already in `mvm-core`. `Cargo.lock` is unchanged (verified).
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `nightly cargo fmt --all --check` clean.
- `cargo nextest run --workspace` green except the 4 pre-existing macOS-dev-host environmental failures (`mvm-guest entrypoint::tests::test_validate_*`, `mvm-oci unpack ... setgid`), which are uid/mode-sensitive and unrelated to this change.