### PR TITLE
Plan 165 WS-B + WS-C — entrypoint-presence policy + sealed-prod interactivity prohibition (claim 15)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -102,6 +102,34 @@ jobs:
       - name: Build prod agent and assert symbol contract
         run: ./scripts/check-prod-agent-no-exec.sh
 
+  # ── Lane 1b: No interactive console in a sealed prod agent ────────
+  # claim 15 / Plan 165 WS-C. The PTY-over-vsock console is the single
+  # dev-only interactive path; it's gated behind `dev-shell`, so a prod
+  # agent must not link it. Asserts the relay symbol is ABSENT (with a
+  # handle_run_entrypoint canary against a stripped table) and a
+  # positive control that it IS detectable WITH dev-shell.
+  prod-agent-no-console:
+    name: Guest agent — no interactive console (claim 15, Plan 165 WS-C)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-prodagent-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-prodagent-
+
+      - name: Build prod agent and assert no console symbols
+        run: ./scripts/check-prod-agent-no-console.sh
+
   # ── Lane 2b: Seccomp tier functional denial (ADR-002 §W2.4) ───────
   # Tier-structure unit tests in `mvm-security` cover cumulative-subset
   # and serde shapes; they don't exercise the BPF program at runtime.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,8 @@ The `RuntimeBuildEnv` in mvm implements only `ShellEnvironment`. The full `Build
 
 ## Security model
 
-mvm makes thirteen CI-enforced security claims. Each one is backed by
+mvm makes fifteen CI-enforced security claims (numbered 1–15 in
+`specs/claims/catalog.md`, the contiguous ledger). Each one is backed by
 a test or a workflow gate. **ADR-002
 (`specs/adrs/002-microvm-security-posture.md`) is the source of truth**
 for the claim numbering, threat model, and per-backend tier matrix;
@@ -168,6 +169,10 @@ Claim lineage:
   no raw secret over broker channel) were added by Plan 104 / ADR-059
   (`specs/adrs/059-host-services-broker.md`) /
   ADR-049 (`specs/adrs/049-vsock-substitution-service.md`).
+- Claim 15 (no interactive access to a sealed production microVM) was
+  added by Plan 165 WS-C
+  (`specs/plans/165-entrypoint-presence-and-sealed-interactivity.md`) —
+  the same interactive-access threat family as claim 4 / `do_exec`.
 
 A fourteenth property — **OCI image provenance recorded in the
 chain-signed audit log** — has its own claim doc at
@@ -330,6 +335,26 @@ the source gap analysis is at
     `oci-reproducibility`, and `oci-image-runner-smoke` lanes in
     `.github/workflows/ci.yml` gate every PR that touches the OCI
     surface.
+15. **No interactive access to a sealed production microVM.** The sole
+    interactive path into a guest is the agent-served PTY-over-vsock
+    console (`crates/mvm-guest/src/console.rs`), which is gated behind
+    the `dev-shell` Cargo feature — so a sealed prod agent (built
+    `--no-default-features`, `withDevShell = false` in `mkGuest`) links
+    no console symbol, exactly mirroring claim 4's `do_exec` exclusion.
+    Plan 165 WS-C. Five independent layers: (1) only the dev `/init`
+    variant serves a shell; (2) the prod rootfs is dm-verity sealed
+    (claim 3); (3) the backend captures the guest console **write-only**
+    to `console.log` with no host input fd
+    (`mvm_backend::libkrun::open_console_capture` /
+    `prod_console_attachment_has_no_input`); (4) the host
+    `enforce_accessible_gate` refuses `mvmctl console` on a sealed VM
+    (`console_refused_on_sealed_image`); (5) the agent console + `do_exec`
+    are `dev-shell`-gated. CI: the `prod-agent-no-console` symbol-grep job
+    in `.github/workflows/security.yml` (`scripts/check-prod-agent-no-console.sh`)
+    asserts the console symbol is absent from a production agent build,
+    sibling to `prod-agent-runentry-contract`. Serial-console passthrough
+    was considered and rejected (fatal on Vz's input-less console); there
+    is exactly one interactive transport and it is dev-only.
 
 The guest agent itself runs as uid 901 under setpriv (W4.5); the
 host-side vsock proxy socket is mode 0700 (W1.2), the proxy port

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -62,6 +62,20 @@ const VSOCK_SOCKET_TIMEOUT: Duration = Duration::from_secs(10);
 /// means `mvmctl stop` returns in 2 s instead of 5 s.
 const STOP_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Open the per-VM guest-console capture sink. OUTPUT-ONLY by
+/// construction (write-only, create+truncate): the guest console
+/// streams here and NO host-readable fd is ever attached as console
+/// input. The sole interactive path into a guest is the dev-shell-gated
+/// agent vsock console (Plan 165 WS-C / claim 15), absent from sealed
+/// prod agents. Centralized so the write-only invariant lives in one place.
+pub(crate) fn open_console_capture(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)
+}
+
 /// Default kernel cmdline for libkrun-launched guests.
 /// `console=hvc0` matches libkrun's virtio-console wiring (plan 57 W3
 /// finding); `root=/dev/vda rw init=/init` matches Apple Container's
@@ -277,7 +291,7 @@ impl VmBackend for LibkrunBackend {
         // per-VM log so a boot failure / kernel panic is diagnosable
         // (mirrors firecracker.log). Best-effort: fall back to null if
         // the file can't be created.
-        let console_log = std::fs::File::create(vm_console_log(&config.name))
+        let console_log = open_console_capture(&vm_console_log(&config.name))
             .map(Stdio::from)
             .unwrap_or_else(|_| Stdio::null());
         let mut child = Command::new(&supervisor_path)
@@ -618,6 +632,26 @@ fn send_signal(pid: libc::pid_t, sig: libc::c_int) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prod_console_attachment_has_no_input() {
+        // claim 15 / Plan 165 WS-C: the backend captures the guest console
+        // to a WRITE-ONLY sink — there is no host fd from which the guest
+        // could read console input. The only interactive path is the
+        // dev-shell-gated agent vsock console, which a sealed prod agent
+        // does not link.
+        use std::io::{Read, Write};
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let p = tmp.path().join("console.log");
+        let mut f = open_console_capture(&p).expect("open sink");
+        f.write_all(b"boot log line\n")
+            .expect("console capture must accept output");
+        let mut buf = String::new();
+        assert!(
+            f.read_to_string(&mut buf).is_err(),
+            "console capture sink must be write-only — no guest console input path"
+        );
+    }
 
     #[test]
     fn libkrun_backend_name() {

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -253,7 +253,7 @@ impl VmBackend for VzBackend {
         // gives users a fresh boot log on each start, matching what
         // most VM tools do. Best-effort.
         let console_log = state_dir.join("console.log");
-        let _ = std::fs::File::create(&console_log);
+        let _ = crate::libkrun::open_console_capture(&console_log);
 
         let json = cfg
             .to_json()
@@ -779,7 +779,7 @@ impl VzBackend {
         }
         let _ = std::fs::remove_file(&pid_file);
         let console_log = state_dir.join("console.log");
-        let _ = std::fs::File::create(&console_log);
+        let _ = crate::libkrun::open_console_capture(&console_log);
 
         ui::info(&format!(
             "Restoring Vz VM '{}' from {} via {}...",

--- a/crates/mvm-cli/src/commands/vm/audit_chain.rs
+++ b/crates/mvm-cli/src/commands/vm/audit_chain.rs
@@ -412,6 +412,7 @@ mod tests {
                 name: "vm-test".to_string(),
                 sha256: "a".repeat(64),
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: Resources {
                 cpus: 1,

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -468,6 +468,25 @@ mod accessible_gate_tests {
         });
     }
 
+    // Plan 165 WS-C / claim 15 witness: `mvmctl console` refuses to attach
+    // to a VM built from a sealed (accessible == false) production image.
+    #[test]
+    fn console_refused_on_sealed_image() {
+        with_home(|_| {
+            let name = "sealed-prod-image";
+            write_meta(
+                name,
+                &VmRuntimeMeta {
+                    mode: StartModeKind::Detached,
+                    accessible: false,
+                },
+            )
+            .expect("write");
+            let err = enforce_accessible_gate(name, false).expect_err("must refuse");
+            assert!(err.to_string().contains("sealed image"), "msg: {err}");
+        });
+    }
+
     #[test]
     fn gate_force_bypasses_sealed_refusal() {
         with_home(|_| {

--- a/crates/mvm-cli/src/commands/vm/plan_builder.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_builder.rs
@@ -205,6 +205,11 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
         name: input.image_name.to_string(),
         sha256: input.image_sha256.to_string(),
         cosign_bundle: input.image_cosign_bundle.map(str::to_string),
+        // Plan 165 WS-B B4: the CLI only ever synthesizes plans for
+        // images that carry an entrypoint (the SDK's B3 compile gate
+        // refuses to produce one without). The supervisor's admission
+        // gate rejects entrypoint_present == false as defense in depth.
+        entrypoint_present: true,
     };
 
     Ok(ExecutionPlan {

--- a/crates/mvm-cli/src/commands/vm/plan_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_persist.rs
@@ -134,6 +134,7 @@ mod tests {
                 name: "vm-test".to_string(),
                 sha256: "a".repeat(64),
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: Resources {
                 cpus: 1,

--- a/crates/mvm-cli/src/commands/vm/policy_resolver.rs
+++ b/crates/mvm-cli/src/commands/vm/policy_resolver.rs
@@ -587,6 +587,7 @@ mod tests {
                 name: "vm-test".to_string(),
                 sha256: "a".repeat(64),
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: Resources {
                 cpus: 1,

--- a/crates/mvm-core/src/plan/signing.rs
+++ b/crates/mvm-core/src/plan/signing.rs
@@ -144,6 +144,7 @@ mod tests {
                 name: "tenant-worker-aarch64".to_string(),
                 sha256: "a".repeat(64),
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: Resources {
                 cpus: 2,

--- a/crates/mvm-core/src/plan/types.rs
+++ b/crates/mvm-core/src/plan/types.rs
@@ -46,6 +46,26 @@ pub struct SignedImageRef {
     /// Cosign-keyless `.bundle` reference. Path on disk or URL
     /// resolvable by the supervisor. Stub in dev.
     pub cosign_bundle: Option<String>,
+    /// Plan 165 WS-B B4: false iff the sealed image declares no workload
+    /// entrypoint. Defaults to true (every legacy plan + every dev image),
+    /// and is skip-serialized when true so existing signed-plan fixtures
+    /// stay byte-identical (the field is inside the signed payload). The
+    /// supervisor refuses a plan whose image asserts entrypoint_present ==
+    /// false — admission-time defense in depth behind the SDK's B3 compile
+    /// gate.
+    #[serde(
+        default = "default_entrypoint_present",
+        skip_serializing_if = "is_entrypoint_present"
+    )]
+    pub entrypoint_present: bool,
+}
+
+fn default_entrypoint_present() -> bool {
+    true
+}
+
+fn is_entrypoint_present(v: &bool) -> bool {
+    *v
 }
 
 /// Resource budget. Hard caps; the supervisor refuses to start a VM
@@ -607,5 +627,51 @@ mod host_share_grant_tests {
             "kind":"disk","read_only":false}"#;
         let g: HostShareGrant = serde_json::from_str(json).unwrap();
         assert!(!g.encrypted);
+    }
+}
+
+#[cfg(test)]
+mod signed_image_ref_tests {
+    use super::*;
+
+    /// Byte-identity guard (Plan 165 WS-B B4): a default-true
+    /// `entrypoint_present` must NOT serialize, so every existing
+    /// signed-plan fixture (which never carried the field) hashes the
+    /// same bytes and its Ed25519 signature stays valid.
+    #[test]
+    fn serde_omits_entrypoint_present_when_true() {
+        let r = SignedImageRef {
+            name: "img".into(),
+            sha256: "a".repeat(64),
+            cosign_bundle: None,
+            entrypoint_present: true,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(
+            !json.contains("entrypoint_present"),
+            "default-true field leaked into wire: {json}"
+        );
+
+        // A plan JSON without the key round-trips to true (default).
+        let back: SignedImageRef =
+            serde_json::from_str(r#"{"name":"img","sha256":"deadbeef","cosign_bundle":null}"#)
+                .unwrap();
+        assert!(back.entrypoint_present);
+    }
+
+    /// The guard field is serialized only when false — the one case the
+    /// supervisor's B4 admission gate must see on the wire.
+    #[test]
+    fn serde_emits_entrypoint_present_when_false() {
+        let r = SignedImageRef {
+            name: "img".into(),
+            sha256: "a".repeat(64),
+            cosign_bundle: None,
+            entrypoint_present: false,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"entrypoint_present\":false"), "{json}");
+        let back: SignedImageRef = serde_json::from_str(&json).unwrap();
+        assert!(!back.entrypoint_present);
     }
 }

--- a/crates/mvm-core/tests/replay_protection.rs
+++ b/crates/mvm-core/tests/replay_protection.rs
@@ -26,6 +26,7 @@ fn fixture_plan(nonce: [u8; 16]) -> ExecutionPlan {
             name: "test".to_string(),
             sha256: "0".repeat(64),
             cosign_bundle: None,
+            entrypoint_present: true,
         },
         resources: Resources {
             cpus: 1,

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -2236,6 +2236,13 @@ fn handle_client(
             }
         }
 
+        // PTY-over-vsock console — the single dev-only interactive path. The
+        // relay lives behind `#[cfg(feature = "dev-shell")]` so its symbols are
+        // absent from a sealed production agent (Plan 165 WS-C, claim 15;
+        // mirrors the `do_exec` gate, ADR-002 §W4.3). The protocol profile gate
+        // above already rejects these verbs in sealed-prod, but the compile-time
+        // gate is the load-bearing guarantee — no console code is even linked.
+        #[cfg(feature = "dev-shell")]
         GuestRequest::ConsoleOpen { cols, rows } => {
             // Check security policy — console requires access.console = true.
             // When no policy file is provisioned (dev mode), use permissive defaults.
@@ -2276,6 +2283,13 @@ fn handle_client(
             }
         }
 
+        #[cfg(not(feature = "dev-shell"))]
+        GuestRequest::ConsoleOpen { .. } => GuestResponse::Error {
+            message: "console not available: guest agent built without dev-shell feature"
+                .to_string(),
+        },
+
+        #[cfg(feature = "dev-shell")]
         GuestRequest::ConsoleClose { session_id: _ } => {
             // Console sessions end when the shell exits or the host disconnects.
             // Explicit close is a no-op if already closed.
@@ -2292,6 +2306,13 @@ fn handle_client(
             }
         }
 
+        #[cfg(not(feature = "dev-shell"))]
+        GuestRequest::ConsoleClose { .. } => GuestResponse::Error {
+            message: "console not available: guest agent built without dev-shell feature"
+                .to_string(),
+        },
+
+        #[cfg(feature = "dev-shell")]
         GuestRequest::ConsoleResize {
             session_id,
             cols,
@@ -2306,6 +2327,12 @@ fn handle_client(
                 }
             }
         }
+
+        #[cfg(not(feature = "dev-shell"))]
+        GuestRequest::ConsoleResize { .. } => GuestResponse::Error {
+            message: "console not available: guest agent built without dev-shell feature"
+                .to_string(),
+        },
 
         // ADR-007 / plan 41 W5 — report whether boot-time entrypoint
         // validation succeeded. Used by `mvmctl doctor` against a

--- a/crates/mvm-guest/src/lib.rs
+++ b/crates/mvm-guest/src/lib.rs
@@ -2,6 +2,12 @@
 // Depends on mvm-core
 
 pub mod builder_agent;
+/// PTY-over-vsock interactive console — the single dev-only interactive path
+/// into a guest. Gated behind `dev-shell` so the relay symbols are absent from
+/// a sealed production agent (Plan 165 WS-C, claim 15), mirroring `do_exec`
+/// (ADR-002 §W4.3). The host-side console client talks to it over vsock and is
+/// unaffected by this gate.
+#[cfg(feature = "dev-shell")]
 pub mod console;
 pub mod entrypoint;
 pub mod fs_rpc;

--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -141,6 +141,13 @@ pub enum SupervisorError {
         #[source]
         source: VolumeError,
     },
+
+    /// Plan 165 WS-B B4: the plan's sealed image asserted it carries no
+    /// workload entrypoint. The SDK's B3 compile gate refuses to
+    /// produce such an image; this admission-time refusal is defense in
+    /// depth if one reaches the supervisor anyway.
+    #[error("sealed image declares no entrypoint (entrypoint.absent)")]
+    EntrypointAbsent,
 }
 
 pub struct Supervisor {
@@ -367,6 +374,22 @@ impl Supervisor {
             self.emit_audit_then_fail(&plan, "plan.rejected.deps_volume", &e.to_string())
                 .await?;
             return Err(e);
+        }
+
+        // Plan 165 WS-B B4: fail closed if a sealed image reached us with
+        // no declared entrypoint. The SDK's B3 compile gate refuses to
+        // produce such an image; this is the admission-time defense in
+        // depth. The wire field defaults to true (skip-serialized), so
+        // every legacy plan admits unchanged — the guard only fires when
+        // a plan explicitly carries entrypoint_present == false.
+        if !plan.image.entrypoint_present {
+            // NB: spec-mandated `plan.failed` (Plan 165 B4), NOT the
+            // `plan.rejected.*` shape the sibling admission rejects use — the
+            // machine reason lives in the `entrypoint.absent` label. Don't
+            // "consistency-fix" this to plan.rejected.entrypoint.
+            self.emit_audit_then_fail(&plan, "plan.failed", "entrypoint.absent")
+                .await?;
+            return Err(SupervisorError::EntrypointAbsent);
         }
 
         // Plan is fully admitted at this point — signature, window,
@@ -1158,6 +1181,7 @@ mod tests {
                 name: "tenant-worker-aarch64".to_string(),
                 sha256: "a".repeat(64),
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: Resources {
                 cpus: 2,
@@ -1699,6 +1723,62 @@ mod tests {
                 "plan.rejected.nonce_replay",
             ]
         );
+    }
+
+    /// Plan 165 WS-B B4: a sealed image asserting no entrypoint is
+    /// refused at admission with `EntrypointAbsent` and the plan lands
+    /// in `Failed`.
+    #[tokio::test]
+    async fn admission_refuses_sealed_plan_with_absent_entrypoint() {
+        let mut plan = sample_plan();
+        plan.image.entrypoint_present = false;
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let backend = Arc::new(MockBackend::new());
+        let (mut s, _audit) = make_supervisor_with_audit(backend.clone());
+
+        let err = s.launch(&signed, &[("test", &vk)]).await.unwrap_err();
+        assert!(matches!(err, SupervisorError::EntrypointAbsent), "{err:?}");
+        assert_eq!(s.state.current(), PlanState::Failed);
+        // The B4 guard fires before backend dispatch — no launch attempt.
+        assert!(backend.launches().is_empty());
+    }
+
+    /// Plan 165 WS-B B4: the refusal is on the claim-8 audit chain as a
+    /// `plan.failed` entry whose reason label is `entrypoint.absent`.
+    #[tokio::test]
+    async fn admission_emits_plan_failed_entrypoint_absent_audit_entry() {
+        let mut plan = sample_plan();
+        plan.image.entrypoint_present = false;
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let backend = Arc::new(MockBackend::new());
+        let (mut s, audit) = make_supervisor_with_audit(backend.clone());
+
+        let _ = s.launch(&signed, &[("test", &vk)]).await;
+
+        assert_eq!(audit_events(&audit), vec!["plan.failed"]);
+        let entry = &audit.entries()[0];
+        assert_eq!(
+            entry.labels.get("reason").map(String::as_str),
+            Some("entrypoint.absent"),
+            "labels: {:?}",
+            entry.labels
+        );
+        assert_eq!(entry.plan_id, plan.plan_id);
+    }
+
+    /// Plan 165 WS-B B4: a normal plan (field defaulted to true) sails
+    /// past the B4 gate — it must NOT trip `EntrypointAbsent`.
+    #[tokio::test]
+    async fn admission_accepts_plan_with_entrypoint_present_default() {
+        let plan = sample_plan();
+        assert!(plan.image.entrypoint_present, "sample defaults to present");
+        let (signed, _sk, vk) = sign_sample(&plan);
+        let backend = Arc::new(MockBackend::new());
+        let (mut s, audit) = make_supervisor_with_audit(backend.clone());
+
+        s.launch(&signed, &[("test", &vk)]).await.unwrap();
+
+        assert_eq!(audit_events(&audit), vec!["plan.admitted", "plan.running"]);
     }
 
     #[tokio::test]

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -323,6 +323,7 @@ mod tests {
                 name: "tenant-worker-aarch64".to_string(),
                 sha256: "ABC123".to_string(), // mixed case → entry should normalise
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: Resources {
                 cpus: 2,

--- a/crates/mvm-hostd/src/supervisor/audit_recorder.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_recorder.rs
@@ -356,6 +356,7 @@ mod tests {
                 name: "vm-test".to_string(),
                 sha256: "a".repeat(64),
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: Resources {
                 cpus: 1,

--- a/crates/mvm-hostd/src/supervisor/backend.rs
+++ b/crates/mvm-hostd/src/supervisor/backend.rs
@@ -232,6 +232,7 @@ mod tests {
                 name: "tenant-worker-aarch64".to_string(),
                 sha256: "a".repeat(64),
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: mvm_core::plan::Resources {
                 cpus: 2,

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
@@ -2250,6 +2250,7 @@ mod tests {
                 name: "img".into(),
                 sha256: "0".repeat(64),
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: Resources {
                 cpus: 1,

--- a/crates/mvm-hostd/src/supervisor/lifecycle_hooks.rs
+++ b/crates/mvm-hostd/src/supervisor/lifecycle_hooks.rs
@@ -307,6 +307,7 @@ mod tests {
                 name: "vm-test".to_string(),
                 sha256: "a".repeat(64),
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: Resources {
                 cpus: 1,

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -907,6 +907,7 @@ mod tests {
                 name: "img".into(),
                 sha256: "0".repeat(64),
                 cosign_bundle: None,
+                entrypoint_present: true,
             },
             resources: Resources {
                 cpus: 1,

--- a/crates/mvm-sdk/src/compile/orchestrator.rs
+++ b/crates/mvm-sdk/src/compile/orchestrator.rs
@@ -55,6 +55,12 @@ pub enum CompileError {
     ManagedSecretsNotSupported {
         targets: Vec<String>,
     },
+    /// Plan 165 WS-B B3: a sealed/prod image must declare a workload
+    /// entrypoint. The SDK only ever emits sealed images, so an app with
+    /// no declared entrypoint can never be compiled into one.
+    SealedWorkloadMissingEntrypoint {
+        app: String,
+    },
 }
 
 impl std::fmt::Display for CompileError {
@@ -93,6 +99,11 @@ impl std::fmt::Display for CompileError {
                  found secret-backed env targets: {}. Use deploy/plan flows for managed refs, or \
                  mount guest-visible files explicitly if you accept guest materialization.",
                 targets.join(", ")
+            ),
+            Self::SealedWorkloadMissingEntrypoint { app } => write!(
+                f,
+                "sealed/prod workloads must declare an entrypoint; dev images may omit it \
+                 for an interactive shell (app {app:?})"
             ),
         }
     }
@@ -135,6 +146,13 @@ pub fn compile_archive(
 /// copying the source tree into `<staging>/src/` before publishing. `path` in
 /// the IR is interpreted relative to `manifest_dir`, or absolute.
 pub fn compile(workload: &Workload, out: &Path, manifest_dir: &Path) -> Result<(), CompileError> {
+    // Plan 165 WS-B B3: fail closed before any staging/IO. Every SDK
+    // artifact is sealed by construction, so an app with no declared
+    // entrypoint is a misconfiguration, not a request for an interactive
+    // dev shell (that path is the Nix-flake `entrypoint.shell`, never
+    // produced here).
+    check_declared_entrypoints(workload)?;
+
     if out.exists() && !out.is_dir() {
         return Err(CompileError::OutputExistsNotDir(out.to_path_buf()));
     }
@@ -266,6 +284,21 @@ pub fn compile(workload: &Workload, out: &Path, manifest_dir: &Path) -> Result<(
             Err(e)
         }
     }
+}
+
+/// Plan 165 WS-B B3: refuse to compile any app that lacks a declared
+/// workload entrypoint. Reuses the B1 predicate so the "is there a
+/// command?" signal has a single definition. Multi-app workloads fail
+/// closed on the first offender (named in the error).
+fn check_declared_entrypoints(workload: &Workload) -> Result<(), CompileError> {
+    for app in &workload.apps {
+        if !app.has_declared_entrypoint() {
+            return Err(CompileError::SealedWorkloadMissingEntrypoint {
+                app: app.name.clone(),
+            });
+        }
+    }
+    Ok(())
 }
 
 fn managed_secret_targets(app: &crate::ir::App) -> Vec<String> {
@@ -789,6 +822,79 @@ mod tests {
                 assert_eq!(missing, vec!["c".to_string()]);
             }
             other => panic!("expected FunctionSchemaMismatch, got {other:?}"),
+        }
+    }
+
+    // ---------- Plan 165 WS-B B3: no-entrypoint policy --------------------
+
+    #[test]
+    fn compile_refuses_sealed_workload_with_no_declared_entrypoint() {
+        let tmp = TempDir::new().unwrap();
+        let manifest_dir = tmp.path().join("manifest");
+        make_src(&manifest_dir);
+        let out = tmp.path().join("artifact");
+        let mut workload = sample();
+        workload.apps[0].entrypoints = vec![];
+
+        let err = compile(&workload, &out, &manifest_dir).unwrap_err();
+        match &err {
+            CompileError::SealedWorkloadMissingEntrypoint { app } => {
+                assert_eq!(app, "hello");
+            }
+            other => panic!("expected SealedWorkloadMissingEntrypoint, got {other:?}"),
+        }
+        assert!(
+            err.to_string()
+                .contains("sealed/prod workloads must declare an entrypoint"),
+            "message was: {err}"
+        );
+    }
+
+    #[test]
+    fn compile_refuses_second_app_missing_entrypoint_and_names_it() {
+        // Guard iterates all apps, not just the first — a valid app[0] must
+        // not mask an empty app[1]. The named offender is the second app.
+        let tmp = TempDir::new().unwrap();
+        let manifest_dir = tmp.path().join("manifest");
+        make_src(&manifest_dir);
+        let out = tmp.path().join("artifact");
+        let mut workload = sample();
+        let mut second = workload.apps[0].clone();
+        second.name = "sidecar".into();
+        second.entrypoints = vec![];
+        workload.apps.push(second);
+
+        let err = compile(&workload, &out, &manifest_dir).unwrap_err();
+        match &err {
+            CompileError::SealedWorkloadMissingEntrypoint { app } => {
+                assert_eq!(app, "sidecar");
+            }
+            other => panic!("expected SealedWorkloadMissingEntrypoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compile_accepts_idle_sleep_infinity_command() {
+        // An idle image declares a real command, so the B3 guard must not
+        // fire. We assert specifically on the ABSENCE of the B3 error —
+        // a bare `sleep infinity` source tree compiles cleanly here.
+        let tmp = TempDir::new().unwrap();
+        let manifest_dir = tmp.path().join("manifest");
+        make_src(&manifest_dir);
+        let out = tmp.path().join("artifact");
+        let mut workload = sample();
+        workload.apps[0].entrypoints = vec![Entrypoint::Command {
+            command: vec!["sleep".into(), "infinity".into()],
+            working_dir: "/app".into(),
+            env: Default::default(),
+        }];
+
+        match compile(&workload, &out, &manifest_dir) {
+            Ok(()) => {}
+            Err(CompileError::SealedWorkloadMissingEntrypoint { .. }) => {
+                panic!("idle sleep-infinity command must not trip the B3 guard")
+            }
+            Err(other) => panic!("unexpected unrelated compile error: {other:?}"),
         }
     }
 

--- a/crates/mvm-sdk/src/ir/workload.rs
+++ b/crates/mvm-sdk/src/ir/workload.rs
@@ -94,6 +94,18 @@ impl App {
             .or_else(|| self.entrypoints.first())
             .expect("App must have at least one entrypoint (validate() rejects empty)")
     }
+
+    /// B1 (Plan 165 WS-B): true iff this app declares a workload command —
+    /// a `Command` argv or a `Function` dispatch target. The IR cannot
+    /// represent "no declared entrypoint" (validate() rejects empty
+    /// `entrypoints`), so for any validated SDK app this is true; the
+    /// predicate is the single named signal the compile gate (B3) and the
+    /// admission gate (B4) read instead of each re-deriving "is there a
+    /// command?" inline. An idle image (`["sleep","infinity"]`) IS a
+    /// declared command, so it is unaffected.
+    pub fn has_declared_entrypoint(&self) -> bool {
+        !self.entrypoints.is_empty()
+    }
 }
 
 /// Per-app dependency declaration. ADR-0009 / plan-0008.
@@ -550,4 +562,66 @@ pub struct Volume {
     pub name: String,
     pub size_mb: u32,
     pub persist: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app_with(entrypoints: Vec<Entrypoint>) -> App {
+        App {
+            name: "hello".into(),
+            source: Source::LocalPath {
+                path: ".".into(),
+                include: vec!["**".into()],
+                exclude: vec![],
+            },
+            image: Image::NixPackages {
+                packages: vec!["python312".into()],
+            },
+            entrypoints,
+            env: Default::default(),
+            mounts: vec![],
+            network: None,
+            resources: Resources {
+                cpu_cores: 1,
+                memory_mb: 256,
+                rootfs_size_mb: 512,
+            },
+            dependencies: None,
+            threat_tier: Default::default(),
+            addons: vec![],
+            hooks: Default::default(),
+        }
+    }
+
+    #[test]
+    fn has_declared_entrypoint_true_for_command_and_function() {
+        let cmd = app_with(vec![Entrypoint::Command {
+            command: vec!["python".into(), "-m".into(), "hello".into()],
+            working_dir: "/app".into(),
+            env: Default::default(),
+        }]);
+        assert!(cmd.has_declared_entrypoint());
+
+        let func = app_with(vec![Entrypoint::Function {
+            language: "python".into(),
+            module: "adder".into(),
+            function: "add".into(),
+            format: Format::Json,
+            working_dir: "/app".into(),
+            env: Default::default(),
+            args_schema: None,
+            return_schema: None,
+            extra_imports: vec![],
+            primary: true,
+            concurrency: None,
+        }]);
+        assert!(func.has_declared_entrypoint());
+    }
+
+    #[test]
+    fn has_declared_entrypoint_false_for_empty_entrypoints() {
+        assert!(!app_with(vec![]).has_declared_entrypoint());
+    }
 }

--- a/crates/mvm-sdk/src/ir/workload.rs
+++ b/crates/mvm-sdk/src/ir/workload.rs
@@ -99,10 +99,12 @@ impl App {
     /// a `Command` argv or a `Function` dispatch target. The IR cannot
     /// represent "no declared entrypoint" (validate() rejects empty
     /// `entrypoints`), so for any validated SDK app this is true; the
-    /// predicate is the single named signal the compile gate (B3) and the
-    /// admission gate (B4) read instead of each re-deriving "is there a
-    /// command?" inline. An idle image (`["sleep","infinity"]`) IS a
-    /// declared command, so it is unaffected.
+    /// predicate is the single named signal the compile gate (B3) reads
+    /// instead of re-deriving "is there a command?" inline. The admission
+    /// gate (B4) enforces the same property one layer down, via the
+    /// `SignedImageRef.entrypoint_present` wire field (a different crate —
+    /// no shared symbol crosses the boundary). An idle image
+    /// (`["sleep","infinity"]`) IS a declared command, so it is unaffected.
     pub fn has_declared_entrypoint(&self) -> bool {
         !self.entrypoints.is_empty()
     }

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -117,6 +117,11 @@ let
     if dev == null then entrypointKind == "shell"
     else dev;
   isSealed = !isDev;
+  # Whether the agent is compiled with the `dev-shell` Cargo feature.
+  # Identical to `isDev` today, named separately because it is the
+  # console-wiring fact (see `mvmMeta.withDevShell`) — distinct from the
+  # accessible/sealed classification it happens to track.
+  withDevShell = isDev;
 
   # ── Guest agent build (W6.1.2) ─────────────────────────────────
   #
@@ -138,8 +143,7 @@ let
   #
   # Either way the binary is the production Rust build, not a stub.
   guestAgentPkg = pkgs.callPackage ../packages/mvm-guest-agent.nix {
-    inherit mvmSrc;
-    withDevShell = isDev;
+    inherit mvmSrc withDevShell;
   };
 
   # ── mvm-addon-dns — in-guest loopback DNS resolver ─────────────
@@ -979,6 +983,13 @@ let
     accessible = isDev;
     sealed = isSealed;
     entrypointKind = entrypointKind;
+    # Plan 165 WS-B/WS-C: true iff the agent is built with the `dev-shell`
+    # Cargo feature — which gates BOTH `do_exec` AND the PTY-over-vsock
+    # interactive console (ADR-002 §W4.3, claim 15). `withDevShell == true`
+    # means a dev image whose console is wired; `false` is a sealed prod
+    # agent with no interactive surface. mvmctl / admission gates read this
+    # to refuse interactive access to a sealed image.
+    withDevShell = withDevShell;
     initSystem = "busybox";
     # ADR-013 §"Per-backend boot budgets" — single 300ms floor across
     # every backend. Custom /init + trimmed kernel + direct vmlinux

--- a/nix/tests/mk-guest-eval.nix
+++ b/nix/tests/mk-guest-eval.nix
@@ -177,4 +177,25 @@ in
   overlay_aware_metadata_set_on_shell = (meta shellGuest).overlayAware == true;
   overlay_aware_metadata_set_on_command = (meta commandGuest).overlayAware == true;
   overlay_aware_metadata_set_on_services = (meta servicesGuest).overlayAware == true;
+
+  # ── Plan 165 WS-B B2: dev console wiring ──────────────────────
+  #
+  # `withDevShell` is the console-wiring fact: it gates the agent's
+  # PTY-over-vsock relay (and `do_exec`) via the `dev-shell` Cargo
+  # feature. A dev image wires the interactive console; a sealed
+  # image has no console symbol. These assert the surfaced metadata
+  # tracks the entrypoint classification AND its dev/sealed override.
+
+  dev_shell_image_wires_console = (meta shellGuest).withDevShell == true
+    && (meta shellGuest).accessible == true
+    && (meta shellGuest).entrypointKind == "shell";
+
+  sealed_command_image_has_no_console = (meta commandGuest).withDevShell == false
+    && (meta commandGuest).sealed == true;
+
+  # dev=true on a command entrypoint still wires the console
+  dev_override_command_wires_console = (meta commandAccessibleGuest).withDevShell == true;
+
+  # dev=false on a shell entrypoint drops the console
+  sealed_override_shell_has_no_console = (meta shellSealedGuest).withDevShell == false;
 }

--- a/scripts/check-prod-agent-no-console.sh
+++ b/scripts/check-prod-agent-no-console.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Plan 165 WS-C (claim 15) — sealed-production interactivity contract.
+#
+# The agent-served PTY-over-vsock console (crates/mvm-guest/src/console.rs) is
+# the SINGLE dev-only interactive path into a guest. On the `mvm-guest-agent`
+# binary built in its PRODUCTION configuration (no `dev-shell` feature), assert:
+#
+#   1. `handle_run_entrypoint` is PRESENT — the constrained RunEntrypoint
+#      handler ships (ADR-007 §W5). It is `#[inline(never)]` precisely so it
+#      survives optimization. This also serves as a CANARY: if it's missing,
+#      the symbol table was stripped and the absence check below would be
+#      meaningless (vacuously true), so we fail instead of trusting it.
+#   2. The console relay is ABSENT — `mvm_guest::console` is gated behind
+#      `dev-shell`, so a sealed prod agent must not link `open_session` /
+#      `run_console_relay` / `resize_active_session`. No interactive path can
+#      reach a sealed workload (claim 15), mirroring the `do_exec` no-exec gate.
+#
+# Then a POSITIVE CONTROL: built WITH `dev-shell`, the console symbol MUST be
+# detectable. This proves the detector works (so #2 can't silently pass against
+# a renamed/inlined symbol) — if the gate or the symbol changes, this turns the
+# lane red and points here, instead of letting the absence assertion rot.
+#
+# `[profile.release] strip = true` in the root Cargo.toml would erase the
+# symbol table, so each build overrides it with CARGO_PROFILE_RELEASE_STRIP=false
+# — real release codegen, readable symbols.
+set -euo pipefail
+
+# Symbol greps are scoped to the console module path (mvm_guest::console::<name>)
+# so an unrelated `open_session` in a dependency can't mask a leak. NB: the
+# console fns live in the mvm-guest *library*, so the mangled prefix is
+# `mvm_guest..console..` — NOT `mvm_guest_agent..` (the binary crate) as in the
+# sibling no-exec gate. Match ALL THREE relay entry points, not just one: gating
+# the whole module keeps them absent together today, but the alternation means a
+# future partial de-gating (e.g. moving `open_session` out while leaving the
+# relay) still trips the absence assertion.
+
+PKG=mvm-guest
+BIN=mvm-guest-agent
+CONSOLE_SYM='mvm_guest.*console.*(open_session|run_console_relay|resize_active_session)'
+
+echo "::group::Build production agent (release, no dev-shell)"
+CARGO_PROFILE_RELEASE_STRIP=false \
+  cargo build --release --locked -p "$PKG" --bin "$BIN" --no-default-features
+echo "::endgroup::"
+prod_syms=$(nm "target/release/$BIN")
+
+fail=0
+
+if grep -q 'mvm_guest_agent.*handle_run_entrypoint' <<<"$prod_syms"; then
+  echo "ok: handle_run_entrypoint present (W5 handler ships; symbol table is populated)"
+else
+  echo "::error::ADR-007 §W5: handle_run_entrypoint is ABSENT from the production agent." >&2
+  echo "Either the constrained RunEntrypoint handler was removed, or the symbol table" >&2
+  echo "was stripped — which would make the console absence check below vacuous. The" >&2
+  echo "no-interactivity guarantee cannot be trusted until this is resolved." >&2
+  fail=1
+fi
+
+if grep -qE "$CONSOLE_SYM" <<<"$prod_syms"; then
+  echo "::error::claim 15 / Plan 165 WS-C: console relay is PRESENT in the production agent." >&2
+  echo "The dev-only PTY-over-vsock console leaked into a non-dev-shell build." >&2
+  grep -E "$CONSOLE_SYM" <<<"$prod_syms" >&2 || true
+  fail=1
+else
+  echo "ok: console relay absent from the production agent (claim 15)"
+fi
+
+echo "::group::Positive control — build WITH dev-shell; console relay MUST be detectable"
+CARGO_PROFILE_RELEASE_STRIP=false \
+  cargo build --release --locked -p "$PKG" --bin "$BIN" \
+    --no-default-features --features dev-shell \
+    --target-dir target/claim15-poscontrol
+echo "::endgroup::"
+if grep -qE "$CONSOLE_SYM" <<<"$(nm "target/claim15-poscontrol/release/$BIN")"; then
+  echo "ok: positive control — console relay is detectable when dev-shell is enabled"
+else
+  echo "::error::Positive control FAILED: console relay not found even WITH dev-shell on." >&2
+  echo "The symbol was probably renamed or inlined away. Update this script's grep so the" >&2
+  echo "production absence assertion stays meaningful (otherwise it silently passes)." >&2
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "::error::Production guest-agent console contract FAILED — see annotations above." >&2
+  exit 1
+fi
+echo "All assertions passed: prod agent ships handle_run_entrypoint and omits the console relay."

--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -121,7 +121,13 @@ Followups A + B.1/B.2/B.3 + C + D. Claims 12 and 13 (host services
 broker — binding-gated dispatch + workload audit-entry attribution)
 were added by Plan 104 / ADR-059, with Claim 13 rewritten by ADR-062
 when `host.secrets.v1` was dropped from v1 scope and `host.audit.v1`
-took its place as the load-bearing workload service.
+took its place as the load-bearing workload service. Claim 15
+(no interactive access to a sealed production microVM) was added by
+Plan 165 WS-C. The table jumps 13→15 deliberately: claim 14 (OCI image
+provenance) is already in `specs/claims/catalog.md` and
+`CLAUDE.md::Security model` but its promotion into this numbered table
+is tracked under Plan 111, so the number is held aligned with the
+catalog ledger rather than reused.
 
 | # | Claim | Primary layer | Workstream | CI gate |
 |---|---|---|---|---|
@@ -138,6 +144,7 @@ took its place as the load-bearing workload service.
 | 11 | Every application-dep volume is hash-locked, attestation-checked, CVE-scanned, SBOM-enumerated, and bound to the workload's audit chain | cross-cutting (supply chain — app-layer deps) | ADR-047, Plan 73 Followups A + B.1/B.2/B.3 + C + D | `mvm_sdk::compile::deps_audit::{seal_volume, verify_sealed_volume}` tamper-detection unit tests; `mvm_build::app_deps_gate::apply_install_gate` prod/dev rejection tests; `app-deps-audit` CI lane in `ci.yml` (Followup D) — drives `mvmctl compile` on `examples/python/hello-app-with-deps/`, seals a clean + a HIGH-CVE fixture via `mvm-app-deps-fixture-tool`, asserts `mvmctl deps inspect --json` produces a well-formed report, asserts the prod gate refuses the HIGH-CVE fixture and the dev gate admits it, asserts a byte-flip on `cve.json` makes inspect refuse |
 | 12 | Every host-side service the broker exposes is bound to a signed `ExecutionPlan.services` binding, enforced before handler dispatch, and audited via the chain-signed log | cross-cutting (policy + audit) | Plan 104 W2, ADR-059 | `service_call_denied_when_unbound` + `service_call_denied_outside_profile` + `audit_chain_contains_service_call_entries` + `audit_chain_carries_no_payload_bytes` rejection-ladder tests; `xtask check-handler-adr-coverage` + `xtask check-handler-policy-schema` + `xtask check-handler-composition` lints; `fuzz_service_call.rs` lane (Plan 104 W6) |
 | 13 | No raw secret value crosses the broker channel; `host.secrets.v1` returns destination-bound, time-bound signed credentials only; raw secret bytes never leave the supervisor's address space | cross-cutting (data containment) | Plan 104 W5, ADR-049, ADR-059 | `host_secrets_v1_denied_outside_allowed_destinations` + `zeroize_drop_zeros_secret_bytes` + `handler_inter_call_memory_hygiene` + `host_secrets_v1_signed_payload_jcs_roundtrip` + `secrets_subprocess_cannot_reach_supervisor_memory` + `placeholder_in_outbound_request_dropped_and_audited` (S25 backstop) tests; ADR-049 hostile-guest matrix in W7 |
+| 15 | No interactive access to a sealed production microVM | L4 | Plan 165 WS-C | `prod-agent-no-console` symbol-grep job in `security.yml` (the agent's PTY-over-vsock console is `dev-shell`-gated, so a sealed prod agent links no console symbol — same shape as claim 4's `do_exec` gate); host `console_refused_on_sealed_image` accessible-gate test; `prod_console_attachment_has_no_input` write-only-console-capture test |
 
 L1 (host + hypervisor) has no claim of its own — the host is trusted
 by definition (see Threat model). L1 *enables* claim 3 (verified boot
@@ -199,6 +206,7 @@ only — the CI gate is the source of truth, not the framework code.
 | 11 | T1195.001 (Compromise Software Dependencies and Development Tools — app-layer variant), T1565.001 (Stored Data Manipulation — deps volume variant) | D3FEND: Software Composition Analysis, Executable Integrity · CREF: Substantiated Integrity (hash-locked + SBOM + attestation + CVE-scanned sealed volume bound to audit chain) |
 | 12 | T1574 (Hijack Execution Flow — capability-granting variant), T1078 (Valid Accounts — unauthorized service invocation) | D3FEND: Authorization · CREF: Substantiated Integrity (signed binding gate → enforced dispatch → chain-signed audit on every call) |
 | 13 | T1078 (Valid Accounts — unauthorized audit attribution), T1565 (Data Manipulation — audit-chain variant) | D3FEND: Authentication, Authorization · CREF: Substantiated Integrity (workload-emitted entries chain-signed under distinct `WorkloadAudit` category; workload-id mismatch refused at admission; chain verifier displays category alongside entry so operators can tell workload-asserted from supervisor-observed) |
+| 15 | T1021 (Remote Services — interactive session into a sealed workload), T1059 (Command and Scripting Interpreter — interactive console surface eliminated, not detected) | CREF: Realignment (scope reduction by build-time exclusion — same family as claim 4 / `do_exec`) · D3FEND: Process Segmentation |
 
 The cold-state guarantee (per-workload fresh boot, no warm pools — see
 CLAUDE.md and the `mvmctl run` lifecycle) is not in the seven-claim

--- a/specs/claims/catalog.md
+++ b/specs/claims/catalog.md
@@ -41,6 +41,7 @@ tracked separately as a follow-up audit (see "deferred follow-ups").
 | 12 | Every host-side service binding is plan-gated and audited | fn:unbound_service_returns_not_bound, fn:service_call_rejects_unknown_envelope_fields | ExecutionPlan.services binding (ADR-059) | Shipped |
 | 13 | No raw secret value crosses the broker channel | fn:resolved_secrets_placeholders, fn:substitute | destination-bound signed credentials (ADR-049) | Shipped |
 | 14 | OCI image provenance is recorded in the chain-signed audit log | fn:prod_pull_requires_digest_pin_before_network, fn:prod_run_image_requires_digest_pin_before_network | cosign + OCI digest (specs/claims/claim-10-oci-image-provenance.md) | Shipped |
+| 15 | No interactive access to a sealed production microVM | fn:console_refused_on_sealed_image, ci:prod-agent-no-console, fn:prod_console_attachment_has_no_input | dev-image-only console + dm-verity + host accessible-gate + dev-shell-gated agent (Plan 165 WS-C, ADR-002 §W4.3 extension) | Shipped |
 
 ## Maintaining this catalog
 

--- a/specs/plans/165-entrypoint-presence-and-sealed-interactivity.md
+++ b/specs/plans/165-entrypoint-presence-and-sealed-interactivity.md
@@ -1,6 +1,9 @@
 # Plan 165 — Entrypoint-presence policy + sealed-prod interactivity prohibition
 
-> **Status (2026-06-05):** Designed (brainstorm settled); not started.
+> **Status (2026-06-05):** WS-B (no-entrypoint policy) and WS-C (sealed-prod
+> interactivity prohibition + CI-gated claim 15) **implemented** on
+> `feat/plan-165-entrypoint-sealed-interactivity`. WS-A is verified done on
+> `main` except A4 (E2E invoke witness), which is deferred (see below).
 > Sequenced after the artifact-model line (Plan 134) and the default-image
 > work (Plan 158, shipped in v0.16.1). Builds directly on the
 > `is_entrypoint_not_offered` classification merged in PR #631.
@@ -118,7 +121,7 @@ placement), `crates/mvm-guest/src/entrypoint.rs` (validation, unchanged).
       variant fails `cannot open /proc/self/fd/3` (proving the requirement).
       So the fexecve-on-script concern is solved upstream; WS-A reduces to
       pure conformance (path/owner/mode/marker).
-- [ ] **A1 — Emit the wrapper at the conforming path/owner/mode.** The
+- [x] **A1 — Emit the wrapper at the conforming path/owner/mode.** The
       factory must write the per-call wrapper to
       `/usr/lib/mvm/wrappers/<workload_id>` (regular file), and mkGuest's
       rootfs-hardening pass must leave it **root:root `0555`** on the verity
@@ -127,12 +130,12 @@ placement), `crates/mvm-guest/src/entrypoint.rs` (validation, unchanged).
       --regid=<uid> --clear-groups --no-new-privs -- <command> "$@"` (uid 0
       wrapper that drops to the entrypoint uid — matches ADR-002 W2.3 and
       the existing `setprivWrap`).
-- [ ] **A2 — Write the marker as the wrapper's absolute path.**
+- [x] **A2 — Write the marker as the wrapper's absolute path.**
       `/etc/mvm/entrypoint` contains exactly
       `/usr/lib/mvm/wrappers/<workload_id>\n` (an absolute path, not a
       script). For function workloads this is the factory's `extraFiles`
       entry; assert it is consistent with the wrapper A1 bakes.
-- [ ] **A3 — Pass-through of call args/stdin.** The wrapper appends `"$@"`
+- [x] **A3 — Pass-through of call args/stdin.** The wrapper appends `"$@"`
       so `RunEntrypoint`'s argv reaches the command; stdin/stdout/stderr are
       already wired by the agent's spawn. Add a function fixture that echoes
       argv + stdin and assert round-trip.
@@ -141,7 +144,13 @@ placement), `crates/mvm-guest/src/entrypoint.rs` (validation, unchanged).
       image, boots it, and asserts `EntrypointPolicy::production().validate()`
       returns `Ok` and a `RunEntrypoint` call returns the function's output +
       exit code. This is the standing proof the collision is resolved.
-- [ ] **A5 — Host-side runner.** Confirm `mvmctl` invokes `RunEntrypoint`
+      **DEFERRED** (see Deferred follow-ups): a full function-image
+      build+boot E2E lane is environmentally fragile on the current dev
+      host (Vz dev VM exits ~5s on input-less console; libkrun core_demo is
+      flaky). `crates/mvm-cli/examples/agent_invoke.rs` already drives a
+      real `RunEntrypoint` by VM name and `core_demo_e2e` proves the agent
+      path; A4 only adds the function-dispatch assertion on top.
+- [x] **A5 — Host-side runner.** Confirm `mvmctl` invokes `RunEntrypoint`
       against a sealed function image end-to-end (no console, no exec) and
       surfaces the exit code; extend `examples/` with a function fixture.
 
@@ -155,29 +164,29 @@ entrypoint, split by tier.
 `crates/mvm-hostd/src/supervisor/` (admission-time refusal + audit),
 `crates/mvm-guest/src/bin/mvm-guest-agent.rs` (boot-state reporting).
 
-- [ ] **B1 — Define "no entrypoint."** It means *no declared workload
+- [x] **B1 — Define "no entrypoint."** It means *no declared workload
       command*: the SDK IR carries neither a function nor a command/service
       entrypoint. (`sleep infinity` / the default idle image *is* a declared
       command and is unaffected — it boots.) Encode the predicate once in
       `mvm-sdk` IR (`crates/mvm-sdk/src/ir/workload.rs`) so both the compile
       path and admission read the same signal.
-- [ ] **B2 — Dev: drop to the interactive console.** A **dev** image with no
+- [x] **B2 — Dev: drop to the interactive console.** A **dev** image with no
       declared entrypoint boots and idles PID 1 (as today), and the agent's
       console serves `/bin/sh -i` — i.e., the developer lands in the
       interactive console (WS-C's single method). No new code beyond
       ensuring classification routes an empty-entrypoint dev build to the
       console-capable dev `/init` variant.
-- [ ] **B3 — Prod: fail closed at compile time.** `mvm-sdk` compile **must
+- [x] **B3 — Prod: fail closed at compile time.** `mvm-sdk` compile **must
       refuse** to produce a *sealed* image with no declared entrypoint —
       a sealed workload that does nothing is a misconfiguration. Emit a clear
       `CompileError` ("sealed/prod workloads must declare an entrypoint;
       `dev` images may omit it for an interactive shell").
-- [ ] **B4 — Prod: fail closed at admission (defense in depth).** If a
+- [x] **B4 — Prod: fail closed at admission (defense in depth).** If a
       sealed image with no valid entrypoint reaches the supervisor anyway,
       `admit_for_run` refuses it and emits a chain-signed audit entry
       (`plan.failed` with reason `entrypoint.absent`). Reuses the existing
       admission audit path (claim 8).
-- [ ] **B5 — Tests.** compile-refusal unit test (B3), admission-refusal +
+- [x] **B5 — Tests.** compile-refusal unit test (B3), admission-refusal +
       audit-entry test (B4), and a dev-empty-entrypoint build that asserts
       the console path is wired (B2).
 
@@ -193,7 +202,7 @@ gate), `crates/mvm-cli/src/commands/vm/console.rs` (host gate),
 `specs/adrs/002-microvm-security-posture.md`, `.github/workflows/`,
 `xtask`.
 
-- [ ] **C1 — Audit the five existing barriers; close any gaps.**
+- [x] **C1 — Audit the five existing barriers; close any gaps.**
       (1) only the **dev** `/init` variant runs/relays a shell
       (`mk-guest.nix:485` `variant=dev` branch); (2) prod rootfs is
       dm-verity sealed (claim 3); (3) prod VMM console attaches a
@@ -205,11 +214,11 @@ gate), `crates/mvm-cli/src/commands/vm/console.rs` (host gate),
       console symbol (mirror the `do_exec` / `prod-agent-no-exec` gate).
       Fix whichever of these is not currently true (item 5 is the most
       likely gap — confirm and gate it if not).
-- [ ] **C2 — Prod console is input-less by construction.** In the backend
+- [x] **C2 — Prod console is input-less by construction.** In the backend
       VM-launch path, a sealed image's guest console is wired output-only
       (to `console.log`); never attach a readable host fd. Add a unit/assert
       that the prod console attachment carries no input side.
-- [ ] **C3 — New claim 15 + witnesses.** Add to
+- [x] **C3 — New claim 15 + witnesses.** Add to
       `specs/claims/catalog.md`:
       `| 15 | No interactive access to a sealed production microVM |
       fn:console_refused_on_sealed_image, ci:prod-agent-no-console,
@@ -220,11 +229,11 @@ gate), `crates/mvm-cli/src/commands/vm/console.rs` (host gate),
       `prod-agent-no-console` CI lane asserting the console symbol is absent
       from a prod agent build (mirror `prod-agent-no-exec`), and a
       `prod_console_attachment_has_no_input` backend test.
-- [ ] **C4 — ADR-002 update.** Add claim 15 to the numbered table + the
+- [x] **C4 — ADR-002 update.** Add claim 15 to the numbered table + the
       threat-model note (keep §"Out of scope" discipline — this is the same
       interactive-access threat as claim 4 / `do_exec`; co-locate the
       narrative). Update CLAUDE.md §"Security model" to fourteen→fifteen.
-- [ ] **C5 — `xtask check-claim-catalog` passes** with the new row; run the
+- [x] **C5 — `xtask check-claim-catalog` passes** with the new row; run the
       Lint gate locally.
 
 ---
@@ -292,3 +301,22 @@ background + `gtimeout` + reap):
       host-binaries build (Plan 164) rather than per-image.
 - [ ] Multiplex/queue concurrent `mvmctl console` attaches (today: one
       session at a time) — DX nicety, not security.
+- [ ] **A4 — `RunEntrypoint` invoke round-trip witness** (`invoke
+      greet("ari") → "hello ari"`), gated behind the libkrun/Vz E2E lane.
+      Deferred from WS-A: a function-image build+boot E2E is environmentally
+      fragile on the current dev host (Vz dev VM exits ~5s on the input-less
+      console; libkrun `core_demo_e2e` is flaky and must never run unbounded),
+      so it can't be validated locally and a flaky/red lane is worse than a
+      tracked deferral. Building blocks already exist:
+      `crates/mvm-cli/examples/agent_invoke.rs` drives a real `RunEntrypoint`
+      by VM name, and `core_demo_e2e` proves the agent path — A4 only adds the
+      function-dispatch output+exit-code assertion. Land it once the E2E lane
+      is stable (KVM runner / hardened libkrun boot).
+- [ ] **B4 admission gate is currently latent** — no non-test producer sets
+      `SignedImageRef.entrypoint_present = false`. By design: the SDK's B3
+      compile gate refuses to *produce* a sealed image with no entrypoint
+      (never emitting a `false`-flagged plan), so B4 is pure defense-in-depth
+      for "if a malformed sealed plan reaches the supervisor anyway." If a
+      future producer path can legitimately synthesize a no-entrypoint sealed
+      plan, wire it to set `entrypoint_present = false` so the gate fires on a
+      real signal rather than only in tests.


### PR DESCRIPTION
Implements Plan 165 **WS-B** (no-entrypoint policy) and **WS-C** (sealed-prod
interactivity prohibition + CI-gated **claim 15**). WS-A was verified done on
`main`; its only remaining sliver (A4, the E2E invoke witness) is deferred — see
below. Plan: `specs/plans/165-entrypoint-presence-and-sealed-interactivity.md`.

## WS-B — no-entrypoint policy (fail-closed)
- **B1/B3** (`mvm-sdk`): `App::has_declared_entrypoint()` predicate + `CompileError::SealedWorkloadMissingEntrypoint`, an early guard in `compile()` that refuses to produce a sealed image with no declared entrypoint.
- **B4** (`mvm-core` + `mvm-hostd`): `SignedImageRef.entrypoint_present` (skip-serialized default-true → existing signed plans stay byte-identical) + an admission guard in `supervisor/aggregate.rs::launch` emitting a chain-signed `plan.failed` / reason `entrypoint.absent`.
- **B2** (Nix): surfaced `passthru.mvm.withDevShell` in `mk-guest.nix` + assertions in `nix/tests/mk-guest-eval.nix` (dev image wires the console; sealed image does not).

## WS-C — sealed-prod interactivity prohibition (claim 15)
- Gated the agent's PTY-over-vsock console (`crates/mvm-guest/src/console.rs`) behind `#[cfg(feature = "dev-shell")]`, mirroring the `do_exec` gate. **This was the real gap:** `mk-guest` already builds the sealed agent with `withDevShell = false`, but the console relay still linked in. Verified by `nm`: 0 console symbols in the prod build, present with `dev-shell`.
- New `prod-agent-no-console` lane (`scripts/check-prod-agent-no-console.sh` + `security.yml`), the `open_console_capture` write-only console-capture helper (libkrun + vz), and witnesses `console_refused_on_sealed_image` / `prod_console_attachment_has_no_input`.
- **Claim 15** added to `specs/claims/catalog.md`, ADR-002, and CLAUDE.md.

## Verification (local)
nightly `fmt --check`, `clippy -D warnings`, nextest **3304 passed + 325** (mvm-guest `dev-shell`), doctests, and Lint gates `check-claim-catalog` (15 claims / 36 witnesses), `check-spec-numbers`, `check-core-runtime-free`, `check-no-overclaim`. **mvm-backend tests are left to Linux CI** — the test binary SIGKILLs under macOS codesign locally.

## Three decisions to ratify (not rubber-stamp)
1. **Claim numbering jumps 13→15 in ADR-002's table.** Console is claim 15 everywhere (catalog + CLAUDE were already at 14/OCI). I deliberately did **not** promote OCI to #14 in ADR-002 — that's Plan 111's job — so the table gaps 13→15, documented in its lineage. Say if you'd rather pull OCI promotion forward to close the gap.
2. **B4 is a latent gate.** Nothing sets `entrypoint_present = false` outside tests today, by design: B3 refuses at compile so a bad sealed plan is never produced. It's documented defense-in-depth; flagging so it's a conscious call, not an oversight.
3. **A4 (E2E `RunEntrypoint` invoke witness) deferred.** A function-image build+boot E2E lane is environmentally fragile on the dev host; tracked in the plan's Deferred follow-ups. `examples/agent_invoke.rs` + `core_demo_e2e` are the building blocks.

## Caveat: claim-15 enforcement cadence
The actual symbol-absence check runs in `security.yml` (release-tags + nightly), **not per-PR** — identical to claim 4's sibling lane. The per-PR gate is `xtask check-claim-catalog` verifying the witnesses exist. Moving the lane into `ci.yml` for per-PR enforcement (for both claim 4 and 15) would be a separate, deliberate change.
