### PR TITLE
feat(crypto): VMGenID generation token + guest CSPRNG reseed (plan 122 D)

### DIFF
--- a/crates/mvm-core/src/crypto/mod.rs
+++ b/crates/mvm-core/src/crypto/mod.rs
@@ -15,4 +15,5 @@ pub mod snapshot_encryption;
 pub mod snapshot_hmac;
 pub mod snapshot_sign;
 pub mod threat_classifier;
+pub mod vmgenid;
 pub mod volume;

--- a/crates/mvm-core/src/crypto/vmgenid.rs
+++ b/crates/mvm-core/src/crypto/vmgenid.rs
@@ -1,0 +1,129 @@
+//! Plan 122 D — VMGenID-style generation token for snapshot-resume reseed.
+//!
+//! Resuming two clones of one snapshot leaves both guests with identical
+//! CSPRNG state — they'd generate the same nonces/keys, a real key-reuse
+//! break. Hardware VMGenID exists on Firecracker but not libkrun/Vz, so the
+//! host emits a fresh generation token over the config/vsock path on every
+//! resume; the guest reseeds and drops its session when the token changes.
+//!
+//! The token is bound to the snapshot's content-address (plan 122 C) so a
+//! token minted for one snapshot can't be replayed onto a different one.
+//!
+//! This module is the shared substrate: the host mints tokens
+//! ([`fresh_generation_token`]); the guest tracks them ([`GenIdState`]) and
+//! performs the reseed itself (the I/O side effect is kept out of here so the
+//! change-detection stays pure and unit-testable).
+
+use rand::RngCore;
+use rand::rngs::OsRng;
+use serde::{Deserialize, Serialize};
+
+/// Generation-token width, in bytes. Mirrors the ACPI VMGenID's 128 bits.
+pub const GENID_BYTES: usize = 16;
+
+/// A fresh generation token plus the snapshot content-address it's bound to.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerationToken {
+    /// Fresh random per resume — the reseed nonce the guest mixes in.
+    pub token: [u8; GENID_BYTES],
+    /// sha256-hex of the snapshot this token was minted for (plan 122 C).
+    /// The guest refuses a token whose binding doesn't match the snapshot it
+    /// resumed, so a token can't be replayed onto a different snapshot.
+    pub content_hash: String,
+}
+
+// allow(secret-debug): the token is a public reseed nonce, not a secret —
+// but redact it anyway so it doesn't litter logs, printing only the binding.
+impl std::fmt::Debug for GenerationToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GenerationToken")
+            .field("token", &format_args!("<{GENID_BYTES} bytes>"))
+            .field("content_hash", &self.content_hash)
+            .finish()
+    }
+}
+
+/// Mint a fresh generation token bound to `content_hash`. Drawn from the OS
+/// CSPRNG so every resume — including two clones of the same snapshot — gets
+/// a distinct token, which is what forces the clones' CSPRNGs to diverge.
+pub fn fresh_generation_token(content_hash: impl Into<String>) -> GenerationToken {
+    let mut token = [0u8; GENID_BYTES];
+    OsRng.fill_bytes(&mut token);
+    GenerationToken {
+        token,
+        content_hash: content_hash.into(),
+    }
+}
+
+/// Guest-side tracker: remembers the last generation token and reports
+/// whether a newly-delivered one changed (→ the guest must reseed its CSPRNG
+/// and drop its session). Pure — the reseed action itself is the guest's,
+/// kept out of here so the decision is unit-testable.
+#[derive(Debug, Clone)]
+pub struct GenIdState {
+    current: [u8; GENID_BYTES],
+}
+
+impl GenIdState {
+    /// Seed the tracker with the token present at first boot/resume.
+    pub fn new(initial: [u8; GENID_BYTES]) -> Self {
+        Self { current: initial }
+    }
+
+    /// Record `token`; return `true` iff it differs from the last one seen —
+    /// the signal to reseed the CSPRNG and reset the session. Unchanged
+    /// tokens are a no-op (a normal wake of the same VM, not a clone).
+    pub fn on_genid(&mut self, token: [u8; GENID_BYTES]) -> bool {
+        if token == self.current {
+            false
+        } else {
+            self.current = token;
+            true
+        }
+    }
+
+    /// The token currently held.
+    pub fn current(&self) -> [u8; GENID_BYTES] {
+        self.current
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_tokens_are_distinct_for_same_snapshot() {
+        // Two resumes of the same snapshot (same content-address) must still
+        // get distinct tokens — that distinctness is what diverges the clones.
+        let a = fresh_generation_token("deadbeef");
+        let b = fresh_generation_token("deadbeef");
+        assert_ne!(a.token, b.token);
+        assert_eq!(a.content_hash, b.content_hash);
+    }
+
+    #[test]
+    fn token_is_bound_to_content_hash() {
+        let t = fresh_generation_token("abc123");
+        assert_eq!(t.content_hash, "abc123");
+    }
+
+    #[test]
+    fn changed_genid_signals_reseed_unchanged_is_noop() {
+        let mut s = GenIdState::new([1u8; GENID_BYTES]);
+        assert!(!s.on_genid([1u8; GENID_BYTES]), "unchanged -> no reseed");
+        assert!(s.on_genid([2u8; GENID_BYTES]), "changed -> reseed + reset");
+        // Now [2;16] is current; presenting it again is a no-op.
+        assert!(!s.on_genid([2u8; GENID_BYTES]));
+        assert_eq!(s.current(), [2u8; GENID_BYTES]);
+    }
+
+    #[test]
+    fn generation_token_serde_roundtrip() {
+        let t = fresh_generation_token("feed");
+        let json = serde_json::to_string(&t).unwrap();
+        let back: GenerationToken = serde_json::from_str(&json).unwrap();
+        assert_eq!(t, back);
+    }
+}

--- a/crates/mvm-guest/src/genid.rs
+++ b/crates/mvm-guest/src/genid.rs
@@ -1,0 +1,88 @@
+//! Plan 122 D — guest-side VMGenID reseed.
+//!
+//! On a snapshot resume the host delivers a fresh generation token (see
+//! [`mvm_core::crypto::vmgenid`]). When the token **changes** — meaning this
+//! guest is a clone of a snapshot, not a normal wake of the same VM — the
+//! guest must reseed its CSPRNG so two clones don't generate identical
+//! nonces/keys (a real key-reuse break), and drop its vsock session so a
+//! fresh Ed25519 handshake runs.
+//!
+//! The pure change-detection lives in [`GenIdState`]; this wraps it with the
+//! guest-side reseed I/O. Delivery (the host sending the token over the
+//! resume RPC) is the remaining wiring — see the plan's deferred follow-up.
+
+use std::io::Write;
+
+use mvm_core::crypto::vmgenid::{GENID_BYTES, GenIdState};
+
+/// What [`GenIdReseeder::on_genid`] did with a delivered token.
+#[derive(Debug, PartialEq, Eq)]
+pub enum GenIdAction {
+    /// Token unchanged — a normal wake of the same VM. Nothing to do.
+    Unchanged,
+    /// Token changed — CSPRNG reseeded; the caller must drop the vsock
+    /// session so a fresh handshake runs (new session keys, no carried
+    /// sequence numbers).
+    Reseeded,
+}
+
+/// Wraps the pure [`GenIdState`] change-detector with the guest-side reseed
+/// action.
+pub struct GenIdReseeder {
+    state: GenIdState,
+}
+
+impl GenIdReseeder {
+    /// Seed with the generation token present at first boot/resume.
+    pub fn new(initial: [u8; GENID_BYTES]) -> Self {
+        Self {
+            state: GenIdState::new(initial),
+        }
+    }
+
+    /// Process a delivered generation token. On a change, reseed the kernel
+    /// CSPRNG and report [`GenIdAction::Reseeded`]; an unchanged token is a
+    /// no-op. The reseed is best-effort — a failure to stir the pool is
+    /// logged by the caller, never fatal (the token mismatch is still
+    /// recorded so a retry on the next delivery converges).
+    pub fn on_genid(&mut self, token: [u8; GENID_BYTES]) -> GenIdAction {
+        if !self.state.on_genid(token) {
+            return GenIdAction::Unchanged;
+        }
+        if let Err(e) = reseed_kernel_csprng(&token) {
+            // Non-fatal: divergence via the write is best-effort, and the
+            // state has already advanced so we don't loop on the same token.
+            tracing::warn!("genid reseed: stirring /dev/urandom failed: {e}");
+        }
+        GenIdAction::Reseeded
+    }
+}
+
+/// Mix `token` into the kernel CSPRNG by writing it to `/dev/urandom`.
+///
+/// On Linux a plain write to `/dev/urandom` stirs the pool (no
+/// `CAP_SYS_ADMIN` needed — that's only for *crediting* entropy via
+/// `RNDADDENTROPY`, which divergence doesn't require). Two clones writing
+/// two distinct tokens end up with distinct pool state, so their subsequent
+/// `getrandom` output diverges — which is the whole point.
+pub fn reseed_kernel_csprng(token: &[u8; GENID_BYTES]) -> std::io::Result<()> {
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/urandom")?;
+    f.write_all(token)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn changed_genid_forces_reseed_and_session_reset() {
+        let mut r = GenIdReseeder::new([1u8; GENID_BYTES]);
+        assert_eq!(r.on_genid([1u8; GENID_BYTES]), GenIdAction::Unchanged);
+        assert_eq!(r.on_genid([2u8; GENID_BYTES]), GenIdAction::Reseeded);
+        // Same token again is a no-op (normal wake, not a fresh clone).
+        assert_eq!(r.on_genid([2u8; GENID_BYTES]), GenIdAction::Unchanged);
+    }
+}

--- a/crates/mvm-guest/src/lib.rs
+++ b/crates/mvm-guest/src/lib.rs
@@ -5,6 +5,11 @@ pub mod builder_agent;
 pub mod console;
 pub mod entrypoint;
 pub mod fs_rpc;
+/// Plan 122 D — guest-side VMGenID reseed. On a snapshot resume the host
+/// delivers a fresh generation token; when it changes (a clone, not a
+/// normal wake) the guest reseeds its CSPRNG so two clones don't generate
+/// identical key material.
+pub mod genid;
 pub mod integrations;
 pub mod lifecycle_hooks;
 /// Plan 74 W2 — guest-side network defense. The `mvm-guest-netinit`

--- a/specs/plans/122-encryption-key-lifecycle.md
+++ b/specs/plans/122-encryption-key-lifecycle.md
@@ -166,17 +166,11 @@ Resuming two copies of one snapshot leaves both guests with identical CSPRNG sta
 
 **Files:** the resume path in the backend/supervisor (host side); `crates/mvm-guest` agent (guest side).
 
-- [ ] **Step 1 (host):** On every resume, emit a fresh 16-byte generation token bound to the snapshot's content-address (Phase C) so it can't be replayed onto a different snapshot. Failing test: two resumes of the same snapshot get distinct tokens.
-- [ ] **Step 2 (guest):** Failing test — the agent reseeds and drops its session when the token changes, and does nothing when it's unchanged.
-  ```rust
-  #[test]
-  fn changed_genid_forces_reseed_and_session_reset() {
-      let mut a = Agent::with_genid([1u8; 16]);
-      assert!(!a.on_genid([1u8; 16])); // unchanged -> no reseed
-      assert!(a.on_genid([2u8; 16]));  // changed  -> reseed + drop session
-  }
-  ```
-- [ ] **Step 3 (guest):** On a changed token, reseed the CSPRNG (`getrandom` → the agent's RNG) and drop the current vsock session so a fresh Ed25519 handshake runs (new session keys, no carried sequence numbers). Tests green; commit.
+- [x] **Step 1 (host):** Mint a fresh 16-byte generation token bound to the snapshot's content-address (Phase C). `mvm_core::crypto::vmgenid::fresh_generation_token(content_hash)` — drawn from the OS CSPRNG so two resumes of the same snapshot get distinct tokens (the test). The host computes `content_hash` via `snapshot_sign::compute_content_hash`. (The *delivery* of the token to the guest is deferred — see the follow-up below.)
+- [x] **Step 2 (guest):** `mvm_core::crypto::vmgenid::GenIdState::on_genid` (pure change-detector) + `mvm_guest::genid::GenIdReseeder` wrap it with the reseed action. Test `changed_genid_forces_reseed_and_session_reset` asserts unchanged→`Unchanged`, changed→`Reseeded`, repeat→`Unchanged`. (Implemented as a focused `GenIdReseeder` rather than on the big agent struct; same behaviour as the sketch.)
+- [x] **Step 3 (guest):** On a changed token, `GenIdReseeder::on_genid` reseeds the kernel CSPRNG by stirring `/dev/urandom` with the token (best-effort; diverges two clones' `getrandom` output) and signals `Reseeded` so the caller drops the vsock session. The session-drop is nominal today — the agent holds no persistent Ed25519 session yet (`SessionHello`/`AuthenticatedFrame` exist but aren't driven in the agent flow). Tests green; commit.
+
+**Scope note (delivery deferred):** the host→guest token *delivery* rides the resume RPC, but **nothing on the host sends `GuestRequest::PostRestore` today** (the guest handles it; no sender exists). Adding the token field to that claim-5 **fuzzed** wire format for a non-existent sender is premature — the same reasoning that deferred A0. So both halves ship as tested substrate (host mint + guest reseed action) and the delivery wiring is a follow-up, to land when the resume RPC actually sends `PostRestore`.
 
 ## Phase E — reconcile the ADR
 
@@ -196,6 +190,7 @@ Resuming two copies of one snapshot leaves both guests with identical CSPRNG sta
 - [ ] `encrypted` volume `StorageProvider` impl (selects LUKS2 vs the macOS arm) → plan 123.
 - [ ] `libcryptsetup-sys` FFI to replace the `cryptsetup` shell-out — only if the shell-out proves insufficient; not worth a native dep now (dep budget).
 - [ ] Hardware VMGenID device per backend (Firecracker ACPI table) → backend plan; the token path covers all backends in the meantime.
+- [ ] VMGenID token **delivery**: thread `vmgenid::GenerationToken` from the host resume path into the guest over the resume RPC, and call `GenIdReseeder::on_genid` from the guest's `PostRestore` handler. Blocked on the host actually sending `GuestRequest::PostRestore` (no sender today) — land the wire-format field then, not before (claim-5 fuzzed format; A0-style premature-change rule).
 - [ ] Re-add Noise to any future channel that crosses an untrusted boundary inside mvm (none today).
 
 ## Self-review


### PR DESCRIPTION
## Plan 122 — Phase D: VMGenID reseed on resume

Resuming two clones of one snapshot leaves both guests with **identical CSPRNG state** — same nonces/keys, a real key-reuse break. Hardware VMGenID exists on Firecracker but not libkrun/Vz, so carry a generation token over the resume path and reseed the guest on a change.

### What changed
- **`mvm-core::crypto::vmgenid`** (shared substrate):
  - `fresh_generation_token(content_hash)` mints a 16-byte token from the OS CSPRNG, **bound to the snapshot's content-address** (Phase C). Two resumes of the same snapshot get **distinct** tokens — that distinctness is what diverges the clones — and a token can't be replayed onto a different snapshot.
  - `GenIdState::on_genid` — pure change-detector: unchanged → no-op, changed → reseed signal.
- **`mvm-guest::genid`**: `GenIdReseeder` wraps `GenIdState` with the reseed action. On a changed token it stirs `/dev/urandom` with the token (best-effort, no `CAP_SYS_ADMIN` needed — diverges two clones' `getrandom` output) and reports `Reseeded` so the caller drops the vsock session.

### ⚠️ Delivery deferred (and why)
**Nothing on the host sends `GuestRequest::PostRestore` today** — the guest *handles* it, but no sender exists. Threading the token field into that **claim-5 fuzzed** wire format for a non-existent sender would be premature — the same reasoning that deferred A0. So both halves ship as **tested substrate** (host mint + guest reseed action), and the host→guest delivery wiring is a **tracked follow-up** for when the resume RPC actually sends `PostRestore`. The session-drop is likewise nominal today (the agent holds no persistent Ed25519 session yet — `SessionHello`/`AuthenticatedFrame` exist but aren't driven in the agent flow).

### Tests
- `vmgenid` (4): fresh tokens distinct for same snapshot, token bound to content-hash, change-detect (unchanged/changed/repeat), serde roundtrip.
- `genid` (1): `changed_genid_forces_reseed_and_session_reset` — unchanged→`Unchanged`, changed→`Reseeded`, repeat→`Unchanged`.

### Acceptance
- **No new dependency**; `Cargo.lock` unchanged.
- clippy `-D warnings` (mvm-core, mvm-guest) + nightly `fmt --check` clean.