### PR TITLE
fix(bridge): bind gvproxy-facing datagram socket + live DHCP e2e test

### DIFF
--- a/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
@@ -878,10 +878,23 @@ async fn run_libkrun_gvproxy_bridge(
             return;
         }
     };
-    let outbound = match UnixDatagram::unbound() {
+    // The gvproxy-facing socket MUST be bound to a pathname, not left
+    // unbound/autobind: gvproxy refuses datagrams from an empty-address
+    // peer ("vfkit accept error: vfkit socket address is empty") and needs
+    // a concrete address to send replies back to. macOS additionally never
+    // autobinds AF_UNIX datagram sockets, so an unbound socket here has no
+    // address at all and the gateway can neither accept our frames nor
+    // reply. Bind a sibling path next to the libkrun-facing listener.
+    let outbound_bind_path = gvproxy_outbound_bind_path(&supervisor_listen_path);
+    let _ = std::fs::remove_file(&outbound_bind_path);
+    let outbound = match UnixDatagram::bind(&outbound_bind_path) {
         Ok(s) => s,
         Err(e) => {
-            tracing::error!(error = %e, "gvproxy bridge: failed to create gvproxy-facing socket");
+            tracing::error!(
+                path = %outbound_bind_path.display(),
+                error = %e,
+                "gvproxy bridge: failed to bind gvproxy-facing socket"
+            );
             return;
         }
     };
@@ -1106,8 +1119,19 @@ async fn run_libkrun_gvproxy_bridge(
 
     let result = tokio::join!(egress, ingress);
     let _ = result;
-    // Cleanup the listener socket on shutdown.
+    // Cleanup both bound sockets on shutdown.
     let _ = std::fs::remove_file(&supervisor_listen_path);
+    let _ = std::fs::remove_file(&outbound_bind_path);
+}
+
+/// Bind path for the bridge's gvproxy-facing datagram socket — a sibling
+/// of the libkrun-facing listener (`<listen>.gw-out`). Must be a real
+/// pathname: gvproxy rejects empty-address peers and macOS never
+/// autobinds AF_UNIX datagram sockets.
+fn gvproxy_outbound_bind_path(supervisor_listen_path: &std::path::Path) -> PathBuf {
+    let mut s = supervisor_listen_path.as_os_str().to_os_string();
+    s.push(".gw-out");
+    PathBuf::from(s)
 }
 
 // ============================================================================
@@ -1931,6 +1955,216 @@ mod tests {
         }
         assert!(saw_fault, "an ObserverFault event must be emitted on drop");
         bridge.abort();
+    }
+
+    // -----------------------------------------------------------------
+    // Plan 141 follow-up — live DHCP handshake through a REAL gateway
+    // (gvproxy / rvproxy). Opt-in (MVM_GATEWAY_DHCP_E2E=1); skips when
+    // unset or when the gateway binary is absent. Validates the macOS
+    // gvproxy datagram arm end-to-end against a real userspace gateway:
+    // no microVM, no KVM. Doubles as an rvproxy drop-in conformance check
+    // (point MVM_GATEWAY_BIN at it once it speaks the gvproxy `-listen-vfkit`
+    // CLI + vfkit/DHCP contract — see rvproxy's GVPROXY_CONFORMANCE.md).
+    // -----------------------------------------------------------------
+
+    fn free_tcp_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    /// A minimal BOOTP/DHCP DISCOVER wrapped in UDP/IPv4/Ethernet. `src`
+    /// MAC is the pretend-guest; destination is L2 broadcast, IP
+    /// 0.0.0.0 → 255.255.255.255, UDP 68 → 67. Option 53 = 1 (DISCOVER).
+    fn build_dhcp_discover(mac: [u8; 6]) -> Vec<u8> {
+        // op = BOOTREQUEST, htype = Ethernet, hlen = 6, hops = 0.
+        let mut dhcp = vec![1u8, 1, 6, 0];
+        dhcp.extend_from_slice(&0x1234_5678u32.to_be_bytes()); // xid
+        dhcp.extend_from_slice(&0u16.to_be_bytes()); // secs
+        dhcp.extend_from_slice(&0u16.to_be_bytes()); // flags (unicast)
+        dhcp.extend_from_slice(&[0u8; 4]); // ciaddr
+        dhcp.extend_from_slice(&[0u8; 4]); // yiaddr
+        dhcp.extend_from_slice(&[0u8; 4]); // siaddr
+        dhcp.extend_from_slice(&[0u8; 4]); // giaddr
+        let mut chaddr = [0u8; 16];
+        chaddr[..6].copy_from_slice(&mac);
+        dhcp.extend_from_slice(&chaddr); // chaddr (16)
+        dhcp.extend_from_slice(&[0u8; 64]); // sname
+        dhcp.extend_from_slice(&[0u8; 128]); // file
+        dhcp.extend_from_slice(&[0x63, 0x82, 0x53, 0x63]); // DHCP magic cookie
+        dhcp.extend_from_slice(&[53, 1, 1]); // option 53 = DISCOVER
+        dhcp.push(255); // end
+        while dhcp.len() < 300 {
+            dhcp.push(0); // pad to a conventional minimum BOOTP size
+        }
+        let builder = etherparse::PacketBuilder::ethernet2(mac, [0xff; 6])
+            .ipv4([0, 0, 0, 0], [255, 255, 255, 255], 64)
+            .udp(68, 67);
+        let mut out = Vec::with_capacity(builder.size(dhcp.len()));
+        builder.write(&mut out, &dhcp).unwrap();
+        out
+    }
+
+    /// Extract the DHCP message-type (option 53) from an ethernet frame,
+    /// or `None` if it isn't a well-formed DHCP packet. 2 = OFFER.
+    fn dhcp_msg_type(frame: &[u8]) -> Option<u8> {
+        let sliced = etherparse::SlicedPacket::from_ethernet(frame).ok()?;
+        let payload = match sliced.transport? {
+            etherparse::TransportSlice::Udp(u) => u.payload(),
+            _ => return None,
+        };
+        if payload.len() < 240 || payload[236..240] != [0x63, 0x82, 0x53, 0x63] {
+            return None;
+        }
+        let mut i = 240;
+        while i < payload.len() {
+            match payload[i] {
+                255 => break, // end
+                0 => i += 1,  // pad
+                code => {
+                    let len = *payload.get(i + 1)? as usize;
+                    if code == 53 && len >= 1 {
+                        return payload.get(i + 2).copied();
+                    }
+                    i += 2 + len;
+                }
+            }
+        }
+        None
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gvproxy_dhcp_offer_roundtrips_through_bridge() {
+        if std::env::var("MVM_GATEWAY_DHCP_E2E").is_err() {
+            eprintln!("skip: set MVM_GATEWAY_DHCP_E2E=1 to run the live gateway DHCP test");
+            return;
+        }
+        let gw_bin = std::env::var("MVM_GATEWAY_BIN").unwrap_or_else(|_| "gvproxy".to_string());
+        let tmp = tempfile::tempdir().unwrap();
+        let gw_sock = tmp.path().join("gw.sock");
+        let gw_log = tmp.path().join("gw.log");
+        let stdio = std::fs::File::create(tmp.path().join("gw-stdio.log")).unwrap();
+
+        // Real gateway: `-listen-vfkit unixgram://<sock>` is the contract
+        // (gvproxy's, and what rvproxy must match). `-ssh-port` is
+        // gvproxy-specific (it always binds an SSH-forward listener); only
+        // pass it for gvproxy so other gateways aren't tripped by an
+        // unknown flag.
+        let mut cmd = std::process::Command::new(&gw_bin);
+        cmd.arg("-listen-vfkit")
+            .arg(format!("unixgram://{}", gw_sock.display()))
+            .arg("-log-file")
+            .arg(&gw_log)
+            .stdout(stdio.try_clone().unwrap())
+            .stderr(stdio);
+        let is_gvproxy = std::path::Path::new(&gw_bin)
+            .file_name()
+            .is_none_or(|n| n == "gvproxy");
+        if is_gvproxy {
+            cmd.arg("-ssh-port").arg(free_tcp_port().to_string());
+        }
+        let mut gateway = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skip: cannot spawn gateway {gw_bin:?}: {e}");
+                return;
+            }
+        };
+
+        // Wait for the gateway to create its listener socket.
+        let mut ready = false;
+        for _ in 0..100 {
+            if gw_sock.exists() {
+                ready = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        if !ready {
+            let _ = gateway.kill();
+            let log = std::fs::read_to_string(tmp.path().join("gw-stdio.log")).unwrap_or_default();
+            panic!(
+                "gateway {gw_bin:?} never created {} (stdio: {log})",
+                gw_sock.display()
+            );
+        }
+
+        // Bridge: gvproxy-facing = the gateway's socket; libkrun-facing =
+        // a listener the harness connects to.
+        let sup_listen = tmp.path().join("sup.sock");
+        let (tx, mut rx) = mpsc::channel::<FlowEvent>(64);
+        let policy: Arc<dyn FlowPolicy> = Arc::new(AllowAll);
+        let bridge = tokio::spawn(run_libkrun_gvproxy_bridge(
+            gw_sock.clone(),
+            sup_listen.clone(),
+            "vm-dhcp".to_string(),
+            "t".to_string(),
+            policy,
+            tx,
+            wiring_with(vec![]),
+        ));
+
+        // Harness plays the VMM (vfkit/libkrun). It MUST be bound to a
+        // pathname so the gateway can address its DHCP reply back.
+        let harness_path = tmp.path().join("harness.sock");
+        let harness = tokio::net::UnixDatagram::bind(&harness_path).unwrap();
+        let mut connected = false;
+        for _ in 0..100 {
+            if harness.connect(&sup_listen).is_ok() {
+                connected = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(connected, "bridge never bound {}", sup_listen.display());
+
+        // vfkit announces itself with a 4-byte "VFKT" handshake datagram,
+        // then sends ethernet frames. (Bridge forwards both verbatim.)
+        let mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x42];
+        harness.send(b"VFKT").await.unwrap();
+        harness.send(&build_dhcp_discover(mac)).await.unwrap();
+
+        // Read until we see a DHCP OFFER or time out. The gateway may emit
+        // other frames (ARP, etc.) first.
+        let mut buf = vec![0u8; 65536];
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(8);
+        let mut got_offer = false;
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(
+                std::time::Duration::from_millis(500),
+                harness.recv(&mut buf),
+            )
+            .await
+            {
+                Ok(Ok(n)) if dhcp_msg_type(&buf[..n]) == Some(2) => {
+                    got_offer = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        // A FlowOpened must have been emitted (observer pipeline fired on
+        // the real-gateway path).
+        let mut saw_open = false;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev.kind, FlowEventKind::Opened) {
+                saw_open = true;
+            }
+        }
+
+        let _ = gateway.kill();
+        let _ = gateway.wait();
+        bridge.abort();
+
+        let log = std::fs::read_to_string(tmp.path().join("gw-stdio.log")).unwrap_or_default();
+        assert!(
+            got_offer,
+            "no DHCP OFFER returned through the bridge from {gw_bin:?} (gateway stdio: {log})"
+        );
+        assert!(saw_open, "bridge must emit a FlowOpened for the exchange");
     }
 
     /// Plan-doc-shaped `ExecutionPlan` for fan-out tests. Mirrors the


### PR DESCRIPTION
## What

Adds a live, no-KVM **real-gateway DHCP round-trip test** for the libkrun
gvproxy gateway bridge (Plan 141 follow-up) — and it found a real,
**pre-existing** bug, which this PR fixes.

## The bug

`run_libkrun_gvproxy_bridge` created its gvproxy-facing socket with
`UnixDatagram::unbound()`. Against the **real** gvproxy binary that fails:

```
gvproxy exiting: vfkit accept error: vfkit socket address is empty
```

macOS never autobinds AF_UNIX datagram sockets, and gvproxy refuses an
empty-address peer (it has nowhere to send DHCP/replies back to). So the
`LibkrunGvproxy` audit bridge never actually worked against real gvproxy
on macOS. The in-process tests missed it because they used a fake gateway
that replied to the cached peer without enforcing a pathname.

This predates Plan 141 (the unbound socket was in the original W6.A
gvproxy bridge); Plan 141's framing work just gave us the live test that
surfaced it.

## The fix

Bind the gvproxy-facing socket to a sibling pathname (`<listen>.gw-out`)
before connecting, via `gvproxy_outbound_bind_path()`, and clean it up on
shutdown.

## The test

New opt-in, gateway-agnostic in-crate test
`gvproxy_dhcp_offer_roundtrips_through_bridge`:

- Gate: `MVM_GATEWAY_DHCP_E2E=1`; gateway binary via `MVM_GATEWAY_BIN`
  (default `gvproxy`). Skips cleanly when unset or the binary is absent,
  so the default suite is unaffected.
- Spawns the **real** gateway (`-listen-vfkit unixgram://<sock>`), runs the
  bridge, plays the VMM: sends the 4-byte `VFKT` handshake + a hand-built
  DHCP `DISCOVER`, and asserts a DHCP `OFFER` returns through the bridge
  plus a `FlowOpened` audit event.
- **No microVM, no KVM** — pure userspace; runs on macOS.
- Gateway-agnostic so it doubles as an **rvproxy drop-in conformance
  check** (`MVM_GATEWAY_BIN=rvproxy`). The contract rvproxy must meet is
  documented in rvproxy's `docs/gvproxy-conformance.md`.

## Verification

- `MVM_GATEWAY_DHCP_E2E=1 cargo test … gvproxy_dhcp_offer_roundtrips_through_bridge` — green against gvproxy v0.8.8.
- clippy `--workspace -D warnings` clean; nightly `fmt --all --check` clean; `nextest -p mvm-hostd` 676/676.

Distinct framing note confirmed along the way: vfkit (gvproxy/macOS) is one
raw ethernet frame per datagram (no length prefix); passt (Firecracker)
uses the 4-byte-BE qemu-socket stream framing.