### PR TITLE
release: v0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3075,7 +3075,7 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libkrun-sys"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bindgen",
  "libc",
@@ -3281,7 +3281,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mvm"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-backend"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "block2",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-build"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-guest"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-guest-helpers"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "hickory-proto 0.26.1",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-hostd"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-mcp"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-network"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "mvm-core",
  "mvm-sdk",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-oci"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "hex",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -3605,11 +3605,11 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk-macros"
-version = "0.16.0"
+version = "0.16.1"
 
 [[package]]
 name = "mvm-storage"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-verify"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-vm-host"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "mvmctl"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ resolver = "3"
 # functionally different software. Bumping the minor signals "0.x
 # breaking changes" without prematurely committing to a 1.0 stability
 # promise.
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -304,34 +304,34 @@ tree-sitter-typescript = "0.23.2"
 # here because member crates can't override that on a workspace-inherited
 # dependency unless the workspace entry already carries it. The root binary
 # opts back into user-facing defaults through its own `[features]` block.
-mvm-core = { path = "crates/mvm-core", version = "0.16.0" }
-mvm-guest = { path = "crates/mvm-guest", version = "0.16.0" }
-mvm-build = { path = "crates/mvm-build", version = "0.16.0", default-features = false }
-mvm = { path = "crates/mvm", version = "0.16.0", default-features = false }
-mvm-oci = { path = "crates/mvm-oci", version = "0.16.0" }
-mvm-storage = { path = "crates/mvm-storage", version = "0.16.0" }
-mvm-network = { path = "crates/mvm-network", version = "0.16.0" }
-mvm-cli = { path = "crates/mvm-cli", version = "0.16.0", default-features = false }
-mvm-hostd = { path = "crates/mvm-hostd", version = "0.16.0" }
+mvm-core = { path = "crates/mvm-core", version = "0.16.1" }
+mvm-guest = { path = "crates/mvm-guest", version = "0.16.1" }
+mvm-build = { path = "crates/mvm-build", version = "0.16.1", default-features = false }
+mvm = { path = "crates/mvm", version = "0.16.1", default-features = false }
+mvm-oci = { path = "crates/mvm-oci", version = "0.16.1" }
+mvm-storage = { path = "crates/mvm-storage", version = "0.16.1" }
+mvm-network = { path = "crates/mvm-network", version = "0.16.1" }
+mvm-cli = { path = "crates/mvm-cli", version = "0.16.1", default-features = false }
+mvm-hostd = { path = "crates/mvm-hostd", version = "0.16.1" }
 
 # plan 60 Phase 5 — build-time SDK port from ../mvmforge.
-mvm-sdk = { path = "crates/mvm-sdk", version = "0.16.0" }
-mvm-sdk-macros = { path = "crates/mvm-sdk-macros", version = "0.16.0" }
-mvm-mcp = { path = "crates/mvm-mcp", version = "0.16.0" }
+mvm-sdk = { path = "crates/mvm-sdk", version = "0.16.1" }
+mvm-sdk-macros = { path = "crates/mvm-sdk-macros", version = "0.16.1" }
+mvm-mcp = { path = "crates/mvm-mcp", version = "0.16.1" }
 # Plan 57 W1 — libkrun FFI bindings split out of mvm-providers so the
 # bindgen + libclang build cost is isolated from the Apple-VZ objc2
 # stack. Default feature set is empty; consumers wanting real FFI
 # enable `libkrun-sys` on a host with libkrun installed.
-libkrun-sys = { path = "crates/deps/libkrun-sys", version = "0.16.0" }
+libkrun-sys = { path = "crates/deps/libkrun-sys", version = "0.16.1" }
 # Plan 97 Phase B — type-safe interface to `mvm-vz-supervisor`. No FFI,
 # Linux-safe (compiles everywhere; `Platform::has_vz()` short-circuits
 # on non-macOS).
-mvm-backend = { path = "crates/mvm-backend", version = "0.16.0", default-features = false }
+mvm-backend = { path = "crates/mvm-backend", version = "0.16.1", default-features = false }
 
 # Plan 73 Followup B.2.x — builder-VM egress allowlist proxy.
 # mvm-host-vm-init spawns this as a subprocess before the
 # installer + tears it down after.
-mvm-egress-proxy = { path = "crates/mvm-egress-proxy", version = "0.16.0" }
+mvm-egress-proxy = { path = "crates/mvm-egress-proxy", version = "0.16.1" }
 
 # Plan 113 / ADR-064 §Decision 5 — A2 confinement helper (seccompiler +
 # landlock). Consumed by the per-VM `mvm-firecracker-bridge` sidecar.


### PR DESCRIPTION
Patch release. Bumps the workspace to 0.16.1 so the next tag ships the fixes merged since v0.16.0 — most importantly #621 (apple-container rootfs double-prep), without which `mvmctl up` could not boot the default microVM image on macOS.

Version bump only (Cargo.toml + Cargo.lock).