### PR TITLE
docs(plans 123,140): cross-ref the plan 122 D VMGenID substrate

### DIFF
--- a/specs/plans/123-network-storage-warmstart.md
+++ b/specs/plans/123-network-storage-warmstart.md
@@ -119,7 +119,7 @@ The honest matrix from the capability check. `VmBackend` already carries a pause
 
 ADR-066 §7 — the ~1s resume recipe. Builds on `instance_snapshot.rs` (`vmstate.bin`/`mem.bin`/`PostRestore`).
 
-- [ ] **Step 1:** Failing test (live-KVM gated) — a snapshot + restore round-trips: the guest resumes, vsock re-auths via `PostRestore`, and **the VMGenID rotates + the guest CSPRNG reseeds** (122 Phase D — composes here).
+- [ ] **Step 1:** Failing test (live-KVM gated) — a snapshot + restore round-trips: the guest resumes, vsock re-auths via `PostRestore`, and **the VMGenID rotates + the guest CSPRNG reseeds** (122 Phase D — composes here). 122 D shipped the *substrate* (`vmgenid::fresh_generation_token` host mint; `mvm_guest::genid::GenIdReseeder` guest reseed); the piece to build here is the **delivery** — send `GuestRequest::PostRestore` carrying the `GenerationToken` and call `GenIdReseeder::on_genid` in the guest handler (no host `PostRestore` sender exists today). Entropy-source note: 122 D stirs `/dev/urandom`; 140 gap #2 may swap that for virtio-rng + `RNDADDENTROPY` — `GenIdReseeder` isolates the reseed source from the change-detection, so either composes.
 - [ ] **Step 2:** Wire: diff/layered snapshots (one read-only golden base + a COW per-VM delta — Phase B3's snapshot-upper), a `userfaultfd` page-fault handler streaming from a content-addressed memfile, an NBD-served rootfs, 2 MB hugepages. Evaluate `userfaultfd` crate vs raw `libc` ioctls (dep budget). Snapshot artifacts are content-addressed + signed (122 Phase C). Commit per sub-piece.
 - [ ] **Step 3:** SIGUSR1 ready-barrier — a workload signals "primed"; the host snapshots at that point for a deterministic warm base. Test the barrier. Commit.
 

--- a/specs/plans/140-snapshot-restore-productionization.md
+++ b/specs/plans/140-snapshot-restore-productionization.md
@@ -45,6 +45,18 @@ gated by `macos_supports_vz_snapshots()`. So the snapshot lever splits:
       seed over vsock) and `RNDADDENTROPY` into `/dev/random`. Add an on-resume
       agent action; host provides a unique seed per wake.
 
+  > **Substrate already shipped (plan 122 D):** `mvm_guest::genid::GenIdReseeder`
+  > *is* the on-resume agent action — it tracks the host's per-wake
+  > `mvm_core::crypto::vmgenid::GenerationToken` (content-bound, fresh per
+  > resume) and reseeds on a change. It currently stirs `/dev/urandom` with the
+  > token, so this gap is to **extend the reseed source** to virtio-rng (or a
+  > vsock-delivered seed) + `RNDADDENTROPY` into `/dev/random` — `GenIdReseeder`
+  > isolates the reseed source from the change-detection, so swap the source,
+  > don't rebuild the detector. The host→guest **delivery** (send
+  > `GuestRequest::PostRestore` carrying the token; call `GenIdReseeder::on_genid`
+  > in the guest handler) is unwired today — no host `PostRestore` sender exists —
+  > and lands with plan 123 C2/C3's restore round-trip.
+
 ### 3. No clock resync — frozen wallclock
 - [ ] Restored VM resumes at snapshot wallclock. On resume the guest agent reads
       host time over vsock and `settimeofday()` (pairs with #2 in one on-resume


### PR DESCRIPTION
The VMGenID reseed story spans several plans. **122 D** (merged) shipped the substrate; the **delivery** + **production reseed** land in **123** and **140**. This points those plans at the real symbols so the next person wiring it doesn't rebuild it or miss the entropy-source decision.

- **123 C2 Step 1** (Firecracker restore) already said "122 D composes here" — now names the substrate (`vmgenid::fresh_generation_token`, `mvm_guest::genid::GenIdReseeder`), spells out that the piece to build is the **delivery** (host sends `PostRestore` carrying the `GenerationToken`; guest calls `GenIdReseeder::on_genid`) — no host `PostRestore` sender exists today — and notes the `/dev/urandom` vs virtio-rng source choice.
- **140 gap #2** (entropy reseed) had **no 122-D reference** and described building the on-resume reseed action fresh. Reframed as **extending the reseed source** (virtio-rng + `RNDADDENTROPY`) without rebuilding the change-detector, with a pointer to where delivery lands (123 C2/C3).

Docs only — no code, no new spec numbers.