### PR TITLE
docs(plan-167): renumber non-persistence plan 166->167 (spec-number collision)

### DIFF
--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -15,7 +15,7 @@ The 2026-05-07 revision adds the **Trust layers (Matryoshka model)** section, na
 
 The 2026-05-10 revision adds the **Framework references** subsection (MITRE ATT&CK / D3FEND / CREF mapping for each of the seven claims). Doc-only; no code, CI, or test impact.
 
-The 2026-06-05 revision reframes the **cold-state guarantee** as a property *being promoted* to a witnessed claim (Plan 166), pending its catalog witness. Doc-only; no code, CI, or test impact yet — the witness and numbered-table entry land in a follow-up implementation PR.
+The 2026-06-05 revision reframes the **cold-state guarantee** as a property *being promoted* to a witnessed claim (Plan 167), pending its catalog witness. Doc-only; no code, CI, or test impact yet — the witness and numbered-table entry land in a follow-up implementation PR.
 
 ## Context
 
@@ -208,7 +208,7 @@ of the runtime rather than a single CI gate. In framework terms it is
 **CREF: Non-Persistence**, and denies T1546 (Event-Triggered Execution) /
 T1547 (Boot or Logon Autostart) classes of persistence outright.
 
-It is being **promoted to a witnessed claim** (Plan 166): a workload's
+It is being **promoted to a witnessed claim** (Plan 167): a workload's
 runtime state must not survive its own teardown, and the next boot on the
 same host must be fresh. The promotion is *pending its witness* — the
 catalog entry and `fn:` tests do not exist yet, so this property is not

--- a/specs/plans/167-witnessed-non-persistence.md
+++ b/specs/plans/167-witnessed-non-persistence.md
@@ -1,4 +1,4 @@
-# Plan 166 — Promote the cold-state guarantee to a witnessed non-persistence claim
+# Plan 167 — Promote the cold-state guarantee to a witnessed non-persistence claim
 
 **Source post:** *MicroVMs for Agent Sandboxing in Regulated Environments*
 (kondasamy.com, 2026). The post argues the single thing microVMs give you
@@ -114,7 +114,7 @@ This pass writes **docs only** — `specs/plans/` (this file) and
 
 - This plan.
 - An ADR-002 amendment that records the **decision** to promote cold-state
-  to a witnessed claim and marks it **pending the Plan 166 witness** — it
+  to a witnessed claim and marks it **pending the Plan 167 witness** — it
   does *not* yet assert a CI gate that does not exist (that would be a false
   claim and would not survive `xtask check-claim-catalog`). Tasks 2–3 (the
   test, the catalog row, the final numbered promotion) are deferred to an


### PR DESCRIPTION
Follow-up to #650. That PR landed `specs/plans/166-witnessed-non-persistence.md`, but the in-flight branch `feat/plan-166-qemu-builder` already owns `specs/plans/166-qemu-dev-builder-backend.md` (committed, no PR yet). `xtask check-spec-numbers` hard-fails on duplicate integer prefixes, so the two would have collided at the QEMU branch's merge.

The QEMU-builder plan is substantive backend work and held 166 first, so this renumbers the **docs** plan to **167** (verified free across all local + remote branches) and fixes the ADR-002 cross-references. Pure rename + reference update — no content change.