### PR TITLE
docs(plan-126): A1 dependency baseline + correct the Phase-B premises

### DIFF
--- a/docs/investigations/dep-baseline.md
+++ b/docs/investigations/dep-baseline.md
@@ -48,12 +48,37 @@ tree contradicts. What's actually true:
 | `sigstore` | **No** — gated behind `manifest-verify` (off by default) | ~62 added when on | B1's *default-build* benefit is **already realized**. Only a `manifest-verify` build pays for it. B1 is now purely the cross-repo "relocate cosign-verify to mvmd" decision (the prod/admit gate lives in mvmd), not a default-closure cut. |
 | `opendal` | **No** — gated behind `template-registry-s3` (off by default) | part of the 355 | Same as sigstore: B2's default benefit is **already realized**. B2 (→`object_store`) only helps the `template-registry-s3` build, and is coordinated with plan 123. |
 | `pgp` (rpgp 0.17) | **Yes** — unconditional dep of `mvm-build` | **168** | **B3's premise is wrong.** `pgp` is **not** our release signing. It verifies the **Alpine minirootfs tarball's upstream PGP signature** against an embedded Alpine release key in Stage 0 (`crates/mvm-build/src/stage0.rs::verify_alpine_pgp_signature`). It **cannot** move to minisign — Alpine dictates the format. See below. |
-| `aws-lc-rs` 1.16 | **Yes** — `rustls` default crypto provider | **16** + a C/cmake build | **B4 stands.** Pulled `reqwest(rustls-tls) → hyper-rustls → rustls → aws-lc-rs`. Pinning rustls to the `ring` provider removes it and kills the native cmake build. |
+| `aws-lc-rs` 1.16 | **Yes** | **16** + a C/cmake build | **B4 is entangled with C1, not a standalone cut** — see below. |
 
 ### The only two default-closure targets are `pgp` (168) and `aws-lc-rs` (16).
 
 `sigstore` and `opendal` are already out of the default binary — their
 cuts only shrink the respective *feature-on* builds.
+
+## B4 re-scope: aws-lc-rs comes from the `oci-client` / reqwest-0.13 chain (= C1)
+
+Traced where aws-lc-rs actually enters:
+
+- **mvm's own `reqwest 0.12`** is **already aws-lc-free**: reqwest 0.12.28
+  declares `rustls = { default-features = false }` and its `rustls-tls`
+  feature enables `__rustls-ring` (the `ring` provider). So mvm's direct
+  HTTP path uses ring today.
+- **aws-lc-rs enters only via `oci-client 0.16 → reqwest 0.13.3 →
+  rustls-platform-verifier 0.7`** (mvm-oci's registry client). The
+  platform-verifier path pulls aws-lc.
+
+So there are **two reqwest majors** in the tree (0.12 direct, 0.13 via
+oci-client) — that's **Task C1** — and the aws-lc-rs the plan wants gone
+(B4) is dragged in by the 0.13/oci-client/platform-verifier chain. **B4
+and C1 are the same problem.** Removing aws-lc means getting oci-client's
+TLS onto ring + webpki roots (no platform-verifier), which in practice
+means unifying on one reqwest major and pinning that stack to ring.
+
+This is a real TLS-stack-unification task (needs a runtime TLS smoke —
+provider-pinning can compile-green yet fail at connect), **not** the
+"~6 crates, mechanical" the plan estimated. mvmd is unaffected either way
+(it already pins ring via `mvmd-proxy`/`certs.rs` + installs it, and keeps
+its own aws-lc transitively through `iroh → hickory → rustls`).
 
 ## B3 re-scope: `pgp` is Alpine-tarball verification, not release signing
 
@@ -89,10 +114,21 @@ or option 3 if a feature boundary is clean — but not as a silent swap.
 
 ## Suggested task order (revised)
 
-1. **B4 (`aws-lc-rs` → `ring`)** — cleanest default-closure cut; −16 + no
-   C build. Needs a runtime TLS smoke (provider-pinning can compile-green
-   yet break at connect time).
-2. **B3 (`pgp`)** — biggest number (−168) but a security decision (above).
-3. **B1/B2** — no default-build benefit left; pursue only for the
-   feature-on builds / the cross-repo relocation, sequenced with 123.
-4. **C1** (`reqwest`/`oci-client` duplicate majors), **D1** (the gate).
+The plan's "quick mechanical cuts" mostly don't exist as written. The real
+remaining work, honestly scoped:
+
+1. **B4+C1 together (`aws-lc-rs` + the reqwest-major split)** — the only
+   *mechanical-ish* default cut, but it's a TLS-stack-unification effort:
+   collapse reqwest 0.12/0.13 to one major and steer `oci-client` onto
+   ring + webpki (drop `rustls-platform-verifier`). −16 crates + the C
+   build + one reqwest major. **Needs a real TLS-connect smoke**, and an
+   `oci-client` feature/version that avoids platform-verifier (verify
+   first — may need an oci-client bump or a fork-of-features).
+2. **B3 (`pgp`, −168)** — biggest number, but a **security decision**:
+   drop or feature-gate the Alpine-tarball PGP verify (defense-in-depth
+   over the existing SHA-256 pin). Needs owner sign-off + an ADR-002 note.
+3. **B1/B2** — no default-build benefit left (already feature-gated);
+   pursue only for feature-on builds / the cross-repo sigstore relocation,
+   sequenced with 123.
+4. **D1** — the forbidden-dep gate (sibling of `check-core-runtime-free`
+   from B5).

--- a/docs/investigations/dep-baseline.md
+++ b/docs/investigations/dep-baseline.md
@@ -80,6 +80,40 @@ provider-pinning can compile-green yet fail at connect), **not** the
 (it already pins ring via `mvmd-proxy`/`certs.rs` + installs it, and keeps
 its own aws-lc transitively through `iroh → hickory → rustls`).
 
+### Blocker: `oci-client` hardcodes aws-lc-rs (no ring path in any version)
+
+Drilled into the fix and hit a wall. `oci-client` **0.16.1** and **0.17.0**
+both wire their only rustls option to aws-lc, via **two** hardcoded paths:
+
+```toml
+# oci-client 0.16/0.17 [features]
+rustls-tls = ["reqwest/rustls", "jsonwebtoken/aws_lc_rs"]
+# reqwest 0.13 [features]
+rustls = ["__rustls-aws-lc-rs", "dep:rustls-platform-verifier", "__rustls"]
+```
+
+There is **no ring/webpki feature** — the only alternative oci-client
+offers is `native-tls` (OpenSSL, a system dep — worse). Cargo feature
+unification is additive, so a workspace-level rustls/ring pin **cannot
+remove** the aws-lc that oci-client's features force on. So B4 is **not
+achievable by configuration**. Removing aws-lc requires one of:
+
+1. **Fork/patch `oci-client`** (bounded vendor) to add a ring path:
+   `reqwest`'s webpki-roots-ring feature + `jsonwebtoken`'s `rust_crypto`
+   provider. Plus unify the reqwest major. Moderate effort + a runtime
+   TLS smoke. (Allowed per "vendoring as a bounded bridge is OK".)
+2. **Replace `oci-client`** with a registry client that supports ring (or
+   a minimal in-repo client). Large.
+3. **Upstream a `rustls-tls-ring` feature to `oci-client`**, then bump.
+   Slow (depends on maintainers).
+4. **Defer B4** — accept aws-lc while we use `oci-client`.
+
+**Net conclusion for Phase B:** there are **no quick mechanical cuts
+left**. The real reductions are (a) **B3** `pgp` −168 (a *security
+decision* — drop/gate the Alpine PGP verify), and (b) **B4** −16 + the C
+build (an *upstream fork/replace* of `oci-client`). Everything else is
+already feature-gated out of the default binary.
+
 ## B3 re-scope: `pgp` is Alpine-tarball verification, not release signing
 
 `mvm-build/src/stage0.rs` fetches Alpine's official minirootfs and verifies

--- a/docs/investigations/dep-baseline.md
+++ b/docs/investigations/dep-baseline.md
@@ -1,0 +1,98 @@
+# Dependency baseline (plan 126 Task A1)
+
+Measured 2026-06-05 on `main` @ `bb1cbcbe` (post plan-126 B5). This is the
+canonical measurement method + the live numbers every later plan-126 task
+records its delta against. Plan 127's dep-count dashboard reads from here.
+
+## Method (the canonical commands)
+
+Two different numbers, measured two different ways — don't conflate them:
+
+```sh
+# (1) Default binary closure — what actually compiles into a default
+#     `mvmctl` build. This is the number the B-tasks move.
+cargo tree --workspace -e no-dev --prefix none | sed 's/ (.*)//' | sort -u | wc -l
+
+# (2) Full lockfile — every package resolved across all features, targets,
+#     and dev-deps. A coarser supply-chain-surface proxy.
+grep -c '^name = ' Cargo.lock
+
+# Per-target closure (how many crates a target drags):
+cargo tree -p <crate> -e no-dev --prefix none | sed 's/ (.*)//' | sort -u | wc -l
+# Who pulls a target:
+cargo tree -i <crate> -e no-dev
+# Feature-on closure (a gated feature's added cost):
+cargo tree -p mvmctl --no-default-features --features <feat> -e no-dev --prefix none | sed 's/ (.*)//' | sort -u | wc -l
+```
+
+## Baseline numbers
+
+| Metric | Value |
+|---|---|
+| Default binary closure (method 1) | **407** unique packages |
+| Full lockfile (method 2) | **722** packages |
+| `mvmctl` + `manifest-verify` closure | 469 (sigstore adds ~62) |
+| `mvm` + `template-registry-s3` closure | 355 (opendal) |
+
+Lockfile drifted 739 (2026-06-03) → **722** now — B5 + the intervening
+merges + the 0.16.0 version bump. The brief's "723"/"735" earlier counts
+were the lockfile metric at other points in time.
+
+## The four B-task targets — corrected findings
+
+The plan's Phase-B target list was written on assumptions that the live
+tree contradicts. What's actually true:
+
+| Target | In **default** closure? | Closure | Reality |
+|---|---|---|---|
+| `sigstore` | **No** — gated behind `manifest-verify` (off by default) | ~62 added when on | B1's *default-build* benefit is **already realized**. Only a `manifest-verify` build pays for it. B1 is now purely the cross-repo "relocate cosign-verify to mvmd" decision (the prod/admit gate lives in mvmd), not a default-closure cut. |
+| `opendal` | **No** — gated behind `template-registry-s3` (off by default) | part of the 355 | Same as sigstore: B2's default benefit is **already realized**. B2 (→`object_store`) only helps the `template-registry-s3` build, and is coordinated with plan 123. |
+| `pgp` (rpgp 0.17) | **Yes** — unconditional dep of `mvm-build` | **168** | **B3's premise is wrong.** `pgp` is **not** our release signing. It verifies the **Alpine minirootfs tarball's upstream PGP signature** against an embedded Alpine release key in Stage 0 (`crates/mvm-build/src/stage0.rs::verify_alpine_pgp_signature`). It **cannot** move to minisign — Alpine dictates the format. See below. |
+| `aws-lc-rs` 1.16 | **Yes** — `rustls` default crypto provider | **16** + a C/cmake build | **B4 stands.** Pulled `reqwest(rustls-tls) → hyper-rustls → rustls → aws-lc-rs`. Pinning rustls to the `ring` provider removes it and kills the native cmake build. |
+
+### The only two default-closure targets are `pgp` (168) and `aws-lc-rs` (16).
+
+`sigstore` and `opendal` are already out of the default binary — their
+cuts only shrink the respective *feature-on* builds.
+
+## B3 re-scope: `pgp` is Alpine-tarball verification, not release signing
+
+`mvm-build/src/stage0.rs` fetches Alpine's official minirootfs and verifies
+it **two ways**: a source-pinned **SHA-256** (`verify_sha256` against
+`ALPINE_MINIROOTFS_{AARCH64,X86_64}`) **and** a detached **PGP** signature
+against the embedded `ALPINE_RELEASE_KEY_ASC` (fingerprint also pinned).
+The doc comment calls PGP the layer that "catches a malicious upstream
+mirror that signs with the wrong key."
+
+But the tarball is **already byte-pinned by SHA-256** for the pinned
+`ALPINE_VERSION`. For a pinned version the hash is the binding integrity
+check; the PGP verify is **defense-in-depth** whose distinct value is
+mainly at *version-bump* time (verify a new tarball's signature before
+trusting its not-yet-pinned bytes).
+
+So reducing the 168-crate `pgp` closure is **not** a minisign swap. The
+options, each a real decision (not mechanical):
+
+1. **Drop the PGP verify, keep the SHA-256 pin** (−168 crates). Removes a
+   defense-in-depth layer; needs security-owner sign-off + an ADR-002
+   note, and a documented version-bump procedure (verify the new tarball's
+   PGP signature out-of-band before pinning its hash).
+2. **Keep PGP, find a lighter verifier.** rpgp *is* the lean option for
+   OpenPGP detached-signature verification; sequoia is heavier. No obvious
+   smaller crate exists for RSA-OpenPGP verify. Low expected payoff.
+3. **Gate it behind a feature** so only the contributor Stage-0 build pays
+   for it (the published binary doesn't run Stage 0 the same way). Needs a
+   look at whether any default path reaches `verify_alpine_pgp_signature`.
+
+Recommendation: pursue option 1 (biggest win) **as a security decision**,
+or option 3 if a feature boundary is clean — but not as a silent swap.
+
+## Suggested task order (revised)
+
+1. **B4 (`aws-lc-rs` → `ring`)** — cleanest default-closure cut; −16 + no
+   C build. Needs a runtime TLS smoke (provider-pinning can compile-green
+   yet break at connect time).
+2. **B3 (`pgp`)** — biggest number (−168) but a security decision (above).
+3. **B1/B2** — no default-build benefit left; pursue only for the
+   feature-on builds / the cross-repo relocation, sequenced with 123.
+4. **C1** (`reqwest`/`oci-client` duplicate majors), **D1** (the gate).

--- a/specs/plans/126-dependency-reduction.md
+++ b/specs/plans/126-dependency-reduction.md
@@ -56,12 +56,12 @@ The tarball is **already SHA-256 hash-pinned in source** for the pinned `ALPINE_
 
 See `docs/investigations/dep-baseline.md` for the full rationale.
 
-### Task B4: `aws-lc-rs` → `ring` (~6 + kills a C/cmake build)
+### Task B4: `aws-lc-rs` → `ring` — MERGE WITH C1 (not a standalone cut)
 
-`aws-lc-rs` is the C/cmake crypto backend; `ring` covers the same primitives without the native build. (123 already pins `object_store`'s TLS to `ring`; this removes the rest.)
+> **A1 finding (see `docs/investigations/dep-baseline.md`):** mvm's own `reqwest 0.12` is **already** on `ring` (`default-features = false` rustls + `__rustls-ring`). aws-lc-rs enters **only** via `oci-client 0.16 → reqwest 0.13.3 → rustls-platform-verifier`. So B4 = **C1** (collapse the two reqwest majors) + steer `oci-client` onto ring + webpki roots (drop platform-verifier). Do them as one task.
 
-- [ ] **Step 1:** Find what pulls `aws-lc-rs` (`cargo tree -i aws-lc-rs`) — likely rustls's default provider (rustls 0.23+) and/or a TLS stack.
-- [ ] **Step 2:** Pin rustls to the `ring` `CryptoProvider` everywhere it's constructed; set the relevant `default-features = false` + `ring` features. Failing test — `cargo tree -i aws-lc-rs` is empty; TLS still works (a smoke connect). The native cmake build is gone (faster cold build — note it). Commit.
+- [ ] **Step 1:** Find an `oci-client` feature/version whose TLS uses ring + webpki and **not** `rustls-platform-verifier` (verify against oci-client's manifest — may need a version bump). Unify mvm-direct + oci-client on **one reqwest major**.
+- [ ] **Step 2:** Set every rustls consumer to `default-features = false` + ring. Failing test — `cargo tree -i aws-lc-rs` is empty; **a real HTTPS connect succeeds** (provider-pinning compiles green but can fail at handshake); `cargo tree -d | grep reqwest` shows one major. The native cmake build is gone (note the cold-build delta). Commit.
 
 ### Task B5: drop `tokio` from `mvm-core`'s default closure (folds in plan 121's "runtime-free core" follow-up)
 

--- a/specs/plans/126-dependency-reduction.md
+++ b/specs/plans/126-dependency-reduction.md
@@ -10,22 +10,26 @@
 
 **Prereqs:** 121 (final crate homes). Coordinates with 123 (the `object_store` S3 client), 127 (the dep-count dashboard consumes the re-baselined methodology), and 156 (binary-size reduction — these cuts are its primary size driver; its `check-binary-size` gate is the sibling of D1's `check-forbidden-deps`).
 
-**Re-baseline (measured 2026-05-31; re-confirmed 2026-06-03):** `Cargo.lock` was **735 packages** on 2026-05-31 (the brief's "723" was stale) and per-crate closures ~170 *lower* than an earlier count. As of 2026-06-03 the lock has drifted to **739** and this plan is still **unstarted** — all four targets (`sigstore`, `opendal`, `pgp`, `aws-lc-rs`) remain present; `minisign`/`object_store` not yet introduced; `docs/investigations/dep-baseline.md` not yet created. Lock the `cargo tree` methodology in Phase A against the live count before tracking any delta.
+**Baseline (A1 DONE 2026-06-05, `main` @ `bb1cbcbe`):** default binary closure = **407** unique packages; full lockfile = **722**. Method + per-target table in `docs/investigations/dep-baseline.md`. **A1 corrected the Phase-B premises:** `sigstore` + `opendal` are already gated out of the default binary (no default-build cut left); the only default-closure targets are **`pgp` (168)** and **`aws-lc-rs` (16 + a C build)**; and `pgp` is Alpine-tarball verification, not release signing (B3 re-scoped). **Recommended order: B4 first** (cleanest default cut), then the B3 decision.
 
 ---
 
 ## Phase A — re-baseline the methodology
 
-### Task A1: one measurement method, written down
+### Task A1: one measurement method, written down — DONE 2026-06-05
 
-- [ ] **Step 1:** Define the canonical commands: total = `cargo tree --workspace -e no-dev --prefix none | sort -u | wc -l`; per-crate = `cargo tree -p <c> -e no-dev`; default-vs-full-feature = with and without the optional features. Record the **735** baseline + the per-crate closures of the targets below.
-- [ ] **Step 2:** Commit a `docs/investigations/dep-baseline.md` with the method + the numbers. 127's dashboard reads from here. Every later task appends its delta.
+- [x] **Step 1:** Canonical commands defined. Two distinct numbers (don't conflate): **default binary closure** = `cargo tree --workspace -e no-dev --prefix none | sed 's/ (.*)//' | sort -u | wc -l` = **407**; **full lockfile** = `grep -c '^name = ' Cargo.lock` = **722**. Per-crate + feature-on closures recorded in the doc.
+- [x] **Step 2:** `docs/investigations/dep-baseline.md` committed with the method + numbers + the corrected per-target findings below.
+
+> **A1 corrected the Phase-B premises.** `sigstore` + `opendal` are **already gated out of the default binary** (their default-build benefit is realized; only feature-on builds pay). The only two targets in the **default** closure are **`pgp` (168 crates)** and **`aws-lc-rs` (16 + a C build)**. And **B3's premise is wrong** — `pgp` is Alpine-tarball verification, not release signing (see B3). See the baseline doc for the full table + the revised task order (B4 first).
 
 ## Phase B — prune the heavy optional features
 
-### Task B1: `sigstore` (~120–150) — relocate or drop `manifest-verify`
+### Task B1: `sigstore` — relocate or drop `manifest-verify`
 
-The biggest single closure. It backs cosign verification for claim 14 (OCI provenance). Options: move the verification to **mvmd** (the control plane verifies before admit) or drop the in-`mvmctl` path.
+> **A1 finding:** `sigstore` is **already off the default binary** (gated behind `manifest-verify`; adds ~62 crates only when that feature is on). So there is **no default-closure cut left here** — B1 is now purely the cross-repo decision to relocate cosign-verify to mvmd (the `--prod`/admit gate lives in mvmd). Sequence with mvmd; not a quick win.
+
+It backs cosign verification for claim 14 (OCI provenance). Options: move the verification to **mvmd** (the control plane verifies before admit) or drop the in-`mvmctl` path.
 
 - [ ] **Step 1:** Measure `cargo tree -p <crate that pulls sigstore> --features manifest-verify` closure.
 - [ ] **Step 2:** Decide with the claim owner: claim 14's cosign verify is a *prod/admit* concern, and `--prod` admission policy lives in mvmd (memory: prod gate is mvmd's). So **relocate cosign verify to mvmd**; `mvmctl` keeps recording the OCI provenance label (the audit entry) but does not link sigstore. If a local verify is still wanted, gate it behind an off-by-default feature.
@@ -33,17 +37,24 @@ The biggest single closure. It backs cosign verification for claim 14 (OCI prove
 
 ### Task B2: `opendal` (~70) → `object_store`
 
+> **A1 finding:** `opendal` is **already off the default binary** (gated behind `template-registry-s3`). No default-closure cut left; this only shrinks the `template-registry-s3` build. Still worth doing for repo-wide single-S3-client hygiene, coordinated with 123 — but not a default-build win.
+
 Pre-decided with 123: one lean S3 client for the repo.
 
 - [ ] **Step 1:** Replace `opendal` (`crates/mvm/Cargo.toml`, optional, template-registry-s3) with `object_store` (the same crate 123's S3 `MountProvider` uses, TLS pinned to `ring`). Failing test — the template-registry-s3 round-trips against `object_store`'s in-memory backend.
 - [ ] **Step 2:** Drop `opendal` from the workspace; re-measure (expect ~70 gone, minus `object_store`'s own small closure). Commit.
 
-### Task B3: `pgp` (~80) → `minisign`
+### Task B3: `pgp` (168 crates) — re-scoped (NOT a minisign swap)
 
-Release signing. `pgp`/`sequoia` is a large closure for a sign-and-verify a release artifact.
+> **A1 corrected this task.** `pgp` (rpgp 0.17, unconditional dep of `mvm-build`, **168-crate** closure — the single biggest target) is **not** our release signing. It verifies the **Alpine minirootfs tarball's upstream PGP signature** against the embedded `ALPINE_RELEASE_KEY_ASC` in Stage 0 (`crates/mvm-build/src/stage0.rs::verify_alpine_pgp_signature`). It **cannot** move to minisign — Alpine dictates the format.
 
-- [ ] **Step 1:** Measure the `pgp` closure + find its call sites (release signing/verify).
-- [ ] **Step 2:** Replace with `minisign` (tiny, Ed25519). Failing test — a release artifact signs + verifies under the new keypair; an old-format signature is *not* silently accepted (no back-compat — first version). Re-measure. Commit.
+The tarball is **already SHA-256 hash-pinned in source** for the pinned `ALPINE_VERSION` (`verify_sha256`), so PGP is **defense-in-depth** whose distinct value is mainly at version-bump time. Reducing the 168 crates is a **decision**, not a swap:
+
+- [ ] **Option 1 (biggest, −168):** drop the PGP verify, keep the SHA-256 pin. Removes a defense layer → needs security-owner sign-off + an ADR-002 note + a documented version-bump procedure (verify a new tarball's PGP sig out-of-band before pinning its hash).
+- [ ] **Option 3:** gate `verify_alpine_pgp_signature` behind a contributor-only feature if no default/published path reaches it. Audit the call graph first.
+- [ ] **Option 2 (low payoff):** lighter OpenPGP verifier — rpgp already *is* the lean choice; sequoia is heavier; no smaller RSA-OpenPGP-verify crate exists. Likely not worth it.
+
+See `docs/investigations/dep-baseline.md` for the full rationale.
 
 ### Task B4: `aws-lc-rs` → `ring` (~6 + kills a C/cmake build)
 

--- a/specs/plans/126-dependency-reduction.md
+++ b/specs/plans/126-dependency-reduction.md
@@ -58,10 +58,11 @@ See `docs/investigations/dep-baseline.md` for the full rationale.
 
 ### Task B4: `aws-lc-rs` → `ring` — MERGE WITH C1 (not a standalone cut)
 
-> **A1 finding (see `docs/investigations/dep-baseline.md`):** mvm's own `reqwest 0.12` is **already** on `ring` (`default-features = false` rustls + `__rustls-ring`). aws-lc-rs enters **only** via `oci-client 0.16 → reqwest 0.13.3 → rustls-platform-verifier`. So B4 = **C1** (collapse the two reqwest majors) + steer `oci-client` onto ring + webpki roots (drop platform-verifier). Do them as one task.
+> **A1 finding (see `docs/investigations/dep-baseline.md`):** mvm's own `reqwest 0.12` is **already** on `ring`. aws-lc-rs enters **only** via `oci-client → reqwest 0.13 → rustls-platform-verifier` (+ `jsonwebtoken/aws_lc_rs`). **BLOCKED UPSTREAM:** `oci-client` 0.16 **and** 0.17 hardcode aws-lc in their only rustls option (`rustls-tls = ["reqwest/rustls", "jsonwebtoken/aws_lc_rs"]`); no ring feature exists, and feature unification can't remove it. So B4 is **not a config change** — it needs a **fork/replace of `oci-client`** (+ reqwest-major unify + a runtime TLS smoke). Decide before starting.
 
-- [ ] **Step 1:** Find an `oci-client` feature/version whose TLS uses ring + webpki and **not** `rustls-platform-verifier` (verify against oci-client's manifest — may need a version bump). Unify mvm-direct + oci-client on **one reqwest major**.
-- [ ] **Step 2:** Set every rustls consumer to `default-features = false` + ring. Failing test — `cargo tree -i aws-lc-rs` is empty; **a real HTTPS connect succeeds** (provider-pinning compiles green but can fail at handshake); `cargo tree -d | grep reqwest` shows one major. The native cmake build is gone (note the cold-build delta). Commit.
+- [ ] **Step 0 (decision):** fork/patch `oci-client` (add a `reqwest` webpki-ring path + `jsonwebtoken/rust_crypto`), or replace it, or upstream a `rustls-tls-ring` feature, or defer. See the baseline doc's four options.
+- [ ] **Step 1:** Once oci-client has a ring path, unify mvm-direct + oci-client on **one reqwest major** and set every rustls consumer to `default-features = false` + ring.
+- [ ] **Step 2:** Failing test — `cargo tree -i aws-lc-rs` empty; **a real HTTPS connect succeeds**; `cargo tree -d | grep reqwest` shows one major; the cmake build is gone (note the cold-build delta). Commit.
 
 ### Task B5: drop `tokio` from `mvm-core`'s default closure (folds in plan 121's "runtime-free core" follow-up)
 


### PR DESCRIPTION
Plan 126 **Task A1** (the measurement prerequisite) — and it surfaced that the Phase-B target list was written on wrong assumptions. Docs-only.

## Baseline (main @ `bb1cbcbe`)
- Default binary closure: **407** unique packages
- Full lockfile: **722** packages
- Canonical method + per-target table → `docs/investigations/dep-baseline.md`

## A1 corrected the Phase-B premises
| Target | In default build? | Reality |
|---|---|---|
| `sigstore` | **No** (gated behind `manifest-verify`) | B1's default-build cut is **already realized**; only the relocate-to-mvmd decision remains |
| `opendal` | **No** (gated behind `template-registry-s3`) | B2 has **no default cut left**; feature-on hygiene only, coordinate with 123 |
| `pgp` (168) | **Yes** (unconditional in `mvm-build`) | **B3's premise is wrong** — it's **Alpine-tarball PGP verification** in Stage 0, not release signing; **can't** move to minisign |
| `aws-lc-rs` (16 + C build) | **Yes** (`rustls` default provider) | **B4 stands** — the cleanest remaining default-closure cut |

## The pgp re-scope
`pgp` verifies the Alpine minirootfs tarball's upstream signature (`stage0.rs::verify_alpine_pgp_signature`). The tarball is **already SHA-256 hash-pinned**, so the PGP check is defense-in-depth. Reducing those 168 crates is a **security decision** (drop the layer / gate it), not a minisign swap — spelled out in the baseline doc + re-scoped B3.

## Recommended order
**B4 (`aws-lc-rs` → `ring`)** first — only default-closure cut that's a mechanical-ish lever; then the B3 decision.

No code touched — measurement + plan correction only.