### PR TITLE
fix(ci): install libkrun for macOS release builds (unblocks release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,18 @@ env:
 jobs:
   build:
     strategy:
+      # Each target publishes independently — one target's failure must not
+      # cancel the others, or a single flaky job strands the whole release.
+      fail-fast: false
       matrix:
         include:
           - target: aarch64-apple-darwin
             os: macos-latest
+          # macos-latest is Apple Silicon; an x86_64 mvmctl links libkrun
+          # (Plan 87 W5) and can't link the host's arm64 dylib, so build
+          # the Intel binary on an Intel runner where libkrun is native.
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
@@ -45,6 +51,15 @@ jobs:
       # same as the ci.yml Lint job. Without this the release binary build
       # fails at "cargo zigbuild failed for mvm-host-vm-init".
       - uses: ./.github/actions/install-zigbuild
+
+      # macOS mvmctl links libkrun directly (Plan 87 W5): build.rs runs
+      # bindgen against libkrun.h and emits `-lkrun`, and the runtime
+      # kernel-extraction path needs libkrunfw. Both ship via the slp/krun
+      # Homebrew tap. Without them the build panics in libkrun-sys/build.rs
+      # ("libkrun.h was not found"). Linux uses Firecracker — no libkrun.
+      - name: Install libkrun (macOS backend FFI)
+        if: runner.os == 'macOS'
+        run: brew install slp/krun/libkrun slp/krun/libkrunfw
 
       - name: Install cross-compilation tools (Linux aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
Follows #608. With the zig install fixed, the macOS release build reached the real `cargo build` and panicked in `libkrun-sys/build.rs`:

```
error: failed to run custom build command for libkrun-sys v0.16.0
thread 'main' panicked at crates/deps/libkrun-sys/build.rs:26:9:
libkrun-sys feature is enabled but libkrun.h was not found.
```

## Root cause

On macOS the `mvmctl` binary links libkrun directly (Plan 87 W5, root `Cargo.toml:385` — `mvm-cli` gets the `libkrun-sys` feature under `cfg(target_os="macos")`). `libkrun-sys`'s build.rs runs bindgen against `libkrun.h` and emits `-lkrun` so the runtime libkrunfw kernel-extraction path is wired; the no-libkrun fallback is the dead ur-seed stub. The release `build` job never installed libkrun, so **both** macOS targets failed — including native aarch64 (it only built locally on dev Macs that already have the Homebrew trio).

## Fix

- `brew install slp/krun/libkrun slp/krun/libkrunfw` on macOS jobs.
- Build `x86_64-apple-darwin` on **macos-13** (Intel): `macos-latest` is Apple Silicon and can't link an arm64 libkrun dylib into an x86_64 binary; the Intel runner links a native libkrun and the native smoke test runs.
- `fail-fast: false` so one target's failure no longer cancels the rest.

Both apple-darwin targets are required by `install.sh` and the Homebrew formula's `on_intel`/`on_arm`, so neither is dropped. The libkrun-sys zigbuild leg (host-vm musl cross-compile) was separately validated to produce correct static aarch64 ELF binaries on an Apple Silicon host.