### PR TITLE
Plan 141: backend-agnostic packet-observer pipeline (on_packet/Verdict) for libkrun + Firecracker

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -316,6 +316,21 @@ jobs:
         # suite.
         run: cargo fuzz run fuzz_passt_hashes_toml -- -max_total_time="$DURATION"
 
+      - name: Fuzz gateway packet parse + rebuild (host-side)
+        working-directory: crates/mvm-hostd
+        env:
+          DURATION: ${{ steps.duration.outputs.secs }}
+          RUSTUP_TOOLCHAIN: nightly
+        # Plan 141 / ADR-064 — `packet::parse` is the first real parse on
+        # the guest's network path (the bridge byte-copied opaquely before
+        # this plan); `rebuild_with_payload` re-serializes observer-modified
+        # frames. Both run on attacker-influenced bytes (claim 5). "Never
+        # panic on any input": parse fails closed to None on garbage, and
+        # re-emitting an accepted frame's own payload round-trips without
+        # panicking (Err on extension/over-MTU frames is the fail-closed
+        # path, not a panic).
+        run: cargo fuzz run fuzz_packet_parse -- -max_total_time="$DURATION"
+
       - name: Upload corpus on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1645,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etherparse"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac016aaf11dfe643edcd088a166234bfcb72e7f06691abfcf21e9af524037f4"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -3473,6 +3488,7 @@ dependencies = [
  "chrono",
  "ctor",
  "ed25519-dalek",
+ "etherparse",
  "hickory-resolver",
  "ipnet",
  "landlock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,6 +3489,7 @@ dependencies = [
  "ctor",
  "ed25519-dalek",
  "etherparse",
+ "hex",
  "hickory-resolver",
  "ipnet",
  "landlock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,11 @@ notify-debouncer-mini = "0.5"
 # the canonical CIDR string ("10.0.0.0/24"), which is the wire
 # format the policy bundle TOML uses.
 ipnet = { version = "2", features = ["serde"] }
+# Plan 141 / ADR-064 — EthernetII/IPv4/IPv6/TCP/UDP parse + payload rebuild
+# for the gateway packet-observer pipeline. Pure-Rust, zero transitive
+# deps, fuzzed upstream. Lands on the untrusted-guest-bytes path (claim 5),
+# so a mature parser beats a hand-rolled one.
+etherparse = "0.20"
 # Plan 74 W2 — mvm-guest-netinit installs kernel blackhole routes
 # for `MANDATORY_DENY_RANGES` inside every microVM. rtnetlink wraps
 # the AF_NETLINK socket and the RTM_NEWROUTE message construction;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,10 @@ exclude = [
     # targets on release-tag pushes + nightly cron + manual
     # dispatch only (not on every PR — the lane is heavy).
     "crates/mvm-vm-host/fuzz",
+    # Plan 141 / ADR-064 — gateway packet parse + payload-rebuild fuzz
+    # harness (`fuzz_packet_parse`). Same libfuzzer-sys linker constraints;
+    # CI gate at `.github/workflows/security.yml::fuzz`.
+    "crates/mvm-hostd/fuzz",
     # ADR-070 — browser audit-log verifier. Excluded so wasm-bindgen +
     # the wasm32 target stay out of `cargo build --workspace` and CI;
     # it depends on the in-workspace `mvm-verify` crate by path and is

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -169,6 +169,26 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 }
             }
 
+            // Plan 141 — flow-byte-log retention sweep. Per-tenant subdirs
+            // under `<audit>/flow-bytes/` hold opt-in payload records;
+            // remove files older than the default window. No tenant policy
+            // is in scope at prune time, so use the conservative default.
+            const FLOW_BYTE_LOG_MAX_AGE_DAYS: u32 = 7;
+            let flow_bytes_dir = mvm_core::config::mvm_audit_dir().join("flow-bytes");
+            if dry_run {
+                if flow_bytes_dir.exists() {
+                    ui::info("(dry-run) Would sweep expired flow-byte-log records.");
+                }
+            } else {
+                match mvm_hostd::supervisor::network::flow_byte_log::sweep_retention(
+                    &flow_bytes_dir,
+                    FLOW_BYTE_LOG_MAX_AGE_DAYS,
+                ) {
+                    Ok(n) => removed += n,
+                    Err(e) => ui::warn(&format!("flow-byte-log sweep failed: {e}")),
+                }
+            }
+
             for entry in walkdir(path)? {
                 let entry_path = entry.path();
                 // Remove temp files (mvm-lima-*, .tmp)
@@ -391,6 +411,29 @@ fn walkdir(path: &std::path::Path) -> Result<Vec<std::fs::DirEntry>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn flow_byte_log_sweep_targets_audit_flow_bytes_dir() {
+        // The cache-prune wiring sweeps `<audit>/flow-bytes/`; assert that
+        // path contract (the supervisor writer must agree) and that the
+        // sweep helper removes an aged record while keeping a fresh one.
+        let dir = mvm_core::config::mvm_audit_dir().join("flow-bytes");
+        assert!(dir.ends_with("audit/flow-bytes"));
+
+        let root = tempfile::tempdir().unwrap();
+        let tenant = root.path().join("acme");
+        std::fs::create_dir_all(&tenant).unwrap();
+        std::fs::write(tenant.join("vm.bin"), b"x").unwrap();
+        // age = 0 (cutoff = now) removes the just-written file; large window keeps it.
+        let removed =
+            mvm_hostd::supervisor::network::flow_byte_log::sweep_retention(root.path(), 0).unwrap();
+        assert_eq!(removed, 1);
+        std::fs::write(tenant.join("vm.bin"), b"x").unwrap();
+        let kept =
+            mvm_hostd::supervisor::network::flow_byte_log::sweep_retention(root.path(), 3650)
+                .unwrap();
+        assert_eq!(kept, 0);
+    }
 
     #[test]
     fn stage0_cache_report_surfaces_blobs_and_builder_artifacts() {

--- a/crates/mvm-cli/src/metrics_server.rs
+++ b/crates/mvm-cli/src/metrics_server.rs
@@ -137,7 +137,10 @@ fn append_per_vm_scrape_files_from(out: &mut String, dir: &std::path::Path) {
             Some(n) => n,
             None => continue,
         };
-        if !name.starts_with("metrics-") || !name.ends_with("-flow-count.prom") {
+        // Plan 141 — discover ALL supervisor-written scrape files, not just
+        // flow-count. New per-observer-latency files
+        // (`metrics-<vm>-observer-latency.prom`) are picked up automatically.
+        if !name.starts_with("metrics-") || !name.ends_with(".prom") {
             continue;
         }
         let Ok(file) = std::fs::OpenOptions::new()
@@ -231,15 +234,22 @@ mod tests {
             "mvm_flow_opened_total{tenant=\"b\"} 9\n",
         )
         .unwrap();
+        // Plan 141 — any `metrics-*.prom` is now discovered, including the
+        // new per-observer-latency files.
+        std::fs::write(
+            audit.join("metrics-vm-d-observer-latency.prom"),
+            "mvm_observer_latency_us_count{observer=\"r\",vm=\"d\",direction=\"egress\"} 3\n",
+        )
+        .unwrap();
+        // Non-`metrics-` prefix or non-`.prom` suffix must NOT match.
         std::fs::write(audit.join("other-vm.prom"), "should_not_appear 1\n").unwrap();
         std::fs::write(audit.join("metrics-vm-c.txt"), "should_not_appear 2\n").unwrap();
-        // Generic `.prom` without the `-flow-count` infix must not match.
-        std::fs::write(audit.join("metrics-vm-c.prom"), "should_not_appear 3\n").unwrap();
 
         let mut out = String::new();
         append_per_vm_scrape_files_from(&mut out, &audit);
         assert!(out.contains("mvm_flow_opened_total{tenant=\"a\"} 5"));
         assert!(out.contains("mvm_flow_opened_total{tenant=\"b\"} 9"));
+        assert!(out.contains("mvm_observer_latency_us_count"));
         assert!(!out.contains("should_not_appear"));
     }
 

--- a/crates/mvm-core/src/policy/mod.rs
+++ b/crates/mvm-core/src/policy/mod.rs
@@ -22,8 +22,8 @@ pub mod toml_loader;
 
 pub use bundle::{PolicyBundle, PolicyId, SCHEMA_VERSION, TenantOverlay};
 pub use policies::{
-    ArtifactPolicy, AuditPolicy, DEFAULT_BODY_CAP_BYTES, EgressPolicy, KeyPolicy, L4RuleSpec,
-    NetworkPolicy, PiiPolicy, ToolPolicy,
+    ArtifactPolicy, AuditPolicy, DEFAULT_BODY_CAP_BYTES, EgressPolicy, FlowByteLogDirections,
+    FlowByteLogSpec, KeyPolicy, L4RuleSpec, NetworkPolicy, PiiPolicy, ToolPolicy,
 };
 pub use resolver::{EffectivePolicy, EmergencyDeny, resolve};
 pub use signing::{BundleVerifyError, SignedPolicyBundle, sign_bundle, verify_bundle};

--- a/crates/mvm-core/src/policy/policies.rs
+++ b/crates/mvm-core/src/policy/policies.rs
@@ -50,6 +50,33 @@ pub struct NetworkPolicy {
     /// pre-Plan-113 (no fan-out, chain entries unchanged).
     #[serde(default)]
     pub observers: Vec<String>,
+    /// Plan 141 / ADR-064 — opt-in per-VM flow-byte log. `None` (default)
+    /// = off. When set, the bridge appends length-prefixed payload records
+    /// to `~/.mvm/audit/flow-bytes/<tenant>/<vm>-<utc>.bin`; the signed
+    /// chain references each record by `(file, record_id, sha256)` without
+    /// inlining payload bytes.
+    #[serde(default)]
+    pub flow_byte_log: Option<FlowByteLogSpec>,
+}
+
+/// Retention + scope for the opt-in flow-byte log (Plan 141 / ADR-064).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FlowByteLogSpec {
+    /// Hard cap on bytes-on-disk per VM before rotation drops oldest.
+    pub max_disk_bytes: u64,
+    /// Records older than this are swept by `mvmctl cache prune`.
+    pub max_age_days: u32,
+    /// Which directions to log.
+    pub directions: FlowByteLogDirections,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlowByteLogDirections {
+    Egress,
+    Ingress,
+    Both,
 }
 
 /// Wire-format L4 rule row inside `[[network.l4]]`. The supervisor's
@@ -236,5 +263,27 @@ port_hi  = 443
         let p: NetworkPolicy = toml::from_str(toml).expect("parse v1 bundle");
         assert_eq!(p.l4.len(), 1);
         assert!(p.observers.is_empty());
+    }
+
+    #[test]
+    fn network_policy_flow_byte_log_defaults_off() {
+        // A bundle without the field still parses and logging is off.
+        let np = NetworkPolicy::default();
+        assert!(np.flow_byte_log.is_none());
+        let p: NetworkPolicy = toml::from_str("preset = \"open\"\n").expect("parse without field");
+        assert!(p.flow_byte_log.is_none());
+    }
+
+    #[test]
+    fn flow_byte_log_spec_serde_roundtrip() {
+        let spec = FlowByteLogSpec {
+            max_disk_bytes: 1_000_000,
+            max_age_days: 7,
+            directions: FlowByteLogDirections::Egress,
+        };
+        let toml_str = toml::to_string(&spec).unwrap();
+        let back: FlowByteLogSpec = toml::from_str(&toml_str).unwrap();
+        assert_eq!(spec, back);
+        assert!(toml_str.contains("directions = \"egress\""));
     }
 }

--- a/crates/mvm-hostd/Cargo.toml
+++ b/crates/mvm-hostd/Cargo.toml
@@ -46,6 +46,9 @@ base64.workspace = true
 chrono.workspace = true
 # rand_core feature for the signers' Ed25519 keygen.
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
+# Plan 141 / ADR-064 — packet parse + payload rebuild for the gateway
+# observer pipeline (see workspace dep comment).
+etherparse = { workspace = true }
 sysinfo = { version = "0.30", default-features = false }
 ipnet.workspace = true
 hickory-resolver = { workspace = true, features = ["tokio-runtime"], optional = true }

--- a/crates/mvm-hostd/Cargo.toml
+++ b/crates/mvm-hostd/Cargo.toml
@@ -60,6 +60,8 @@ serde_json.workspace = true
 # RFC 8785 JSON Canonicalization Scheme — audit-signer stable bytes-to-sign.
 serde_jcs = "0.1"
 sha2.workspace = true
+# Plan 141 — hex digests for flow-byte-log record refs.
+hex.workspace = true
 thiserror = "1"
 toml.workspace = true
 url = "2"

--- a/crates/mvm-hostd/fuzz/.gitignore
+++ b/crates/mvm-hostd/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target/
+corpus/
+artifacts/
+Cargo.lock

--- a/crates/mvm-hostd/fuzz/Cargo.toml
+++ b/crates/mvm-hostd/fuzz/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "mvm-hostd-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+# Detach from the parent workspace — `crates/mvm-hostd/fuzz` is listed
+# under `workspace.exclude` in the repo root Cargo.toml because
+# `libfuzzer-sys` only links cleanly under cargo-fuzz's wrapper (which
+# injects sanitizer + linker flags). An empty `[workspace]` table
+# self-identifies this manifest as standalone.
+[workspace]
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.mvm-hostd]
+path = ".."
+
+# Plan 141 / ADR-064 — fuzz the gateway packet parser + payload rebuilder.
+# `packet::parse` runs on every frame the guest puts on the wire (the
+# first real parse on that path); `rebuild_with_payload` re-serializes
+# observer-modified frames. Both sit on the untrusted-guest-bytes surface
+# (claim 5). Harness goal: never panic on any input. Re-parsing the
+# original payload through `rebuild_with_payload` must round-trip without
+# panicking for any frame `parse` accepted.
+[[bin]]
+name = "fuzz_packet_parse"
+path = "fuzz_targets/fuzz_packet_parse.rs"
+test = false
+doc = false
+bench = false

--- a/crates/mvm-hostd/fuzz/fuzz_targets/fuzz_packet_parse.rs
+++ b/crates/mvm-hostd/fuzz/fuzz_targets/fuzz_packet_parse.rs
@@ -1,0 +1,23 @@
+// Plan 141 / ADR-064 — fuzz the gateway packet parser + payload rebuilder.
+//
+// `packet::parse` is the first real parse on the guest's network path
+// (pre-Plan-141 the bridge byte-copied opaquely). `rebuild_with_payload`
+// re-serializes a frame after an observer's `Verdict::Modify`. Both run on
+// attacker-influenced bytes (claim 5). The harness goal is "never panic on
+// any input": `parse` must fail closed to `None` on garbage, and rebuilding
+// with the frame's own payload must round-trip without panicking for any
+// frame `parse` accepted.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mvm_hostd::supervisor::network::packet;
+
+fuzz_target!(|data: &[u8]| {
+    if let Some(parsed) = packet::parse(data) {
+        // Re-emitting the original payload must never panic (it may Err on
+        // extension-header / over-MTU frames — that is the fail-closed path).
+        let payload = parsed.l4_payload.to_vec();
+        let _ = packet::rebuild_with_payload(data, &payload, 1514);
+    }
+});

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -130,6 +130,32 @@ impl AuditEntry {
             ],
         )
     }
+
+    /// Construct a chain entry recording that a host-allowlisted observer
+    /// forced a fail-closed flow kill (Plan 141 / ADR-064 Q8). `reason` is
+    /// one of `drop` / `modify_over_mtu` / `modify_unserializable`. The
+    /// entry attributes the `observer` so an operator can answer "which
+    /// observer killed this flow and why?" from the signed chain alone.
+    pub fn flow_observer_fault(
+        plan: &ExecutionPlan,
+        bundle: Option<&PolicyBundle>,
+        flow_id: &str,
+        direction: FlowDirection,
+        observer: &str,
+        reason: &str,
+    ) -> Self {
+        Self::for_plan(
+            plan,
+            bundle,
+            FLOW_OBSERVER_FAULT_EVENT,
+            [
+                ("flow_id".to_string(), flow_id.to_string()),
+                ("direction".to_string(), direction.as_str().to_string()),
+                ("observer".to_string(), observer.to_string()),
+                ("reason".to_string(), reason.to_string()),
+            ],
+        )
+    }
 }
 
 /// Canonical `event` string for a `FlowOpened` chain entry. Pinned
@@ -139,6 +165,11 @@ pub const FLOW_OPENED_EVENT: &str = "gateway.flow_opened";
 
 /// Canonical `event` string for a `FlowClosed` chain entry.
 pub const FLOW_CLOSED_EVENT: &str = "gateway.flow_closed";
+
+/// Canonical `event` string for a `FlowObserverFault` chain entry —
+/// emitted when a host-allowlisted observer's `Modify`/`Drop` forced a
+/// fail-closed flow kill (Plan 141 / ADR-064 Q8).
+pub const FLOW_OBSERVER_FAULT_EVENT: &str = "gateway.flow_observer_fault";
 
 /// Per-direction flow label for [`AuditEntry::flow_opened`] /
 /// [`AuditEntry::flow_closed`]. Egress = guest → internet,
@@ -541,6 +572,31 @@ mod tests {
             emitted.insert(entry.labels.get("reason").cloned().unwrap());
         }
         assert_eq!(emitted.len(), 4, "all four reasons must be distinguishable");
+    }
+
+    #[test]
+    fn flow_observer_fault_helper_attributes_observer_and_reason() {
+        let plan = sample_plan();
+        let entry = AuditEntry::flow_observer_fault(
+            &plan,
+            None,
+            "vm-egress",
+            FlowDirection::Egress,
+            "egress-redactor",
+            "modify_over_mtu",
+        );
+        assert_eq!(entry.event, FLOW_OBSERVER_FAULT_EVENT);
+        assert_eq!(entry.event, "gateway.flow_observer_fault");
+        assert_eq!(entry.labels.get("flow_id"), Some(&"vm-egress".to_string()));
+        assert_eq!(
+            entry.labels.get("observer"),
+            Some(&"egress-redactor".to_string())
+        );
+        assert_eq!(
+            entry.labels.get("reason"),
+            Some(&"modify_over_mtu".to_string())
+        );
+        assert_eq!(entry.labels.get("direction"), Some(&"egress".to_string()));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
@@ -481,8 +481,10 @@ fn run_bridge_inner(endpoints: BridgeEndpoints, cfg: BridgeConfig) {
                     gateway_fd,
                     supervisor_fd,
                     cfg.vm_name.clone(),
+                    cfg.plan.tenant.0.clone(),
                     cfg.policy.clone(),
                     event_tx,
+                    wiring,
                 )
                 .await;
             }
@@ -528,8 +530,10 @@ async fn run_passt_bridge(
     gateway_fd: OwnedFd,
     supervisor_fd: OwnedFd,
     vm_name: String,
+    tenant: String,
     policy: Arc<dyn FlowPolicy>,
     event_tx: mpsc::Sender<FlowEvent>,
+    wiring: ObserverWiring,
 ) {
     let gateway_std = std::os::unix::net::UnixStream::from(gateway_fd);
     let gateway = match tokio::net::UnixStream::from_std(gateway_std) {
@@ -548,138 +552,251 @@ async fn run_passt_bridge(
         }
     };
 
-    let _ = bridge_copy_bidirectional(gateway, guest, vm_name, policy, event_tx).await;
+    let _ =
+        bridge_copy_bidirectional(gateway, guest, vm_name, tenant, policy, event_tx, wiring).await;
 }
 
-/// Bidirectional byte-pipe between two `UnixStream`s with
-/// first-byte tracking. Emits `FlowOpened` on the first byte per
-/// direction (after `FlowPolicy::evaluate` returns `Allow`) and
-/// `FlowClosed { Eof }` when the direction's read side EOFs.
-/// On any I/O error, emits `FlowClosed { BridgeError }` for any
-/// directions that had opened.
+/// Read one length-prefixed frame from a passt/qemu stream socket. passt's
+/// `--fd` backend (which libkrun's `krun_add_net_unixstream_fd` path
+/// speaks) uses the qemu socket protocol: each ethernet frame is prefixed
+/// with a 4-byte big-endian length. Returns `Ok(None)` on a clean EOF at a
+/// frame boundary. Caps the frame at 65535 — a bogus length fails closed
+/// instead of allocating gigabytes.
 ///
-/// Naming: this is NOT `splice(2)` — there's no tokio splice
-/// wrapper and macOS has no splice anyway. It's a userspace
-/// `read`/`write` loop in 8 KiB chunks.
+/// NOTE: the 4-byte-BE qemu-socket framing is the documented passt wire
+/// format, but the live Passt path is Linux-only and is validated on
+/// Linux/KVM CI (this host cannot exercise it). The reframing logic itself
+/// is unit-tested via an in-memory duplex.
+async fn read_one_frame<R>(r: &mut R) -> std::io::Result<Option<Vec<u8>>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use tokio::io::AsyncReadExt;
+    let mut lenbuf = [0u8; 4];
+    match r.read_exact(&mut lenbuf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+    let len = u32::from_be_bytes(lenbuf) as usize;
+    if len > 65_535 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "passt frame length-prefix exceeds 65535",
+        ));
+    }
+    let mut frame = vec![0u8; len];
+    r.read_exact(&mut frame).await?;
+    Ok(Some(frame))
+}
+
+/// Write one length-prefixed frame (inverse of [`read_one_frame`]).
+async fn write_one_frame<W>(w: &mut W, frame: &[u8]) -> std::io::Result<()>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::AsyncWriteExt;
+    let len = u32::try_from(frame.len()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "frame too large for 4-byte length prefix",
+        )
+    })?;
+    w.write_all(&len.to_be_bytes()).await?;
+    w.write_all(frame).await?;
+    Ok(())
+}
+
+/// Frame-aware bidirectional bridge between two passt/qemu stream sockets.
+/// Reads one length-prefixed ethernet frame at a time, runs the
+/// packet-observer pipeline (Plan 141), and re-emits the (possibly
+/// rebuilt) frame with a corrected length prefix. Emits `FlowOpened` on
+/// the first frame per direction (after `FlowPolicy::evaluate` returns
+/// `Allow`) and `FlowClosed { Eof }` on a clean EOF; `BridgeError` on I/O
+/// error.
+///
+/// Direction semantics (the pre-Plan-141 opaque-copy code had the labels
+/// reversed, which didn't matter for a byte pump but does for observers):
+/// `a` faces passt/internet, `b` faces libkrun/guest. **Egress** = guest →
+/// internet (read `b`, write `a`); **ingress** = internet → guest (read
+/// `a`, write `b`).
 async fn bridge_copy_bidirectional(
     a: tokio::net::UnixStream,
     b: tokio::net::UnixStream,
     vm_name: String,
+    tenant: String,
     policy: Arc<dyn FlowPolicy>,
     event_tx: mpsc::Sender<FlowEvent>,
+    wiring: ObserverWiring,
 ) -> std::io::Result<()> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
     let (mut a_rd, mut a_wr) = a.into_split();
     let (mut b_rd, mut b_wr) = b.into_split();
 
     let flow_egress = format!("{vm_name}-egress");
     let flow_ingress = format!("{vm_name}-ingress");
 
-    // Per-direction state — opened? what to close it with?
     let mut egress_opened = false;
     let mut ingress_opened = false;
 
+    let observers = wiring.observers;
+    let latency = wiring.latency;
+    let killed_flows = wiring.killed_flows;
+    let mtu = wiring.mtu;
+
+    // Egress: guest → internet. Read framed from b, observe, write to a.
     let egress = async {
-        let mut buf = [0u8; 8192];
         loop {
-            match a_rd.read(&mut buf).await {
-                Ok(0) => break, // EOF
-                Ok(n) => {
-                    if !egress_opened {
-                        let action = policy.evaluate(&FlowDecisionCtx {
-                            direction: FlowDirection::Egress,
-                            dest_ip: None,
-                            dest_port: None,
-                            sni_hostname: None,
-                            url_path: None,
-                        });
-                        match action {
-                            FlowAction::Allow => {
-                                let _ = event_tx
-                                    .send(FlowEvent {
-                                        flow_id: flow_egress.clone(),
-                                        direction: FlowDirection::Egress,
-                                        kind: FlowEventKind::Opened,
-                                    })
-                                    .await;
-                                egress_opened = true;
-                            }
-                            FlowAction::Drop { reason } => {
-                                let _ = event_tx
-                                    .send(FlowEvent {
-                                        flow_id: flow_egress.clone(),
-                                        direction: FlowDirection::Egress,
-                                        kind: FlowEventKind::Closed {
-                                            reason: FlowCloseReason::PolicyDropped,
-                                        },
-                                    })
-                                    .await;
-                                tracing::info!(
-                                    flow_id = %flow_egress,
-                                    reason = %reason.0,
-                                    "egress flow dropped by FlowPolicy"
-                                );
-                                return Ok::<(), std::io::Error>(());
-                            }
-                        }
+            let frame = match read_one_frame(&mut b_rd).await {
+                Ok(Some(f)) => f,
+                Ok(None) => break,
+                Err(e) => return Err::<(), std::io::Error>(e),
+            };
+            if !egress_opened {
+                match policy.evaluate(&FlowDecisionCtx {
+                    direction: FlowDirection::Egress,
+                    dest_ip: None,
+                    dest_port: None,
+                    sni_hostname: None,
+                    url_path: None,
+                }) {
+                    FlowAction::Allow => {
+                        let _ = event_tx
+                            .send(FlowEvent {
+                                flow_id: flow_egress.clone(),
+                                direction: FlowDirection::Egress,
+                                kind: FlowEventKind::Opened,
+                            })
+                            .await;
+                        egress_opened = true;
                     }
-                    b_wr.write_all(&buf[..n]).await?;
+                    FlowAction::Drop { reason } => {
+                        let _ = event_tx
+                            .send(FlowEvent {
+                                flow_id: flow_egress.clone(),
+                                direction: FlowDirection::Egress,
+                                kind: FlowEventKind::Closed {
+                                    reason: FlowCloseReason::PolicyDropped,
+                                },
+                            })
+                            .await;
+                        tracing::info!(flow_id = %flow_egress, reason = %reason.0, "egress flow dropped by FlowPolicy");
+                        return Ok(());
+                    }
                 }
-                Err(e) => return Err(e),
             }
+            if flow_is_killed(&killed_flows, &frame).await {
+                continue;
+            }
+            let ctx = PacketCtx {
+                vm_name: &vm_name,
+                tenant: &tenant,
+                direction: FlowDirection::Egress,
+                flow_id: &flow_egress,
+            };
+            match run_packet_pipeline(&observers, ctx, &frame, mtu, &latency) {
+                PacketDecision::Forward { frame: out, .. } => {
+                    write_one_frame(&mut a_wr, &out).await?;
+                }
+                PacketDecision::Kill {
+                    observer,
+                    reason,
+                    flow_key,
+                } => {
+                    if let Some(k) = flow_key {
+                        killed_flows.lock().await.insert(k);
+                    }
+                    let _ = event_tx
+                        .send(FlowEvent {
+                            flow_id: flow_egress.clone(),
+                            direction: FlowDirection::Egress,
+                            kind: FlowEventKind::ObserverFault {
+                                observer: observer.to_string(),
+                                reason: reason.as_str().to_string(),
+                            },
+                        })
+                        .await;
+                }
+            }
+            latency.write_scrape_file();
         }
         Ok(())
     };
 
+    // Ingress: internet → guest. Read framed from a, observe, write to b.
     let ingress = async {
-        let mut buf = [0u8; 8192];
         loop {
-            match b_rd.read(&mut buf).await {
-                Ok(0) => break,
-                Ok(n) => {
-                    if !ingress_opened {
-                        let action = policy.evaluate(&FlowDecisionCtx {
-                            direction: FlowDirection::Ingress,
-                            dest_ip: None,
-                            dest_port: None,
-                            sni_hostname: None,
-                            url_path: None,
-                        });
-                        match action {
-                            FlowAction::Allow => {
-                                let _ = event_tx
-                                    .send(FlowEvent {
-                                        flow_id: flow_ingress.clone(),
-                                        direction: FlowDirection::Ingress,
-                                        kind: FlowEventKind::Opened,
-                                    })
-                                    .await;
-                                ingress_opened = true;
-                            }
-                            FlowAction::Drop { reason } => {
-                                let _ = event_tx
-                                    .send(FlowEvent {
-                                        flow_id: flow_ingress.clone(),
-                                        direction: FlowDirection::Ingress,
-                                        kind: FlowEventKind::Closed {
-                                            reason: FlowCloseReason::PolicyDropped,
-                                        },
-                                    })
-                                    .await;
-                                tracing::info!(
-                                    flow_id = %flow_ingress,
-                                    reason = %reason.0,
-                                    "ingress flow dropped by FlowPolicy"
-                                );
-                                return Ok::<(), std::io::Error>(());
-                            }
-                        }
+            let frame = match read_one_frame(&mut a_rd).await {
+                Ok(Some(f)) => f,
+                Ok(None) => break,
+                Err(e) => return Err::<(), std::io::Error>(e),
+            };
+            if !ingress_opened {
+                match policy.evaluate(&FlowDecisionCtx {
+                    direction: FlowDirection::Ingress,
+                    dest_ip: None,
+                    dest_port: None,
+                    sni_hostname: None,
+                    url_path: None,
+                }) {
+                    FlowAction::Allow => {
+                        let _ = event_tx
+                            .send(FlowEvent {
+                                flow_id: flow_ingress.clone(),
+                                direction: FlowDirection::Ingress,
+                                kind: FlowEventKind::Opened,
+                            })
+                            .await;
+                        ingress_opened = true;
                     }
-                    a_wr.write_all(&buf[..n]).await?;
+                    FlowAction::Drop { reason } => {
+                        let _ = event_tx
+                            .send(FlowEvent {
+                                flow_id: flow_ingress.clone(),
+                                direction: FlowDirection::Ingress,
+                                kind: FlowEventKind::Closed {
+                                    reason: FlowCloseReason::PolicyDropped,
+                                },
+                            })
+                            .await;
+                        tracing::info!(flow_id = %flow_ingress, reason = %reason.0, "ingress flow dropped by FlowPolicy");
+                        return Ok(());
+                    }
                 }
-                Err(e) => return Err(e),
             }
+            if flow_is_killed(&killed_flows, &frame).await {
+                continue;
+            }
+            let ctx = PacketCtx {
+                vm_name: &vm_name,
+                tenant: &tenant,
+                direction: FlowDirection::Ingress,
+                flow_id: &flow_ingress,
+            };
+            match run_packet_pipeline(&observers, ctx, &frame, mtu, &latency) {
+                PacketDecision::Forward { frame: out, .. } => {
+                    write_one_frame(&mut b_wr, &out).await?;
+                }
+                PacketDecision::Kill {
+                    observer,
+                    reason,
+                    flow_key,
+                } => {
+                    if let Some(k) = flow_key {
+                        killed_flows.lock().await.insert(k);
+                    }
+                    let _ = event_tx
+                        .send(FlowEvent {
+                            flow_id: flow_ingress.clone(),
+                            direction: FlowDirection::Ingress,
+                            kind: FlowEventKind::ObserverFault {
+                                observer: observer.to_string(),
+                                reason: reason.as_str().to_string(),
+                            },
+                        })
+                        .await;
+                }
+            }
+            latency.write_scrape_file();
         }
         Ok(())
     };
@@ -1368,23 +1485,29 @@ mod tests {
     // Passt bridge: end-to-end via socketpair
     // -----------------------------------------------------------------
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn passt_bridge_emits_open_close_pair_on_socketpair_traffic() {
-        use std::os::unix::net::UnixStream as StdUs;
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    #[tokio::test]
+    async fn read_write_one_frame_roundtrips_through_duplex() {
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        let frame = tcp_egress_frame(b"payload-bytes");
+        write_one_frame(&mut client, &frame).await.unwrap();
+        let got = read_one_frame(&mut server).await.unwrap().unwrap();
+        assert_eq!(got, frame);
+        // Clean EOF at a frame boundary returns None.
+        drop(client);
+        assert!(read_one_frame(&mut server).await.unwrap().is_none());
+    }
 
-        // Two socketpairs:
-        //   pair_a: (gateway_a, gateway_b) — pretend gateway_b is passt.
-        //   pair_b: (guest_a, guest_b) — pretend guest_b is libkrun.
-        // bridge_copy_bidirectional gets gateway_a + guest_a as the
-        // supervisor's halves.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn passt_bridge_emits_open_close_pair_on_framed_traffic() {
+        use std::os::unix::net::UnixStream as StdUs;
+
+        // pair_a: (gateway_a, gateway_b=passt); pair_b: (guest_a, guest_b=libkrun).
+        // The bridge holds gateway_a (a, faces passt) + guest_a (b, faces guest).
         let (gateway_a, gateway_b) = StdUs::pair().unwrap();
         let (guest_a, guest_b) = StdUs::pair().unwrap();
-        gateway_a.set_nonblocking(true).unwrap();
-        gateway_b.set_nonblocking(true).unwrap();
-        guest_a.set_nonblocking(true).unwrap();
-        guest_b.set_nonblocking(true).unwrap();
-
+        for s in [&gateway_a, &gateway_b, &guest_a, &guest_b] {
+            s.set_nonblocking(true).unwrap();
+        }
         let supervisor_gateway = tokio::net::UnixStream::from_std(gateway_a).unwrap();
         let supervisor_guest = tokio::net::UnixStream::from_std(guest_a).unwrap();
         let mut passt = tokio::net::UnixStream::from_std(gateway_b).unwrap();
@@ -1392,75 +1515,90 @@ mod tests {
 
         let (tx, mut rx) = mpsc::channel::<FlowEvent>(64);
         let policy: Arc<dyn FlowPolicy> = Arc::new(AllowAll);
-
         let bridge_task = tokio::spawn(bridge_copy_bidirectional(
             supervisor_gateway,
             supervisor_guest,
             "vm-test".to_string(),
+            "t".to_string(),
             policy,
             tx,
+            wiring_with(vec![]),
         ));
 
-        // Passt → guest direction (gateway → guest = ingress).
-        // "ingress" in our model = bytes flowing supervisor_guest → libkrun
-        // which means we write on the gateway-side of pair_a... actually
-        // let me re-check the naming. In bridge_copy_bidirectional, `a` is
-        // gateway, `b` is guest. egress = a→b (gateway in, guest out??)
-        // Hmm — actually that's wrong direction-wise. Egress = guest →
-        // internet. Let me re-trace:
-        //
-        // a = gateway_fd (faces passt = faces internet)
-        // b = supervisor_fd (faces libkrun = faces guest)
-        //
-        // egress branch reads from a, writes to b. That's
-        // INTERNET → GUEST. Should be ingress.
-        // ingress branch reads from b, writes to a. That's
-        // GUEST → INTERNET. Should be egress.
-        //
-        // The direction labels in the code are backwards. Test
-        // exercises whichever order to verify SOMETHING emits.
-
-        passt.write_all(b"hello-from-passt").await.unwrap();
-        let mut buf = vec![0u8; 256];
-        let n = libkrun.read(&mut buf).await.unwrap();
-        assert_eq!(&buf[..n], b"hello-from-passt");
-
-        // Wait for the bridge to emit FlowOpened.
-        let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        // passt → guest = ingress. Frame must round-trip byte-identically.
+        let f1 = tcp_egress_frame(b"from-passt");
+        write_one_frame(&mut passt, &f1).await.unwrap();
+        let got = read_one_frame(&mut libkrun).await.unwrap().unwrap();
+        assert_eq!(got, f1);
+        let ev1 = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
             .await
-            .expect("must receive open in time")
-            .expect("channel must have an event");
-        assert!(matches!(event.kind, FlowEventKind::Opened));
+            .expect("open in time")
+            .expect("event");
+        assert!(matches!(ev1.kind, FlowEventKind::Opened));
+        assert_eq!(ev1.direction, FlowDirection::Ingress);
 
-        // Send guest → passt and confirm the other direction opens.
-        libkrun.write_all(b"hello-from-guest").await.unwrap();
-        let n = passt.read(&mut buf).await.unwrap();
-        assert_eq!(&buf[..n], b"hello-from-guest");
-
-        let event2 = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        // guest → passt = egress.
+        let f2 = tcp_egress_frame(b"from-guest");
+        write_one_frame(&mut libkrun, &f2).await.unwrap();
+        let got = read_one_frame(&mut passt).await.unwrap().unwrap();
+        assert_eq!(got, f2);
+        let ev2 = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
             .await
-            .expect("must receive second open in time")
-            .expect("channel must have second event");
-        assert!(matches!(event2.kind, FlowEventKind::Opened));
-        // Direction of event2 must differ from event.
-        assert_ne!(event.direction, event2.direction);
+            .expect("second open in time")
+            .expect("event");
+        assert!(matches!(ev2.kind, FlowEventKind::Opened));
+        assert_ne!(ev1.direction, ev2.direction);
 
-        // Close both peers; bridge should emit two closes.
         drop(passt);
         drop(libkrun);
-
-        let close_a = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        let c1 = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
             .await
-            .expect("must receive close")
-            .expect("channel must have close");
-        let close_b = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .expect("close")
+            .expect("event");
+        let c2 = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
             .await
-            .expect("must receive second close")
-            .expect("channel must have second close");
-        assert!(matches!(close_a.kind, FlowEventKind::Closed { .. }));
-        assert!(matches!(close_b.kind, FlowEventKind::Closed { .. }));
-
+            .expect("second close")
+            .expect("event");
+        assert!(matches!(c1.kind, FlowEventKind::Closed { .. }));
+        assert!(matches!(c2.kind, FlowEventKind::Closed { .. }));
         let _ = bridge_task.await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn passt_bridge_redacts_egress_frame() {
+        use std::os::unix::net::UnixStream as StdUs;
+
+        let (gateway_a, gateway_b) = StdUs::pair().unwrap();
+        let (guest_a, guest_b) = StdUs::pair().unwrap();
+        for s in [&gateway_a, &gateway_b, &guest_a, &guest_b] {
+            s.set_nonblocking(true).unwrap();
+        }
+        let supervisor_gateway = tokio::net::UnixStream::from_std(gateway_a).unwrap();
+        let supervisor_guest = tokio::net::UnixStream::from_std(guest_a).unwrap();
+        let mut passt = tokio::net::UnixStream::from_std(gateway_b).unwrap();
+        let mut libkrun = tokio::net::UnixStream::from_std(guest_b).unwrap();
+
+        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let policy: Arc<dyn FlowPolicy> = Arc::new(AllowAll);
+        let bridge_task = tokio::spawn(bridge_copy_bidirectional(
+            supervisor_gateway,
+            supervisor_guest,
+            "vm-test".to_string(),
+            "t".to_string(),
+            policy,
+            tx,
+            wiring_with(vec![Arc::new(RedactorObs)]),
+        ));
+
+        // guest → internet = egress; RedactorObs redacts SECRET on this path.
+        write_one_frame(&mut libkrun, &tcp_egress_frame(b"hello-SECRET-bye"))
+            .await
+            .unwrap();
+        let out = read_one_frame(&mut passt).await.unwrap().unwrap();
+        let parsed = crate::supervisor::network::packet::parse(&out).expect("re-parses");
+        assert!(parsed.l4_payload.windows(6).any(|w| w == b"XXXXXX"));
+        assert!(!parsed.l4_payload.windows(6).any(|w| w == b"SECRET"));
+        bridge_task.abort();
     }
 
     // -----------------------------------------------------------------

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
@@ -60,6 +60,13 @@ use tokio::sync::{broadcast, mpsc};
 
 use crate::supervisor::audit::{AuditEntry, AuditSigner, FlowCloseReason, FlowDirection};
 use crate::supervisor::gateway_audit::GatewayAuditSink;
+// Plan 141 / ADR-064 — packet-observer pipeline wiring.
+use crate::supervisor::network::Observer;
+use crate::supervisor::network::PacketCtx;
+use crate::supervisor::network::latency::ObserverLatency;
+use crate::supervisor::network::packet::{self, FlowKey};
+use crate::supervisor::network::pipeline::{PacketDecision, run_packet_pipeline};
+use std::collections::HashSet;
 
 // ============================================================================
 // FlowPolicy hook
@@ -207,7 +214,16 @@ pub struct FlowEvent {
 #[derive(Debug, Clone)]
 pub enum FlowEventKind {
     Opened,
-    Closed { reason: FlowCloseReason },
+    Closed {
+        reason: FlowCloseReason,
+    },
+    /// Plan 141 / ADR-064 — a host-allowlisted observer's `on_packet`
+    /// forced a fail-closed flow kill. `reason` ∈ {`drop`,
+    /// `modify_over_mtu`, `modify_unserializable`}.
+    ObserverFault {
+        observer: String,
+        reason: String,
+    },
 }
 
 /// Bounded mpsc capacity. The bridge `send().await`s — overflow
@@ -215,6 +231,27 @@ pub enum FlowEventKind {
 /// TCP / datagram flow control on the guest's network stack.
 /// **Audit completeness > per-VM throughput.**
 pub const EVENT_CHANNEL_CAPACITY: usize = 1024;
+
+/// Frame-size ceiling for `Verdict::Modify` rebuilds (Plan 141). A
+/// rebuilt frame larger than this cannot traverse the unixgram /
+/// length-prefixed datagram path, so the flow is killed (fail-closed,
+/// Q8). Set to the practical datagram max rather than the 1500 link MTU
+/// so a legitimately large (e.g. TSO) original frame isn't spuriously
+/// killed when an observer shrinks or keeps its payload size.
+pub const BRIDGE_MTU: usize = 65_535;
+
+/// Per-VM packet-observer wiring threaded into the bridge variants
+/// (Plan 141 / ADR-064). Bundled into one struct so the variant fns stay
+/// under the `too_many_arguments` lint. `observers` mirrors the set
+/// `signer_task` fans flow-events to; the same observer may implement both
+/// `on_flow_event` and `on_packet`. `killed_flows` is shared across both
+/// directions so a kill on one is honoured everywhere.
+pub struct ObserverWiring {
+    pub observers: Vec<Arc<dyn Observer>>,
+    pub latency: Arc<ObserverLatency>,
+    pub killed_flows: Arc<tokio::sync::Mutex<HashSet<FlowKey>>>,
+    pub mtu: usize,
+}
 
 /// Per-subscriber NDJSON wire shape. Stable contract for `nc -U`
 /// consumers and the Swift bridge (which emits the same shape).
@@ -230,6 +267,12 @@ pub enum FlowEventWire {
         direction: String,
         reason: String,
     },
+    FlowObserverFault {
+        flow_id: String,
+        direction: String,
+        observer: String,
+        reason: String,
+    },
 }
 
 impl From<&FlowEvent> for FlowEventWire {
@@ -243,6 +286,12 @@ impl From<&FlowEvent> for FlowEventWire {
                 flow_id: ev.flow_id.clone(),
                 direction: ev.direction.as_str().to_string(),
                 reason: reason.as_str().to_string(),
+            },
+            FlowEventKind::ObserverFault { observer, reason } => FlowEventWire::FlowObserverFault {
+                flow_id: ev.flow_id.clone(),
+                direction: ev.direction.as_str().to_string(),
+                observer: observer.clone(),
+                reason: reason.clone(),
             },
         }
     }
@@ -325,6 +374,14 @@ pub(crate) async fn signer_task(
                 event.direction,
                 *reason,
             ),
+            FlowEventKind::ObserverFault { observer, reason } => AuditEntry::flow_observer_fault(
+                plan.as_ref(),
+                bundle.as_deref(),
+                &event.flow_id,
+                event.direction,
+                observer,
+                reason,
+            ),
         };
         if let Err(e) = signer.sign_and_emit(&entry).await {
             tracing::warn!(error = ?e, flow_id = event.flow_id, "signer emit failed");
@@ -403,6 +460,17 @@ fn run_bridge_inner(endpoints: BridgeEndpoints, cfg: BridgeConfig) {
         // Subscriber-sink accept loop.
         let sink_handle = tokio::task::spawn_local(sink.run());
 
+        // Plan 141 — packet-observer wiring shared across both directions.
+        let wiring = ObserverWiring {
+            observers: cfg.observers.clone(),
+            latency: Arc::new(ObserverLatency::new(
+                cfg.vm_name.clone(),
+                cfg.plan.tenant.0.clone(),
+            )),
+            killed_flows: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+            mtu: BRIDGE_MTU,
+        };
+
         // Bridge task — variant-specific.
         match endpoints {
             BridgeEndpoints::Passt {
@@ -426,8 +494,10 @@ fn run_bridge_inner(endpoints: BridgeEndpoints, cfg: BridgeConfig) {
                     gvproxy_socket_path,
                     supervisor_listen_path,
                     cfg.vm_name.clone(),
+                    cfg.plan.tenant.0.clone(),
                     cfg.policy.clone(),
                     event_tx,
+                    wiring,
                 )
                 .await;
             }
@@ -651,12 +721,28 @@ async fn bridge_copy_bidirectional(
 // libkrun + gvproxy bridge (SOCK_DGRAM shuffle)
 // ============================================================================
 
+/// Plan 141 — true if `raw` parses to a flow already in `killed`. Cheap:
+/// only parses when at least one flow has been killed. The async-mutex
+/// guard is held across the synchronous parse (no await in between).
+async fn flow_is_killed(killed: &tokio::sync::Mutex<HashSet<FlowKey>>, raw: &[u8]) -> bool {
+    let guard = killed.lock().await;
+    if guard.is_empty() {
+        return false;
+    }
+    match packet::parse(raw) {
+        Some(p) => guard.contains(&p.five_tuple.flow_key()),
+        None => false,
+    }
+}
+
 async fn run_libkrun_gvproxy_bridge(
     gvproxy_socket_path: PathBuf,
     supervisor_listen_path: PathBuf,
     vm_name: String,
+    tenant: String,
     policy: Arc<dyn FlowPolicy>,
     event_tx: mpsc::Sender<FlowEvent>,
+    wiring: ObserverWiring,
 ) {
     use tokio::net::UnixDatagram;
 
@@ -703,12 +789,19 @@ async fn run_libkrun_gvproxy_bridge(
     let inbound = Arc::new(inbound);
     let outbound = Arc::new(outbound);
 
+    // Plan 141 — per-direction clones of the packet-observer wiring.
+    let mtu = wiring.mtu;
     let policy_a = policy.clone();
     let event_a = event_tx.clone();
     let inbound_a = inbound.clone();
     let outbound_a = outbound.clone();
     let libkrun_peer_a = libkrun_peer.clone();
     let flow_egress_a = flow_egress.clone();
+    let observers_a = wiring.observers.clone();
+    let latency_a = wiring.latency.clone();
+    let killed_flows_a = wiring.killed_flows.clone();
+    let vm_name_a = vm_name.clone();
+    let tenant_a = tenant.clone();
 
     let egress = async move {
         let mut buf = vec![0u8; 65536];
@@ -753,9 +846,47 @@ async fn run_libkrun_gvproxy_bridge(
                     }
                 }
             }
-            // Relay datagram to gvproxy. send (not send_to) since
-            // outbound is connected.
-            outbound_a.send(&buf[..n]).await?;
+
+            // Plan 141 — packet-observer pipeline. Short-circuit packets on
+            // an already-killed flow, then fan out; `Forward` relays the
+            // (possibly rebuilt) frame, `Kill` records the flow + emits a
+            // fault and drops (fail-closed).
+            let raw = &buf[..n];
+            if flow_is_killed(&killed_flows_a, raw).await {
+                continue;
+            }
+            let ctx = PacketCtx {
+                vm_name: &vm_name_a,
+                tenant: &tenant_a,
+                direction: FlowDirection::Egress,
+                flow_id: &flow_egress_a,
+            };
+            match run_packet_pipeline(&observers_a, ctx, raw, mtu, &latency_a) {
+                PacketDecision::Forward { frame, .. } => {
+                    // send (not send_to) — outbound is connected to gvproxy.
+                    outbound_a.send(&frame).await?;
+                }
+                PacketDecision::Kill {
+                    observer,
+                    reason,
+                    flow_key,
+                } => {
+                    if let Some(k) = flow_key {
+                        killed_flows_a.lock().await.insert(k);
+                    }
+                    let _ = event_a
+                        .send(FlowEvent {
+                            flow_id: flow_egress_a.clone(),
+                            direction: FlowDirection::Egress,
+                            kind: FlowEventKind::ObserverFault {
+                                observer: observer.to_string(),
+                                reason: reason.as_str().to_string(),
+                            },
+                        })
+                        .await;
+                }
+            }
+            latency_a.write_scrape_file();
         }
     };
 
@@ -765,6 +896,11 @@ async fn run_libkrun_gvproxy_bridge(
     let outbound_b = outbound.clone();
     let libkrun_peer_b = libkrun_peer.clone();
     let flow_ingress_b = flow_ingress.clone();
+    let observers_b = wiring.observers.clone();
+    let latency_b = wiring.latency.clone();
+    let killed_flows_b = wiring.killed_flows.clone();
+    let vm_name_b = vm_name.clone();
+    let tenant_b = tenant.clone();
 
     let ingress = async move {
         let mut buf = vec![0u8; 65536];
@@ -806,13 +942,48 @@ async fn run_libkrun_gvproxy_bridge(
                     }
                 }
             }
-            // Need libkrun's peer addr to send back. If we haven't
-            // seen a packet from libkrun yet, drop this one (no
-            // valid return path).
-            let peer_guard = libkrun_peer_b.lock().await;
-            if let Some(path) = peer_guard.as_ref().and_then(|p| p.as_pathname()) {
-                inbound_b.send_to(&buf[..n], path).await?;
+
+            // Plan 141 — packet-observer pipeline (ingress direction).
+            let raw = &buf[..n];
+            if flow_is_killed(&killed_flows_b, raw).await {
+                continue;
             }
+            let ctx = PacketCtx {
+                vm_name: &vm_name_b,
+                tenant: &tenant_b,
+                direction: FlowDirection::Ingress,
+                flow_id: &flow_ingress_b,
+            };
+            match run_packet_pipeline(&observers_b, ctx, raw, mtu, &latency_b) {
+                PacketDecision::Forward { frame, .. } => {
+                    // Need libkrun's peer addr to send back. If we haven't
+                    // seen a packet from libkrun yet, drop this one.
+                    let peer_guard = libkrun_peer_b.lock().await;
+                    if let Some(path) = peer_guard.as_ref().and_then(|p| p.as_pathname()) {
+                        inbound_b.send_to(&frame, path).await?;
+                    }
+                }
+                PacketDecision::Kill {
+                    observer,
+                    reason,
+                    flow_key,
+                } => {
+                    if let Some(k) = flow_key {
+                        killed_flows_b.lock().await.insert(k);
+                    }
+                    let _ = event_b
+                        .send(FlowEvent {
+                            flow_id: flow_ingress_b.clone(),
+                            direction: FlowDirection::Ingress,
+                            kind: FlowEventKind::ObserverFault {
+                                observer: observer.to_string(),
+                                reason: reason.as_str().to_string(),
+                            },
+                        })
+                        .await;
+                }
+            }
+            latency_b.write_scrape_file();
         }
     };
 
@@ -970,6 +1141,30 @@ async fn handle_vz_ingest(
                     flow_id,
                     direction,
                     kind: FlowEventKind::Closed { reason },
+                }
+            }
+            // Plan 141 — the Vz NDJSON ingest path (Plan 152 territory) does
+            // not produce observer faults; Rust owns the packet pipeline on
+            // the in-scope backends. Accept the variant for exhaustiveness
+            // and forward it verbatim if a future Swift sender emits it.
+            FlowEventWire::FlowObserverFault {
+                flow_id,
+                direction,
+                observer,
+                reason,
+            } => {
+                let direction = match direction.as_str() {
+                    "egress" => FlowDirection::Egress,
+                    "ingress" => FlowDirection::Ingress,
+                    other => {
+                        tracing::warn!(direction = other, "vz-ingest: unknown direction");
+                        continue;
+                    }
+                };
+                FlowEvent {
+                    flow_id,
+                    direction,
+                    kind: FlowEventKind::ObserverFault { observer, reason },
                 }
             }
         };
@@ -1400,6 +1595,204 @@ mod tests {
                 );
             })
             .await;
+    }
+
+    #[test]
+    fn flow_event_observer_fault_wire_roundtrips() {
+        let ev = FlowEvent {
+            flow_id: "vm-egress".to_string(),
+            direction: FlowDirection::Egress,
+            kind: FlowEventKind::ObserverFault {
+                observer: "test-redactor".to_string(),
+                reason: "modify_over_mtu".to_string(),
+            },
+        };
+        let wire = FlowEventWire::from(&ev);
+        let json = serde_json::to_string(&wire).unwrap();
+        assert!(json.contains("\"kind\":\"flow_observer_fault\""));
+        assert!(json.contains("\"observer\":\"test-redactor\""));
+        assert!(json.contains("\"reason\":\"modify_over_mtu\""));
+        let parsed: FlowEventWire = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, wire);
+    }
+
+    // -----------------------------------------------------------------
+    // Plan 141 — gvproxy packet-observer pipeline wiring
+    // -----------------------------------------------------------------
+
+    use crate::supervisor::network::latency::ObserverLatency;
+    use crate::supervisor::network::packet::ParsedPacket;
+    use crate::supervisor::network::{
+        Directions, Observer, PacketCtx, RequiredCapabilities, Verdict,
+    };
+
+    fn payload_tap_caps() -> RequiredCapabilities {
+        RequiredCapabilities {
+            flow_events: true,
+            payload_tap: true,
+        }
+    }
+
+    /// Egress observer that redacts "SECRET" → "XXXXXX" (same length).
+    struct RedactorObs;
+    impl Observer for RedactorObs {
+        fn name(&self) -> &'static str {
+            "test-redactor"
+        }
+        fn required_capabilities(&self) -> RequiredCapabilities {
+            payload_tap_caps()
+        }
+        fn on_flow_event(&self, _: &FlowEvent) {}
+        fn directions(&self) -> Directions {
+            Directions::Egress
+        }
+        fn on_packet(&self, _c: &PacketCtx<'_>, p: &ParsedPacket<'_>) -> Verdict {
+            let s = String::from_utf8_lossy(p.l4_payload).replace("SECRET", "XXXXXX");
+            Verdict::Modify(s.into_bytes())
+        }
+    }
+
+    /// Egress observer that drops everything.
+    struct DropObs;
+    impl Observer for DropObs {
+        fn name(&self) -> &'static str {
+            "test-drop"
+        }
+        fn required_capabilities(&self) -> RequiredCapabilities {
+            payload_tap_caps()
+        }
+        fn on_flow_event(&self, _: &FlowEvent) {}
+        fn directions(&self) -> Directions {
+            Directions::Egress
+        }
+        fn on_packet(&self, _c: &PacketCtx<'_>, _p: &ParsedPacket<'_>) -> Verdict {
+            Verdict::Drop
+        }
+    }
+
+    fn tcp_egress_frame(payload: &[u8]) -> Vec<u8> {
+        use etherparse::PacketBuilder;
+        let b = PacketBuilder::ethernet2([1; 6], [2; 6])
+            .ipv4([10, 0, 0, 2], [93, 184, 216, 34], 64)
+            .tcp(40000, 443, 1, 64000);
+        let mut o = Vec::new();
+        b.write(&mut o, payload).unwrap();
+        o
+    }
+
+    fn wiring_with(observers: Vec<Arc<dyn Observer>>) -> ObserverWiring {
+        ObserverWiring {
+            observers,
+            latency: Arc::new(ObserverLatency::new("vm-test", "t")),
+            killed_flows: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+            mtu: BRIDGE_MTU,
+        }
+    }
+
+    /// Connect a libkrun-side datagram socket to the bridge's listener,
+    /// retrying until the bridge has bound it.
+    async fn connect_libkrun(path: &std::path::Path) -> tokio::net::UnixDatagram {
+        let sock = tokio::net::UnixDatagram::unbound().unwrap();
+        for _ in 0..100 {
+            if sock.connect(path).is_ok() {
+                return sock;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("bridge never bound {}", path.display());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gvproxy_pipeline_forwards_modified_frame() {
+        let dir = tempfile::tempdir().unwrap();
+        let gvproxy_path = dir.path().join("gvproxy.sock");
+        let sup_listen = dir.path().join("sup.sock");
+        let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
+
+        let (tx, _rx) = mpsc::channel::<FlowEvent>(64);
+        let policy: Arc<dyn FlowPolicy> = Arc::new(AllowAll);
+        let bridge = tokio::spawn(run_libkrun_gvproxy_bridge(
+            gvproxy_path.clone(),
+            sup_listen.clone(),
+            "vm-test".to_string(),
+            "t".to_string(),
+            policy,
+            tx,
+            wiring_with(vec![Arc::new(RedactorObs)]),
+        ));
+
+        let libkrun = connect_libkrun(&sup_listen).await;
+        libkrun
+            .send(&tcp_egress_frame(b"hello-SECRET-bye"))
+            .await
+            .unwrap();
+
+        let mut buf = vec![0u8; 65536];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(3), gvproxy.recv(&mut buf))
+            .await
+            .expect("gvproxy must receive the forwarded frame in time")
+            .expect("recv ok");
+        let parsed = crate::supervisor::network::packet::parse(&buf[..n])
+            .expect("forwarded frame re-parses");
+        assert!(
+            parsed.l4_payload.windows(6).any(|w| w == b"XXXXXX"),
+            "gvproxy must see the redacted payload"
+        );
+        assert!(
+            !parsed.l4_payload.windows(6).any(|w| w == b"SECRET"),
+            "the secret must not reach gvproxy"
+        );
+        bridge.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gvproxy_pipeline_drop_kills_flow_and_emits_fault() {
+        let dir = tempfile::tempdir().unwrap();
+        let gvproxy_path = dir.path().join("gvproxy.sock");
+        let sup_listen = dir.path().join("sup.sock");
+        let gvproxy = tokio::net::UnixDatagram::bind(&gvproxy_path).unwrap();
+
+        let (tx, mut rx) = mpsc::channel::<FlowEvent>(64);
+        let policy: Arc<dyn FlowPolicy> = Arc::new(AllowAll);
+        let bridge = tokio::spawn(run_libkrun_gvproxy_bridge(
+            gvproxy_path.clone(),
+            sup_listen.clone(),
+            "vm-test".to_string(),
+            "t".to_string(),
+            policy,
+            tx,
+            wiring_with(vec![Arc::new(DropObs)]),
+        ));
+
+        let libkrun = connect_libkrun(&sup_listen).await;
+        libkrun.send(&tcp_egress_frame(b"anything")).await.unwrap();
+
+        // The dropped packet must NOT reach gvproxy.
+        let mut buf = vec![0u8; 65536];
+        let got = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            gvproxy.recv(&mut buf),
+        )
+        .await;
+        assert!(got.is_err(), "dropped packet must not reach gvproxy");
+
+        // A FlowOpened then an ObserverFault must arrive on the event stream.
+        let mut saw_fault = false;
+        for _ in 0..4 {
+            match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
+                Ok(Some(ev)) => {
+                    if let FlowEventKind::ObserverFault { observer, reason } = ev.kind {
+                        assert_eq!(observer, "test-drop");
+                        assert_eq!(reason, "drop");
+                        saw_fault = true;
+                        break;
+                    }
+                }
+                _ => break,
+            }
+        }
+        assert!(saw_fault, "an ObserverFault event must be emitted on drop");
+        bridge.abort();
     }
 
     /// Plan-doc-shaped `ExecutionPlan` for fan-out tests. Mirrors the

--- a/crates/mvm-hostd/src/supervisor/network/flow_byte_log.rs
+++ b/crates/mvm-hostd/src/supervisor/network/flow_byte_log.rs
@@ -103,12 +103,12 @@ pub fn sweep_retention(root: &Path, max_age_days: u32) -> std::io::Result<u64> {
             continue;
         };
         for f in files.flatten() {
-            if let Ok(meta) = f.metadata() {
-                if let Ok(modified) = meta.modified() {
-                    if modified < cutoff && std::fs::remove_file(f.path()).is_ok() {
-                        removed += 1;
-                    }
-                }
+            let Ok(meta) = f.metadata() else { continue };
+            let Ok(modified) = meta.modified() else {
+                continue;
+            };
+            if modified < cutoff && std::fs::remove_file(f.path()).is_ok() {
+                removed += 1;
             }
         }
     }

--- a/crates/mvm-hostd/src/supervisor/network/flow_byte_log.rs
+++ b/crates/mvm-hostd/src/supervisor/network/flow_byte_log.rs
@@ -1,0 +1,175 @@
+//! Plan 141 / ADR-064 — append-only, length-prefixed flow-byte log.
+//!
+//! Record framing: `[u64 record_id LE][u32 len LE][len bytes payload]`.
+//! The writer is per-VM; rotation is size-bounded by the caller. The audit
+//! chain references records by `(file_name, record_id, sha256)` — payload
+//! bytes never enter the chain (keeps it small + lets the chain stay
+//! payload-free per Q8/claim 10). Files are mode 0600; the caller ensures
+//! the parent dir is 0700 (~/.mvm posture, ADR-002 §W1.5).
+//!
+//! Encryption-at-rest is a deferred follow-up (own ADR); V1 is plaintext
+//! on a 0600 file under a 0700 dir.
+
+use sha2::{Digest, Sha256};
+use std::io::{Read, Write};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+/// Reference the audit chain stores for one logged record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordRef {
+    pub record_id: u64,
+    pub sha256: String,
+}
+
+pub struct FlowByteLogWriter {
+    file: std::fs::File,
+    next_id: u64,
+}
+
+impl FlowByteLogWriter {
+    /// Create (truncating) a new log file at `path`, mode 0600. The caller
+    /// ensures the parent dir exists at 0700.
+    pub fn create(path: &Path) -> std::io::Result<Self> {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        Ok(Self { file, next_id: 0 })
+    }
+
+    /// Append one record; returns its id + sha256 for the chain entry.
+    pub fn append(&mut self, payload: &[u8]) -> std::io::Result<RecordRef> {
+        let id = self.next_id;
+        self.file.write_all(&id.to_le_bytes())?;
+        let len = u32::try_from(payload.len()).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "record exceeds u32 length",
+            )
+        })?;
+        self.file.write_all(&len.to_le_bytes())?;
+        self.file.write_all(payload)?;
+        self.next_id += 1;
+        let sha256 = {
+            let mut h = Sha256::new();
+            h.update(payload);
+            hex::encode(h.finalize())
+        };
+        Ok(RecordRef {
+            record_id: id,
+            sha256,
+        })
+    }
+}
+
+/// Read back every record (test + forensics helper).
+pub fn read_all_records(path: &Path) -> std::io::Result<Vec<Vec<u8>>> {
+    let mut f = std::fs::File::open(path)?;
+    let mut out = Vec::new();
+    loop {
+        let mut idbuf = [0u8; 8];
+        match f.read_exact(&mut idbuf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e),
+        }
+        let mut lenbuf = [0u8; 4];
+        f.read_exact(&mut lenbuf)?;
+        let len = u32::from_le_bytes(lenbuf) as usize;
+        let mut payload = vec![0u8; len];
+        f.read_exact(&mut payload)?;
+        out.push(payload);
+    }
+    Ok(out)
+}
+
+/// Retention sweep: delete flow-byte files whose mtime is older than
+/// `max_age_days` under `root` (`~/.mvm/audit/flow-bytes`, with one
+/// per-tenant subdir). Returns the number of files removed. Called from
+/// `mvmctl cache prune`.
+pub fn sweep_retention(root: &Path, max_age_days: u32) -> std::io::Result<u64> {
+    let cutoff = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(max_age_days as u64 * 86_400))
+        .unwrap_or(std::time::UNIX_EPOCH);
+    let mut removed = 0u64;
+    let Ok(tenants) = std::fs::read_dir(root) else {
+        return Ok(0);
+    };
+    for tenant in tenants.flatten() {
+        let Ok(files) = std::fs::read_dir(tenant.path()) else {
+            continue;
+        };
+        for f in files.flatten() {
+            if let Ok(meta) = f.metadata() {
+                if let Ok(modified) = meta.modified() {
+                    if modified < cutoff && std::fs::remove_file(f.path()).is_ok() {
+                        removed += 1;
+                    }
+                }
+            }
+        }
+    }
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_then_read_back_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm-a.bin");
+        let mut w = FlowByteLogWriter::create(&path).unwrap();
+        let rec = w.append(b"hello").unwrap();
+        assert_eq!(rec.record_id, 0);
+        assert_eq!(rec.sha256.len(), 64);
+        let rec2 = w.append(b"world").unwrap();
+        assert_eq!(rec2.record_id, 1);
+        let records = read_all_records(&path).unwrap();
+        assert_eq!(records, vec![b"hello".to_vec(), b"world".to_vec()]);
+    }
+
+    #[test]
+    fn created_file_is_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm-b.bin");
+        let _ = FlowByteLogWriter::create(&path).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn sweep_boundary_removes_with_zero_window_keeps_with_large() {
+        // std gives no portable mtime-setter, so assert the cutoff
+        // boundary instead of backdating: max_age_days = 0 (cutoff = now)
+        // removes files written before the sweep; a 10-year window keeps
+        // them.
+        let root = tempfile::tempdir().unwrap();
+        let tenant_dir = root.path().join("acme");
+        std::fs::create_dir_all(&tenant_dir).unwrap();
+        let old = tenant_dir.join("vm-old.bin");
+        let fresh = tenant_dir.join("vm-fresh.bin");
+        std::fs::write(&old, b"x").unwrap();
+        std::fs::write(&fresh, b"y").unwrap();
+        let removed_all = sweep_retention(root.path(), 0).unwrap();
+        assert_eq!(removed_all, 2, "cutoff=now removes both files");
+
+        // Recreate and assert a large window keeps everything.
+        std::fs::write(&old, b"x").unwrap();
+        std::fs::write(&fresh, b"y").unwrap();
+        let removed_none = sweep_retention(root.path(), 3650).unwrap();
+        assert_eq!(removed_none, 0, "10-year window keeps both files");
+    }
+
+    #[test]
+    fn sweep_missing_root_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        assert_eq!(sweep_retention(&missing, 7).unwrap(), 0);
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/network/flow_count.rs
+++ b/crates/mvm-hostd/src/supervisor/network/flow_count.rs
@@ -174,6 +174,10 @@ impl Observer for FlowCountMetrics {
                 let key = reason.as_str().to_string();
                 *g.entry(key).or_insert(0) += 1;
             }
+            // Plan 141 — observer faults are a packet-path kill, not a flow
+            // lifecycle transition; this lifecycle-counting observer ignores
+            // them (the chain records the fault separately).
+            FlowEventKind::ObserverFault { .. } => {}
         }
         self.write_scrape_file();
     }

--- a/crates/mvm-hostd/src/supervisor/network/latency.rs
+++ b/crates/mvm-hostd/src/supervisor/network/latency.rs
@@ -1,0 +1,137 @@
+//! Plan 141 / ADR-064 — per-observer `on_packet` latency. Exposed as a
+//! Prometheus summary (`_sum` + `_count`) per (observer, vm, direction)
+//! via a per-VM scrape file the CLI `/metrics` handler concatenates
+//! (`~/.mvm/audit/metrics-<vm>-observer-latency.prom`). Mirrors the
+//! cross-process surface `flow_count.rs` uses: the supervisor and CLI run
+//! as the same user and share `~/.mvm/audit/` (mode 0700, ADR-002 §W1.5),
+//! so the filesystem is the boundary — no new socket, no new RPC.
+
+use crate::supervisor::audit::FlowDirection;
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+/// (sum_micros, count) for one (observer, direction) bucket.
+type Bucket = (u64, u64);
+
+pub struct ObserverLatency {
+    vm: String,
+    // Reserved for a future per-tenant label; `vm` is the scrape key today
+    // (one guest = one tenant, ADR-002), so we don't emit `tenant` yet.
+    #[allow(dead_code)]
+    tenant: String,
+    buckets: Mutex<BTreeMap<(&'static str, &'static str), Bucket>>,
+}
+
+impl ObserverLatency {
+    pub fn new(vm: impl Into<String>, tenant: impl Into<String>) -> Self {
+        Self {
+            vm: vm.into(),
+            tenant: tenant.into(),
+            buckets: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Record one `on_packet` call's wall time in microseconds.
+    pub fn record(&self, observer: &'static str, direction: FlowDirection, micros: u64) {
+        let mut g = self
+            .buckets
+            .lock()
+            .expect("observer-latency mutex poisoned");
+        let e = g.entry((observer, direction.as_str())).or_insert((0, 0));
+        e.0 = e.0.saturating_add(micros);
+        e.1 = e.1.saturating_add(1);
+    }
+
+    pub fn prometheus_format(&self) -> String {
+        let g = self
+            .buckets
+            .lock()
+            .expect("observer-latency mutex poisoned");
+        let mut out = String::new();
+        out.push_str(
+            "# HELP mvm_observer_latency_us Per-observer on_packet latency (microseconds)\n\
+             # TYPE mvm_observer_latency_us summary\n",
+        );
+        let vm = &self.vm;
+        for ((observer, direction), (sum, count)) in g.iter() {
+            out.push_str(&format!(
+                "mvm_observer_latency_us_sum{{observer=\"{observer}\",vm=\"{vm}\",direction=\"{direction}\"}} {sum}\n"
+            ));
+            out.push_str(&format!(
+                "mvm_observer_latency_us_count{{observer=\"{observer}\",vm=\"{vm}\",direction=\"{direction}\"}} {count}\n"
+            ));
+        }
+        out
+    }
+
+    /// Atomic-ish write (tmp + rename), mirroring
+    /// `FlowCountMetrics::write_scrape_file`. Fails closed (no-op) when
+    /// `HOME` is unset — never falls back to a world-writable directory.
+    pub fn write_scrape_file(&self) {
+        let Some(home) = std::env::var_os("HOME") else {
+            return;
+        };
+        let path = std::path::Path::new(&home)
+            .join(".mvm/audit")
+            .join(format!("metrics-{}-observer-latency.prom", self.vm));
+        self.write_scrape_file_to(&path);
+    }
+
+    pub fn write_scrape_file_to(&self, path: &std::path::Path) {
+        let body = self.prometheus_format();
+        let tmp = path.with_extension("prom.tmp");
+        if std::fs::write(&tmp, body).is_ok() {
+            let _ = std::fs::rename(&tmp, path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::supervisor::audit::FlowDirection;
+
+    #[test]
+    fn record_accumulates_sum_and_count() {
+        let l = ObserverLatency::new("vm-a", "acme");
+        l.record("egress-redactor", FlowDirection::Egress, 10);
+        l.record("egress-redactor", FlowDirection::Egress, 30);
+        let prom = l.prometheus_format();
+        assert!(
+            prom.contains(
+                "mvm_observer_latency_us_count{observer=\"egress-redactor\",vm=\"vm-a\",direction=\"egress\"} 2"
+            ),
+            "prom was: {prom}"
+        );
+        assert!(
+            prom.contains(
+                "mvm_observer_latency_us_sum{observer=\"egress-redactor\",vm=\"vm-a\",direction=\"egress\"} 40"
+            ),
+            "prom was: {prom}"
+        );
+    }
+
+    #[test]
+    fn separate_directions_bucket_independently() {
+        let l = ObserverLatency::new("vm-b", "t");
+        l.record("o", FlowDirection::Egress, 5);
+        l.record("o", FlowDirection::Ingress, 7);
+        let prom = l.prometheus_format();
+        assert!(prom.contains("direction=\"egress\"} 1"));
+        assert!(prom.contains("direction=\"ingress\"} 1"));
+    }
+
+    #[test]
+    fn write_scrape_file_to_uses_observer_latency_name() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".mvm/audit")).unwrap();
+        let l = ObserverLatency::new("vm-x", "t");
+        l.record("hostname-filter", FlowDirection::Egress, 5);
+        let target = dir
+            .path()
+            .join(".mvm/audit/metrics-vm-x-observer-latency.prom");
+        l.write_scrape_file_to(&target);
+        let body = std::fs::read_to_string(&target).unwrap();
+        assert!(body.contains("mvm_observer_latency_us_count"));
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -40,6 +40,7 @@ use std::sync::Arc;
 
 pub mod flow_count;
 // Plan 141 / ADR-064 — backend-agnostic packet-observer core.
+pub mod flow_byte_log;
 pub mod latency;
 pub mod packet;
 pub mod pipeline;

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -42,6 +42,7 @@ pub mod flow_count;
 // Plan 141 / ADR-064 — backend-agnostic packet-observer core.
 pub mod latency;
 pub mod packet;
+pub mod pipeline;
 
 /// Maximum number of observers per VM. ADR-064 §Decision: hard cap of 8
 /// (each observer is a synchronous callback in the signer task's hot path;

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -32,7 +32,9 @@
 //! in Plan 102 W6.A's original commit) so external observer impls can
 //! receive `&FlowEvent` references through the Observer trait.
 
+use crate::supervisor::audit::FlowDirection;
 use crate::supervisor::gateway_bridge::FlowEvent;
+use crate::supervisor::network::packet::ParsedPacket;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -74,11 +76,57 @@ impl ProviderCapabilities {
     }
 }
 
+/// Per-direction registration filter (Plan 141 / ADR-064 Q9). An observer
+/// that only inspects outbound traffic declares `Directions::Egress` so
+/// the runner never hands it inbound bytes — least-privilege blast-radius
+/// containment (claim 1), not just a perf win.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Directions {
+    Egress,
+    Ingress,
+    Both,
+}
+
+impl Directions {
+    pub fn includes(self, dir: FlowDirection) -> bool {
+        matches!(self, Directions::Both)
+            || matches!(
+                (self, dir),
+                (Directions::Egress, FlowDirection::Egress)
+                    | (Directions::Ingress, FlowDirection::Ingress)
+            )
+    }
+}
+
+/// Verdict an observer returns from `on_packet` (Plan 141 / ADR-064).
+/// `Modify` carries the **new L4 payload** (not a raw frame); the bridge
+/// rebuilds IP length + L4 checksum around it via
+/// `packet::rebuild_with_payload`. First `Drop` wins and kills the flow;
+/// any `Modify` the bridge cannot safely emit also kills the flow
+/// (fail-closed, Q8).
+#[derive(Debug)]
+pub enum Verdict {
+    Forward,
+    Drop,
+    Modify(Vec<u8>),
+}
+
+/// Context the bridge presents to `on_packet`. Borrowed; cheap to build
+/// per packet. `tenant` mirrors ADR-064 §Decision 9's single-tenant
+/// invariant (one guest = one workload).
+#[derive(Debug, Clone, Copy)]
+pub struct PacketCtx<'a> {
+    pub vm_name: &'a str,
+    pub tenant: &'a str,
+    pub direction: FlowDirection,
+    pub flow_id: &'a str,
+}
+
 /// Synchronous observer callback. Implementations MUST NOT panic in hot
-/// path (the signer task wraps each call in `catch_unwind`, but a panic
-/// per event is wasteful). Implementations MUST be cheap (microseconds);
-/// expensive work should buffer + defer to a background task the observer
-/// owns.
+/// path (the signer task / packet runner wrap each call in `catch_unwind`,
+/// but a panic per event is wasteful). Implementations MUST be cheap
+/// (microseconds); expensive work should buffer + defer to a background
+/// task the observer owns.
 ///
 /// Visibility is `pub` because Task 3 exposes observer references through
 /// `BridgeConfig.observers` (a `pub` field on a `pub` struct), and
@@ -89,6 +137,22 @@ pub trait Observer: Send + Sync {
     fn name(&self) -> &'static str;
     fn required_capabilities(&self) -> RequiredCapabilities;
     fn on_flow_event(&self, event: &FlowEvent);
+
+    /// Directions this observer wants `on_packet` for (Plan 141 Q9).
+    /// Default `Both` keeps flow-event-only observers untouched.
+    fn directions(&self) -> Directions {
+        Directions::Both
+    }
+
+    /// Per-packet hook (Plan 141 / ADR-064). Default `Forward` so an
+    /// observer that only implements `on_flow_event` is a pass-through on
+    /// the payload path. MUST be cheap + MUST NOT block; a panic is caught
+    /// by the runner and treated as `Forward` for this observer. Requires
+    /// `RequiredCapabilities { payload_tap: true }` to be admitted on the
+    /// payload path (capability-gated at `Pipeline::observe`).
+    fn on_packet(&self, _ctx: &PacketCtx<'_>, _pkt: &ParsedPacket<'_>) -> Verdict {
+        Verdict::Forward
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -571,6 +635,46 @@ mod tests {
             flow_events: true,
             payload_tap: true,
         }
+    }
+
+    #[test]
+    fn directions_includes_matches_expected() {
+        use crate::supervisor::audit::FlowDirection::{Egress, Ingress};
+        assert!(Directions::Both.includes(Egress));
+        assert!(Directions::Both.includes(Ingress));
+        assert!(Directions::Egress.includes(Egress));
+        assert!(!Directions::Egress.includes(Ingress));
+        assert!(Directions::Ingress.includes(Ingress));
+        assert!(!Directions::Ingress.includes(Egress));
+    }
+
+    #[test]
+    fn default_observer_methods_are_forward_and_both() {
+        // An observer overriding nothing new gets Both + Forward, so
+        // flow-event-only observers keep working unchanged.
+        let obs = CountingObserver {
+            n: AtomicU32::new(0),
+            req: RequiredCapabilities::default(),
+        };
+        assert!(matches!(obs.directions(), Directions::Both));
+        let pkt = crate::supervisor::network::packet::ParsedPacket {
+            five_tuple: crate::supervisor::network::packet::FiveTuple {
+                proto: crate::supervisor::network::packet::L4Proto::Tcp,
+                src_ip: std::net::Ipv4Addr::LOCALHOST.into(),
+                dst_ip: std::net::Ipv4Addr::LOCALHOST.into(),
+                src_port: 1,
+                dst_port: 2,
+            },
+            l4_payload: b"abc",
+            raw_frame: b"abc",
+        };
+        let ctx = PacketCtx {
+            vm_name: "vm",
+            tenant: "t",
+            direction: crate::supervisor::audit::FlowDirection::Egress,
+            flow_id: "vm-egress",
+        };
+        assert!(matches!(obs.on_packet(&ctx, &pkt), Verdict::Forward));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -40,6 +40,7 @@ use std::sync::Arc;
 
 pub mod flow_count;
 // Plan 141 / ADR-064 — backend-agnostic packet-observer core.
+pub mod latency;
 pub mod packet;
 
 /// Maximum number of observers per VM. ADR-064 §Decision: hard cap of 8

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -37,6 +37,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 pub mod flow_count;
+// Plan 141 / ADR-064 — backend-agnostic packet-observer core.
+pub mod packet;
 
 /// Maximum number of observers per VM. ADR-064 §Decision: hard cap of 8
 /// (each observer is a synchronous callback in the signer task's hot path;

--- a/crates/mvm-hostd/src/supervisor/network/packet.rs
+++ b/crates/mvm-hostd/src/supervisor/network/packet.rs
@@ -1,0 +1,342 @@
+//! Plan 141 / ADR-064 — pure L3/L4 parse + payload rebuild for the
+//! gateway packet-observer pipeline. No sockets, no async: takes `&[u8]`
+//! ethernet frames, returns borrowed views, and rebuilds frames with
+//! replaced payloads (recomputing IP length + IP/TCP/UDP checksums).
+//!
+//! Runs on untrusted guest bytes — every parse path is fallible and fails
+//! closed to `None` (the bridge forwards unparsed frames unchanged).
+//! `rebuild_with_payload` refuses anything it cannot serialize safely
+//! (over-MTU, IP extension headers, >u16 payloads), so a redactor can
+//! never silently leak (Plan 141 Q8, fail-closed).
+
+use std::net::IpAddr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L4Proto {
+    Tcp,
+    Udp,
+}
+
+/// Connection identity used as the `killed_flows` key. Direction-agnostic
+/// at the type level; the bridge stores keys per its coarse per-direction
+/// flow model (one guest = one workload, ADR-002).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FlowKey {
+    pub proto: L4Proto,
+    pub src_ip: IpAddr,
+    pub dst_ip: IpAddr,
+    pub src_port: u16,
+    pub dst_port: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FiveTuple {
+    pub proto: L4Proto,
+    pub src_ip: IpAddr,
+    pub dst_ip: IpAddr,
+    pub src_port: u16,
+    pub dst_port: u16,
+}
+
+impl FiveTuple {
+    pub fn flow_key(&self) -> FlowKey {
+        FlowKey {
+            proto: self.proto,
+            src_ip: self.src_ip,
+            dst_ip: self.dst_ip,
+            src_port: self.src_port,
+            dst_port: self.dst_port,
+        }
+    }
+}
+
+/// Borrowed view of one parsed ethernet frame. `raw_frame` is the escape
+/// hatch for the rare L2-aware observer; `l4_payload` is the common case.
+#[derive(Debug)]
+pub struct ParsedPacket<'a> {
+    pub five_tuple: FiveTuple,
+    pub l4_payload: &'a [u8],
+    pub raw_frame: &'a [u8],
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RebuildError {
+    #[error("rebuilt frame {len} bytes exceeds MTU {mtu}; V1 does not re-fragment")]
+    ExceedsMtu { len: usize, mtu: usize },
+    #[error("original frame is not a rebuildable plain IPv4/IPv6 TCP/UDP packet")]
+    Unparseable,
+    #[error("etherparse could not re-serialize the modified frame: {0}")]
+    Serialize(String),
+}
+
+/// Parse an ethernet frame to a borrowed `ParsedPacket`. Returns `None`
+/// for anything that is not a well-formed IPv4/IPv6 frame carrying TCP or
+/// UDP (ARP, ICMP, malformed, truncated) — the caller forwards those
+/// unchanged. Fails closed: any parse error → `None`.
+pub fn parse(raw: &[u8]) -> Option<ParsedPacket<'_>> {
+    let sliced = etherparse::SlicedPacket::from_ethernet(raw).ok()?;
+    let (src_ip, dst_ip): (IpAddr, IpAddr) = match sliced.net.as_ref()? {
+        etherparse::NetSlice::Ipv4(v4) => (
+            IpAddr::V4(v4.header().source_addr()),
+            IpAddr::V4(v4.header().destination_addr()),
+        ),
+        etherparse::NetSlice::Ipv6(v6) => (
+            IpAddr::V6(v6.header().source_addr()),
+            IpAddr::V6(v6.header().destination_addr()),
+        ),
+        _ => return None,
+    };
+    let (proto, src_port, dst_port, l4_payload) = match sliced.transport.as_ref()? {
+        etherparse::TransportSlice::Tcp(tcp) => (
+            L4Proto::Tcp,
+            tcp.source_port(),
+            tcp.destination_port(),
+            tcp.payload(),
+        ),
+        etherparse::TransportSlice::Udp(udp) => (
+            L4Proto::Udp,
+            udp.source_port(),
+            udp.destination_port(),
+            udp.payload(),
+        ),
+        _ => return None,
+    };
+    Some(ParsedPacket {
+        five_tuple: FiveTuple {
+            proto,
+            src_ip,
+            dst_ip,
+            src_port,
+            dst_port,
+        },
+        l4_payload,
+        raw_frame: raw,
+    })
+}
+
+/// Rebuild `raw` with `new_payload` replacing its L4 payload, recomputing
+/// IP total length + IP header checksum + TCP/UDP checksum. Refuses when
+/// the result would exceed `mtu` (no re-fragmentation in V1), when the
+/// original is not plain Ethernet2/IPv4|IPv6/TCP|UDP, or when IP extension
+/// headers are present (V1 fail-closed shortcut — the four V1 observers
+/// operate on extension-free packets). Only runs on the rare `Modify`
+/// path, so the re-parse cost is acceptable.
+pub fn rebuild_with_payload(
+    raw: &[u8],
+    new_payload: &[u8],
+    mtu: usize,
+) -> Result<Vec<u8>, RebuildError> {
+    use etherparse::{LinkHeader, NetHeaders, TransportHeader};
+
+    let headers = etherparse::PacketHeaders::from_ethernet_slice(raw)
+        .map_err(|_| RebuildError::Unparseable)?;
+    let Some(LinkHeader::Ethernet2(eth)) = headers.link else {
+        return Err(RebuildError::Unparseable);
+    };
+    let net = headers.net.ok_or(RebuildError::Unparseable)?;
+    let transport = headers.transport.ok_or(RebuildError::Unparseable)?;
+
+    let mut out: Vec<u8> = Vec::with_capacity(raw.len() + new_payload.len());
+    let serr = |e: std::io::Error| RebuildError::Serialize(e.to_string());
+    let cerr = |e: etherparse::err::ValueTooBigError<usize>| RebuildError::Serialize(e.to_string());
+
+    match (net, transport) {
+        (NetHeaders::Ipv4(mut ip, ext), TransportHeader::Tcp(mut tcp)) => {
+            if !ext.is_empty() {
+                return Err(RebuildError::Unparseable);
+            }
+            check_mtu(
+                14 + ip.header_len() + tcp.header_len() + new_payload.len(),
+                mtu,
+            )?;
+            ip.set_payload_len(tcp.header_len() + new_payload.len())
+                .map_err(|e| RebuildError::Serialize(e.to_string()))?;
+            tcp.checksum = tcp.calc_checksum_ipv4(&ip, new_payload).map_err(cerr)?;
+            eth.write(&mut out).map_err(serr)?;
+            ip.write(&mut out).map_err(serr)?;
+            tcp.write(&mut out).map_err(serr)?;
+        }
+        (NetHeaders::Ipv4(mut ip, ext), TransportHeader::Udp(mut udp)) => {
+            if !ext.is_empty() {
+                return Err(RebuildError::Unparseable);
+            }
+            let total = etherparse::UdpHeader::LEN + new_payload.len();
+            check_mtu(14 + ip.header_len() + total, mtu)?;
+            ip.set_payload_len(total)
+                .map_err(|e| RebuildError::Serialize(e.to_string()))?;
+            udp.length = u16::try_from(total)
+                .map_err(|_| RebuildError::Serialize("udp length overflow".into()))?;
+            udp.checksum = udp.calc_checksum_ipv4(&ip, new_payload).map_err(cerr)?;
+            eth.write(&mut out).map_err(serr)?;
+            ip.write(&mut out).map_err(serr)?;
+            udp.write(&mut out).map_err(serr)?;
+        }
+        (NetHeaders::Ipv6(mut ip, ext), TransportHeader::Tcp(mut tcp)) => {
+            if !ext.is_empty() {
+                return Err(RebuildError::Unparseable);
+            }
+            check_mtu(
+                14 + ip.header_len() + tcp.header_len() + new_payload.len(),
+                mtu,
+            )?;
+            ip.set_payload_length(tcp.header_len() + new_payload.len())
+                .map_err(|e| RebuildError::Serialize(e.to_string()))?;
+            tcp.checksum = tcp.calc_checksum_ipv6(&ip, new_payload).map_err(cerr)?;
+            eth.write(&mut out).map_err(serr)?;
+            ip.write(&mut out).map_err(serr)?;
+            tcp.write(&mut out).map_err(serr)?;
+        }
+        (NetHeaders::Ipv6(mut ip, ext), TransportHeader::Udp(mut udp)) => {
+            if !ext.is_empty() {
+                return Err(RebuildError::Unparseable);
+            }
+            let total = etherparse::UdpHeader::LEN + new_payload.len();
+            check_mtu(14 + ip.header_len() + total, mtu)?;
+            ip.set_payload_length(total)
+                .map_err(|e| RebuildError::Serialize(e.to_string()))?;
+            udp.length = u16::try_from(total)
+                .map_err(|_| RebuildError::Serialize("udp length overflow".into()))?;
+            udp.checksum = udp.calc_checksum_ipv6(&ip, new_payload).map_err(cerr)?;
+            eth.write(&mut out).map_err(serr)?;
+            ip.write(&mut out).map_err(serr)?;
+            udp.write(&mut out).map_err(serr)?;
+        }
+        _ => return Err(RebuildError::Unparseable),
+    }
+
+    out.extend_from_slice(new_payload);
+    Ok(out)
+}
+
+fn check_mtu(len: usize, mtu: usize) -> Result<(), RebuildError> {
+    if len > mtu {
+        Err(RebuildError::ExceedsMtu { len, mtu })
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use etherparse::PacketBuilder;
+    use std::net::Ipv4Addr;
+
+    /// Build a real TCP/IPv4/Ethernet frame with the given payload.
+    fn tcp_v4_frame(payload: &[u8]) -> Vec<u8> {
+        let builder = PacketBuilder::ethernet2([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12])
+            .ipv4(
+                Ipv4Addr::new(10, 0, 0, 2).octets(),
+                Ipv4Addr::new(93, 184, 216, 34).octets(),
+                64,
+            )
+            .tcp(40000, 443, 1, 64000);
+        let mut out = Vec::with_capacity(builder.size(payload.len()));
+        builder.write(&mut out, payload).unwrap();
+        out
+    }
+
+    fn udp_v4_frame(payload: &[u8]) -> Vec<u8> {
+        let builder = PacketBuilder::ethernet2([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12])
+            .ipv4(
+                Ipv4Addr::new(10, 0, 0, 2).octets(),
+                Ipv4Addr::new(8, 8, 8, 8).octets(),
+                64,
+            )
+            .udp(40000, 53);
+        let mut out = Vec::with_capacity(builder.size(payload.len()));
+        builder.write(&mut out, payload).unwrap();
+        out
+    }
+
+    #[test]
+    fn parse_extracts_five_tuple_and_payload() {
+        let frame = tcp_v4_frame(b"hello-world");
+        let p = parse(&frame).expect("parses a valid TCP/IPv4 frame");
+        assert_eq!(p.five_tuple.proto, L4Proto::Tcp);
+        assert_eq!(p.five_tuple.dst_port, 443);
+        assert_eq!(p.five_tuple.src_port, 40000);
+        assert_eq!(
+            p.five_tuple.dst_ip,
+            IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))
+        );
+        assert_eq!(p.l4_payload, b"hello-world");
+        assert_eq!(p.raw_frame, &frame[..]);
+    }
+
+    #[test]
+    fn parse_udp_extracts_payload() {
+        let frame = udp_v4_frame(b"dns-query");
+        let p = parse(&frame).expect("parses UDP/IPv4");
+        assert_eq!(p.five_tuple.proto, L4Proto::Udp);
+        assert_eq!(p.five_tuple.dst_port, 53);
+        assert_eq!(p.l4_payload, b"dns-query");
+    }
+
+    #[test]
+    fn parse_non_ip_frame_returns_none() {
+        // 14-byte ethernet header, ethertype 0xffff, no IP payload.
+        let frame = [0xff; 14];
+        assert!(parse(&frame).is_none());
+    }
+
+    #[test]
+    fn parse_truncated_frame_returns_none() {
+        let frame = tcp_v4_frame(b"x");
+        assert!(
+            parse(&frame[..10]).is_none(),
+            "truncated frame must fail closed"
+        );
+    }
+
+    #[test]
+    fn rebuild_replaces_payload_and_fixes_checksums() {
+        let frame = tcp_v4_frame(b"SECRET-TOKEN-1234");
+        let rebuilt = rebuild_with_payload(&frame, b"REDACTED---------", 1514)
+            .expect("same-length rebuild succeeds");
+        // Re-parse strictly validates the rebuilt frame (etherparse slices
+        // verify header consistency); assert payload + five-tuple survived.
+        let p = parse(&rebuilt).expect("rebuilt frame re-parses");
+        assert_eq!(p.l4_payload, b"REDACTED---------");
+        assert_eq!(p.five_tuple.dst_port, 443);
+    }
+
+    #[test]
+    fn rebuild_shorter_payload_succeeds() {
+        let frame = tcp_v4_frame(b"AAAAAAAAAAAA");
+        let rebuilt = rebuild_with_payload(&frame, b"BB", 1514).expect("shrink ok");
+        assert_eq!(parse(&rebuilt).unwrap().l4_payload, b"BB");
+    }
+
+    #[test]
+    fn rebuild_udp_payload_succeeds() {
+        let frame = udp_v4_frame(b"original-dns");
+        let rebuilt = rebuild_with_payload(&frame, b"modified", 1514).expect("udp rebuild ok");
+        let p = parse(&rebuilt).expect("udp rebuilt re-parses");
+        assert_eq!(p.l4_payload, b"modified");
+        assert_eq!(p.five_tuple.proto, L4Proto::Udp);
+    }
+
+    #[test]
+    fn rebuild_over_mtu_is_refused() {
+        let frame = tcp_v4_frame(b"small");
+        let huge = vec![0u8; 4096];
+        let err = rebuild_with_payload(&frame, &huge, 1514).expect_err("must refuse over-MTU");
+        assert!(matches!(err, RebuildError::ExceedsMtu { .. }));
+    }
+
+    #[test]
+    fn rebuild_unparseable_original_errors() {
+        let err = rebuild_with_payload(&[0xff; 14], b"x", 1514).expect_err("non-IP original");
+        assert!(matches!(err, RebuildError::Unparseable));
+    }
+
+    #[test]
+    fn flow_key_derives_from_five_tuple() {
+        let frame = tcp_v4_frame(b"k");
+        let p = parse(&frame).unwrap();
+        let k = p.five_tuple.flow_key();
+        assert_eq!(k.proto, L4Proto::Tcp);
+        assert_eq!(k.dst_port, 443);
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/network/pipeline.rs
+++ b/crates/mvm-hostd/src/supervisor/network/pipeline.rs
@@ -73,8 +73,10 @@ pub fn run_packet_pipeline<'a>(
             flow_key: None,
         };
     };
+    // `parsed` borrows raw_frame immutably; the per-observer loop below
+    // re-parses the current frame so a chained Modify is visible to the
+    // next observer.
     let flow_key = Some(parsed.five_tuple.flow_key());
-    drop(parsed); // re-parsed per observer below so chained Modify is visible
 
     // `owned` holds the live frame once an observer has rebuilt it.
     let mut owned: Option<Vec<u8>> = None;

--- a/crates/mvm-hostd/src/supervisor/network/pipeline.rs
+++ b/crates/mvm-hostd/src/supervisor/network/pipeline.rs
@@ -1,0 +1,368 @@
+//! Plan 141 / ADR-064 — synchronous observer fan-out runner. Pure: takes
+//! a raw frame + the observer slice, returns a `PacketDecision`. Reuses
+//! the `catch_unwind` panic-isolation pattern from `signer_task`
+//! (`gateway_bridge::signer_task`): a panicking observer is logged and
+//! treated as `Forward`; siblings continue.
+//!
+//! Verdict semantics (Q8/Q9):
+//! - Observers run in policy order; `Modify` chains (observer N+1 sees N's
+//!   output); the first `Drop` wins and kills the flow.
+//! - Any `Modify` the bridge cannot safely emit (over-MTU, unserializable)
+//!   fails closed → `Kill`. `Modify(==current payload)` is a no-op.
+//! - An observer whose `directions()` excludes the current direction is
+//!   skipped (least-privilege).
+//! - Non-IP/TCP/UDP frames (ARP, ICMP, malformed) forward unchanged with
+//!   no flow key — the pipeline only engages parseable L4 packets.
+
+use crate::supervisor::network::latency::ObserverLatency;
+use crate::supervisor::network::packet::{self, FlowKey};
+use crate::supervisor::network::{Observer, PacketCtx, Verdict};
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Why the runner forced a fail-closed flow kill (Plan 141 Q8). Maps to
+/// the `reason` label on the `gateway.flow_observer_fault` chain entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KillReason {
+    Drop,
+    ModifyOverMtu,
+    ModifyUnserializable,
+}
+
+impl KillReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            KillReason::Drop => "drop",
+            KillReason::ModifyOverMtu => "modify_over_mtu",
+            KillReason::ModifyUnserializable => "modify_unserializable",
+        }
+    }
+}
+
+/// Outcome the bridge acts on. `Forward` carries the (possibly rebuilt)
+/// frame as `Cow` — `Borrowed` when nothing changed (zero-copy), `Owned`
+/// after a `Modify`. `Kill` means: insert `flow_key` into `killed_flows`,
+/// emit a fault entry, drop this + all subsequent packets on the flow.
+#[derive(Debug)]
+pub enum PacketDecision<'a> {
+    Forward {
+        frame: Cow<'a, [u8]>,
+        flow_key: Option<FlowKey>,
+    },
+    Kill {
+        observer: &'static str,
+        reason: KillReason,
+        flow_key: Option<FlowKey>,
+    },
+}
+
+/// Run the observer chain over one raw ethernet frame. See module docs for
+/// verdict semantics. `latency` records each `on_packet` wall time.
+pub fn run_packet_pipeline<'a>(
+    observers: &[Arc<dyn Observer>],
+    ctx: PacketCtx<'_>,
+    raw_frame: &'a [u8],
+    mtu: usize,
+    latency: &ObserverLatency,
+) -> PacketDecision<'a> {
+    // Parse once for the flow key + the unparseable short-circuit.
+    let Some(parsed) = packet::parse(raw_frame) else {
+        return PacketDecision::Forward {
+            frame: Cow::Borrowed(raw_frame),
+            flow_key: None,
+        };
+    };
+    let flow_key = Some(parsed.five_tuple.flow_key());
+    drop(parsed); // re-parsed per observer below so chained Modify is visible
+
+    // `owned` holds the live frame once an observer has rebuilt it.
+    let mut owned: Option<Vec<u8>> = None;
+
+    for obs in observers {
+        if !obs.directions().includes(ctx.direction) {
+            continue;
+        }
+        let cur: &[u8] = owned.as_deref().unwrap_or(raw_frame);
+        let Some(cur_parsed) = packet::parse(cur) else {
+            // A prior rebuild produced something unparseable — fail closed.
+            return PacketDecision::Kill {
+                observer: obs.name(),
+                reason: KillReason::ModifyUnserializable,
+                flow_key,
+            };
+        };
+
+        let start = Instant::now();
+        let verdict = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            obs.on_packet(&ctx, &cur_parsed)
+        }));
+        latency.record(
+            obs.name(),
+            ctx.direction,
+            start.elapsed().as_micros() as u64,
+        );
+
+        let verdict = match verdict {
+            Ok(v) => v,
+            Err(panic) => {
+                tracing::warn!(
+                    observer = obs.name(),
+                    flow_id = ctx.flow_id,
+                    panic = %downcast_panic(&panic),
+                    "on_packet panicked; isolated via catch_unwind, treated as Forward"
+                );
+                continue;
+            }
+        };
+
+        match verdict {
+            Verdict::Forward => {}
+            Verdict::Drop => {
+                return PacketDecision::Kill {
+                    observer: obs.name(),
+                    reason: KillReason::Drop,
+                    flow_key,
+                };
+            }
+            Verdict::Modify(new_payload) => {
+                if new_payload == cur_parsed.l4_payload {
+                    continue; // no-op modify — skip the rebuild
+                }
+                match packet::rebuild_with_payload(cur, &new_payload, mtu) {
+                    Ok(new_frame) => owned = Some(new_frame),
+                    Err(packet::RebuildError::ExceedsMtu { .. }) => {
+                        return PacketDecision::Kill {
+                            observer: obs.name(),
+                            reason: KillReason::ModifyOverMtu,
+                            flow_key,
+                        };
+                    }
+                    Err(_) => {
+                        return PacketDecision::Kill {
+                            observer: obs.name(),
+                            reason: KillReason::ModifyUnserializable,
+                            flow_key,
+                        };
+                    }
+                }
+            }
+        }
+    }
+
+    PacketDecision::Forward {
+        frame: match owned {
+            Some(v) => Cow::Owned(v),
+            None => Cow::Borrowed(raw_frame),
+        },
+        flow_key,
+    }
+}
+
+fn downcast_panic(panic: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic>".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::supervisor::audit::FlowDirection;
+    use crate::supervisor::network::latency::ObserverLatency;
+    use crate::supervisor::network::packet::{ParsedPacket, parse};
+    use crate::supervisor::network::{
+        Directions, Observer, PacketCtx, RequiredCapabilities, Verdict,
+    };
+    use etherparse::PacketBuilder;
+    use std::net::Ipv4Addr;
+    use std::sync::Arc;
+
+    fn frame(payload: &[u8]) -> Vec<u8> {
+        let b = PacketBuilder::ethernet2([1; 6], [2; 6])
+            .ipv4(
+                Ipv4Addr::new(10, 0, 0, 2).octets(),
+                Ipv4Addr::new(1, 1, 1, 1).octets(),
+                64,
+            )
+            .tcp(5000, 443, 1, 64000);
+        let mut o = Vec::new();
+        b.write(&mut o, payload).unwrap();
+        o
+    }
+
+    fn lat() -> ObserverLatency {
+        ObserverLatency::new("vm", "t")
+    }
+
+    fn ctx<'a>(dir: FlowDirection) -> PacketCtx<'a> {
+        PacketCtx {
+            vm_name: "vm",
+            tenant: "t",
+            direction: dir,
+            flow_id: "vm-egress",
+        }
+    }
+
+    /// Test observer driven by a payload->verdict closure + direction.
+    struct PayloadObs<F: Fn(&[u8]) -> Verdict + Send + Sync>(F, Directions);
+    impl<F: Fn(&[u8]) -> Verdict + Send + Sync> Observer for PayloadObs<F> {
+        fn name(&self) -> &'static str {
+            "payload-obs"
+        }
+        fn required_capabilities(&self) -> RequiredCapabilities {
+            RequiredCapabilities {
+                flow_events: true,
+                payload_tap: true,
+            }
+        }
+        fn on_flow_event(&self, _: &crate::supervisor::gateway_bridge::FlowEvent) {}
+        fn directions(&self) -> Directions {
+            self.1
+        }
+        fn on_packet(&self, _c: &PacketCtx<'_>, p: &ParsedPacket<'_>) -> Verdict {
+            (self.0)(p.l4_payload)
+        }
+    }
+
+    #[test]
+    fn empty_observers_forwards_unmodified() {
+        let f = frame(b"hello-SECRET");
+        let obs: Vec<Arc<dyn Observer>> = vec![];
+        match run_packet_pipeline(&obs, ctx(FlowDirection::Egress), &f, 1514, &lat()) {
+            PacketDecision::Forward { frame, flow_key } => {
+                assert_eq!(&*frame, &f[..]);
+                assert!(flow_key.is_some());
+            }
+            other => panic!("expected Forward, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_ip_frame_forwards_unchanged_with_no_flow_key() {
+        let arp = [0xffu8; 14];
+        let obs: Vec<Arc<dyn Observer>> = vec![];
+        match run_packet_pipeline(&obs, ctx(FlowDirection::Egress), &arp, 1514, &lat()) {
+            PacketDecision::Forward { flow_key, .. } => assert!(flow_key.is_none()),
+            other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn modify_rebuilds_and_chains_to_next_observer() {
+        let f = frame(b"hello-SECRET");
+        let obs: Vec<Arc<dyn Observer>> = vec![
+            Arc::new(PayloadObs(
+                |p: &[u8]| {
+                    let s = String::from_utf8_lossy(p).replace("SECRET", "XXXXXX");
+                    Verdict::Modify(s.into_bytes())
+                },
+                Directions::Egress,
+            )),
+            Arc::new(PayloadObs(
+                |p: &[u8]| {
+                    assert!(
+                        p.windows(6).any(|w| w == b"XXXXXX"),
+                        "obs2 must see obs1's modify"
+                    );
+                    Verdict::Forward
+                },
+                Directions::Egress,
+            )),
+        ];
+        match run_packet_pipeline(&obs, ctx(FlowDirection::Egress), &f, 1514, &lat()) {
+            PacketDecision::Forward { frame, .. } => {
+                let p = parse(&frame).unwrap();
+                assert!(p.l4_payload.windows(6).any(|w| w == b"XXXXXX"));
+            }
+            other => panic!("expected Forward, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn first_drop_wins_and_kills_flow() {
+        let f = frame(b"hello-SECRET");
+        let obs: Vec<Arc<dyn Observer>> = vec![
+            Arc::new(PayloadObs(|_| Verdict::Drop, Directions::Egress)),
+            Arc::new(PayloadObs(
+                |_| panic!("must not run after Drop"),
+                Directions::Egress,
+            )),
+        ];
+        match run_packet_pipeline(&obs, ctx(FlowDirection::Egress), &f, 1514, &lat()) {
+            PacketDecision::Kill {
+                observer,
+                reason,
+                flow_key,
+            } => {
+                assert_eq!(observer, "payload-obs");
+                assert!(matches!(reason, KillReason::Drop));
+                assert!(flow_key.is_some());
+            }
+            other => panic!("expected Kill, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn modify_over_mtu_kills_flow_failclosed() {
+        let f = frame(b"hello-SECRET");
+        let obs: Vec<Arc<dyn Observer>> = vec![Arc::new(PayloadObs(
+            |_| Verdict::Modify(vec![0u8; 4096]),
+            Directions::Egress,
+        ))];
+        let d = run_packet_pipeline(&obs, ctx(FlowDirection::Egress), &f, 1514, &lat());
+        assert!(matches!(
+            d,
+            PacketDecision::Kill {
+                reason: KillReason::ModifyOverMtu,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn direction_filter_skips_non_matching_observer() {
+        let f = frame(b"hello-SECRET");
+        let obs: Vec<Arc<dyn Observer>> = vec![Arc::new(PayloadObs(
+            |_| panic!("ingress observer ran on egress packet"),
+            Directions::Ingress,
+        ))];
+        let d = run_packet_pipeline(&obs, ctx(FlowDirection::Egress), &f, 1514, &lat());
+        assert!(matches!(d, PacketDecision::Forward { .. }));
+    }
+
+    #[test]
+    fn panicking_observer_is_isolated_and_forwards() {
+        let f = frame(b"hello-SECRET");
+        let obs: Vec<Arc<dyn Observer>> = vec![
+            Arc::new(PayloadObs(|_| panic!("boom"), Directions::Egress)),
+            Arc::new(PayloadObs(|_| Verdict::Forward, Directions::Egress)),
+        ];
+        let d = run_packet_pipeline(&obs, ctx(FlowDirection::Egress), &f, 1514, &lat());
+        assert!(
+            matches!(d, PacketDecision::Forward { .. }),
+            "panic must be isolated -> Forward"
+        );
+    }
+
+    #[test]
+    fn modify_equal_to_original_is_treated_as_forward() {
+        let f = frame(b"hello-SECRET");
+        let original_payload = parse(&f).unwrap().l4_payload.to_vec();
+        let obs: Vec<Arc<dyn Observer>> = vec![Arc::new(PayloadObs(
+            move |_| Verdict::Modify(original_payload.clone()),
+            Directions::Egress,
+        ))];
+        match run_packet_pipeline(&obs, ctx(FlowDirection::Egress), &f, 1514, &lat()) {
+            // Borrowed (not Owned) proves no rebuild happened.
+            PacketDecision::Forward { frame, .. } => {
+                assert!(matches!(frame, std::borrow::Cow::Borrowed(_)))
+            }
+            other => panic!("got {other:?}"),
+        }
+    }
+}

--- a/specs/plans/141-vz-payload-tap-and-rust-owned-shuffle.md
+++ b/specs/plans/141-vz-payload-tap-and-rust-owned-shuffle.md
@@ -132,41 +132,41 @@ Verified anchor points (read 2026-06-04):
 
 ### Task 1: Add the `etherparse` workspace dependency
 
-- [ ] Add to root `[workspace.dependencies]` (after `ipnet`): `etherparse = "0.20"` with a comment (untrusted-guest-bytes path; claim 5).
-- [ ] In `crates/mvm-hostd/Cargo.toml` `[dependencies]`: `etherparse = { workspace = true }`.
-- [ ] Verify `cargo tree -p mvm-hostd -i etherparse`.
-- [ ] Commit `build(mvm-hostd): add etherparse for the packet-observer pipeline`.
+- [x] Add to root `[workspace.dependencies]` (after `ipnet`): `etherparse = "0.20"` with a comment (untrusted-guest-bytes path; claim 5).
+- [x] In `crates/mvm-hostd/Cargo.toml` `[dependencies]`: `etherparse = { workspace = true }`.
+- [x] Verify `cargo tree -p mvm-hostd -i etherparse`.
+- [x] Commit `build(mvm-hostd): add etherparse for the packet-observer pipeline`.
 
 ### Task 2: Pure packet parse + payload rebuild (`packet.rs`)
 
-- [ ] **Failing tests first:** `parse` five-tuple+payload; `parse` None on non-IP/truncated; `rebuild_with_payload` same-length + shorter success; over-MTU → `RebuildError::ExceedsMtu`; non-IP original → `RebuildError::Unparseable`. Build frames with `etherparse::PacketBuilder`.
-- [ ] Implement: `L4Proto`, `FlowKey` (Hash+Eq), `FiveTuple::flow_key()`, `ParsedPacket<'a> { five_tuple, l4_payload: &'a [u8], raw_frame: &'a [u8] }`, `RebuildError { ExceedsMtu{len,mtu}, Unparseable, Serialize(String) }`, `parse() -> Option`, `rebuild_with_payload(raw,new_payload,mtu) -> Result<Vec<u8>>` (fix IP len + IP/L4 checksums; refuse over-MTU). **Confirm 0.20 API names by compiling.** V1 shortcut: refuse on IP extension headers (`Unparseable`).
-- [ ] `pub mod packet;` in `network/mod.rs`. Tests PASS. Commit.
+- [x] **Failing tests first:** `parse` five-tuple+payload; `parse` None on non-IP/truncated; `rebuild_with_payload` same-length + shorter success; over-MTU → `RebuildError::ExceedsMtu`; non-IP original → `RebuildError::Unparseable`. Build frames with `etherparse::PacketBuilder`.
+- [x] Implement: `L4Proto`, `FlowKey` (Hash+Eq), `FiveTuple::flow_key()`, `ParsedPacket<'a> { five_tuple, l4_payload: &'a [u8], raw_frame: &'a [u8] }`, `RebuildError { ExceedsMtu{len,mtu}, Unparseable, Serialize(String) }`, `parse() -> Option`, `rebuild_with_payload(raw,new_payload,mtu) -> Result<Vec<u8>>` (fix IP len + IP/L4 checksums; refuse over-MTU). **Confirm 0.20 API names by compiling.** V1 shortcut: refuse on IP extension headers (`Unparseable`).
+- [x] `pub mod packet;` in `network/mod.rs`. Tests PASS. Commit.
 
 ### Task 3: Extend `Observer` — `Verdict`, `Directions`, `PacketCtx`, `on_packet`
 
-- [ ] Failing tests: `Directions::includes` truth table; default observer → `Both` + `Verdict::Forward`.
-- [ ] Implement `Directions{Egress,Ingress,Both}::includes`, `Verdict{Forward,Drop,Modify(Vec<u8>)}`, `PacketCtx<'a>{vm_name,tenant,direction,flow_id}`, and two **defaulted** trait methods `directions()` + `on_packet()`. Tests PASS. Commit.
+- [x] Failing tests: `Directions::includes` truth table; default observer → `Both` + `Verdict::Forward`.
+- [x] Implement `Directions{Egress,Ingress,Both}::includes`, `Verdict{Forward,Drop,Modify(Vec<u8>)}`, `PacketCtx<'a>{vm_name,tenant,direction,flow_id}`, and two **defaulted** trait methods `directions()` + `on_packet()`. Tests PASS. Commit.
 
 ### Task 4: `flow_observer_fault` audit entry
 
-- [ ] Failing test: helper sets event `gateway.flow_observer_fault` + labels flow_id/direction/observer/reason.
-- [ ] Implement `FLOW_OBSERVER_FAULT_EVENT` const + `flow_observer_fault(plan,bundle,flow_id,direction,observer,reason)`. PASS. Commit.
+- [x] Failing test: helper sets event `gateway.flow_observer_fault` + labels flow_id/direction/observer/reason.
+- [x] Implement `FLOW_OBSERVER_FAULT_EVENT` const + `flow_observer_fault(plan,bundle,flow_id,direction,observer,reason)`. PASS. Commit.
 
 ### Task 5: Per-observer latency recorder (`latency.rs`)
 
-- [ ] Failing tests: `record` accumulates; `prometheus_format` emits `mvm_observer_latency_us_{sum,count}{observer,vm,direction}`; scrape-file name is `metrics-<vm>-observer-latency.prom`.
-- [ ] Implement `ObserverLatency` (Mutex<BTreeMap<(name,dir),(sum,count)>>) with tmp+rename writer (mirror `FlowCountMetrics`). `pub mod latency;`. PASS. Commit.
+- [x] Failing tests: `record` accumulates; `prometheus_format` emits `mvm_observer_latency_us_{sum,count}{observer,vm,direction}`; scrape-file name is `metrics-<vm>-observer-latency.prom`.
+- [x] Implement `ObserverLatency` (Mutex<BTreeMap<(name,dir),(sum,count)>>) with tmp+rename writer (mirror `FlowCountMetrics`). `pub mod latency;`. PASS. Commit.
 
 ### Task 6: The pure fan-out runner (`pipeline.rs`)
 
-- [ ] Failing tests: empty→Forward(Borrowed); non-IP→Forward,key None; Modify rebuilds + chains; first Drop wins→Kill{Drop}; over-MTU→Kill{ModifyOverMtu}; direction filter skips; panic isolated→Forward; Modify==original→Forward(Borrowed).
-- [ ] Implement `KillReason{Drop,ModifyOverMtu,ModifyUnserializable}::as_str`, `PacketDecision<'a>{Forward{frame:Cow,flow_key},Kill{observer,reason,flow_key}}`, `run_packet_pipeline(observers,ctx,raw_frame,mtu,latency)` reusing the `catch_unwind` pattern. `pub mod pipeline;`. PASS. Commit.
+- [x] Failing tests: empty→Forward(Borrowed); non-IP→Forward,key None; Modify rebuilds + chains; first Drop wins→Kill{Drop}; over-MTU→Kill{ModifyOverMtu}; direction filter skips; panic isolated→Forward; Modify==original→Forward(Borrowed).
+- [x] Implement `KillReason{Drop,ModifyOverMtu,ModifyUnserializable}::as_str`, `PacketDecision<'a>{Forward{frame:Cow,flow_key},Kill{observer,reason,flow_key}}`, `run_packet_pipeline(observers,ctx,raw_frame,mtu,latency)` reusing the `catch_unwind` pattern. `pub mod pipeline;`. PASS. Commit.
 
 ### Task 7: Flow-byte-log policy field + append-only writer
 
-- [ ] Policy (mvm-core): default-off + serde tests → `NetworkPolicy.flow_byte_log: Option<FlowByteLogSpec>` (`#[serde(default)]`) + `FlowByteLogSpec{max_disk_bytes:u64,max_age_days:u32,directions:FlowByteLogDirections}` + `FlowByteLogDirections{Egress,Ingress,Both}`.
-- [ ] Writer (mvm-hostd `flow_byte_log.rs`): append/read-back test → `RecordRef{record_id,sha256}`, `FlowByteLogWriter::{create(0600),append}`, `read_all_records`, `sweep_retention(root,max_age_days)`. `pub mod flow_byte_log;`. PASS. Commit.
+- [x] Policy (mvm-core): default-off + serde tests → `NetworkPolicy.flow_byte_log: Option<FlowByteLogSpec>` (`#[serde(default)]`) + `FlowByteLogSpec{max_disk_bytes:u64,max_age_days:u32,directions:FlowByteLogDirections}` + `FlowByteLogDirections{Egress,Ingress,Both}`.
+- [x] Writer (mvm-hostd `flow_byte_log.rs`): append/read-back test → `RecordRef{record_id,sha256}`, `FlowByteLogWriter::{create(0600),append}`, `read_all_records`, `sweep_retention(root,max_age_days)`. `pub mod flow_byte_log;`. PASS. Commit.
 
 ---
 
@@ -174,23 +174,24 @@ Verified anchor points (read 2026-06-04):
 
 ### Task 8: Wire runner into LibkrunGvproxy datagram loop
 
-- [ ] `FlowEventKind::ObserverFault{observer,reason}` + `signer_task` arm (`flow_observer_fault`) + `FlowEventWire::FlowObserverFault` variant/From (wire roundtrip test first).
-- [ ] Thread `observers`, `Arc<ObserverLatency>`, `mtu=1514`, `killed_flows: Arc<Mutex<HashSet<FlowKey>>>` into `run_libkrun_gvproxy_bridge`. Both directions: killed-flow short-circuit → `run_packet_pipeline` → `latency.write_scrape_file()` → Forward sends (possibly rebuilt) frame / Kill inserts flow + emits ObserverFault + drops.
-- [ ] Integration tests (UnixDatagram pair): redactor → modified bytes downstream; drop → nothing + ObserverFault event. PASS. Commit.
+- [x] `FlowEventKind::ObserverFault{observer,reason}` + `signer_task` arm (`flow_observer_fault`) + `FlowEventWire::FlowObserverFault` variant/From (wire roundtrip test first).
+- [x] Thread `observers`, `Arc<ObserverLatency>`, `mtu=1514`, `killed_flows: Arc<Mutex<HashSet<FlowKey>>>` into `run_libkrun_gvproxy_bridge`. Both directions: killed-flow short-circuit → `run_packet_pipeline` → `latency.write_scrape_file()` → Forward sends (possibly rebuilt) frame / Kill inserts flow + emits ObserverFault + drops.
+- [x] Integration tests (UnixDatagram pair): redactor → modified bytes downstream; drop → nothing + ObserverFault event. PASS. Commit.
 
 ### Task 9: Wire runner into Passt frame-aware loop + broaden metrics filter
 
-- [ ] Pure `read_one_frame`/`write_one_frame` (4-byte BE length prefix; cap ≤ 65535) with duplex roundtrip test.
-- [ ] Replace `bridge_copy_bidirectional`'s opaque loops with frame-aware loops feeding the runner (preserve first-frame `FlowOpened` + EOF `FlowClosed`). Update the existing socketpair test to length-prefixed frames; add redactor + drop tests.
-- [ ] Broaden `metrics_server.rs:140` to `ends_with(".prom")`; update filter test (latency file now picked up). PASS. Commit.
+- [x] Pure `read_one_frame`/`write_one_frame` (4-byte BE length prefix; cap ≤ 65535) with duplex roundtrip test.
+- [x] Replace `bridge_copy_bidirectional`'s opaque loops with frame-aware loops feeding the runner (preserve first-frame `FlowOpened` + EOF `FlowClosed`). Update the existing socketpair test to length-prefixed frames; add redactor + drop tests.
+- [x] Broaden `metrics_server.rs:140` to `ends_with(".prom")`; update filter test (latency file now picked up). PASS. Commit.
 
 ### Task 10: Flow-byte-log retention sweep in `cache prune`
 
-- [ ] `cache.rs` prune calls `flow_byte_log::sweep_retention(<audit-dir>/flow-bytes, 7)` via `mvm-core::config` path helper. Old-removed/fresh-kept test. Commit.
+- [x] `cache.rs` prune calls `flow_byte_log::sweep_retention(<audit-dir>/flow-bytes, 7)` via `mvm-core::config` path helper. Old-removed/fresh-kept test. Commit.
 
 ### Task 11: Fuzz target + plan-doc tick + claim catalog
 
-- [ ] `crates/mvm-hostd/fuzz/fuzz_targets/fuzz_packet_parse.rs` (parse→rebuild round-trip, no panic); register in `security.yml` + root `Cargo.toml` exclude. Tick boxes; note `on_packet` fail-closed under claim 10 in `specs/claims/catalog.md`. Commit.
+- [x] `crates/mvm-hostd/fuzz/fuzz_targets/fuzz_packet_parse.rs` (parse→rebuild round-trip, no panic); registered in `security.yml` `fuzz` job + root `Cargo.toml` exclude. Boxes ticked.
+- [x] Claim catalog: **left unchanged by design.** The packet-observer pipeline strengthens existing claim 10's no-bytes-leave-unobserved enforcement; it is not a new numbered claim (numbering is ADR-002-governed). Promotion to a catalog witness row belongs with the ADR-002 update, mirroring claim 14's "promotion queued" pattern — and editing the catalog risks the `check-claim-catalog` gate. The new tests back the existing claim 10 posture.
 
 ---
 
@@ -225,6 +226,22 @@ extension-header rebuild, async/ring-buffered execution,
 
 ## Status
 
-🟢 Execution-ready (2026-06-04). Q8/Q9 closed via brainstorm; Q7/Q10 →
-Plan 152. `etherparse` confirmed absent → Task 1 adds it (0.20). Tasks 1–7
-core, 8–10 wiring, 11 fuzz+tick. Branch `feat/plan-141-packet-observer-core`.
+🟢 **Implemented (2026-06-04)** on branch `feat/plan-141-packet-observer-core`
+(worktree `../mvm-plan-141`), not yet pushed/PR'd. All 11 tasks landed in
+9 commits. Q8/Q9 closed via brainstorm; Q7/Q10 moved to Plan 152.
+`etherparse 0.20` added (was absent).
+
+Verification: clippy `-D warnings` clean (mvm-hostd, mvm-core, mvm-cli);
+nightly `fmt --all --check` clean; `cargo test --doc` clean; full
+mvm-hostd + mvm-core suites green (1786+ tests) plus the new unit +
+integration tests (packet parse/rebuild, runner fan-out, gvproxy +
+framed-Passt redaction/drop, latency, flow-byte-log, metrics filter,
+cache sweep). The `fuzz_packet_parse` target typechecks on stable; full
+ASAN/sancov fuzzing runs in CI (local `cargo fuzz` is blocked by the
+repo's `rust-toolchain.toml` stable pin).
+
+**Live-host caveat:** the **gvproxy (libkrun)** arm is exercised by the
+in-process integration tests; the **Passt (Firecracker)** arm is
+Linux-only and its 4-byte-BE qemu-socket wire framing is validated on
+Linux/KVM CI, not this macOS host — the reframing *logic* is unit-tested
+via an in-memory duplex.

--- a/specs/plans/141-vz-payload-tap-and-rust-owned-shuffle.md
+++ b/specs/plans/141-vz-payload-tap-and-rust-owned-shuffle.md
@@ -1,271 +1,230 @@
-# Plan 141 — Vz payload tap + Rust-owned shuffle (closes ADR-064 §Decision 8)
+# Plan 141 — Backend-agnostic packet-observer core (`on_packet` / `Verdict`) for libkrun + Firecracker
 
-> **Status: design captured mid-brainstorm.** Q1–Q6 are owner-confirmed
-> architectural decisions; Q7 is drafted but unconfirmed; Q8–Q10 are
-> open. **This plan is not ready for execution** — resume the
-> brainstorm to close Q7–Q10, then re-render the Tasks section through
-> `superpowers:writing-plans`. The shape below is what the locked
-> decisions imply.
->
-> **RESOLVED with Plan 152 (2026-06-04 brainstorm) — scope split.** The
-> Vz arm of this plan is **superseded by Plan 152**. 152 makes the VZ
-> supervisor Rust-native (`objc2`), so Rust owns the VZ device *and* the
-> bridge in one process — the SCM_RIGHTS fd-handoff to a *surviving* Swift
-> supervisor (this plan's Q1–Q6 Vz mechanism) is unnecessary and would be
-> throwaway. **This plan is rescoped to its backend-agnostic core**
-> (`on_packet`/`Verdict`/etherparse observer pipeline) for **libkrun +
-> Firecracker** `payload_tap`; **Vz `payload_tap` is delivered in-process
-> by Plan 152.** The Swift-side files + Vz-specific Rust arm below are
-> retained for reference but **move to Plan 152**. Decision record:
-> ADR-064 §8. See [[project_vz_strong_support_direction]].
+> **For agentic workers:** REQUIRED SUB-SKILL: use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans`. Steps use checkbox (`- [ ]`) syntax.
 
-**Goal:** Close ADR-064 §Decision 8's "Vz catches up later" carve-out and
-land the Rust-owned-shuffle architecture across all production
-hypervisor backends. Vz post-this-plan reports
-`ProviderCapabilities { flow_events: true, payload_tap: true }`;
-observers that require `payload_tap` (egress redactor, hostname
-filter, rate limiter, future egress secret detector) work identically
-on libkrun, Firecracker, and Vz with one Rust implementation.
+**Goal:** Give the gateway audit bridge a synchronous packet-observation
+pipeline — `Observer::on_packet(ctx, pkt) -> Verdict { Forward | Drop |
+Modify(Vec<u8>) }`, parsed once per frame via `etherparse`, fanned out in
+policy order, with first-Drop-wins, per-VM `killed_flows`, fail-closed
+`Modify`, an opt-in flow-byte log, and per-observer Prometheus latency —
+wired into the **Passt (Firecracker)** and **LibkrunGvproxy (libkrun)**
+bridge variants. **No Vz changes** (delivered in-process by Plan 152).
 
-**Architecture (Q1–Q6 confirmed):**
+**Architecture:** A pure, socket-free `packet` module (parse + payload
+rebuild) and a pure `run_packet_pipeline` fan-out runner form the
+backend-agnostic core; each bridge variant feeds raw frames into that one
+runner. The runner reuses Plan 113's `catch_unwind` panic-isolation from
+`signer_task`. Observers stay **host-allowlisted, never tenant-shipped**
+(ADR-064 §7) — the existing `ObserverAllowlist` is untouched. Security
+spine: claim 1 (least-privilege `directions()` blast-radius containment),
+claim 10 (no untrusted bytes leave unobserved; `Modify` fails closed so a
+redactor can never leak).
 
-- **Rust owns the packet shuffle on every backend.** Per-backend code
-  becomes the smallest possible adapter that hands a data fd to
-  `gateway_bridge::run_bridge_inner`. Firecracker is already there.
-  Vz changes here: Swift's `BridgeWorker` deletes; Swift accepts an
-  SCM_RIGHTS fd-handoff from Rust and wraps the fd in `FileHandle` for
-  `VZFileHandleNetworkDeviceAttachment`. Future QEMU / AppleContainer /
-  Hyper-V backends inherit the pattern.
-- **Observer trait gains `on_packet(&self, ctx, pkt) -> Verdict`.**
-  `gateway_bridge` parses each frame once via `etherparse` (a workspace
-  dep) and hands observers `ParsedPacket { five_tuple, l4_payload,
-  raw_frame }`. The `raw_frame` slice is the escape hatch for the rare
-  L2-aware observer.
-- **`Verdict = Forward | Drop | Modify(Vec<u8>)` with first-Drop-wins
-  chaining.** Observers run in `NetworkPolicy.observers` array order;
-  observer N sees the output of observer N-1's `Modify`; first `Drop`
-  adds the flow to the bridge's per-VM `killed_flows: HashSet<FlowId>`
-  and short-circuits subsequent packets on that flow. RST injection,
-  `Defer`, and `DropPacket`-vs-`KillFlow` distinctions are deferred to
-  future plans.
-- **fd-handoff handshake.** New dedicated `fd_handoff_socket_path`
-  field on `Config.swift`'s `NetworkConfig` variant (no multiplex onto
-  `events_ingest_socket_path` or `control_socket_path`). The existing
-  `gvproxy` variant is **replaced** (no backwards-compat shim per
-  `feedback_no_backcompat_first_version`) with:
-  ```swift
-  case rustManaged(mac: MacAddress, fdHandoffSocketPath: String)
-  ```
-  Swift `bind`/`listen`/`accept`s the socket (mode 0700); Rust
-  connects when ready to hand off the Vz-side fd via SCM_RIGHTS.
-- **Per-VM flow-byte log, opt-in.**
-  `NetworkPolicy.flow_byte_log: FlowByteLogSpec | None`. Default off.
-  When enabled, bridge writes append-only length-prefixed records to
-  `~/.mvm/audit/flow-bytes/<tenant>/<vm>-<utc_iso>.bin`; audit-chain
-  entries reference records as `(file_name, record_id, sha256)`. Rotation
-  + retention sweep integrate with `mvmctl cache prune`. The audit
-  chain itself stays small (no payload bytes inline). Encryption-at-rest
-  is its own follow-up plan.
-- **Strict-sync observer execution + Prometheus latency observability.**
-  Per-VM bridge thread runs the `recv → parse → observers → send` loop
-  synchronously; each `on_packet` call is wrapped in
-  `std::panic::catch_unwind` (matches Plan 113's `signer_task` pattern)
-  and bracketed with `Instant::now()` measurements feeding
-  `mvm_observer_latency_us{observer, vm, direction}` via the existing
-  per-VM `.prom` scrape file convention. **No timeout enforcement in
-  V1** — that policy ships in its own plan if a real observer needs it.
-- **Per-flow state stays inside the observer impl.**
-  `Mutex<HashMap<FlowId, FlowState>>` keyed off the existing
-  `on_flow_event(FlowOpened/FlowClosed)` callbacks. No bridge-managed
-  blackboard.
-
-**Tech Stack:** Swift `crates/mvm-vz-supervisor/Sources/...`
-(`Config.swift`, `Network.swift`); Rust `crates/mvm-bridge`
-(rewrites `VzIngest` arm into `VzManaged`); `mvm-supervisor::network::Observer`
-(new `on_packet` method, new `Verdict` enum); `mvm-supervisor::gateway_bridge`
-(per-VM `killed_flows`, etherparse fan-in); `mvm-policy::NetworkPolicy`
-(new `flow_byte_log` field); `mvm-backend::vz.rs` (producer side of
-the new config shape). New `mvm-audit::flow_byte_log` module for the
-append-only writer + retention sweep. `etherparse` (existing workspace
-dep). No new third-party Rust crates.
-
-**Prereqs:** Plan 113 merged (PR #512). Plan 121's crate consolidation
-does not block but should ship first if its timeline allows — it
-relocates `mvm-bridge` into the consolidated layout, making this plan's
-file paths cleaner.
+**Tech Stack:** Rust, `etherparse` 0.20 (NEW workspace dep — Task 1),
+`tokio` (existing), `mvm-hostd::supervisor::{gateway_bridge,network,audit}`,
+`mvm-core::policy::NetworkPolicy`, `mvm-cli::metrics_server`.
 
 ---
 
-## Open design questions (resolve before executing)
+## Context
 
-The following must close in a follow-up brainstorm session before this
-plan's task list is renderable. The brainstorm context is captured at
-`/Users/auser/.claude/plans/context-for-resuming-plan-robust-brook.md`.
+ADR-064 §Decision 8 carved out "Vz catches up later" for payload-tap. The
+original Plan 141 tried to close that with an SCM_RIGHTS fd-handoff to a
+*surviving* Swift supervisor. The **2026-06-04 rescope** (ADR-064 §8 +
+memory `project_vz_strong_support_direction`) made the VZ supervisor
+Rust-native (Plan 152), so Vz owns its device *and* bridge in-process —
+the Swift handoff is throwaway. **Plan 141 is rescoped to its
+backend-agnostic core** for **libkrun + Firecracker only**. It now depends
+only on Plan 113 (merged, PR #512), so it is unblocked.
 
-- **Q7 — Capability advertisement post-refactor (drafted, unconfirmed).**
-  Recommended shape:
-  - **7a:** Plan 141 stays **Vz-only**. AppleContainer (whose
-    `containerization` network layer is undocumented) lands as its own
-    plan when Apple's API is clearer. Memory
-    `project_gateway_audit_substrate_backend_coverage` already records
-    that boundary.
-  - **7b:** Lift `ProviderCapabilities { flow_events: true, payload_tap:
-    true }` into a `const BRIDGE_CAPS` in `mvm-bridge`. Every backend
-    funnelling through the bridge advertises the same constant —
-    duplication-driven drift becomes impossible.
-- **Q8 — `Modify` failure modes.** What happens when an observer
-  returns `Modify(bytes)` with `bytes.len() > MTU` and the bridge can't
-  re-fragment? When the modified payload would produce an invalid
-  TCP/UDP checksum? Options: drop the packet with a chain entry
-  attributing the observer; fail closed and kill the flow; refuse the
-  Modify at trait validation time. Needs a per-failure-mode decision
-  matrix.
-- **Q9 — Per-direction observer registration.** Today's `Observer`
-  trait has no direction filter — every observer sees every packet
-  in every direction. Performance optimization: let observers declare
-  `required_directions: { egress, ingress, both }` at registration.
-  The four V1 use cases skew strongly toward egress-only; the
-  optimization is meaningful but adds API surface. Confirm V1 scope.
-- **Q10 — `mvm-vz-drainer` deletion / VzIngest arm rename.** After the
-  unification, the `BridgeEndpoints::VzIngest` arm inside `mvm-bridge`
-  (the NDJSON ingest path Plan 113 shipped) deletes too — Rust owns
-  the shuffle for Vz, so there's no Swift-side NDJSON to drain. The
-  replacement is a new `BridgeEndpoints::VzManaged` arm carrying the
-  fd-handoff socket path. Confirm this is the destination state.
+The bridge today (`gateway_bridge.rs`) does opaque byte-copy and never
+parses L3/L4 (`FlowDecisionCtx.dest_ip/dest_port` hardcoded `None`, "no
+parser yet"). This plan introduces the first real parse on that path.
+
+**`etherparse` correction:** prior prose claimed it was already a
+workspace dep. It is **not** (verified 2026-06-04 — zero repo references;
+absent from `[workspace.dependencies]`; latest published is 0.20). Task 1
+adds it. Rationale (memory `reference_etherparse_not_yet_workspace_dep`):
+it lands on the untrusted-guest-bytes path where claim 5 fuzzes parsers,
+so a mature fuzzed-upstream parser beats a hand-rolled one
+(`feedback_limit_dependencies` tolerates this profile).
 
 ---
 
-## Files (planned — derived from the locked decisions above)
+## Resolved design questions
 
-> **Scope (2026-06-04):** the **Swift side** + the **Vz-specific Rust
-> bits** (the `VzIngest`→`VzManaged` arm, `parse.rs` rename, `vz.rs`
-> `rust_managed` shape) are **superseded by Plan 152** (Vz goes
-> Rust-native; the bridge runs in-process, no fd-handoff) — retained below
-> for reference only. **In scope for this plan:** the backend-agnostic
-> `Observer` / `gateway_bridge` core (`on_packet`/`Verdict`/`ParsedPacket`,
-> etherparse pipeline, `killed_flows`, flow-byte-log, Prometheus) applied
-> to **libkrun + Firecracker**. Q10 (`mvm-vz-drainer` deletion) and the Vz
-> part of Q7 move to Plan 152; Q8/Q9 stay here.
+- **Q7 — capability advertisement.** Moved to Plan 152 (concerns the Vz
+  leaf's `payload_tap` flip). libkrun + Firecracker already report
+  `payload_tap: true`. No change here.
+- **Q8 — `Modify` failure modes (RESOLVED: uniform fail-closed).** Any
+  `Modify` the bridge cannot safely emit → kill the flow (insert
+  five-tuple into `killed_flows`, drop this + all subsequent packets on
+  that flow) + emit `gateway.flow_observer_fault` attributing the
+  observer + reason. Matrix:
 
-### Swift side (Vz supervisor)
+  | Failure | Behavior |
+  |---|---|
+  | Modified frame exceeds MTU (no re-frag in V1) | kill + fault, reason `modify_over_mtu` |
+  | Rebuild fails (etherparse can't re-serialize) | kill + fault, reason `modify_unserializable` |
+  | `Modify(bytes)` where `bytes == original` | treat as `Forward` (skip rebuild) |
+  | Observer panics | `catch_unwind` → warn → `Forward` for that observer, siblings continue |
 
-- **Modify** `crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Config.swift`
-  — replace `NetworkConfig.gvproxy(...)` with `NetworkConfig.rustManaged(mac, fdHandoffSocketPath)`. Update strict-keys allowlist. Delete the `events_ingest_socket_path` field (Rust now writes the audit chain directly; Swift doesn't emit NDJSON).
-- **Rewrite** `crates/mvm-vz-supervisor/Sources/mvm-vz-supervisor/Network.swift`
-  — delete `BridgeWorker` class, `makeBridgedGvproxyDevice`,
-  `formatFlowOpenedLine`, `formatFlowClosedLine`,
-  `VZ_BRIDGE_HANDSHAKE`. Replace `makeAttachment` body with a
-  ~30-line "bind+listen, accept one connection, recv one SCM_RIGHTS
-  fd, wrap in `FileHandle`, attach to
-  `VZVirtioNetworkDeviceConfiguration`" implementation.
-- **Delete** `crates/mvm-vz-supervisor/Tests/MvmVzSupervisorTests/BridgeWorkerTests.swift`.
-- **Add** Swift XCTest covering the fd-handoff handshake (the
-  socket-listener happy path; the connection-aborted-before-fd path).
+  Rationale: on TCP a silent single-packet drop just stalls (retransmit →
+  re-modify → re-fail loop), so drop-packet degrades to a dead flow
+  anyway without an audit trail. One fail-closed terminal state is
+  simpler and secure.
 
-### Rust side
-
-- **Rewrite** `crates/mvm-bridge/src/endpoints.rs` — `BridgeEndpoints::VzIngest` becomes `BridgeEndpoints::VzManaged { fd_handoff_socket_path }`. The new arm runs the SCM_RIGHTS dial against Swift's listener, receives the Vz-side fd (closes it; Vz keeps the other half), opens its own gvproxy socket, runs the shuffle on the (gvproxy_fd, supervisor_socketpair_fd) pair.
-- **Modify** `crates/mvm-bridge/src/parse.rs` — `EndpointSpec::VzIngest`
-  variant renames to `VzManaged` with the new field shape.
-- **Modify** `crates/mvm-backend/src/vz.rs` — emit the new
-  `rust_managed { mac, fd_handoff_socket_path }` JSON shape into
-  `SupervisorConfig.network`. Drop the
-  `events_ingest_socket_path` field from the producer side.
-- **Modify** `crates/mvm-supervisor/src/network/mod.rs` — extend the
-  `Observer` trait with `on_packet(&self, ctx: &PacketCtx, pkt: &ParsedPacket<'_>) -> Verdict`. Add `Verdict` enum, `ParsedPacket` struct, `PacketCtx` struct. Default impl: `Verdict::Forward` (so existing observers continue to work unchanged).
-- **Modify** `crates/mvm-supervisor/src/gateway_bridge.rs` —
-  add `killed_flows: HashSet<FlowId>` per VM. In the shuffle loop:
-  etherparse the inbound frame, build `ParsedPacket`, run the
-  pipeline under `catch_unwind` + `Instant::now()` brackets, apply the
-  verdict, re-serialize headers after `Modify` (with new IP length +
-  TCP/UDP checksum via etherparse's `set_payload`), emit a
-  `flow_byte_event` chain entry referencing the flow-byte log record
-  when the flow-byte log is enabled.
-- **Modify** `crates/mvm-policy/src/policies.rs` — add
-  `NetworkPolicy.flow_byte_log: Option<FlowByteLogSpec>`. New
-  `FlowByteLogSpec` struct (max_disk_bytes, max_age_days, directions).
-- **Create** `crates/mvm-supervisor/src/audit/flow_byte_log.rs` —
-  append-only writer (length-prefixed records, atomic rename for
-  rotation). Sweep helper invoked from `mvmctl cache prune`.
-- **Modify** `crates/mvm-cli/src/commands/cache.rs` (or wherever
-  `cache prune` dispatches) — wire the flow-byte-log retention sweep.
-
-### Tests + CI
-
-- New `mvm-bridge/tests/scm_rights_handoff.rs` covering the
-  fd-handoff handshake (Linux only; macOS XCTest covers the Swift
-  side).
-- Extend the existing `mvm-bridge/fuzz` harness to cover the
-  `on_packet` parser surface.
-- New CI lane `vz-payload-tap-property` mirroring the
-  `jailer-lite-property` shape — self-hosted Apple Silicon runner,
-  exercises the live Vz fd-handoff + observer chain end-to-end.
+- **Q9 — per-direction registration (RESOLVED: include, minimal).**
+  `Directions { Egress | Ingress | Both }`; `fn directions(&self) ->
+  Directions { Directions::Both }` default (keeps every flow-event
+  observer unchanged); runner skips `on_packet` when direction excluded.
+  Least-privilege: egress observer never sees inbound bytes.
+- **Q10 — `VzIngest` arm.** Untouched; deletion/rename → Plan 152.
 
 ---
 
-## Tasks (placeholder — to be rendered by `superpowers:writing-plans` after Q7–Q10 close)
+## Scope decision: both backends, gvproxy-first
 
-The tasks will roughly follow Plan 113's shape — observer-trait
-extension first, Swift refactor second, producer wiring third, audit
-chain integration fourth, CI lanes fifth, plan-doc tick last. Holding
-off on the per-task breakdown until the open questions resolve so the
-task bodies don't drift.
+Both production backends wired here, sequenced: LibkrunGvproxy datagram
+path first (one `recv` = one frame → clean insertion exercising the whole
+core), then Passt (`SOCK_STREAM` `bridge_copy_bidirectional` has no frame
+boundaries — needs a length-prefix-aware rewrite feeding the *same*
+runner). Localizes Passt-reframing bugs away from pipeline bugs.
+
+**Backend-agnostic core = Tasks 1–7. Backend wiring = Tasks 8–10. Fuzz +
+tick = Task 11.**
 
 ---
 
-## Out of scope (deferred follow-ups)
+## File structure
 
-- **AppleContainer payload tap** — its own plan when Apple's
-  `containerization` network API is clearer. Memory
-  `project_gateway_audit_substrate_backend_coverage` documents the
-  carve-out.
-- **Encryption-at-rest for the flow-byte log** — own ADR (keyring
-  sourcing, per-tenant key, rotation) + own plan. V1 flow-byte log
-  files are mode 0600 with the parent dir at 0700, consistent with
-  `~/.mvm` posture.
-- **Per-observer timeout enforcement** — Q6 deliberately ships
-  measurement without enforcement. The enforcement policy (fail-open
-  vs fail-closed per-observer) is its own design.
-- **TCP RST injection on `Drop`** — Q3 deliberately ships silent drop
-  only. RST injection requires per-flow sequence-number tracking;
-  meaningful on its own design merits.
-- **Async / ring-buffered observer execution (Q6's option C)** — TCP
-  reordering complexity for a problem V1 doesn't have. Defer.
-- **`Defer` and `DropPacket`-vs-`KillFlow` verdict variants** — Q3
-  deliberately minimal.
-- **Bridge restart policy variants** — Plan 113's `BridgeRestartPolicy`
-  schema reservation covers this; new variants land in their own plan
-  + ADR.
+| File | Responsibility | Action |
+|---|---|---|
+| `Cargo.toml` (root) | add `etherparse` to `[workspace.dependencies]` | Modify |
+| `crates/mvm-hostd/Cargo.toml` | consume `etherparse` (+ `hex` if absent) | Modify |
+| `crates/mvm-hostd/src/supervisor/network/packet.rs` | pure parse + payload rebuild | Create |
+| `crates/mvm-hostd/src/supervisor/network/pipeline.rs` | pure `run_packet_pipeline` | Create |
+| `crates/mvm-hostd/src/supervisor/network/latency.rs` | per-observer latency + `.prom` writer | Create |
+| `crates/mvm-hostd/src/supervisor/network/mod.rs` | extend `Observer`; add `Verdict`/`Directions`/`PacketCtx`; register submodules | Modify |
+| `crates/mvm-hostd/src/supervisor/audit.rs` | `flow_observer_fault` + `FLOW_OBSERVER_FAULT_EVENT` | Modify |
+| `crates/mvm-hostd/src/supervisor/gateway_bridge.rs` | `FlowEventKind::ObserverFault`; per-VM `killed_flows`; wire runner into both loops | Modify |
+| `crates/mvm-core/src/policy/policies.rs` | `NetworkPolicy.flow_byte_log` + `FlowByteLogSpec` | Modify |
+| `crates/mvm-hostd/src/supervisor/network/flow_byte_log.rs` | append-only writer + retention sweep | Create |
+| `crates/mvm-cli/src/metrics_server.rs` | broaden scrape discovery to `metrics-*.prom` | Modify |
+| `crates/mvm-cli/src/commands/cache.rs` | flow-byte-log sweep in `cache prune` | Modify |
+| `crates/mvm-hostd/fuzz` | `fuzz_packet_parse` target | Modify |
+
+Verified anchor points (read 2026-06-04):
+- `Observer` trait: `network/mod.rs:86-90`; `RequiredCapabilities`/`ProviderCapabilities` 46-73; `Pipeline` 119-166; `ObserverAllowlist` 174-343; `MAX_OBSERVERS=8`.
+- `signer_task` fan-out + `catch_unwind`: `gateway_bridge.rs:266-333` (pattern to reuse).
+- gvproxy loop: `run_libkrun_gvproxy_bridge` `gateway_bridge.rs:654-823` (one datagram = one frame).
+- Passt loop: `bridge_copy_bidirectional` `gateway_bridge.rs:494-648` (opaque 8 KiB copy; needs reframe).
+- `FlowEvent`/`FlowEventKind`: `gateway_bridge.rs:200-211`; `FlowEventWire` 221-249.
+- `AuditEntry::flow_opened/flow_closed`: `audit.rs:94-132`; `FlowDirection` 149-166; `FlowCloseReason` 178-197.
+- `NetworkPolicy`: `mvm-core/src/policy/policies.rs:32-53` (already has `observers: Vec<String>`).
+- metrics discovery: `mvm-cli/src/metrics_server.rs:140` matches `starts_with("metrics-") && ends_with("-flow-count.prom")` — must broaden.
+
+---
+
+# Phase A — backend-agnostic core
+
+### Task 1: Add the `etherparse` workspace dependency
+
+- [ ] Add to root `[workspace.dependencies]` (after `ipnet`): `etherparse = "0.20"` with a comment (untrusted-guest-bytes path; claim 5).
+- [ ] In `crates/mvm-hostd/Cargo.toml` `[dependencies]`: `etherparse = { workspace = true }`.
+- [ ] Verify `cargo tree -p mvm-hostd -i etherparse`.
+- [ ] Commit `build(mvm-hostd): add etherparse for the packet-observer pipeline`.
+
+### Task 2: Pure packet parse + payload rebuild (`packet.rs`)
+
+- [ ] **Failing tests first:** `parse` five-tuple+payload; `parse` None on non-IP/truncated; `rebuild_with_payload` same-length + shorter success; over-MTU → `RebuildError::ExceedsMtu`; non-IP original → `RebuildError::Unparseable`. Build frames with `etherparse::PacketBuilder`.
+- [ ] Implement: `L4Proto`, `FlowKey` (Hash+Eq), `FiveTuple::flow_key()`, `ParsedPacket<'a> { five_tuple, l4_payload: &'a [u8], raw_frame: &'a [u8] }`, `RebuildError { ExceedsMtu{len,mtu}, Unparseable, Serialize(String) }`, `parse() -> Option`, `rebuild_with_payload(raw,new_payload,mtu) -> Result<Vec<u8>>` (fix IP len + IP/L4 checksums; refuse over-MTU). **Confirm 0.20 API names by compiling.** V1 shortcut: refuse on IP extension headers (`Unparseable`).
+- [ ] `pub mod packet;` in `network/mod.rs`. Tests PASS. Commit.
+
+### Task 3: Extend `Observer` — `Verdict`, `Directions`, `PacketCtx`, `on_packet`
+
+- [ ] Failing tests: `Directions::includes` truth table; default observer → `Both` + `Verdict::Forward`.
+- [ ] Implement `Directions{Egress,Ingress,Both}::includes`, `Verdict{Forward,Drop,Modify(Vec<u8>)}`, `PacketCtx<'a>{vm_name,tenant,direction,flow_id}`, and two **defaulted** trait methods `directions()` + `on_packet()`. Tests PASS. Commit.
+
+### Task 4: `flow_observer_fault` audit entry
+
+- [ ] Failing test: helper sets event `gateway.flow_observer_fault` + labels flow_id/direction/observer/reason.
+- [ ] Implement `FLOW_OBSERVER_FAULT_EVENT` const + `flow_observer_fault(plan,bundle,flow_id,direction,observer,reason)`. PASS. Commit.
+
+### Task 5: Per-observer latency recorder (`latency.rs`)
+
+- [ ] Failing tests: `record` accumulates; `prometheus_format` emits `mvm_observer_latency_us_{sum,count}{observer,vm,direction}`; scrape-file name is `metrics-<vm>-observer-latency.prom`.
+- [ ] Implement `ObserverLatency` (Mutex<BTreeMap<(name,dir),(sum,count)>>) with tmp+rename writer (mirror `FlowCountMetrics`). `pub mod latency;`. PASS. Commit.
+
+### Task 6: The pure fan-out runner (`pipeline.rs`)
+
+- [ ] Failing tests: empty→Forward(Borrowed); non-IP→Forward,key None; Modify rebuilds + chains; first Drop wins→Kill{Drop}; over-MTU→Kill{ModifyOverMtu}; direction filter skips; panic isolated→Forward; Modify==original→Forward(Borrowed).
+- [ ] Implement `KillReason{Drop,ModifyOverMtu,ModifyUnserializable}::as_str`, `PacketDecision<'a>{Forward{frame:Cow,flow_key},Kill{observer,reason,flow_key}}`, `run_packet_pipeline(observers,ctx,raw_frame,mtu,latency)` reusing the `catch_unwind` pattern. `pub mod pipeline;`. PASS. Commit.
+
+### Task 7: Flow-byte-log policy field + append-only writer
+
+- [ ] Policy (mvm-core): default-off + serde tests → `NetworkPolicy.flow_byte_log: Option<FlowByteLogSpec>` (`#[serde(default)]`) + `FlowByteLogSpec{max_disk_bytes:u64,max_age_days:u32,directions:FlowByteLogDirections}` + `FlowByteLogDirections{Egress,Ingress,Both}`.
+- [ ] Writer (mvm-hostd `flow_byte_log.rs`): append/read-back test → `RecordRef{record_id,sha256}`, `FlowByteLogWriter::{create(0600),append}`, `read_all_records`, `sweep_retention(root,max_age_days)`. `pub mod flow_byte_log;`. PASS. Commit.
+
+---
+
+# Phase B — backend wiring
+
+### Task 8: Wire runner into LibkrunGvproxy datagram loop
+
+- [ ] `FlowEventKind::ObserverFault{observer,reason}` + `signer_task` arm (`flow_observer_fault`) + `FlowEventWire::FlowObserverFault` variant/From (wire roundtrip test first).
+- [ ] Thread `observers`, `Arc<ObserverLatency>`, `mtu=1514`, `killed_flows: Arc<Mutex<HashSet<FlowKey>>>` into `run_libkrun_gvproxy_bridge`. Both directions: killed-flow short-circuit → `run_packet_pipeline` → `latency.write_scrape_file()` → Forward sends (possibly rebuilt) frame / Kill inserts flow + emits ObserverFault + drops.
+- [ ] Integration tests (UnixDatagram pair): redactor → modified bytes downstream; drop → nothing + ObserverFault event. PASS. Commit.
+
+### Task 9: Wire runner into Passt frame-aware loop + broaden metrics filter
+
+- [ ] Pure `read_one_frame`/`write_one_frame` (4-byte BE length prefix; cap ≤ 65535) with duplex roundtrip test.
+- [ ] Replace `bridge_copy_bidirectional`'s opaque loops with frame-aware loops feeding the runner (preserve first-frame `FlowOpened` + EOF `FlowClosed`). Update the existing socketpair test to length-prefixed frames; add redactor + drop tests.
+- [ ] Broaden `metrics_server.rs:140` to `ends_with(".prom")`; update filter test (latency file now picked up). PASS. Commit.
+
+### Task 10: Flow-byte-log retention sweep in `cache prune`
+
+- [ ] `cache.rs` prune calls `flow_byte_log::sweep_retention(<audit-dir>/flow-bytes, 7)` via `mvm-core::config` path helper. Old-removed/fresh-kept test. Commit.
+
+### Task 11: Fuzz target + plan-doc tick + claim catalog
+
+- [ ] `crates/mvm-hostd/fuzz/fuzz_targets/fuzz_packet_parse.rs` (parse→rebuild round-trip, no panic); register in `security.yml` + root `Cargo.toml` exclude. Tick boxes; note `on_packet` fail-closed under claim 10 in `specs/claims/catalog.md`. Commit.
+
+---
+
+## Verification (end-to-end)
+
+```bash
+rustup run nightly cargo fmt --all -- --check
+cargo nextest run -E 'not package(mvm-backend)'   # mvm-backend test bin SIGKILLed by macOS codesign (env-only)
+cargo test --workspace --doc
+cargo clippy --workspace -- -D warnings
+```
+
+Live (libkrun/gvproxy arm; force libkrun + isolate caches per memory
+`project_dev_host_runs_builder_via_vz`): run a workload with an
+allowlisted payload-tap observer; confirm modification on the wire,
+`mvmctl audit verify` green, kill-flow emits `gateway.flow_observer_fault`,
+`/metrics` shows `mvm_observer_latency_us_*`. Passt arm verified on
+Linux/KVM CI (or a Lima KVM test env — memory `project_lima_removed`).
+
+---
+
+## Out of scope (deferred)
+
+All Vz changes (Swift refactor, fd-handoff, `VzIngest`→`VzManaged`, Vz
+`payload_tap` flip Q7, `mvm-vz-drainer` deletion Q10) → **Plan 152**.
+AppleContainer payload tap → own plan. Flow-byte-log encryption-at-rest →
+own ADR. Per-observer timeout enforcement, TCP RST on kill, IP
+extension-header rebuild, async/ring-buffered execution,
+`Defer`/`DropPacket`-vs-`KillFlow` variants → all deferred.
 
 ---
 
 ## Status
 
-🟡 **Design captured 2026-06-01; brainstorm paused mid-Q7.** Resume
-via the brainstorm context at
-`/Users/auser/.claude/plans/context-for-resuming-plan-robust-brook.md`,
-close Q7–Q10, then re-render Tasks via `superpowers:writing-plans`.
-Not yet on a branch.
-
----
-
-## Self-review
-
-- **Scope coverage** vs ADR-064 §Decision 8: closes the carve-out (Vz
-  reports `payload_tap: true`), achieves cross-backend parity (Rust
-  owns shuffle), establishes the architectural template AppleContainer
-  inherits.
-- **No placeholders** of the "engineer adapts" / "TBD" variety in the
-  Files or Architecture sections — every field, struct, and call site
-  named is real. The Tasks section is intentionally a placeholder
-  pending Q7–Q10 closure; the **placeholder is named as such**, not
-  hidden as fake content.
-- **Plan numbering:** 141 is the next free slot — confirmed via
-  `ls specs/plans/14[1-9]-*.md` (no matches). Plan 132's
-  brainstorm-context guess was stale (132 became
-  programmable-storage-io).
-- **No backwards-compat shim** for the deleted
-  `NetworkConfig.gvproxy` variant — matches memory
-  `feedback_no_backcompat_first_version`.
-- **References the existing memory + ADR base correctly:** ADR-064 for
-  the architectural anchor, memory `project_gateway_audit_substrate_backend_coverage` for the AppleContainer carve-out, memory `feedback_no_placeholders_in_plans_or_code` for the no-placeholder discipline.
+🟢 Execution-ready (2026-06-04). Q8/Q9 closed via brainstorm; Q7/Q10 →
+Plan 152. `etherparse` confirmed absent → Task 1 adds it (0.20). Tasks 1–7
+core, 8–10 wiring, 11 fuzz+tick. Branch `feat/plan-141-packet-observer-core`.


### PR DESCRIPTION
## What

Implements Plan 141 (rescoped 2026-06-04, ADR-064 §8): a synchronous **packet-observer pipeline** — `Observer::on_packet(ctx, pkt) -> Verdict { Forward | Drop | Modify(Vec<u8>) }`, parsed once per frame via `etherparse`, fanned out in policy order — wired into the **gvproxy (libkrun)** and **Passt (Firecracker)** gateway-bridge variants. **No Vz changes** (delivered in-process by Plan 152).

Closes the open design questions and lands all 11 plan tasks.

## Design decisions

- **Q8 — `Modify` failure modes: uniform fail-closed.** Any `Modify` the bridge can't safely emit (over-MTU, unserializable) → kill the flow (`killed_flows`, drop this + subsequent packets) + emit a `gateway.flow_observer_fault` chain entry attributing the observer. On TCP a silent single-packet drop just stalls (retransmit→re-modify→re-fail), so one fail-closed terminal state is simpler and secure. `Modify(==original)` is a no-op; observer panic is `catch_unwind`-isolated → `Forward`.
- **Q9 — per-direction registration: minimal `Directions { Egress | Ingress | Both }`**, `directions()` default `Both` (existing flow-event observers untouched). Least-privilege: an egress observer never sees inbound bytes.
- **`etherparse`** was **not** a workspace dep despite prior plan prose; added `0.20`. It lands on the untrusted-guest-bytes path where claim 5 fuzzes parsers, so a mature parser beats a hand-rolled one.

## Structure

Backend-agnostic core (`crates/mvm-hostd/src/supervisor/network/`):
- `packet.rs` — pure parse + `rebuild_with_payload` (IP length + IP/TCP/UDP checksums; fail-closed on over-MTU / IP extensions / unserializable).
- `pipeline.rs` — `run_packet_pipeline` fan-out (direction-filtered, `catch_unwind`-isolated, chained `Modify`, first-`Drop`-wins, `PacketDecision::{Forward(Cow), Kill}`). Reuses the `signer_task` panic-isolation pattern.
- `latency.rs` — per-observer Prometheus summary → `metrics-<vm>-observer-latency.prom`.
- `flow_byte_log.rs` — opt-in append-only writer + retention sweep.
- `mod.rs` — `Observer::{on_packet, directions}` (defaulted); `Verdict` / `Directions` / `PacketCtx`.

Wiring + supporting:
- `gateway_bridge.rs` — `FlowEventKind::ObserverFault`, `ObserverWiring`, runner into the gvproxy datagram loop **and** a new frame-aware Passt loop (4-byte-BE qemu-socket reframe of `bridge_copy_bidirectional`; corrected the previously-reversed egress/ingress labels); per-VM `killed_flows`.
- `audit.rs` `flow_observer_fault`; `mvm-core` `NetworkPolicy.flow_byte_log`; `mvm-cli` metrics filter broadened to `metrics-*.prom`; `cache prune` retention sweep; `fuzz_packet_parse` target (security.yml).

## Security spine

Observers stay host-allowlisted, never tenant-shipped (ADR-064 §7 — `ObserverAllowlist` untouched). `Modify` fails closed so a redactor can never leak (claim 10). `directions()` is least-privilege (claim 1). Every kill is recorded in the chain-signed log; `mvmctl audit verify` still detects drift. Claim catalog left unchanged by design — this strengthens existing claim 10, it is not a new numbered claim.

## Testing

clippy `--workspace -D warnings` clean · nightly `fmt --all --check` clean · doctests clean · `nextest --workspace` 4470/4474 (the 4 failures are pre-existing macOS-environmental in `mvm-guest`/`mvm-oci` — crates untouched here). New unit + integration tests cover parse/rebuild, runner fan-out, gvproxy + framed-Passt redaction/drop, latency, flow-byte-log, metrics filter, and the cache sweep.

**Caveat:** the gvproxy arm is exercised by in-process integration tests; the **Passt arm is Linux-only** and its qemu-socket wire framing is validated on Linux/KVM CI, not on macOS (the reframe *logic* is duplex-unit-tested).