### PR TITLE
fix(jailer): use SYS_newfstatat on aarch64 (release aarch64-linux build)

### DIFF
--- a/crates/mvm-hostd/src/jailer/seccomp.rs
+++ b/crates/mvm-hostd/src/jailer/seccomp.rs
@@ -30,7 +30,7 @@ const TARGET_ARCH: TargetArch = TargetArch::aarch64;
 /// asserted-absent in `lib.rs::tests` as defense-in-depth.
 ///
 /// Architecture divergence: `stat` / `lstat` map to `SYS_stat` /
-/// `SYS_lstat` on x86_64 and are folded into `SYS_fstatat` on aarch64
+/// `SYS_lstat` on x86_64 and are folded into `SYS_newfstatat` on aarch64
 /// (aarch64 doesn't expose the path-stat syscalls separately).
 /// `epoll_wait` maps to `SYS_epoll_wait` on x86_64 and is folded into
 /// `SYS_epoll_pwait` on aarch64 for the same reason. The fold happens
@@ -91,10 +91,11 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     ("openat", libc::SYS_openat),
     ("close", libc::SYS_close),
     // arch divergence: aarch64 does not expose `stat` / `lstat` as
-    // their own syscalls — both fold into `fstatat`. The policy layer
-    // still references the names `stat` / `lstat` for readability.
-    ("stat", libc::SYS_fstatat),
-    ("lstat", libc::SYS_fstatat),
+    // their own syscalls — both fold into `newfstatat` (syscall 79; libc
+    // exposes no bare `SYS_fstatat` on aarch64). The policy layer still
+    // references the names `stat` / `lstat` for readability.
+    ("stat", libc::SYS_newfstatat),
+    ("lstat", libc::SYS_newfstatat),
     ("fstat", libc::SYS_fstat),
     ("socket", libc::SYS_socket),
     ("bind", libc::SYS_bind),


### PR DESCRIPTION
With the deadlock (#615) and smoke test (#616) fixed, the release builds run — and `aarch64-apple-darwin` ✅ + `x86_64-unknown-linux-gnu` ✅ now succeed. The last failing target is `aarch64-unknown-linux-gnu`:

```
error[E0425]: cannot find value `SYS_fstatat` in crate `libc`
  --> crates/mvm-hostd/src/jailer/seccomp.rs
error: could not compile `mvm-hostd` (lib) due to 2 previous errors
```

## Root cause

The aarch64 `BRIDGE_SYSCALLS` block folds `stat`/`lstat` into the path-stat syscall, but referenced `libc::SYS_fstatat` — which **does not exist on aarch64**. The folded syscall there is `newfstatat` (#79). x86_64 built fine (its block uses `SYS_stat`/`SYS_lstat`). Never caught because aarch64-linux release builds had never completed before this push.

Confirmed against libc 0.2.182's aarch64 module: `SYS_newfstatat = 79` present, `SYS_fstatat` absent. The change is inside an `#[cfg(target_arch = "aarch64")]` block, so x86_64 builds/tests are unaffected; the aarch64-linux release build is the validator.