### PR TITLE
feat(crypto): 90-day KEK rotation timer (plan 122 B1)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/volume.rs
+++ b/crates/mvm-cli/src/commands/vm/volume.rs
@@ -39,7 +39,8 @@ use mvm::vm::volume_registry::{
 };
 use mvm_core::crypto::key_rotation;
 use mvm_core::crypto::policy::validate_mount_path;
-use mvm_core::domain::volume::{OrgId, WrapAlgorithm, WrappedKey};
+use mvm_core::crypto::rotation_policy;
+use mvm_core::domain::volume::{MasterKeyState, OrgId, WrapAlgorithm, WrappedKey};
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
 use rand::RngCore;
@@ -337,7 +338,79 @@ fn create_mvm_managed(volume_name: &str, root: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+/// Plan 122 B1 — opportunistically roll the local master KEK when it is
+/// past its 90-day lifetime, re-wrapping the catalog's mvm-managed volume
+/// keys onto the new KEK. Invoked whenever a managed volume key is minted —
+/// the closest thing to a periodic "on use" trigger the local CLI has.
+///
+/// Cheap and non-destructive: re-wrapping leaves the underlying DEK (and
+/// the on-disk ciphertext) untouched, so an existing volume keeps
+/// decrypting. Best-effort scope — only keys already at the current active
+/// version are swept (a single re-wrap can't span mixed versions); a volume
+/// wrapped under an older legacy KEK keeps unlocking via its recorded
+/// version and the retained legacy key file. The age check itself lives in
+/// `rotation_policy` and is fully unit-tested there.
+fn maybe_rotate_local_master_key() -> Result<()> {
+    let active_dir = local_master_key_dir();
+    let manifest = key_rotation::load_manifest(&active_dir)?;
+    let Some(active_version) = manifest
+        .entries
+        .iter()
+        .find(|e| e.state == MasterKeyState::Active)
+        .map(|e| e.version)
+    else {
+        return Ok(()); // nothing minted yet — the first key isn't a rotation
+    };
+
+    let mut catalog = LocalVolumeCatalog::load()?;
+    let mut names: Vec<String> = Vec::new();
+    let mut sweep: Vec<WrappedKey> = Vec::new();
+    for (name, entry) in catalog.volumes.iter() {
+        if let LocalVolumeEncryption::MvmManaged(enc) = &entry.encryption
+            && enc.wrapped_key.master_key_version == active_version
+        {
+            names.push(name.clone());
+            sweep.push(enc.wrapped_key.clone());
+        }
+    }
+
+    let org = OrgId::new("local").context("constructing local org id")?;
+    let decision = rotation_policy::rotate_if_due(
+        &active_dir,
+        &org,
+        &mut sweep,
+        rotation_policy::default_interval(),
+        chrono::Utc::now(),
+    )?;
+
+    if let rotation_policy::RotationDecision::Rotated {
+        from_version,
+        to_version,
+        migrated,
+    } = decision
+    {
+        for (name, rewrapped) in names.into_iter().zip(sweep) {
+            if let Some(LocalVolumeEntry {
+                encryption: LocalVolumeEncryption::MvmManaged(enc),
+                ..
+            }) = catalog.volumes.get_mut(&name)
+            {
+                enc.wrapped_key = rewrapped;
+            }
+        }
+        catalog.save()?;
+        eprintln!(
+            "rotated local master KEK v{from_version} → v{to_version}; \
+             re-wrapped {migrated} volume key(s)"
+        );
+    }
+    Ok(())
+}
+
 fn generate_wrapped_volume_key() -> Result<(WrappedKey, secrecy::SecretBox<Vec<u8>>)> {
+    // Roll the KEK first if it's past its lifetime, then mint under the
+    // (possibly fresh) active version.
+    maybe_rotate_local_master_key()?;
     let active_dir = local_master_key_dir();
     let manifest = key_rotation::load_manifest(&active_dir)?;
     let version = if manifest.latest_version() == 0 {
@@ -859,6 +932,43 @@ mod tests {
         fs::remove_dir_all(local_master_key_dir()).unwrap();
         let err = unlock("work").unwrap_err();
         assert!(err.to_string().contains("loading master key"), "got: {err}");
+    }
+
+    #[test]
+    fn create_rotates_stale_local_master_key_and_rewraps_catalog() {
+        let guard = DataDirGuard::new();
+        let root = guard.path().join("vol-root");
+        // First volume mints master v1 and wraps "work" under it.
+        create("work", Some(root.to_str().unwrap()), false).unwrap();
+
+        // Backdate the active KEK to 91 days old so the next mint trips the
+        // 90-day rotation policy.
+        let active_dir = local_master_key_dir();
+        let mut manifest = key_rotation::load_manifest(&active_dir).unwrap();
+        manifest.entries[0].created_at = chrono::Utc::now() - chrono::Duration::days(91);
+        fs::write(
+            active_dir.join("manifest.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        // Creating a second volume runs the rotation check.
+        create("work2", Some(root.to_str().unwrap()), false).unwrap();
+
+        // KEK advanced v1 → v2.
+        let manifest = key_rotation::load_manifest(&active_dir).unwrap();
+        assert_eq!(manifest.latest_version(), 2);
+
+        // The pre-existing "work" volume was re-wrapped onto v2 …
+        let catalog = LocalVolumeCatalog::load().unwrap();
+        match &catalog.get("work").unwrap().encryption {
+            LocalVolumeEncryption::MvmManaged(enc) => {
+                assert_eq!(enc.wrapped_key.master_key_version, 2);
+            }
+            LocalVolumeEncryption::HostBacked => panic!("expected mvm-managed"),
+        }
+        // … and still unlocks, proving the DEK survived the re-wrap.
+        unlock("work").unwrap();
     }
 
     #[test]

--- a/crates/mvm-core/src/crypto/mod.rs
+++ b/crates/mvm-core/src/crypto/mod.rs
@@ -7,6 +7,7 @@ pub mod keystore;
 pub mod policy;
 pub mod posture;
 pub mod rate_limiter;
+pub mod rotation_policy;
 pub mod seccomp;
 pub mod secret_store;
 pub mod snapshot_crypto;

--- a/crates/mvm-core/src/crypto/rotation_policy.rs
+++ b/crates/mvm-core/src/crypto/rotation_policy.rs
@@ -1,0 +1,234 @@
+//! Plan 122 B1 — when to roll the master KEK.
+//!
+//! [`key_rotation::rotate_master_key`](crate::crypto::key_rotation::rotate_master_key)
+//! performs a rotation; this module decides *whether* one is due. The age
+//! check is pure — `now` is injected rather than read from the wall clock —
+//! so the policy is testable without freezing time, and [`rotate_if_due`]
+//! is the one place that combines the check with the rotate + DEK re-wrap
+//! sweep.
+
+use std::path::Path;
+
+use anyhow::Result;
+use chrono::{DateTime, Duration, Utc};
+use secrecy::ExposeSecret;
+
+use crate::crypto::key_rotation::{
+    MasterKeyManifest, MigrationOutcome, load_manifest, load_master_key, migrate_wrapped_keys,
+    rotate_master_key,
+};
+use crate::domain::volume::{MasterKeyRef, MasterKeyState, OrgId, WrappedKey};
+
+/// Default KEK lifetime before rotation is due: 90 days.
+pub const DEFAULT_INTERVAL_DAYS: i64 = 90;
+
+/// The default 90-day rotation interval as a [`Duration`]. A function
+/// rather than a `const` because `chrono::Duration::days` is not `const`.
+pub fn default_interval() -> Duration {
+    Duration::days(DEFAULT_INTERVAL_DAYS)
+}
+
+/// The single `Active` entry in the manifest, if any.
+fn active_entry(manifest: &MasterKeyManifest) -> Option<&MasterKeyRef> {
+    manifest
+        .entries
+        .iter()
+        .find(|e| e.state == MasterKeyState::Active)
+}
+
+/// True when the manifest's active KEK is at least `interval` old as of
+/// `now`.
+///
+/// No active key → not due: minting the first key is initial provisioning,
+/// not rotation. `now` is a parameter so the check never reads the wall
+/// clock — that keeps it a pure, freely-testable function (the plan's
+/// "time comes in as a parameter" rule).
+pub fn rotation_due(manifest: &MasterKeyManifest, interval: Duration, now: DateTime<Utc>) -> bool {
+    match active_entry(manifest) {
+        Some(active) => now.signed_duration_since(active.created_at) >= interval,
+        None => false,
+    }
+}
+
+/// Outcome of [`rotate_if_due`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RotationDecision {
+    /// The active KEK is younger than the interval (or none exists): no-op.
+    NotDue,
+    /// Rotated from `from_version` to `to_version`; `migrated` DEKs were
+    /// re-wrapped onto the new KEK.
+    Rotated {
+        from_version: u32,
+        to_version: u32,
+        migrated: usize,
+    },
+}
+
+/// Rotate the org's master KEK if its active version is past `interval`,
+/// then re-wrap every DEK in `keys` onto the new KEK.
+///
+/// `keys` are the wrapped DEKs the caller holds (e.g. the local volume
+/// catalog's per-volume keys); on a rotation they are migrated in place
+/// from the prior active version to the new one, and the caller persists
+/// them afterwards. Re-wrapping leaves the underlying DEK — and thus the
+/// on-disk ciphertext — untouched, which is why this is cheap and safe to
+/// run on a hot path or at boot.
+///
+/// `keys` must all sit at the current active version (the invariant a
+/// previous sweep maintains); a key at any other version makes
+/// [`migrate_wrapped_keys`] refuse rather than guess. `now` is injected
+/// for the same testability reason as [`rotation_due`].
+pub fn rotate_if_due(
+    active_dir: &Path,
+    org_id: &OrgId,
+    keys: &mut [WrappedKey],
+    interval: Duration,
+    now: DateTime<Utc>,
+) -> Result<RotationDecision> {
+    let manifest = load_manifest(active_dir)?;
+    if !rotation_due(&manifest, interval, now) {
+        return Ok(RotationDecision::NotDue);
+    }
+    // `rotation_due` returning true implies an Active entry exists.
+    let from_version = active_entry(&manifest)
+        .expect("rotation_due implies an active KEK")
+        .version;
+
+    let old_master = load_master_key(active_dir, from_version)?;
+    let new_ref = rotate_master_key(active_dir, org_id)?;
+    let new_master = load_master_key(active_dir, new_ref.version)?;
+
+    let outcomes = migrate_wrapped_keys(
+        keys,
+        from_version,
+        new_ref.version,
+        old_master.expose_secret().as_slice(),
+        new_master.expose_secret().as_slice(),
+    )?;
+    let migrated = outcomes
+        .iter()
+        .filter(|o| matches!(o, MigrationOutcome::Migrated))
+        .count();
+    Ok(RotationDecision::Rotated {
+        from_version,
+        to_version: new_ref.version,
+        migrated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::snapshot_crypto;
+    use crate::domain::volume::WrapAlgorithm;
+
+    fn org() -> OrgId {
+        OrgId::new("local").unwrap()
+    }
+
+    fn manifest_active_created_at(created_at: DateTime<Utc>) -> MasterKeyManifest {
+        MasterKeyManifest {
+            entries: vec![MasterKeyRef {
+                org_id: org(),
+                version: 1,
+                created_at,
+                state: MasterKeyState::Active,
+            }],
+        }
+    }
+
+    fn wrap(dek: &[u8], master: &secrecy::SecretBox<[u8; 32]>, version: u32) -> WrappedKey {
+        WrappedKey {
+            master_key_version: version,
+            wrapped: snapshot_crypto::encrypt(dek, master.expose_secret().as_slice()).unwrap(),
+            algorithm: WrapAlgorithm::Aes256Gcm,
+        }
+    }
+
+    #[test]
+    fn kek_due_for_rotation_past_interval() {
+        let now = Utc::now();
+        let interval = default_interval();
+        let stale = manifest_active_created_at(now - Duration::days(91));
+        assert!(rotation_due(&stale, interval, now));
+        let fresh = manifest_active_created_at(now - Duration::days(10));
+        assert!(!rotation_due(&fresh, interval, now));
+    }
+
+    #[test]
+    fn rotation_due_false_with_no_active_key() {
+        let now = Utc::now();
+        assert!(!rotation_due(
+            &MasterKeyManifest::default(),
+            default_interval(),
+            now
+        ));
+    }
+
+    #[test]
+    fn rotate_if_due_is_noop_when_fresh() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v1 = rotate_master_key(tmp.path(), &org()).unwrap();
+        let m1 = load_master_key(tmp.path(), v1.version).unwrap();
+        let mut keys = vec![wrap(&[0x11u8; 32], &m1, 1)];
+        let before = keys.clone();
+
+        // `now` ~= the key's creation time → not due.
+        let decision = rotate_if_due(
+            tmp.path(),
+            &org(),
+            &mut keys,
+            default_interval(),
+            Utc::now(),
+        )
+        .unwrap();
+        assert_eq!(decision, RotationDecision::NotDue);
+        assert_eq!(keys, before, "no rewrap when not due");
+        assert_eq!(
+            load_manifest(tmp.path()).unwrap().latest_version(),
+            1,
+            "no new version minted"
+        );
+    }
+
+    #[test]
+    fn rotate_if_due_rotates_and_rewraps_when_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v1 = rotate_master_key(tmp.path(), &org()).unwrap();
+        let m1 = load_master_key(tmp.path(), 1).unwrap();
+        let dek_a = [0xAAu8; 32];
+        let dek_b = [0xBBu8; 32];
+        let mut keys = vec![wrap(&dek_a, &m1, 1), wrap(&dek_b, &m1, 1)];
+
+        // Treat "now" as 91 days after the active key was created → due.
+        let now = v1.created_at + Duration::days(91);
+        let decision =
+            rotate_if_due(tmp.path(), &org(), &mut keys, default_interval(), now).unwrap();
+        assert_eq!(
+            decision,
+            RotationDecision::Rotated {
+                from_version: 1,
+                to_version: 2,
+                migrated: 2,
+            }
+        );
+
+        // Both DEKs now ride v2 and recover unchanged.
+        let m2 = load_master_key(tmp.path(), 2).unwrap();
+        assert_eq!(keys[0].master_key_version, 2);
+        assert_eq!(
+            snapshot_crypto::decrypt(&keys[0].wrapped, m2.expose_secret().as_slice()).unwrap(),
+            dek_a
+        );
+        assert_eq!(
+            snapshot_crypto::decrypt(&keys[1].wrapped, m2.expose_secret().as_slice()).unwrap(),
+            dek_b
+        );
+
+        // Manifest advanced; v1 retired to Legacy.
+        let manifest = load_manifest(tmp.path()).unwrap();
+        assert_eq!(manifest.latest_version(), 2);
+        assert_eq!(manifest.get(1).unwrap().state, MasterKeyState::Legacy);
+        assert_eq!(manifest.get(2).unwrap().state, MasterKeyState::Active);
+    }
+}

--- a/specs/plans/122-encryption-key-lifecycle.md
+++ b/specs/plans/122-encryption-key-lifecycle.md
@@ -126,7 +126,7 @@ LUKS2 is Linux-only. macOS volumes have no at-rest encryption today. Add a per-f
 
 **Files:** `crates/mvm-core/src/crypto/rotation_policy.rs` (new); reads the master-key manifest.
 
-- [ ] **Step 1:** Failing test — a KEK whose `created_at` is older than the interval is due; a fresh one is not.
+- [x] **Step 1:** Failing test — a KEK whose `created_at` is older than the interval is due; a fresh one is not.
   ```rust
   #[test]
   fn kek_due_for_rotation_past_interval() {
@@ -136,9 +136,9 @@ LUKS2 is Linux-only. macOS volumes have no at-rest encryption today. Add a per-f
       assert!(!rotation_due(&fresh, DEFAULT_INTERVAL));
   }
   ```
-- [ ] **Step 2:** Implement `rotation_due(&MasterKeyManifest, interval) -> bool` (interval configurable, default 90d) and `rotate_if_due()` that calls `rotate_master_key` then sweeps with `migrate_wrapped_keys`. Time comes in as a parameter — no wall-clock read inside the pure check, so it stays testable.
-- [ ] **Step 3:** Wire `rotate_if_due` into the host startup path (where the supervisor already loads keys). KEK rotation only re-wraps DEKs, so it's cheap and safe to run on boot.
-- [ ] **Step 4:** Tests green; commit.
+- [x] **Step 2:** Implement `rotation_due(&MasterKeyManifest, interval) -> bool` (interval configurable, default 90d) and `rotate_if_due()` that calls `rotate_master_key` then sweeps with `migrate_wrapped_keys`. Time comes in as a parameter — no wall-clock read inside the pure check, so it stays testable.
+- [x] **Step 3:** Wire `rotate_if_due` into the local master-key mint path. (No supervisor-boot key-load exists in this repo; the real local consumer is `mvm-cli` `volume.rs::generate_wrapped_volume_key`, which now rolls the KEK if due and re-wraps the volume catalog. Fleet/multi-tenant scheduling calls the same substrate from mvmd — out of scope here.)
+- [x] **Step 4:** Tests green; commit.
 
 ### Task B2: per-rebuild DEK binding
 


### PR DESCRIPTION
## Plan 122 — Task B1: 90-day KEK rotation timer

`rotate_master_key` existed but was only ever called by hand. This adds the policy that decides *when*, plus the local wiring that runs it.

### What changed
- **`crypto::rotation_policy`** (mvm-core):
  - `rotation_due(manifest, interval, now)` — a **pure** age check. `now` is injected, never read from the wall clock, so the policy is testable without freezing time. No active key → not due (initial provisioning isn't rotation).
  - `rotate_if_due()` — combines the check with `rotate_master_key` + a `migrate_wrapped_keys` sweep that re-wraps the caller's DEKs onto the new KEK. Default interval **90 days**.
- **Wiring** into the real local consumer: `mvm-cli` `volume.rs::generate_wrapped_volume_key` now calls `maybe_rotate_local_master_key` before minting — rolling the KEK if it's 90+ days old and re-wrapping the volume catalog's mvm-managed keys.

### A note on Step 3
The plan said "wire into the host startup path where the supervisor loads keys." There is **no supervisor-boot key-load in this repo** — the only local consumer of the master-key store is the volume mint path, so that's where the trigger lives. Fleet/multi-tenant scheduling would call the same `rotation_policy` substrate from mvmd (out of scope here). Re-wrapping leaves the DEK and the on-disk ciphertext untouched, so it never breaks an existing volume.

### Tests
- Substrate unit tests in `rotation_policy` (due/not-due, no-active-key, noop-when-fresh, rotate-and-rewrap).
- mvm-cli integration test: backdates a KEK to 91 days, creates a second volume to trigger the sweep, asserts the catalog re-wrapped onto v2, and **unlocks the pre-existing volume** to prove the DEK survived.

### Acceptance
- **No new dependency**; `Cargo.lock` unchanged.
- nightly `fmt --check` + `clippy -D warnings` (mvm-core, mvm-cli) clean.