### PR TITLE
Builder: auto-GC the persistent /nix store so it stops growing unbounded (#630)

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -49,6 +49,39 @@ pub const DEFAULT_BUILDER_VM_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 /// disable the safety net.
 pub const MVM_BUILDER_VM_TIMEOUT_SECS_ENV: &str = "MVM_BUILDER_VM_TIMEOUT_SECS";
 
+/// Builder persistent `/nix` store auto-GC threshold (GiB of *used*
+/// space). When the in-guest store exceeds this after a build, the
+/// build script runs `nix-collect-garbage --delete-older-than 14d`.
+/// Default 24 GiB (above doctor's 20 GiB warning, below the 64 GiB
+/// sparse cap [`DEFAULT_NIX_STORE_MIB`](crate::libkrun_builder::DEFAULT_NIX_STORE_MIB)).
+/// Override: [`MVM_BUILDER_STORE_GC_GIB_ENV`]. #630
+///
+/// Lives here (always compiled) rather than in `libkrun_builder`
+/// (feature-gated `builder-vm`) because `render_flake_cmd_sh` reads it
+/// at render time and that path compiles unconditionally;
+/// `libkrun_builder` re-exports it near `DEFAULT_NIX_STORE_MIB` for
+/// discoverability.
+pub const DEFAULT_BUILDER_STORE_GC_GIB: u32 = 24;
+
+/// Env var that overrides [`DEFAULT_BUILDER_STORE_GC_GIB`]. Plain
+/// integer GiB; a missing/garbage/zero value falls back to the
+/// default (this is a best-effort space cap, not a correctness gate —
+/// a typo must not disable the just-built-closure-preserving GC). #630
+pub const MVM_BUILDER_STORE_GC_GIB_ENV: &str = "MVM_BUILDER_STORE_GC_GIB";
+
+/// Resolve the builder-store GC cap, in KiB, for substitution into the
+/// in-guest build script's `du -k` comparison. Reads
+/// [`MVM_BUILDER_STORE_GC_GIB_ENV`]; an unset, non-integer, or zero
+/// value falls back to [`DEFAULT_BUILDER_STORE_GC_GIB`]. #630
+pub fn builder_store_gc_cap_kib() -> u64 {
+    let gib = std::env::var(MVM_BUILDER_STORE_GC_GIB_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .filter(|g| *g > 0)
+        .unwrap_or(DEFAULT_BUILDER_STORE_GC_GIB);
+    u64::from(gib) * 1024 * 1024
+}
+
 /// Per-job dir filename mvm-host-vm-init detects to dispatch
 /// through the application-dependency install pipeline (Plan 73
 /// Followup B.2). Migrated from `libkrun_builder.rs` because the
@@ -310,6 +343,9 @@ fn render_flake_cmd_sh(flake_ref: &str, attr_path: &str, override_mvm: bool) -> 
             String::new(),
         )
     };
+    // #630: resolved on the host, baked as a literal into the script so
+    // the in-guest `du` comparison needs no env plumbing through the VM.
+    let gc_cap_kib = builder_store_gc_cap_kib();
     format!(
         r#"#!/bin/sh
 # mvm-builder-vm cmd.sh — emitted by BuilderVmRuntime (Plan 97
@@ -448,10 +484,21 @@ else
     cat /job/sidecar-direct.log /job/sidecar-rootfs.log >&2 || true
     rm -f /out/mvm-meta.json
 fi
+
+# Bound the persistent /nix store (#630): GC stale closures once it grows
+# past the cap. `--delete-older-than 14d` keeps the just-built closure
+# (recent) so rebuilds stay warm; only old-revision garbage is freed.
+# Best-effort and POST-build so it can never fail the build or lose output.
+store_kib=$(du -s -k /nix 2>/dev/null | cut -f1 || echo 0)
+if [ "$store_kib" -gt {gc_cap_kib} ]; then
+  echo "mvm-builder: /nix store ${{store_kib}} KiB > cap {gc_cap_kib} KiB — nix-collect-garbage --delete-older-than 14d" >&2
+  nix-collect-garbage --delete-older-than 14d >&2 2>&1 || echo "mvm-builder: nix-collect-garbage failed (continuing)" >&2
+fi
 "#,
         flake_ref_assign = flake_ref_assign,
         override_flag = override_flag,
         attr_path = shell_single_quote_escape(attr_path),
+        gc_cap_kib = gc_cap_kib,
     )
 }
 
@@ -1791,6 +1838,87 @@ mod tests {
             match old {
                 Some(v) => std::env::set_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV, v),
                 None => std::env::remove_var(MVM_BUILDER_VM_TIMEOUT_SECS_ENV),
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Builder persistent /nix store auto-GC (#630). The cap is resolved
+    // on the host and baked into the rendered cmd.sh; env mutation is
+    // serialised through GC_ENV_LOCK like the timeout tests above.
+    // -----------------------------------------------------------------
+
+    static GC_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    #[test]
+    fn render_flake_cmd_sh_embeds_gc_tail_with_default_cap() {
+        let _lock = GC_ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os(MVM_BUILDER_STORE_GC_GIB_ENV);
+        // SAFETY: tests serialise env mutation via GC_ENV_LOCK.
+        unsafe {
+            std::env::remove_var(MVM_BUILDER_STORE_GC_GIB_ENV);
+        }
+        let body = render_flake_cmd_sh(".", "default", false);
+        // Age-based GC is required (keeps the just-built closure warm).
+        assert!(
+            body.contains("nix-collect-garbage --delete-older-than 14d"),
+            "missing GC command in:\n{body}"
+        );
+        // 24 GiB default → 24 * 1024 * 1024 = 25165824 KiB, baked literal.
+        assert!(
+            body.contains("-gt 25165824 ]"),
+            "missing default cap literal in:\n{body}"
+        );
+        // GC must be POST-build — after the mvm-meta.json emission block.
+        let meta_idx = body.find("mvm-meta.json").expect("meta block present");
+        let gc_idx = body.find("nix-collect-garbage").expect("gc present");
+        assert!(gc_idx > meta_idx, "GC tail must follow output emission");
+        unsafe {
+            match old {
+                Some(v) => std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, v),
+                None => std::env::remove_var(MVM_BUILDER_STORE_GC_GIB_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn builder_store_gc_cap_kib_default_override_and_garbage() {
+        let _lock = GC_ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os(MVM_BUILDER_STORE_GC_GIB_ENV);
+
+        // Unset → default 24 GiB in KiB.
+        // SAFETY: tests serialise env mutation via GC_ENV_LOCK.
+        unsafe {
+            std::env::remove_var(MVM_BUILDER_STORE_GC_GIB_ENV);
+        }
+        assert_eq!(
+            builder_store_gc_cap_kib(),
+            u64::from(DEFAULT_BUILDER_STORE_GC_GIB) * 1024 * 1024
+        );
+        assert_eq!(builder_store_gc_cap_kib(), 25_165_824);
+
+        // Valid override → that many GiB in KiB.
+        unsafe {
+            std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, "8");
+        }
+        assert_eq!(builder_store_gc_cap_kib(), 8 * 1024 * 1024);
+
+        // Garbage → fall back to default (best-effort cap, never disabled).
+        unsafe {
+            std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, "not-a-number");
+        }
+        assert_eq!(builder_store_gc_cap_kib(), 25_165_824);
+
+        // Zero → also falls back (zero would GC the just-built closure).
+        unsafe {
+            std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, "0");
+        }
+        assert_eq!(builder_store_gc_cap_kib(), 25_165_824);
+
+        unsafe {
+            match old {
+                Some(v) => std::env::set_var(MVM_BUILDER_STORE_GC_GIB_ENV, v),
+                None => std::env::remove_var(MVM_BUILDER_STORE_GC_GIB_ENV),
             }
         }
     }

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -104,6 +104,16 @@ pub const DEFAULT_MEMORY_MIB: u32 = 16384;
 /// runaway build can't fill the host disk.
 pub const DEFAULT_NIX_STORE_MIB: u32 = 65536;
 
+/// Builder persistent /nix store auto-GC threshold (GiB of *used* space).
+/// When the in-guest store exceeds this after a build, the build script runs
+/// `nix-collect-garbage --delete-older-than 14d`. Override: MVM_BUILDER_STORE_GC_GIB.
+/// Default 24 GiB (above doctor's 20 GiB warning, below the 64 GiB sparse cap). #630
+///
+/// Canonical definition lives in `builder_vm_runtime` (always compiled;
+/// `render_flake_cmd_sh` bakes the resolved cap into the in-guest script).
+/// Re-exported here next to [`DEFAULT_NIX_STORE_MIB`] for discoverability.
+pub use crate::builder_vm_runtime::{DEFAULT_BUILDER_STORE_GC_GIB, builder_store_gc_cap_kib};
+
 /// Where the workspace gets mounted inside the builder VM
 /// (read-only virtio-fs). Plan 72 W4 wires this.
 pub const GUEST_WORK_DIR: &str = "/work";

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -227,6 +227,15 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                     human_bytes(freed)
                 ));
             }
+
+            // #630: make the persistent /nix store images' footprint
+            // visible at prune time. We don't boot a VM to GC on demand
+            // (out of scope); GC now runs automatically in-build past the
+            // cap. Report the sizes + the cap so the operator can see the
+            // bloat and understand the auto-reclaim behaviour.
+            for line in builder_store_gc_report(path) {
+                println!("{line}");
+            }
             // Plan 37 §6: every state-changing CLI verb emits one
             // audit record. We only mutate disk on the non-dry-run
             // path; dry-run reads only and stays out of the log.
@@ -356,6 +365,68 @@ fn stage0_cache_report(
         }
     }
 
+    lines
+}
+
+/// Report the builder VM's persistent `nix-store-*.img` footprints plus
+/// the in-build GC cap (#630). Path-injectable + side-effect-free so it's
+/// hermetically testable. `len()` is the sparse *apparent* cap; allocated
+/// blocks (`st_blocks * 512`, via [`file_allocated_bytes`]) are the real
+/// footprint that grows unbounded without GC — so we surface both.
+///
+/// We only *report* here: booting a builder VM to GC on demand is out of
+/// scope for #630. GC runs automatically at the end of every in-VM build
+/// once the store crosses the cap.
+fn builder_store_gc_report(cache_root: &std::path::Path) -> Vec<String> {
+    let builder = cache_root.join("builder-vm");
+    if !builder.is_dir() {
+        return Vec::new();
+    }
+    let Ok(entries) = std::fs::read_dir(&builder) else {
+        return Vec::new();
+    };
+    let mut imgs: Vec<std::path::PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && p.file_name()
+                    .map(|n| {
+                        let n = n.to_string_lossy();
+                        n.starts_with("nix-store-") && n.ends_with(".img")
+                    })
+                    .unwrap_or(false)
+        })
+        .collect();
+    if imgs.is_empty() {
+        return Vec::new();
+    }
+    imgs.sort();
+
+    let mut lines = vec!["Builder persistent /nix store images:".to_string()];
+    for p in imgs {
+        if let Ok(m) = std::fs::metadata(&p) {
+            let name = p
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            lines.push(format!(
+                "  {name}: {} on disk / {} cap (sparse)",
+                human_bytes(file_allocated_bytes(&m)),
+                human_bytes(m.len())
+            ));
+        }
+    }
+    // Surface the resolved cap (honours MVM_BUILDER_STORE_GC_GIB) and note
+    // that GC is automatic — so the operator doesn't go hunting for a
+    // `cache gc` verb that intentionally doesn't exist (#630).
+    let cap_gib = mvm_build::builder_vm_runtime::builder_store_gc_cap_kib() / 1024 / 1024;
+    lines.push(format!(
+        "  auto-GC cap: {cap_gib} GiB used (override {}). \
+         Past the cap, `nix-collect-garbage --delete-older-than 14d` runs \
+         automatically at the end of each in-VM build (#630).",
+        mvm_build::builder_vm_runtime::MVM_BUILDER_STORE_GC_GIB_ENV,
+    ));
     lines
 }
 
@@ -508,5 +579,40 @@ mod tests {
         // No stage0 dir, no builder-vm dir, no blobs.
         let lines = stage0_cache_report(tmp.path(), &tmp.path().join("stage0"), &[]);
         assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn builder_store_gc_report_empty_without_images() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No builder-vm dir at all.
+        assert!(builder_store_gc_report(tmp.path()).is_empty());
+        // builder-vm dir present but no nix-store images.
+        std::fs::create_dir_all(tmp.path().join("builder-vm")).unwrap();
+        assert!(builder_store_gc_report(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn builder_store_gc_report_surfaces_images_cap_and_note() {
+        let tmp = tempfile::tempdir().unwrap();
+        let builder = tmp.path().join("builder-vm");
+        std::fs::create_dir_all(&builder).unwrap();
+        // A sparse-looking store image + a non-matching file that must be ignored.
+        let img = builder.join("nix-store-aarch64.img");
+        std::fs::File::create(&img)
+            .unwrap()
+            .set_len(64 * 1024 * 1024 * 1024)
+            .unwrap();
+        std::fs::write(builder.join("rootfs.ext4"), b"not a store img").unwrap();
+
+        let joined = builder_store_gc_report(tmp.path()).join("\n");
+        assert!(joined.contains("Builder persistent /nix store images:"));
+        assert!(joined.contains("nix-store-aarch64.img:"));
+        assert!(joined.contains("cap (sparse)"));
+        // The auto-GC note + env override name must be present (#630).
+        assert!(joined.contains("auto-GC cap:"));
+        assert!(joined.contains("MVM_BUILDER_STORE_GC_GIB"));
+        assert!(joined.contains("--delete-older-than 14d"));
+        // The non-matching file is not reported as a store image.
+        assert!(!joined.contains("rootfs.ext4"));
     }
 }


### PR DESCRIPTION
Fixes #630.

## What
The builder VM's persistent nix stores (`nix-store-<arch>.img`, 64 GiB sparse) accumulated every build's closure with **no garbage collection** — 40 GB observed on a dev host. The only `nix-collect-garbage` logic in the tree was `#[cfg(test)]` dead scaffolding, and `cache prune` never touched these images.

## Change
- **Automatic, in-guest, post-build GC.** The in-guest build script (`builder_vm_runtime.rs::render_flake_cmd_sh`) now, at the very end — *after* the rootfs/kernel/`mvm-meta.json` are written — checks `du -s /nix` and, if it exceeds the cap, runs `nix-collect-garbage --delete-older-than 14d`. Best-effort under `set -eu` (`|| echo`), so it can never fail the build or lose output. **Age-based** so the just-built closure (recent) stays warm; only stale old-revision garbage is freed.
- **Cap:** `MVM_BUILDER_STORE_GC_GIB` (default **24 GiB** — above doctor's 20 GiB warning, below the 64 GiB sparse cap); 0/garbage fall back to default.
- **`mvmctl cache prune`** now reports each `nix-store-*.img`'s allocated/apparent size + the GC cap + a note that GC is automatic.

## Tests
Unit: rendered script embeds the GC tail + resolved cap; cap resolver (default/override/garbage/zero); prune reporting. `cargo check --workspace`, clippy `-D warnings`, nightly fmt — all green.

## Deferred
The **warm-preserving correctness** (that `--delete-older-than 14d` keeps the *current* build live across a real persistent-store `nix build`) needs a cache-using builder-VM E2E — deferred (a build was in progress on the test host). Worst case if a build doesn't root its outputs: the store still stays bounded, with an occasional cold rebuild after a GC. The unbounded-growth bug is fixed either way.

## Note
This bloat likely *caused* this session's GC'd-source corruption (`…-source/flake.nix does not exist`) — an external GC removed a still-referenced path. Age-based in-build GC keeps the live build, avoiding that.