### PR TITLE
chore: gitignore default mvmctl compile output dir (/out/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ nix/images/dev-prebuilt/
 .worktrees/
 graphify-out/
 specs/scratch.md
+
+# Default `mvmctl compile` output dir — generated flake + bundled src,
+# regenerable, never committed (header says "re-run `mvmctl compile`").
+/out/


### PR DESCRIPTION
The default `mvmctl compile` output dir lands at repo-root `out/` (generated flake + bundled `src/`; its header says "re-run \`mvmctl compile\`"), but it wasn't gitignored — so it surfaced in `git status` after every compile from the repo root. This anchors `/out/` so it's ignored. `**/.build/` already covers stray SwiftPM caches.

Also cleaned up two strays found in the working tree (untracked, regenerable, no tracked files touched): a misplaced `crates/mvm-providers/swift/.build/` cache (the crate is now `mvm-backend/src/providers/` per Plan 121) and a `mvmctl compile` `out/`.