### PR TITLE
build(release): defer x86_64-apple-darwin (Intel-macOS runners unavailable)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,15 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             os: macos-latest
-          # macos-latest is Apple Silicon; an x86_64 mvmctl links libkrun
-          # (Plan 87 W5) and can't link the host's arm64 dylib, so build
-          # the Intel binary on an Intel runner where libkrun is native.
-          - target: x86_64-apple-darwin
-            os: macos-13
+          # x86_64-apple-darwin (Intel mac) is DEFERRED. The macOS mvmctl
+          # links libkrun (Plan 87 W5), so an x86_64 binary must build on a
+          # native Intel runner — but GitHub's macos-13 Intel runners are
+          # unavailable to this org (jobs sit queued for hours, never
+          # starting), which blocked the whole release. Apple Silicon is the
+          # product baseline (macOS 26+); restore this when an Intel runner
+          # is available (hosted capacity or self-hosted) or via a libkrun
+          # cross-link. install.sh / the Homebrew on_intel arm still point at
+          # the (currently absent) asset.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
@@ -89,7 +93,7 @@ jobs:
         run: cargo build --release --target "${TARGET}" --features "${MVMCTL_RELEASE_FEATURES}"
 
       - name: Smoke test binary (native targets only)
-        if: matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-apple-darwin' || matrix.target == 'x86_64-apple-darwin'
+        if: matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-apple-darwin'
         env:
           TARGET: ${{ matrix.target }}
         shell: bash

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,9 @@ detect_target() {
   case "$os" in
     Darwin) case "$arch" in
         arm64|aarch64) echo "aarch64-apple-darwin" ;;
-        x86_64) echo "x86_64-apple-darwin" ;;
+        # Intel mac is deferred — no x86_64-apple-darwin asset is published
+        # yet (Intel-macOS CI runners unavailable). Apple Silicon only.
+        x86_64) die "Intel macOS is not supported yet — Apple Silicon macs and Linux only" ;;
         *) die "unsupported macOS arch: $arch" ;;
       esac ;;
     Linux) case "$arch" in

--- a/packaging/homebrew/mvmctl.rb.tmpl
+++ b/packaging/homebrew/mvmctl.rb.tmpl
@@ -10,13 +10,13 @@ class Mvmctl < Formula
   license "Apache-2.0"
 
   on_macos do
+    # Apple Silicon only. Intel mac (x86_64-apple-darwin) is deferred — no
+    # release asset is published for it yet (Intel-macOS CI runners are
+    # unavailable to this org). On an Intel mac Homebrew reports no bottle,
+    # which is the honest state until the target is restored.
     on_arm do
       url "https://github.com/tinylabscom/mvm/releases/download/v@@VERSION@@/mvmctl-aarch64-apple-darwin.tar.gz"
       sha256 "@@SHA_AARCH64_DARWIN@@"
-    end
-    on_intel do
-      url "https://github.com/tinylabscom/mvm/releases/download/v@@VERSION@@/mvmctl-x86_64-apple-darwin.tar.gz"
-      sha256 "@@SHA_X86_64_DARWIN@@"
     end
   end
 

--- a/packaging/homebrew/render-formula.sh
+++ b/packaging/homebrew/render-formula.sh
@@ -7,19 +7,18 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 
 sha_for() { grep " $1\$" "$CHECKSUMS" | awk '{print $1}' | head -n1; }
 
+# x86_64-apple-darwin (Intel mac) is deferred — no asset / checksum for it.
 A_DARWIN="$(sha_for mvmctl-aarch64-apple-darwin.tar.gz)"
-X_DARWIN="$(sha_for mvmctl-x86_64-apple-darwin.tar.gz)"
 A_LINUX="$(sha_for mvmctl-aarch64-unknown-linux-gnu.tar.gz)"
 X_LINUX="$(sha_for mvmctl-x86_64-unknown-linux-gnu.tar.gz)"
 
-for v in "$A_DARWIN" "$X_DARWIN" "$A_LINUX" "$X_LINUX"; do
+for v in "$A_DARWIN" "$A_LINUX" "$X_LINUX"; do
   [ -n "$v" ] || { echo "missing a checksum in $CHECKSUMS" >&2; exit 1; }
 done
 
 sed \
   -e "s/@@VERSION@@/$VERSION/g" \
   -e "s/@@SHA_AARCH64_DARWIN@@/$A_DARWIN/g" \
-  -e "s/@@SHA_X86_64_DARWIN@@/$X_DARWIN/g" \
   -e "s/@@SHA_AARCH64_LINUX@@/$A_LINUX/g" \
   -e "s/@@SHA_X86_64_LINUX@@/$X_LINUX/g" \
   "$HERE/mvmctl.rb.tmpl" > "$OUT"

--- a/tests/homebrew_render.rs
+++ b/tests/homebrew_render.rs
@@ -13,8 +13,8 @@ fn render_formula_fills_all_placeholders() {
     let checks = tmp.path().join("checksums-sha256.txt");
     std::fs::write(
         &checks,
+        // No x86_64-apple-darwin (Intel mac) — that target is deferred.
         "aaaa  mvmctl-aarch64-apple-darwin.tar.gz\n\
-         bbbb  mvmctl-x86_64-apple-darwin.tar.gz\n\
          cccc  mvmctl-aarch64-unknown-linux-gnu.tar.gz\n\
          dddd  mvmctl-x86_64-unknown-linux-gnu.tar.gz\n",
     )


### PR DESCRIPTION
## Why

With the five build bugs fixed (#608/#612/#615/#616/#617), the release builds **succeed** on three targets — `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`. The fourth, `x86_64-apple-darwin`, can only build on a native Intel runner (the macOS mvmctl links libkrun, Plan 87 W5), and GitHub's `macos-13` Intel runners are **unavailable to this org** — the job sat queued ~2.5h across runs and never started. Since the release-gate needs every build leg and queue time doesn't count against the 45-min execution timeout, it blocked the entire release indefinitely.

Apple Silicon is the product baseline (macOS 26+). Ship the three buildable targets now rather than block on an unobtainable runner.

## Changes

- **release.yml**: drop the `x86_64-apple-darwin` matrix leg + its smoke-test arm.
- **Homebrew** template/render/test: drop the macOS `on_intel` arm and its checksum. `render-formula.sh` hard-fails on a missing checksum, so leaving it would block the formula bump for *all* platforms. Linux `on_intel` (x86_64) stays — that target ships.
- **install.sh**: Intel mac now exits with a clear "not supported yet" message instead of fetching a 404.

Validated locally: render produces a valid formula (ruby -c OK, 0 placeholders), `homebrew_render` test passes, shellcheck clean.

## Restore path

Re-add the matrix leg (+ template/render/install arms) once an Intel runner is available (hosted capacity or self-hosted) or via a libkrun cross-link from the arm64 runner.