### PR TITLE
fix(guest): non-wrapper entrypoint marker is 'not offered', not a failure

### DIFF
--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -365,8 +365,13 @@ impl AgentBootState {
 
     fn set_entrypoint(&self, state: ComponentState) {
         if let Ok(mut s) = self.inner.lock() {
-            let became_terminal =
-                matches!(state, ComponentState::Ready | ComponentState::Failed { .. });
+            // `Disabled` is terminal too — an image that offers no per-call
+            // entrypoint resolves immediately (entrypoint starts as
+            // `Starting`), same as `set_warm_pool` treats its Disabled.
+            let became_terminal = matches!(
+                state,
+                ComponentState::Ready | ComponentState::Failed { .. } | ComponentState::Disabled
+            );
             s.entrypoint = state;
             if became_terminal && s.timing.entrypoint_ready_ms.is_none() {
                 s.timing.entrypoint_ready_ms = Some(self.elapsed_ms());
@@ -1438,18 +1443,30 @@ fn run_before_stop_hook() {
 /// `ReadinessStatus` reports `Ready` (or `Failed { message }`) and
 /// stamps `entrypoint_ready_ms` for cold-path timing.
 fn init_entrypoint_validation(boot_state: &Arc<AgentBootState>) {
-    let result = EntrypointPolicy::production()
-        .validate()
-        .map_err(|e| e.to_string());
-    match &result {
+    let result = match EntrypointPolicy::production().validate() {
         Ok(v) => {
             eprintln!(
                 "mvm-guest-agent: entrypoint validated at {} (held open for fexecve)",
                 v.resolved.display()
             );
             boot_state.set_entrypoint(ComponentState::Ready);
+            Ok(v)
         }
-        Err(msg) => {
+        Err(e) if e.is_entrypoint_not_offered() => {
+            // Boot-script image: the entrypoint is baked as PID 1's boot
+            // command, not a per-call wrapper under /usr/lib/mvm/wrappers/.
+            // RunEntrypoint is simply not offered here — a clean state, not a
+            // failure (the default/sealed-idle image and every command/shell
+            // image today). Reported as `Disabled`, logged calmly.
+            eprintln!(
+                "mvm-guest-agent: no per-call entrypoint wrapper baked; \
+                 RunEntrypoint not offered for this image"
+            );
+            boot_state.set_entrypoint(ComponentState::Disabled);
+            Err("this image does not offer a per-call entrypoint (RunEntrypoint)".to_string())
+        }
+        Err(e) => {
+            let msg = e.to_string();
             eprintln!(
                 "mvm-guest-agent: entrypoint validation failed at boot: {msg}; \
                  RunEntrypoint requests will return EntrypointInvalid"
@@ -1457,8 +1474,9 @@ fn init_entrypoint_validation(boot_state: &Arc<AgentBootState>) {
             boot_state.set_entrypoint(ComponentState::Failed {
                 message: msg.clone(),
             });
+            Err(msg)
         }
-    }
+    };
     let _ = VALIDATED_ENTRYPOINT.set(result);
 }
 

--- a/crates/mvm-guest/src/entrypoint.rs
+++ b/crates/mvm-guest/src/entrypoint.rs
@@ -232,6 +232,23 @@ pub enum ValidationError {
     },
 }
 
+impl ValidationError {
+    /// True when the marker shows the image simply does not expose a
+    /// per-call entrypoint *wrapper* — it bakes its entrypoint as PID 1's
+    /// boot command instead (the shape every `command`/`shell` image emits
+    /// today; mkGuest does not yet produce a `/usr/lib/mvm/wrappers/`
+    /// wrapper — see the wrapper-model plan). This is a clean "RunEntrypoint
+    /// not offered" state, NOT a failure.
+    ///
+    /// Deliberately narrow: only a non-absolute marker (a script body or a
+    /// relative path, never a wrapper path) counts. A marker that *is* an
+    /// absolute path but fails the ownership / mode / prefix / same-fs checks
+    /// is a real misconfiguration or tamper and stays a hard failure.
+    pub fn is_entrypoint_not_offered(&self) -> bool {
+        matches!(self, ValidationError::NotAbsolute { .. })
+    }
+}
+
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -1022,6 +1039,48 @@ mod tests {
             Err(ValidationError::NotAbsolute { .. }) => {}
             other => panic!("expected NotAbsolute, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn script_marker_classifies_as_not_offered_not_failed() {
+        // A boot-script image bakes a shell script at /etc/mvm/entrypoint
+        // (what `command`/`shell` mkGuest images emit), not an absolute
+        // wrapper path. The agent must treat that as "RunEntrypoint not
+        // offered", never a hard validation failure.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("etc/mvm")).unwrap();
+        let marker = tmp.path().join("etc/mvm/entrypoint");
+        std::fs::write(&marker, "#!/bin/sh\nexec /bin/sleep infinity\n").unwrap();
+        let policy = test_policy(marker, tmp.path().join("usr/lib/mvm/wrappers"), 0o755);
+        let err = policy
+            .validate()
+            .expect_err("script marker is not a wrapper");
+        assert!(
+            err.is_entrypoint_not_offered(),
+            "script marker must classify as not-offered, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn security_failure_is_not_classified_as_not_offered() {
+        // A marker that IS an absolute path but fails an ownership/mode/prefix
+        // check is a real failure, never silently downgraded to "not offered".
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("usr/lib/mvm/wrappers")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("etc/mvm")).unwrap();
+        let outside = tmp.path().join("usr/bin/evil");
+        std::fs::create_dir_all(outside.parent().unwrap()).unwrap();
+        std::fs::write(&outside, "x").unwrap();
+        let marker = tmp.path().join("etc/mvm/entrypoint");
+        std::fs::write(&marker, format!("{}\n", outside.display())).unwrap();
+        let policy = test_policy(marker, tmp.path().join("usr/lib/mvm/wrappers"), 0o755);
+        let err = policy
+            .validate()
+            .expect_err("path outside the allowed prefix");
+        assert!(
+            !err.is_entrypoint_not_offered(),
+            "a real security failure must stay a failure, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Option 3 of the entrypoint-marker follow-up — the narrow, safe fix.

## Problem

The agent (ADR-007) validates `/etc/mvm/entrypoint` at boot, expecting an absolute path to a per-call wrapper under `/usr/lib/mvm/wrappers/`. But every mkGuest image today bakes its entrypoint as **PID 1's boot command** — a setpriv shell script at that path — and produces no wrapper. So validation always failed `NotAbsolute` and logged `entrypoint validation failed at boot`, including on the **default microVM image** (observed while validating the v0.16.1 default-image boot), which has no per-call entrypoint by design.

## Fix

Reclassify the single non-absolute-marker case as **"RunEntrypoint not offered"** (a clean state), not a failure:
- `ComponentState::Disabled` instead of `Failed`; calm log line.
- `RunEntrypoint` returns a clear "this image does not offer a per-call entrypoint" message.
- A marker that **is** an absolute path but fails ownership/mode/prefix/same-fs stays a hard failure (`EntrypointInvalid`). **Security posture unchanged** — RunEntrypoint still refuses any non-wrapper marker; only the severity/classification of the boot-script case changes.

`ValidationError::is_entrypoint_not_offered()` + two tests (script marker → not offered; outside-prefix absolute path → still a failure). `set_entrypoint` now treats `Disabled` as terminal for timing, matching `set_warm_pool`.

## Follow-up (option 1, separate)

The real reconciliation — mkGuest emits a real `/usr/lib/mvm/wrappers/` wrapper + writes its absolute path to `/etc/mvm/entrypoint`, moving PID 1's boot command elsewhere, so `RunEntrypoint` works end-to-end — is being written up as its own implementation plan (security-sensitive; needs the wrapper-exec path designed carefully).