### PR TITLE
fix(ci): correct zig macOS arch in install-zigbuild (unblocks release build)

### DIFF
--- a/.github/actions/install-zigbuild/action.yml
+++ b/.github/actions/install-zigbuild/action.yml
@@ -17,11 +17,14 @@ runs:
         ZIG_VERSION=0.13.0
         OS=$(uname -s)
         ARCH=$(uname -m)
+        # macOS `uname -m` reports arm64; zig's release tarballs are named aarch64.
+        [ "$ARCH" = "arm64" ] && ARCH=aarch64
         if [ "$OS" = "Darwin" ]; then
           TARBALL="zig-macos-${ARCH}-${ZIG_VERSION}.tar.xz"
         else
           TARBALL="zig-linux-${ARCH}-${ZIG_VERSION}.tar.xz"
         fi
+        sudo mkdir -p /opt
         curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/${TARBALL}" \
           | sudo tar xJ -C /opt
         DIR="${TARBALL%.tar.xz}"


### PR DESCRIPTION
## Problem

The v0.16.0 release run failed at `build (aarch64-apple-darwin)` in the `install-zigbuild` composite action:

```
+ TARBALL=zig-macos-arm64-0.13.0.tar.xz
+ curl -fsSL https://ziglang.org/download/0.13.0/zig-macos-arm64-0.13.0.tar.xz
curl: (22) The requested URL returned error: 404
```

`uname -m` reports **arm64** on Apple Silicon, but zig's release tarballs are named with **aarch64** (`zig-macos-aarch64-0.13.0.tar.xz`). Linux never tripped this because its `uname -m` already matches zig's naming, and the only prior caller (`ci.yml` Lint) runs on ubuntu — the release `build` job is the first macOS consumer of this action.

## Fix

- Normalize `arm64` → `aarch64` before composing the tarball name.
- `mkdir -p /opt` since it isn't guaranteed on the macOS runner image.

## Validation

Reproduced the exact release build natively on an Apple Silicon host:
`OPENSSL_STATIC=1 OPENSSL_VENDORED=1 cargo build --release --target aarch64-apple-darwin --features <release features>` — the binary + build.rs host-vm zigbuild cross-compile both succeed. The corrected URL returns HTTP 200.