### PR TITLE
test(ci): per-PR passt framing regression gate (Plan 141)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,23 @@ jobs:
       - name: Build mvmctl + run MCP roundtrip smoke
         run: ./scripts/test-mcp-roundtrip.sh
 
+  passt-framing:
+    name: Passt framing (real passt, no KVM)
+    runs-on: ubuntu-latest
+    # Plan 141 — lock in the gateway bridge's qemu-socket framing assumption
+    # against the real passt binary. passt is userspace (no KVM, no microVM),
+    # so this is a fast per-PR regression gate: it confirms passt's `--fd`
+    # transport frames each ethernet frame with a 4-byte big-endian length
+    # (what `gateway_bridge::{read,write}_one_frame` assume) by round-tripping
+    # a DHCP DISCOVER -> OFFER. The full Firecracker-boot E2E (needs /dev/kvm)
+    # remains a tracked deferred follow-up in specs/plans/141.
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install passt
+        run: sudo apt-get update && sudo apt-get install -y passt
+      - name: Confirm real passt uses the 4-byte-BE qemu-socket framing
+        run: python3 scripts/passt-framing-check.py
+
   nix-flake-check:
     name: Nix flake check (Linux eval)
     runs-on: ubuntu-latest

--- a/scripts/passt-framing-check.py
+++ b/scripts/passt-framing-check.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Confirm real passt's `--fd` qemu-socket framing matches the mvm bridge's
+assumption: each ethernet frame is prefixed with a 4-byte big-endian length.
+
+Spawns real passt on one end of an AF_UNIX SOCK_STREAM socketpair, sends a
+4-byte-BE-framed DHCP DISCOVER (exactly how `gateway_bridge::write_one_frame`
+frames it), and asserts passt replies with a 4-byte-BE-framed DHCP OFFER
+(read exactly how `read_one_frame` reads it). No KVM, no microVM — passt is
+userspace. This is the empirical check behind Plan 141's Passt-arm framing.
+"""
+import os, socket, struct, subprocess, sys, time
+
+def ip_checksum(b):
+    if len(b) % 2:
+        b += b"\x00"
+    s = sum(struct.unpack(f">{len(b)//2}H", b))
+    s = (s & 0xFFFF) + (s >> 16)
+    s = (s & 0xFFFF) + (s >> 16)
+    return (~s) & 0xFFFF
+
+def dhcp_discover(mac=b"\x02\x00\x00\x00\x00\x42"):
+    # BOOTP/DHCP DISCOVER
+    d = bytes([1, 1, 6, 0]) + struct.pack(">I", 0x12345678)
+    d += struct.pack(">HH", 0, 0)            # secs, flags
+    d += b"\x00" * 16                         # ciaddr,yiaddr,siaddr,giaddr
+    d += mac + b"\x00" * 10                   # chaddr (16)
+    d += b"\x00" * 64 + b"\x00" * 128         # sname, file
+    d += bytes([0x63, 0x82, 0x53, 0x63])      # magic cookie
+    d += bytes([53, 1, 1])                    # opt 53 = DISCOVER
+    d += bytes([55, 3, 1, 3, 6])              # opt 55 param request list
+    d += bytes([255])                         # end
+    d += b"\x00" * (300 - len(d))             # pad
+    # UDP 68 -> 67
+    udp = struct.pack(">HHHH", 68, 67, 8 + len(d), 0) + d
+    # IPv4 0.0.0.0 -> 255.255.255.255, proto 17
+    total = 20 + len(udp)
+    ip = struct.pack(">BBHHHBBH4s4s", 0x45, 0, total, 0, 0, 64, 17, 0,
+                     b"\x00\x00\x00\x00", b"\xff\xff\xff\xff")
+    ip = ip[:10] + struct.pack(">H", ip_checksum(ip)) + ip[12:]
+    # Ethernet: dst broadcast, src mac, IPv4
+    return b"\xff" * 6 + mac + b"\x08\x00" + ip + udp
+
+def dhcp_msg_type(frame):
+    # eth(14) + ip + udp(8) + bootp ... option 53 after magic cookie
+    if len(frame) < 14 + 20 + 8:
+        return None
+    ihl = (frame[14] & 0x0F) * 4
+    udp_off = 14 + ihl
+    if frame[14 + 9] != 17:  # proto UDP
+        return None
+    dhcp = frame[udp_off + 8:]
+    if len(dhcp) < 240 or dhcp[236:240] != bytes([0x63, 0x82, 0x53, 0x63]):
+        return None
+    i = 240
+    while i < len(dhcp):
+        c = dhcp[i]
+        if c == 255:
+            break
+        if c == 0:
+            i += 1
+            continue
+        ln = dhcp[i + 1]
+        if c == 53 and ln >= 1:
+            return dhcp[i + 2]
+        i += 2 + ln
+    return None
+
+def main():
+    passt = sys.argv[1] if len(sys.argv) > 1 else "passt"
+    parent, child = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    os.set_inheritable(child.fileno(), True)
+    proc = subprocess.Popen(
+        [passt, "--fd", str(child.fileno()), "-f", "--quiet", "--mtu", "65520"],
+        pass_fds=[child.fileno()],
+    )
+    child.close()
+    time.sleep(0.7)  # let passt initialize
+    try:
+        frame = dhcp_discover()
+        parent.sendall(struct.pack(">I", len(frame)) + frame)  # 4-byte BE prefix
+        parent.settimeout(6.0)
+        deadline = time.time() + 6.0
+        buf = b""
+        while time.time() < deadline:
+            try:
+                chunk = parent.recv(65536)
+            except socket.timeout:
+                break
+            if not chunk:
+                break
+            buf += chunk
+            # parse 4-byte-BE-framed frames out of the stream
+            while len(buf) >= 4:
+                n = struct.unpack(">I", buf[:4])[0]
+                if n > 65535:
+                    print(f"FAIL: implausible frame length {n} -> framing mismatch")
+                    return 1
+                if len(buf) < 4 + n:
+                    break
+                f, buf = buf[4:4 + n], buf[4 + n:]
+                mt = dhcp_msg_type(f)
+                if mt == 2:
+                    print("PASS: real passt accepted 4-byte-BE-framed DISCOVER and "
+                          "returned a 4-byte-BE-framed DHCP OFFER")
+                    return 0
+        print("FAIL: no DHCP OFFER seen within timeout (framing or passt config)")
+        return 1
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except Exception:
+            proc.kill()
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/plans/141-vz-payload-tap-and-rust-owned-shuffle.md
+++ b/specs/plans/141-vz-payload-tap-and-rust-owned-shuffle.md
@@ -228,17 +228,23 @@ extension-header rebuild, async/ring-buffered execution,
 
 ### Deferred follow-ups
 
-- [ ] **Passt/Firecracker live KVM validation.** The gvproxy arm is now
-  live-validated against the real gateway (PR #614); the Passt arm is
-  protocol-confirmed + unit-tested but has never run a real
-  Firecracker+passt packet round-trip. Closing it needs a Linux host with
-  `/dev/kvm`. **Route A (no extra infra):** a CI lane on a KVM-capable
+- [x] **Passt framing confirmed against real passt + CI-gated.** The
+  gvproxy arm is live-validated against the real gateway (PR #614); the
+  Passt arm's qemu-socket framing is now confirmed against the real passt
+  binary by `scripts/passt-framing-check.py` (spawns `passt --fd`, sends a
+  4-byte-BE-framed DHCP DISCOVER, asserts a 4-byte-BE-framed OFFER comes
+  back — no KVM, passt is userspace). Wired as the per-PR `passt-framing`
+  job in `ci.yml`. This locks in the framing assumption behind
+  `gateway_bridge::{read,write}_one_frame`.
+- [ ] **Full Firecracker-boot E2E on `/dev/kvm`.** A real microVM boot +
+  passt + the bridge, end-to-end, still hasn't run — it needs a Linux host
+  with `/dev/kvm`. **Route A (no extra infra):** a lane on a KVM-capable
   runner — GitHub `ubuntu-latest` exposes `/dev/kvm` and `ci-full.yml`'s
   `workload-spawn-smoke-linux` already boots Firecracker there; add a
   passt+bridge DHCP/observer assertion. **Route B:** a remote `/dev/kvm`
-  box for interactive runs. Low risk (the framing is the documented
-  qemu-socket 4-byte-BE format; the reframer is duplex-unit-tested) — the
-  gap is a live KVM environment, not code.
+  box for interactive runs. Low marginal value now that the framing
+  (the actual risk) is confirmed + CI-gated — the boot mostly re-confirms
+  it; intentionally left deferred.
 
 ---
 
@@ -270,9 +276,14 @@ flow-byte-log, metrics filter, cache sweep). `fuzz_packet_parse` runs in
   is documented in rvproxy's `docs/gvproxy-conformance.md` (rvproxy PR #7);
   the same test is rvproxy's drop-in conformance gate (gvproxy passes;
   rvproxy fails only at the `-listen-vfkit` CLI surface).
-- **Passt (Firecracker) arm — protocol-confirmed, live test deferred.**
-  passt uses the qemu-socket protocol (4-byte-BE length prefix, confirmed
-  via passt.top); the reframer is duplex-unit-tested and Linux CI
-  builds/tests it. A real Firecracker+passt round-trip on `/dev/kvm` has
-  not run — tracked under [§Deferred follow-ups](#deferred-follow-ups).
-  Low risk; the gap is a live KVM environment, not code.
+- **Passt (Firecracker) arm — framing confirmed against real passt +
+  CI-gated; full boot deferred.** passt uses the qemu-socket protocol
+  (4-byte-BE length prefix). This is now confirmed against the **real
+  passt binary** by `scripts/passt-framing-check.py` (DHCP DISCOVER→OFFER
+  round-trip over `passt --fd`, no KVM), wired as the per-PR
+  `passt-framing` job in `ci.yml` — locking in the assumption behind
+  `gateway_bridge::{read,write}_one_frame`. The reframer is also
+  duplex-unit-tested. The only thing not run is a full Firecracker microVM
+  boot on `/dev/kvm` — tracked under
+  [§Deferred follow-ups](#deferred-follow-ups); low marginal value now,
+  the gap is a live KVM environment, not code.


### PR DESCRIPTION
Turns the one-off confirmation that the gateway bridge's framing matches
real passt into a durable, per-PR regression gate — the last cheap Plan 141
follow-up.

## What

- `scripts/passt-framing-check.py`: spawns `passt --fd`, sends a
  **4-byte-BE-framed DHCP DISCOVER**, asserts a **4-byte-BE-framed DHCP
  OFFER** comes back — exactly the framing `gateway_bridge::{read,write}_one_frame`
  use. passt is userspace, so **no KVM / no microVM**.
- New `passt-framing` job in `ci.yml` (ubuntu-latest): `apt install passt`
  + run the harness. Fast (no Rust build).
- `specs/plans/141`: deferred-follow-ups updated — framing now confirmed +
  CI-gated; only the full Firecracker-boot-on-`/dev/kvm` E2E remains
  deferred (low marginal value now).

## Why this approach

The bridge's framing code is already duplex-unit-tested; the real-world
unknown was whether **real passt** uses exactly that 4-byte-BE qemu-socket
framing. This pins that. I verified the harness passes against real passt
(ubuntu noble, in an OrbStack VM) before committing, so the new lane should
be green on first run.

## Not in scope

Full Firecracker microVM boot + passt E2E on `/dev/kvm` — tracked deferred
item; the boot mostly re-confirms the framing this gate already locks in.