### PR TITLE
fix(release): install zig in the binary build job (unblocks releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,14 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # ADR-065: mvm-cli's build.rs cross-compiles the embedded host-vm
+      # binaries (mvm-host-vm-init, mvm-egress-proxy) as static
+      # aarch64-unknown-linux-musl via cargo-zigbuild — so zig +
+      # cargo-zigbuild must be present at `cargo build`-of-mvmctl time, the
+      # same as the ci.yml Lint job. Without this the release binary build
+      # fails at "cargo zigbuild failed for mvm-host-vm-init".
+      - uses: ./.github/actions/install-zigbuild
+
       - name: Install cross-compilation tools (Linux aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |


### PR DESCRIPTION
## Why the v0.16.0 release failed

The `build` job failed on **all 4 targets** at `cargo zigbuild failed for mvm-host-vm-init`. `mvm-cli`'s `build.rs` cross-compiles the embedded host-vm binaries (`mvm-host-vm-init`, `mvm-egress-proxy`) to static `aarch64-unknown-linux-musl` via `cargo-zigbuild` (ADR-065 / Plan 115) — but `release.yml`'s build job **never installed zig/cargo-zigbuild**. The `ci.yml` Lint job does (`./.github/actions/install-zigbuild`), which is why regular CI is green but releases aren't.

Because the binary build failed, the `release` job was correctly skipped (the #566 `needs.build.result == 'success'` gate), so **no release / crates.io / tap fired** — no damage, just no assets. This is the latent reason recent releases had zero downloadable assets.

## Fix

Add the shared `./.github/actions/install-zigbuild` step to the build job, right after the Rust toolchain install.

## Note (separate, best-effort)
`builder-vm-image` also failed (FlakeHub login / nix). It's decoupled (#566) so it won't block the release — `default-microvm` ✅ and `runtime-overlay` ✅ both built. Tracking that separately.

After this merges I'll re-tag v0.16.0 (the failed tag published nothing).