### PR TITLE
Dev VM: idle PID 1 in /init so it survives the console EOF on Vz (Plan 162 Part 3)

### DIFF
--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -484,6 +484,18 @@ let
     # is the host-side gate).
     if [ -e /etc/mvm/variant ] && [ "$(/bin/busybox cat /etc/mvm/variant)" = "dev" ]; then
       exec </dev/console >/dev/console 2>&1
+      # Plan 162: the dev VM is long-lived, so PID 1 idles here instead of
+      # running the /etc/mvm/entrypoint `/bin/sh` on /dev/console. The guest
+      # agent (forked above) serves the interactive shell over vsock — it
+      # openpty()s and forks its OWN `/bin/sh -i` (mvm-guest::console),
+      # independent of PID 1 — so PID 1 doesn't need to be a shell at all.
+      # Running `/bin/sh` on /dev/console here is fatal on Vz: its serial
+      # console is input-less, the read hits EOF, the shell exits, PID 1
+      # dies, and the VM powers off ~5 s after boot (the Plan 120 symptom).
+      # On libkrun this just swaps a blocking console read for an explicit
+      # idle — same "stay alive", no change to the agent shell path. A
+      # busybox-portable loop avoids depending on `sleep infinity`.
+      while :; do /bin/busybox sleep 2147483647; done
     fi
 
     # Stage 4.5 — Plan 74 W1.4b (ADR-051) — mvm runtime overlay env.

--- a/specs/plans/162-dev-mode-interactivity.md
+++ b/specs/plans/162-dev-mode-interactivity.md
@@ -99,6 +99,36 @@ marker, not a force-attach. Without a TTY, dev commands boot the VM and
 return (with the `dev shell` hint), exactly as the non-interactive path does
 today.
 
+## Part 3 — Guest: dev VM PID 1 must idle, not run `/bin/sh` on the console (the Vz blocker)
+
+**Found while verifying Parts 1+2 on Vz (2026-06-05):** `dev up` on the
+macOS-26 Vz-default host *started* the dev VM and then died — `console.log`
+empty, `vz.pid` dead, no agent vsock socket ever appeared. Root cause:
+mkGuest `/init`'s dev variant ran the `/etc/mvm/entrypoint` `/bin/sh` as
+**PID 1 on `/dev/console`**. Vz's serial console is **input-less**
+(output-capture only), so the shell's read hits EOF → the shell exits →
+PID 1 dies → the VM powers off ~5 s after boot. (Vz-specific: libkrun's
+console *blocks* on read, so its dev VM survived — which is why core_demo
+is green on libkrun.) This makes Parts 1+2 moot on Vz: the VM is dead
+before anything can `openpty()` into it.
+
+Key realization: the interactive shell does **not** come from PID 1's
+`/dev/console` shell. `console_interactive` / `dev shell` go through the
+**agent**, which `openpty()`s and forks its OWN `/bin/sh -i`
+(`crates/mvm-guest/src/console.rs:159-184`), independent of PID 1. So PID 1
+never needed to be a shell.
+
+Fix (`nix/lib/mk-guest.nix` `/init`, dev variant): after the agent fork,
+**PID 1 idles** (busybox-portable `while :; do sleep …; done`) instead of
+running the entrypoint `/bin/sh` on `/dev/console`. The dev VM stays alive
+on both backends; the agent serves the interactive shell. Workload/prod
+variants are unchanged (PID 1 is still the workload; its exit/poweroff
+handling is Plan 152 WS-A — the *opposite* variant at the same `/init`
+edit site: a finished workload should poweroff + propagate `$?`).
+
+- [x] Dev-variant `/init` idles PID 1 (agent serves the shell); don't `exec`/source `/bin/sh` on the input-less Vz console.
+- [ ] Verify on Vz: `dev up` keeps the dev VM alive (`vz.pid` stays up, agent reachable) and `dev shell` attaches. Needs the Swift Vz supervisor built; libkrun verified separately (`dev up` → VM stays up → `dev shell`).
+
 ## Verification
 
 - [ ] **Live (manual, needs a real terminal):** `mvmctl dev up` from a TTY drops into a working shell on the dev VM; `exit` returns cleanly. Repeat with `MVM_ENV=dev mvmctl dev up`.


### PR DESCRIPTION
## What

Make the dev VM survive boot on **Vz** by idling PID 1 instead of running `/bin/sh` on `/dev/console`. Plan 162 Part 3 (the proper fix the Vz dev VM needed).

## Why

On a macOS-26 Vz-default host, `dev up` *started* the dev VM and then it died — `console.log` empty, `vz.pid` dead, no agent vsock socket. Root cause: mkGuest `/init`'s dev variant ran the `/etc/mvm/entrypoint` `/bin/sh` as **PID 1 on `/dev/console`**. Vz's serial console is **input-less** (output-capture only), so the read hits EOF → the shell exits → PID 1 dies → the VM powers off ~5 s after boot. (libkrun's console *blocks* on read, so its dev VM survived — which is why core_demo is green there.) This made the devpts + `MVM_ENV=dev` work (Parts 1–2) moot on Vz: the VM was dead before anything could `openpty()` into it.

## Key realization

The interactive shell does **not** come from PID 1's `/dev/console` shell. `console_interactive` / `dev shell` go through the **agent**, which `openpty()`s and forks its **own** `/bin/sh -i` (`crates/mvm-guest/src/console.rs:159-184`), independent of PID 1. So PID 1 never needed to be a shell.

## Change

`nix/lib/mk-guest.nix` `/init`, **dev variant only**: after the agent is forked, **PID 1 idles** (busybox-portable `while :; do sleep …; done`) instead of running `/bin/sh` on `/dev/console`. The dev VM stays alive on both backends; the agent serves the interactive shell. Workload/prod variants are unchanged (PID 1 is still the workload; its exit/poweroff handling is Plan 152 WS-A — the *opposite* variant at the same `/init` edit site).

## Verification

- Agent-spawns-its-own-shell verified by reading `mvm-guest::console` (forks `/bin/sh -i` on the openpty'd PTY, PID-1-independent).
- **Live verification pending:** a clean libkrun `dev up` should show the dev VM staying alive past boot (old behavior died ~5 s) + `dev shell` attaching. This was blocked locally by a degraded nix store on the test host (a GC'd `*-source` path → cold builds erroring) — environmental, unrelated to this runtime guest edit. Will confirm on a healed cache; the Vz proof needs the Swift Vz supervisor built.

## Sequencing

Part of the trio that makes `dev up` work end-to-end on a Vz Mac: #589 (devpts + `MVM_ENV=dev`, merged), #593 (Vz builder gvproxy, open), and this (dev VM stays alive on Vz). The devpts mount (#589) + this fix together make the interactive `dev` shell actually work on Vz.
