### PR TITLE
feat(crypto): per-rebuild DEK binding on WrappedKey (plan 122 B2)

### DIFF
--- a/crates/mvm-cli/src/commands/vm/volume.rs
+++ b/crates/mvm-cli/src/commands/vm/volume.rs
@@ -309,9 +309,11 @@ fn create_mvm_managed(volume_name: &str, root: Option<&str>) -> Result<()> {
         );
     }
 
-    let (wrapped_key, dek) = generate_wrapped_volume_key()?;
+    let (mut wrapped_key, dek) = generate_wrapped_volume_key()?;
     let scratch = tempfile::tempdir_in(&root).context("creating empty volume scratch dir")?;
     write_encrypted_volume_archive(scratch.path(), &ciphertext_path, dek.expose_secret())?;
+    // Plan 122 B2 — bind the DEK to the ciphertext archive it now protects.
+    wrapped_key.rebind_content(ciphertext_content_hash(&ciphertext_path)?);
 
     let mut catalog = LocalVolumeCatalog::load()?;
     catalog.add(LocalVolumeEntry {
@@ -429,9 +431,19 @@ fn generate_wrapped_volume_key() -> Result<(WrappedKey, secrecy::SecretBox<Vec<u
             master_key_version: version,
             wrapped,
             algorithm: WrapAlgorithm::Aes256Gcm,
+            // Bound to the ciphertext archive once it exists (the caller sets
+            // this via `rebind_content` after writing the archive). Plan 122 B2.
+            bound: None,
         },
         secrecy::SecretBox::new(Box::new(dek)),
     ))
+}
+
+/// sha256-hex of a ciphertext archive — the per-volume content-hash a DEK
+/// binds to (plan 122 B2).
+fn ciphertext_content_hash(path: &Path) -> Result<String> {
+    mvm_core::crypto::image_verify::sha256_file(path)
+        .with_context(|| format!("hashing ciphertext archive {}", path.display()))
 }
 
 fn unwrap_volume_key(entry: &LocalVolumeEntry) -> Result<secrecy::SecretBox<Vec<u8>>> {
@@ -444,6 +456,17 @@ fn unwrap_volume_key(entry: &LocalVolumeEntry) -> Result<secrecy::SecretBox<Vec<
             )
         }
     };
+    // Plan 122 B2 — admit gate: refuse a DEK presented against a different
+    // ciphertext than it was bound to (a swapped archive). Unbound (pre-B2)
+    // keys pass. Runs before the master is even loaded.
+    let actual = ciphertext_content_hash(Path::new(&enc.ciphertext_path))?;
+    if !enc.wrapped_key.binding_matches_content(&actual) {
+        bail!(
+            "volume {:?} DEK binding mismatch: ciphertext content_hash does not \
+             match the artifact this key was bound to; refusing to unwrap",
+            entry.volume_name
+        );
+    }
     let master =
         key_rotation::load_master_key(&local_master_key_dir(), enc.wrapped_key.master_key_version)
             .with_context(|| format!("loading master key for volume {:?}", entry.volume_name))?;
@@ -634,11 +657,15 @@ fn lock(volume_name: &str) -> Result<()> {
     })?;
     fs::remove_dir_all(&host_path)
         .with_context(|| format!("removing plaintext volume dir {}", host_path.display()))?;
+    // Re-sealing rewrote the ciphertext, so its hash changed — move the DEK
+    // binding to the new archive (plan 122 B2) before persisting.
+    let new_hash = ciphertext_content_hash(&ciphertext_path)?;
     let entry = catalog
         .get_mut(volume_name)
         .expect("entry existed before lock mutation");
     if let LocalVolumeEncryption::MvmManaged(enc) = &mut entry.encryption {
         enc.state = LocalVolumeState::Locked;
+        enc.wrapped_key.rebind_content(new_hash);
     }
     catalog.save()?;
     println!("locked volume {volume_name:?}");
@@ -917,9 +944,37 @@ mod tests {
         bytes[last] ^= 0xff;
         fs::write(&ciphertext, bytes).unwrap();
         let err = unlock("work").unwrap_err();
+        // Plan 122 B2: the DEK binding now catches a flipped byte at admit
+        // (the ciphertext hash no longer matches the bound artifact), before
+        // the archive is even decrypted. Either gate is a valid rejection.
         assert!(
-            err.to_string().contains("decrypting volume archive")
+            err.to_string().contains("DEK binding mismatch")
+                || err.to_string().contains("decrypting volume archive")
                 || err.to_string().contains("authentication failure"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn mvm_managed_unlock_rejects_dek_bound_to_different_artifact() {
+        // A DEK whose recorded binding points at a different content_hash than
+        // the on-disk ciphertext is refused at admit (plan 122 B2 Step 1).
+        let guard = DataDirGuard::new();
+        let root = guard.path().join("vol-root");
+        create("work", Some(root.to_str().unwrap()), false).unwrap();
+
+        // Corrupt only the binding, leaving the ciphertext intact.
+        let mut catalog = LocalVolumeCatalog::load().unwrap();
+        if let LocalVolumeEncryption::MvmManaged(enc) =
+            &mut catalog.get_mut("work").unwrap().encryption
+        {
+            enc.wrapped_key.rebind_content("0".repeat(64)); // a hash the archive can't have
+        }
+        catalog.save().unwrap();
+
+        let err = unlock("work").unwrap_err();
+        assert!(
+            err.to_string().contains("DEK binding mismatch"),
             "got: {err}"
         );
     }

--- a/crates/mvm-core/src/crypto/key_rotation.rs
+++ b/crates/mvm-core/src/crypto/key_rotation.rs
@@ -120,6 +120,9 @@ pub fn rewrap_dek(
                 master_key_version: new_version,
                 wrapped: new_ct,
                 algorithm: WrapAlgorithm::Aes256Gcm,
+                // Re-wrapping changes only the master that protects the DEK,
+                // not the artifact it's bound to (plan 122 B2) — carry it.
+                bound: wrapped.bound.clone(),
             })
         }
         algo @ WrapAlgorithm::AesKwp => Err(RotationError::UnsupportedAlgorithm { algo }.into()),
@@ -477,6 +480,7 @@ mod tests {
             master_key_version: version,
             wrapped: ct,
             algorithm: WrapAlgorithm::Aes256Gcm,
+            bound: None,
         }
     }
 
@@ -498,6 +502,23 @@ mod tests {
         // Underlying plaintext DEK must be recoverable under m2.
         let recovered = snapshot_crypto::decrypt(&rewrapped.wrapped, &m2).unwrap();
         assert_eq!(recovered, dek);
+    }
+
+    #[test]
+    fn rewrap_dek_preserves_binding() {
+        // Plan 122 B2 — re-wrapping rolls the master, not the artifact, so
+        // the DEK's binding must survive a rotation.
+        let dek = [0x5u8; 32];
+        let m1 = random_master_key();
+        let m2 = random_master_key();
+        let mut wrapped = wrap_with_aes256gcm(&dek, &m1, 1);
+        wrapped.bound = Some(crate::domain::volume::DekBinding {
+            content_hash: "deadbeef".into(),
+            plan_id: Some("plan-9".into()),
+            audit_head: None,
+        });
+        let rewrapped = rewrap_dek(&wrapped, &m1, &m2, 2).unwrap();
+        assert_eq!(rewrapped.bound, wrapped.bound);
     }
 
     #[test]
@@ -525,6 +546,7 @@ mod tests {
             master_key_version: 1,
             wrapped: vec![0u8; 40], // arbitrary; rewrap won't reach decode
             algorithm: WrapAlgorithm::AesKwp,
+            bound: None,
         };
         let m1 = random_master_key();
         let m2 = random_master_key();

--- a/crates/mvm-core/src/crypto/rotation_policy.rs
+++ b/crates/mvm-core/src/crypto/rotation_policy.rs
@@ -142,6 +142,7 @@ mod tests {
             master_key_version: version,
             wrapped: snapshot_crypto::encrypt(dek, master.expose_secret().as_slice()).unwrap(),
             algorithm: WrapAlgorithm::Aes256Gcm,
+            bound: None,
         }
     }
 

--- a/crates/mvm-core/src/domain/volume.rs
+++ b/crates/mvm-core/src/domain/volume.rs
@@ -411,6 +411,32 @@ pub enum WrapAlgorithm {
     Aes256Gcm,
 }
 
+/// Plan 122 B2 — binds a wrapped DEK to the artifact it protects, so a DEK
+/// can't be lifted onto a different volume than it was minted for.
+///
+/// `content_hash` is the only field mvm populates today (the sha256 of the
+/// local volume's ciphertext archive, re-checked before the DEK is
+/// unwrapped). `plan_id` / `audit_head` are reserved for the workload
+/// rebuild path, which mvmd owns — it runs the per-rebuild `EncryptedBackend`
+/// and holds the signed plan + audit chain. They stay `None` for local
+/// volumes, which have no plan at create time. (The deps-volume → signed-plan
+/// binding for workloads already exists separately as
+/// [`crate::plan::DepsVolumeBinding`]; this is the distinct DEK-envelope ↔
+/// artifact layer.)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DekBinding {
+    /// sha256-hex of the bound artifact (the local volume's ciphertext
+    /// archive).
+    pub content_hash: String,
+    /// Signed-plan id this DEK was minted for. mvmd-populated; `None` local.
+    #[serde(default)]
+    pub plan_id: Option<String>,
+    /// Audit-chain head at mint. mvmd-populated; `None` local.
+    #[serde(default)]
+    pub audit_head: Option<String>,
+}
+
 /// A per-volume AEAD key, wrapped under a versioned master key.
 /// Stored in the volume registry record alongside the volume metadata.
 ///
@@ -430,6 +456,41 @@ pub struct WrappedKey {
     pub wrapped: Vec<u8>,
 
     pub algorithm: WrapAlgorithm,
+
+    /// Plan 122 B2 — optional binding to the artifact this DEK protects.
+    /// `None` for pre-B2 / unbound keys (accepted, treated as "no binding
+    /// to check").
+    #[serde(default)]
+    pub bound: Option<DekBinding>,
+}
+
+impl WrappedKey {
+    /// True when this key is unbound, or its binding's `content_hash`
+    /// matches `actual_content_hash`. The admit/unlock gate: a DEK presented
+    /// against a different artifact than it was minted for is refused.
+    pub fn binding_matches_content(&self, actual_content_hash: &str) -> bool {
+        match &self.bound {
+            None => true,
+            Some(b) => b.content_hash == actual_content_hash,
+        }
+    }
+
+    /// Re-point the binding at a new artifact `content_hash`, preserving any
+    /// `plan_id` / `audit_head`. A mutable local volume is re-sealed on every
+    /// lock, so its ciphertext — and thus its hash — changes; the binding
+    /// must follow.
+    pub fn rebind_content(&mut self, content_hash: String) {
+        let (plan_id, audit_head) = self
+            .bound
+            .take()
+            .map(|b| (b.plan_id, b.audit_head))
+            .unwrap_or((None, None));
+        self.bound = Some(DekBinding {
+            content_hash,
+            plan_id,
+            audit_head,
+        });
+    }
 }
 
 // allow(secret-debug): hand-written Debug below redacts the wrapped
@@ -440,6 +501,7 @@ impl std::fmt::Debug for WrappedKey {
             .field("master_key_version", &self.master_key_version)
             .field("wrapped", &format_args!("<{} bytes>", self.wrapped.len()))
             .field("algorithm", &self.algorithm)
+            .field("bound", &self.bound)
             .finish()
     }
 }
@@ -675,10 +737,49 @@ mod tests {
             master_key_version: 7,
             wrapped: vec![1, 2, 3, 4, 5, 6, 7, 8],
             algorithm: WrapAlgorithm::AesKwp,
+            bound: None,
         };
         let json = serde_json::to_string(&w).unwrap();
         let w2: WrappedKey = serde_json::from_str(&json).unwrap();
         assert_eq!(w, w2);
+    }
+
+    #[test]
+    fn wrapped_key_without_bound_field_deserializes_as_unbound() {
+        // Pre-B2 records carried no `bound` key; `#[serde(default)]` must
+        // load them as unbound rather than failing the deny_unknown_fields
+        // envelope.
+        let legacy = r#"{"master_key_version":1,"wrapped":[1,2,3],"algorithm":"aes256-gcm"}"#;
+        let w: WrappedKey = serde_json::from_str(legacy).unwrap();
+        assert!(w.bound.is_none());
+        assert!(w.binding_matches_content("anything"), "unbound matches all");
+    }
+
+    #[test]
+    fn binding_refuses_mismatched_content_hash() {
+        let mut w = WrappedKey {
+            master_key_version: 1,
+            wrapped: vec![9, 9, 9],
+            algorithm: WrapAlgorithm::Aes256Gcm,
+            bound: None,
+        };
+        w.rebind_content("aaaa".to_string());
+        assert!(w.binding_matches_content("aaaa"));
+        assert!(
+            !w.binding_matches_content("bbbb"),
+            "different artifact refused"
+        );
+
+        // rebind preserves plan_id / audit_head while moving the content hash.
+        if let Some(b) = w.bound.as_mut() {
+            b.plan_id = Some("plan-1".into());
+            b.audit_head = Some("head-1".into());
+        }
+        w.rebind_content("cccc".to_string());
+        let b = w.bound.as_ref().unwrap();
+        assert_eq!(b.content_hash, "cccc");
+        assert_eq!(b.plan_id.as_deref(), Some("plan-1"));
+        assert_eq!(b.audit_head.as_deref(), Some("head-1"));
     }
 
     #[test]

--- a/crates/mvm/src/vm/volume_registry.rs
+++ b/crates/mvm/src/vm/volume_registry.rs
@@ -338,6 +338,7 @@ mod tests {
                     master_key_version: 1,
                     wrapped: vec![1, 2, 3],
                     algorithm: mvm_core::domain::volume::WrapAlgorithm::Aes256Gcm,
+                    bound: None,
                 },
             }),
             created_at: "2026-05-05T00:00:00Z".to_string(),

--- a/specs/plans/122-encryption-key-lifecycle.md
+++ b/specs/plans/122-encryption-key-lifecycle.md
@@ -146,9 +146,9 @@ ADR-066 §5: a per-volume DEK rides the rebuild cycle and binds to the artifact 
 
 **Files:** extend `WrappedKey` metadata in `key_rotation.rs`; the admit path that already verifies plans (`mvm-cli` up / supervisor).
 
-- [ ] **Step 1:** Failing test — a `WrappedKey` whose bound `content_hash` differs from the volume it's presented with is refused at admit.
-- [ ] **Step 2:** Add `bound: { content_hash, plan_id, audit_head }` to `WrappedKey`; mint a fresh DEK per rebuild and record the binding. Verify it in the admit path next to the existing plan check.
-- [ ] **Step 3:** Tests green; commit.
+- [x] **Step 1:** Failing test — a `WrappedKey` whose bound `content_hash` differs from the volume it's presented with is refused at admit.
+- [x] **Step 2:** Add `bound: Option<DekBinding{ content_hash, plan_id, audit_head }>` to `WrappedKey` (Option B). mvm populates+verifies `content_hash` (local volume ciphertext) at the unlock/mount admit gate; `plan_id`/`audit_head` are reserved for the mvmd rebuild path (it owns `EncryptedBackend` + the signed plan/audit chain). Distinct layer from the existing `DepsVolumeBinding` (deps-volume → signed plan).
+- [x] **Step 3:** Tests green; commit.
 
 ## Phase C — snapshots content-addressed + signed
 


### PR DESCRIPTION
## Plan 122 — Task B2: per-rebuild DEK binding (Option B)

> **Stacked on #596 (B1).** Base is `feat/plan-122-b1-kek-rotation`; review/merge B1 first. GitHub retargets this to `main` once B1 lands.

Bind a wrapped DEK to the artifact it protects so a DEK can't be lifted onto a different volume (ADR-066 §5). Implemented as **Option B**, reconciled with what's already in the tree.

### What changed
- **`WrappedKey.bound: Option<DekBinding>`** (mvm-core) — `content_hash` + reserved `plan_id` / `audit_head`. `#[serde(default)]` so pre-B2 records load as unbound. `binding_matches_content` is the admit gate; `rebind_content` moves the binding when a mutable volume is re-sealed. `rewrap_dek` **preserves the binding across KEK rotation** (the master rolls, not the artifact).
- **mvm local wiring** (`mvm-cli` volume.rs): binds a managed volume's DEK to its ciphertext archive's sha256 at create, refreshes it on lock (the archive is rewritten), and **verifies it in `unwrap_volume_key` before the master is even loaded**. A swapped archive or a tampered binding is refused at admit.

### Why Option B (the reconciliation)
- The deps-volume → signed-plan → audit binding for **workloads already exists** as `DepsVolumeBinding` (claim 11) — re-verified by the supervisor. `WrappedKey` is the *different* DEK-envelope ↔ artifact layer.
- `WrappedKey` is only the **local** mvm-managed volume substrate in this repo; there's no `plan_id`/`audit_head` at local create. The per-rebuild population of those is **mvmd's** job (it owns `EncryptedBackend` + the signed plan + audit chain). The field is the shared substrate; mvm wires the content-hash half.

### Tests
- mvm-core: unbound-loads-as-default, binding refuses mismatched hash, rebind preserves plan_id/audit_head, `rewrap_dek_preserves_binding`.
- mvm-cli: a DEK bound to a different artifact is refused at unlock; tampered-ciphertext now caught by the binding gate; create→unlock→lock→unlock roundtrip still green (exercises rebind-on-lock).

### Acceptance
- **No new dependency** (reuses `crypto::image_verify::sha256_file`); `Cargo.lock` unchanged.
- 2166 tests pass across mvm-core/mvm/mvm-cli; workspace `clippy -D warnings` + nightly `fmt --check` clean.