### PR TITLE
fix(ci): release smoke test reads global.requests_total

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,8 @@ jobs:
           "$BIN" metrics --json | python3 -c "
           import sys, json
           d = json.load(sys.stdin)
-          assert 'requests_total' in d, 'metrics JSON missing requests_total'
+          # metrics JSON is sectioned: counters live under 'global'.
+          assert 'requests_total' in d.get('global', {}), 'metrics JSON missing global.requests_total'
           print('smoke test passed')
           "
 


### PR DESCRIPTION
With the deadlock fixed (#615), the release builds now **succeed** — the only remaining failure was the `Smoke test binary` step:

```
AssertionError: metrics JSON missing requests_total
```

`mvmctl metrics --json` is now sectioned — top level is `{global, instances}` and the counters live under `global`. The binary builds and runs fine; only the stale top-level assertion failed (hit all native-smoke-tested targets identically). Assert `global.requests_total` instead.

Verified against the freshly built binary locally: `smoke test passed`.