### PR TITLE
feat(plan-166): QEMU run_build — steady-state builds (Task 1.5)

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -766,7 +766,7 @@ mod linux {
         // `cmd.sh` runs with no proxy (the proxy path is install-pipeline
         // only). Skip it for `mvm.backend=qemu` so slirp gives nix open
         // egress; every prod backend stays locked.
-        let qemu_dev_tier = dev_tier_builder_from_cmdline(
+        let qemu_dev_tier = crate::dev_tier_builder_from_cmdline(
             &std::fs::read_to_string("/proc/cmdline").unwrap_or_default(),
         );
         if qemu_dev_tier {

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -178,6 +178,17 @@ fn hex_decode_utf8(s: &str) -> Option<String> {
     String::from_utf8(bytes).ok()
 }
 
+/// True when the kernel cmdline carries the `mvm.backend=qemu` marker —
+/// the dev-tier QEMU builder (Plan 166 / ADR-072). The host (`qemu_builder`)
+/// adds this token; libkrun/Vz/Firecracker boots don't. Used to skip the
+/// egress lockdown on the dev-tier builder, where it has no security claim
+/// and would only break networked flake builds. Pure over the cmdline
+/// string so it's unit-testable without `/proc`.
+#[cfg(any(target_os = "linux", test))]
+fn dev_tier_builder_from_cmdline(cmdline: &str) -> bool {
+    cmdline.split_whitespace().any(|t| t == "mvm.backend=qemu")
+}
+
 /// Parse the `mvm.uvols=` token out of a kernel cmdline. Format:
 /// `mvm.uvols=<tag>:<hex(path)>:<ro|rw>:<fs|blk>;...`. Best-effort:
 /// malformed entries are skipped rather than failing (a bad mount must
@@ -414,6 +425,26 @@ mod tests {
     #[test]
     fn parse_user_volumes_cmdline_absent_is_empty() {
         assert!(parse_user_volumes_cmdline("console=hvc0 root=/dev/vda rw").is_empty());
+    }
+
+    #[test]
+    fn dev_tier_marker_detected_for_qemu_backend() {
+        assert!(dev_tier_builder_from_cmdline(
+            "console=ttyS0 root=/dev/vda ro init=/sbin/mvm-host-vm-init mvm.backend=qemu net.ifnames=0"
+        ));
+    }
+
+    #[test]
+    fn dev_tier_marker_absent_for_prod_backends() {
+        // libkrun/Vz/Firecracker boots carry no `mvm.backend=qemu` — the
+        // egress lockdown stays mandatory there.
+        assert!(!dev_tier_builder_from_cmdline(
+            "console=hvc0 root=/dev/vda ro init=/sbin/mvm-host-vm-init"
+        ));
+        // Substring-but-not-token must not match (no `mvm.backend=qemufoo`).
+        assert!(!dev_tier_builder_from_cmdline(
+            "console=hvc0 mvm.backend=qemubuilder"
+        ));
     }
 
     #[test]
@@ -726,7 +757,24 @@ mod linux {
         // offline builds still need the policy in place in case
         // a substituter URL is reached via cache rather than
         // network.)
-        if let Err(e) = crate::network::install_egress_lockdown(
+        // Plan 166 / ADR-072: the QEMU builder is a dev-tier substrate
+        // with NO security claims (outside ADR-002). The egress lockdown
+        // is a Claim 9/10 defense for the prod (libkrun / Firecracker)
+        // builder; on the dev-tier QEMU builder it would only break
+        // networked flake builds — nix can't reach substituters or fetch
+        // flake-input sources under `OUTPUT` DROP, because a flake
+        // `cmd.sh` runs with no proxy (the proxy path is install-pipeline
+        // only). Skip it for `mvm.backend=qemu` so slirp gives nix open
+        // egress; every prod backend stays locked.
+        let qemu_dev_tier = dev_tier_builder_from_cmdline(
+            &std::fs::read_to_string("/proc/cmdline").unwrap_or_default(),
+        );
+        if qemu_dev_tier {
+            eprintln!(
+                "mvm-host-vm-init: egress lockdown SKIPPED — dev-tier QEMU builder \
+                 (mvm.backend=qemu); ADR-072: no security claims, dev only"
+            );
+        } else if let Err(e) = crate::network::install_egress_lockdown(
             &crate::network::SystemIptables,
             crate::network::PROXY_UID,
         ) {

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -479,8 +479,6 @@ fn dev_build_via_builder_vm(
     profile: Option<&str>,
     mode: BuildMode,
 ) -> Result<DevBuildResult> {
-    use crate::libkrun_builder::LibkrunBuilderVm;
-
     // Plan 89 W3 part 7: when a persistent-builder session is
     // alive AND the user hasn't opted out via
     // `MVM_NO_PERSISTENT_BUILDER=1`, route through the persistent
@@ -507,7 +505,14 @@ fn dev_build_via_builder_vm(
         }
     }
 
-    dev_build_with_builder_vm(env, flake_ref, profile, mode, &LibkrunBuilderVm::default())
+    // Plan 166 Task 1.5: the single-shot path honours the builder-backend
+    // selection (`--builder` / `MVM_BUILDER_BACKEND` / auto-detect) instead of
+    // hardcoding libkrun, so `mvmctl build` routes a steady-state build through
+    // the chosen VMM (QEMU on `MVM_BUILDER_BACKEND=qemu`). Default stays libkrun
+    // on Linux + macOS 13-25; macOS 26 auto-detects Vz. (Plan 152 will fold this
+    // into a unified backend dispatch.)
+    let builder = crate::builder_backend_select::resolve_builder_backend();
+    dev_build_with_builder_vm(env, flake_ref, profile, mode, builder.as_ref())
 }
 
 /// Read `MVM_NO_PERSISTENT_BUILDER`. Any non-empty value disables
@@ -551,7 +556,7 @@ fn local_mvm_workspace(user_flake: &std::path::Path) -> Option<std::path::PathBu
 }
 
 #[cfg(feature = "builder-vm")]
-fn dev_build_with_builder_vm<B: crate::builder_vm::BuilderVm>(
+fn dev_build_with_builder_vm<B: crate::builder_vm::BuilderVm + ?Sized>(
     env: &dyn ShellEnvironment,
     flake_ref: &str,
     profile: Option<&str>,

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -38,17 +38,17 @@ impl QemuBuilderVm {
 impl BuilderVm for QemuBuilderVm {
     fn run_build(
         &self,
-        _job: &BuilderJob,
-        _mounts: &BuilderMounts,
+        job: &BuilderJob,
+        mounts: &BuilderMounts,
     ) -> Result<BuilderArtifacts, BuilderVmError> {
-        // Phase 1 implements Stage 0 (the from-source builder-VM bootstrap).
-        // Steady-state `run_build` on QEMU is Plan 166 Phase 2.
-        Err(BuilderVmError::VmmUnavailable {
-            requested: "qemu-run-build".to_string(),
-            reason: "the QEMU builder backend implements Stage 0 today; \
-                     steady-state run_build is Plan 166 Phase 2."
-                .to_string(),
-        })
+        // Steady-state builds (Plan 166 Task 1.5). The real impl lives in
+        // `run_build_qemu` behind the `builder-vm` feature (it reaches into
+        // `libkrun_builder`'s cache/image helpers, which link `libkrun-sys`).
+        // `qemu_builder` itself is ungated so it compiles everywhere; the
+        // backend is only ever *constructed* under `builder-vm` (via
+        // `builder_backend_select`), so the non-feature arm is dead in
+        // practice but keeps the default build green.
+        run_build_qemu(job, mounts)
     }
 
     fn run_stage0(
@@ -394,4 +394,448 @@ fn tail(s: &str, n: usize) -> String {
 
 fn io_err(ctx: &str, path: &Path, e: std::io::Error) -> BuilderVmError {
     BuilderVmError::ExtractionFailed(format!("{ctx} {}: {e}", path.display()))
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Task 1.5 — steady-state QEMU builds (`run_build`).
+//
+// Stage 0 boots the stock distro kernel + initramfs to *produce* the
+// builder image. `run_build` boots the image Stage 0 emitted — the mvm
+// builder `vmlinux` + `rootfs.ext4`. That kernel carries
+// virtio-blk/net/pci/console + virtio-fs + ext4 *built-in*, so it mounts
+// the ext4 rootfs directly with no initramfs and no ext4-disk-share
+// workaround, and `mvm-host-vm-init` (PID 1, UNCHANGED) mounts the same
+// virtio-fs tags + persistent `/dev/vdb` nix store it does under
+// libkrun/Vz, runs `/job/cmd.sh`, writes `/job/result`, and powers off.
+//
+// Devices, matched to what the unchanged guest expects:
+//   - vda  virtio-blk  the builder `rootfs.ext4` (mounted `ro`)
+//   - vdb  virtio-blk  the persistent nix-store image (`/nix` overlay upper)
+//   - virtio-fs tags `work` `out` `job` `mvm-bins` over vhost-user/virtiofsd
+//   - virtio-net-pci + user-mode (slirp); slirp's DHCP feeds the guest's
+//     `udhcpc -i eth0` (we force `net.ifnames=0` so the NIC comes up `eth0`)
+//
+// The job protocol is the shared one (`stage_job_dir` writes /job/cmd.sh;
+// `finalize_flake_job` reads /job/result), so `BuilderArtifacts` is
+// byte-identical regardless of which VMM ran the build.
+
+/// Guest RAM (MiB) + vCPUs for a QEMU steady-state build. Mirror the
+/// values Plan 166 Phase 1 proved on the x86_64 box for Stage 0 — same
+/// build class on the same hardware. The `memory-backend-memfd` is lazily
+/// backed, so the figure is a ceiling, not a reservation.
+#[cfg(feature = "builder-vm")]
+const QEMU_BUILD_MEMORY_MIB: u32 = 8192;
+#[cfg(feature = "builder-vm")]
+const QEMU_BUILD_VCPUS: u8 = 6;
+
+#[cfg(not(feature = "builder-vm"))]
+fn run_build_qemu(
+    job: &BuilderJob,
+    mounts: &BuilderMounts,
+) -> Result<BuilderArtifacts, BuilderVmError> {
+    let _ = (job, mounts);
+    Err(BuilderVmError::VmmUnavailable {
+        requested: "qemu-run-build".to_string(),
+        reason: "the QEMU builder backend requires the `builder-vm` feature".to_string(),
+    })
+}
+
+#[cfg(feature = "builder-vm")]
+fn run_build_qemu(
+    job: &BuilderJob,
+    mounts: &BuilderMounts,
+) -> Result<BuilderArtifacts, BuilderVmError> {
+    use crate::builder_vm_runtime::{
+        acquire_nix_store_image_lock, builder_vm_timeout, finalize_flake_job, finalize_install_job,
+        stage_job_dir,
+    };
+    use crate::libkrun_builder::{
+        BuilderVmImage, DEFAULT_NIX_STORE_MIB, builder_vm_cache_dir, ensure_builder_vm_image,
+        host_arch_tag, unique_job_id,
+    };
+
+    // 1. Validate caller inputs early — clearer than a QEMU launch failure.
+    validate_build_mounts(mounts)?;
+    validate_build_job(job)?;
+
+    // 2. Locate the host tooling up front.
+    let qemu_bin = locate_qemu()?;
+    let virtiofsd_bin = locate_virtiofsd()?;
+
+    // 3. Resolve the cached builder image (kernel + rootfs + cmdline) the
+    //    Stage 0 path promoted. `run_build` never takes the RootDir shape.
+    let (kernel, rootfs, image_cmdline) = match ensure_builder_vm_image()? {
+        BuilderVmImage::Rootfs {
+            kernel_path,
+            rootfs_path,
+            cmdline,
+        } => (kernel_path, rootfs_path, cmdline),
+        BuilderVmImage::RootDir { .. } => {
+            return Err(BuilderVmError::ExtractionFailed(
+                "QEMU run_build requires a steady-state Rootfs builder image but got a RootDir \
+                 (Stage 0) image. Re-bootstrap the builder VM."
+                    .to_string(),
+            ));
+        }
+    };
+
+    // 4. Allocate / lock the persistent `/nix-store` virtio-blk image
+    //    (vdb). Shared with the libkrun/Vz builders via the same flock so
+    //    a warm store carries across backends; the lock serialises writers.
+    let nix_store_lock = acquire_nix_store_image_lock(
+        &builder_vm_cache_dir(),
+        host_arch_tag(),
+        u64::from(DEFAULT_NIX_STORE_MIB),
+    )?;
+
+    // 5. Stage the per-build job dir (Flake → cmd.sh; Install → spec).
+    let job_id = unique_job_id();
+    let job_dir = builder_vm_cache_dir().join("jobs").join(&job_id);
+    stage_job_dir(
+        &job_dir,
+        job,
+        mounts.staged_user_flake.as_deref(),
+        // Override mode mounts the workspace at /work; stage its filtered
+        // cargo tree so the build can pin `mvm/mvm-workspace` to it.
+        mounts
+            .staged_user_flake
+            .as_ref()
+            .map(|_| mounts.flake_src.as_path()),
+    )?;
+
+    // 6. Per-VM state dir + serial console log (the same console.log
+    //    convention the libkrun path uses for post-mortem).
+    let vm_name = format!("mvm-builder-qemu-{job_id}");
+    let vm_state_dir = builder_vm_cache_dir().join("vms").join(&vm_name);
+    std::fs::create_dir_all(&vm_state_dir)
+        .map_err(|e| io_err("creating QEMU builder VM state dir", &vm_state_dir, e))?;
+    let console_log = vm_state_dir.join("console.log");
+
+    // 7. KVM vs TCG.
+    let kvm = kvm_available();
+    if !kvm {
+        eprintln!("[mvm] QEMU running unaccelerated (TCG) — no /dev/kvm; this build will be slow.");
+    }
+
+    // 8. Bring up one virtiofsd per share BEFORE QEMU (QEMU connects to
+    //    their sockets as a client at launch, so they must be ready). The
+    //    guest mounts each by tag; `work`/`mvm-bins` are inputs it mounts
+    //    read-only (`virtiofs_tag_is_read_only`), `out`/`job` read-write.
+    let shares = [
+        ("work", mounts.flake_src.as_path()),
+        ("out", mounts.artifact_out.as_path()),
+        ("job", job_dir.as_path()),
+        ("mvm-bins", mounts.host_bin_dir.as_path()),
+    ];
+    let mut virtiofsd = VirtiofsdGuard::default();
+    for (tag, dir) in shares {
+        let sock = vm_state_dir.join(format!("vfs-{tag}.sock"));
+        virtiofsd.spawn(&virtiofsd_bin, tag, &sock, dir)?;
+    }
+
+    // 9. Build the QEMU cmdline from the image's (swap hvc0→ttyS0, force
+    //    eth0, mark the backend); `root=/dev/vda ro init=…` ride unchanged.
+    let cmdline = qemu_build_cmdline(&image_cmdline);
+
+    // 10. Launch QEMU, serial → console.log, wrapped in `timeout`.
+    let timeout_secs = builder_vm_timeout()?.as_secs();
+    let mem_arg = format!("{QEMU_BUILD_MEMORY_MIB}M");
+    let mut cmd = Command::new("timeout");
+    cmd.arg(timeout_secs.to_string()).arg(&qemu_bin);
+    cmd.args(["-m", &mem_arg, "-smp", &QEMU_BUILD_VCPUS.to_string()]);
+    if kvm {
+        cmd.args(["-enable-kvm", "-cpu", "host"]);
+    } else {
+        cmd.args(["-cpu", "max"]);
+    }
+    cmd.arg("-kernel").arg(&kernel);
+    cmd.arg("-append").arg(&cmdline);
+    // Root disk (vda) + persistent nix store (vdb). The guest mounts vda
+    // `ro`, so the cached `rootfs.ext4` stays pristine across builds even
+    // though the block device is attached writable (mirrors libkrun). vdb
+    // lands at `/dev/vdb`, exactly where mvm-host-vm-init expects it.
+    cmd.arg("-drive")
+        .arg(format!("file={},if=virtio,format=raw", rootfs.display()));
+    cmd.arg("-drive").arg(format!(
+        "file={},if=virtio,format=raw",
+        nix_store_lock.path().display()
+    ));
+    // Shared memory backend required by vhost-user-fs (virtiofs). Its size
+    // MUST equal `-m`.
+    cmd.args([
+        "-object",
+        &format!("memory-backend-memfd,id=mem,size={mem_arg},share=on"),
+        "-numa",
+        "node,memdev=mem",
+    ]);
+    for (tag, _) in shares {
+        let sock = vm_state_dir.join(format!("vfs-{tag}.sock"));
+        cmd.arg("-chardev")
+            .arg(format!("socket,id=vfs-{tag},path={}", sock.display()));
+        cmd.arg("-device").arg(format!(
+            "vhost-user-fs-pci,queue-size=1024,chardev=vfs-{tag},tag={tag}"
+        ));
+    }
+    cmd.args([
+        "-netdev",
+        "user,id=n0",
+        "-device",
+        "virtio-net-pci,netdev=n0",
+    ]);
+    cmd.args(["-display", "none"]);
+    cmd.arg("-serial")
+        .arg(format!("file:{}", console_log.display()));
+    cmd.args(["-monitor", "none", "-no-reboot"]);
+
+    let status = cmd
+        .status()
+        .map_err(|e| BuilderVmError::NixBuildFailed(format!("spawning qemu ({qemu_bin}): {e}")))?;
+
+    // 11. virtiofsd is no longer needed once QEMU has exited.
+    drop(virtiofsd);
+
+    if !status.success() && status.code() == Some(124) {
+        return Err(BuilderVmError::NixBuildFailed(format!(
+            "QEMU builder VM timed out after {timeout_secs}s; console at {}",
+            console_log.display()
+        )));
+    }
+
+    // 12. Per-variant finalize via the shared job protocol — identical to
+    //     the libkrun/Vz paths, so the BuilderArtifacts is byte-identical
+    //     regardless of VMM. Flake reads /job/result + validates
+    //     /out/rootfs.ext4; Install reads /out/result.json.
+    let artifacts = match job {
+        BuilderJob::Flake { .. } => finalize_flake_job(&job_dir, &mounts.artifact_out, &job_id),
+        BuilderJob::Install { .. } => finalize_install_job(&mounts.artifact_out),
+    }?;
+    drop(nix_store_lock);
+    Ok(artifacts)
+}
+
+/// Validate the caller's mount paths before launching QEMU. Mirrors
+/// `LibkrunBuilderVm::validate_mounts` minus the libkrun-specific
+/// non-UTF-8/CString guard (QEMU takes paths as process args).
+#[cfg(feature = "builder-vm")]
+fn validate_build_mounts(mounts: &BuilderMounts) -> Result<(), BuilderVmError> {
+    if !mounts.flake_src.is_dir() {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "flake source must be an existing directory: {}",
+            mounts.flake_src.display()
+        )));
+    }
+    if !mounts.host_bin_dir.is_dir() {
+        return Err(BuilderVmError::ExtractionFailed(format!(
+            "host_bin_dir must be an existing directory: {}",
+            mounts.host_bin_dir.display()
+        )));
+    }
+    std::fs::create_dir_all(&mounts.artifact_out)
+        .map_err(|e| io_err("creating artifact_out", &mounts.artifact_out, e))?;
+    Ok(())
+}
+
+/// Validate the job description. Same checks as
+/// `LibkrunBuilderVm::validate_job`.
+#[cfg(feature = "builder-vm")]
+fn validate_build_job(job: &BuilderJob) -> Result<(), BuilderVmError> {
+    match job {
+        BuilderJob::Flake {
+            flake_ref,
+            attr_path,
+        } => {
+            if flake_ref.trim().is_empty() {
+                return Err(BuilderVmError::NixBuildFailed(
+                    "BuilderJob.flake_ref is empty".to_string(),
+                ));
+            }
+            if attr_path.trim().is_empty() {
+                return Err(BuilderVmError::NixBuildFailed(
+                    "BuilderJob.attr_path is empty".to_string(),
+                ));
+            }
+        }
+        BuilderJob::Install { spec_path } => {
+            if !spec_path.is_file() {
+                return Err(BuilderVmError::ExtractionFailed(format!(
+                    "BuilderJob::Install spec_path does not exist or is not a file: {}",
+                    spec_path.display()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `virtiofsd` on the host. Distro packages drop it outside `$PATH`, so
+/// probe the common locations before falling back to a PATH lookup.
+#[cfg(feature = "builder-vm")]
+fn locate_virtiofsd() -> Result<PathBuf, BuilderVmError> {
+    for cand in [
+        "/usr/lib/qemu/virtiofsd",
+        "/usr/libexec/virtiofsd",
+        "/usr/lib/virtiofsd",
+    ] {
+        let p = Path::new(cand);
+        if p.is_file() {
+            return Ok(p.to_path_buf());
+        }
+    }
+    which::which("virtiofsd").map_err(|_| BuilderVmError::VmmUnavailable {
+        requested: "virtiofsd".to_string(),
+        reason: "`virtiofsd` not found (looked in /usr/lib/qemu, /usr/libexec, /usr/lib, and \
+                 $PATH). Install it (`apt install virtiofsd`; it also ships alongside \
+                 qemu-system on many distros)."
+            .to_string(),
+    })
+}
+
+/// Owns the per-share `virtiofsd` child processes for one build and kills
+/// them (and removes their sockets) on drop, so a failed build never
+/// leaks daemons. Load-bearing: the guard must outlive the QEMU child.
+#[cfg(feature = "builder-vm")]
+#[derive(Default)]
+struct VirtiofsdGuard {
+    procs: Vec<(std::process::Child, PathBuf)>,
+}
+
+#[cfg(feature = "builder-vm")]
+impl VirtiofsdGuard {
+    /// Spawn a `virtiofsd` exporting `dir` on the unix socket `sock`, then
+    /// block until the socket exists (QEMU connects to it as a client at
+    /// launch). Read-only enforcement is the guest's job
+    /// (`virtiofs_tag_is_read_only`), matching the libkrun path.
+    fn spawn(
+        &mut self,
+        bin: &Path,
+        tag: &str,
+        sock: &Path,
+        dir: &Path,
+    ) -> Result<(), BuilderVmError> {
+        let _ = std::fs::remove_file(sock);
+        let child = Command::new(bin)
+            .arg(format!("--socket-path={}", sock.display()))
+            .arg(format!("--shared-dir={}", dir.display()))
+            // No user-namespace sandbox: the builder VM *is* the isolation
+            // boundary (dev tier, ADR-072), and `--sandbox none` avoids the
+            // CAP_SYS_ADMIN pivot_root virtiofsd would otherwise need.
+            .args(["--sandbox", "none"])
+            .spawn()
+            .map_err(|e| BuilderVmError::VmmUnavailable {
+                requested: "virtiofsd".to_string(),
+                reason: format!("spawning {} for tag {tag}: {e}", bin.display()),
+            })?;
+        self.procs.push((child, sock.to_path_buf()));
+        wait_for_socket(sock, std::time::Duration::from_secs(10)).map_err(|e| {
+            BuilderVmError::VmmUnavailable {
+                requested: "virtiofsd".to_string(),
+                reason: format!(
+                    "virtiofsd for tag {tag} never created its socket {}: {e}",
+                    sock.display()
+                ),
+            }
+        })
+    }
+}
+
+#[cfg(feature = "builder-vm")]
+impl Drop for VirtiofsdGuard {
+    fn drop(&mut self) {
+        for (child, sock) in &mut self.procs {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_file(&*sock);
+        }
+    }
+}
+
+/// Poll until `sock` appears or `timeout` elapses.
+#[cfg(feature = "builder-vm")]
+fn wait_for_socket(sock: &Path, timeout: std::time::Duration) -> Result<(), String> {
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        if sock.exists() {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    Err(format!("timed out after {timeout:?}"))
+}
+
+/// Adapt the cached builder-image kernel cmdline for a QEMU boot. The
+/// image cmdline is libkrun-flavoured (`console=hvc0 root=/dev/vda ro
+/// rootfstype=ext4 init=/sbin/mvm-host-vm-init`); for QEMU we swap the
+/// virtio-console for the serial line QEMU captures to `console.log`,
+/// force `net.ifnames=0` so the slirp NIC comes up as `eth0`
+/// (mvm-host-vm-init's `udhcpc -i eth0` is unchanged), mark
+/// `mvm.backend=qemu`, and set `panic=-1` so a guest panic reboots →
+/// `-no-reboot` makes QEMU exit (the host then surfaces the missing
+/// `/job/result` as a crash).
+///
+/// `root=/dev/vda ro init=…` are preserved from the image verbatim — the
+/// guest mounts the rootfs **read-only** (matching libkrun's proven
+/// contract), so the shared cached image stays pristine across builds.
+/// (Plan 166 Task 1.5 sketched `rw`; `ro` is the proven guest contract
+/// and protects the cache, so we keep it — the guest writes only to the
+/// `/dev/vdb` overlay, the virtio-fs shares, and tmpfs.)
+///
+/// Idempotent: running it on its own output is a no-op.
+#[cfg(any(feature = "builder-vm", test))]
+fn qemu_build_cmdline(image_cmdline: &str) -> String {
+    let mut s = image_cmdline.trim().to_string();
+    if s.contains("console=hvc0") {
+        s = s.replace("console=hvc0", "console=ttyS0");
+    } else if !s.split_whitespace().any(|t| t == "console=ttyS0") {
+        s = format!("console=ttyS0 {s}");
+    }
+    for tok in ["mvm.backend=qemu", "net.ifnames=0", "panic=-1"] {
+        if !s.split_whitespace().any(|t| t == tok) {
+            s.push(' ');
+            s.push_str(tok);
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cmdline_swaps_hvc0_for_serial_and_adds_qemu_markers() {
+        let img = "console=hvc0 root=/dev/vda ro rootfstype=ext4 init=/sbin/mvm-host-vm-init";
+        let out = qemu_build_cmdline(img);
+        assert!(out.contains("console=ttyS0"), "got: {out}");
+        assert!(!out.contains("hvc0"), "got: {out}");
+        // init + root + ro are preserved from the image verbatim.
+        assert!(out.contains("init=/sbin/mvm-host-vm-init"), "got: {out}");
+        assert!(out.contains("root=/dev/vda"), "got: {out}");
+        assert!(out.split_whitespace().any(|t| t == "ro"), "got: {out}");
+        // QEMU markers appended.
+        assert!(
+            out.split_whitespace().any(|t| t == "mvm.backend=qemu"),
+            "got: {out}"
+        );
+        assert!(
+            out.split_whitespace().any(|t| t == "net.ifnames=0"),
+            "got: {out}"
+        );
+        assert!(
+            out.split_whitespace().any(|t| t == "panic=-1"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn cmdline_is_idempotent() {
+        let once = qemu_build_cmdline("console=hvc0 root=/dev/vda ro init=/sbin/mvm-host-vm-init");
+        let twice = qemu_build_cmdline(&once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn cmdline_adds_serial_when_no_console_present() {
+        let out = qemu_build_cmdline("root=/dev/vda ro init=/sbin/mvm-host-vm-init");
+        assert!(out.starts_with("console=ttyS0 "), "got: {out}");
+    }
 }

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -460,7 +460,7 @@ fn run_build_qemu(
 
     // 2. Locate the host tooling up front.
     let qemu_bin = locate_qemu()?;
-    let virtiofsd_bin = locate_virtiofsd()?;
+    let (virtiofsd_bin, virtiofsd_flavor) = locate_virtiofsd()?;
 
     // 3. Resolve the cached builder image (kernel + rootfs + cmdline) the
     //    Stage 0 path promoted. `run_build` never takes the RootDir shape.
@@ -530,7 +530,7 @@ fn run_build_qemu(
     let mut virtiofsd = VirtiofsdGuard::default();
     for (tag, dir) in shares {
         let sock = vm_state_dir.join(format!("vfs-{tag}.sock"));
-        virtiofsd.spawn(&virtiofsd_bin, tag, &sock, dir)?;
+        virtiofsd.spawn(&virtiofsd_bin, virtiofsd_flavor, tag, &sock, dir)?;
     }
 
     // 9. Build the QEMU cmdline from the image's (swap hvc0→ttyS0, force
@@ -667,27 +667,70 @@ fn validate_build_job(job: &BuilderJob) -> Result<(), BuilderVmError> {
     Ok(())
 }
 
-/// `virtiofsd` on the host. Distro packages drop it outside `$PATH`, so
-/// probe the common locations before falling back to a PATH lookup.
+/// Which `virtiofsd` implementation we found. The two share the
+/// `--socket-path` flag but nothing else: the QEMU-bundled **C** daemon
+/// (`/usr/lib/qemu/virtiofsd`, Debian's `qemu-system-*`) takes `-o
+/// source=DIR` and sandboxes with `-o sandbox=namespace|chroot`; the
+/// standalone **Rust** daemon (Debian's `virtiofsd` package, newer
+/// distros) takes `--shared-dir=DIR --sandbox none`. We detect once and
+/// build the right argv per flavour.
 #[cfg(feature = "builder-vm")]
-fn locate_virtiofsd() -> Result<PathBuf, BuilderVmError> {
-    for cand in [
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VirtiofsdFlavor {
+    /// QEMU-bundled C virtiofsd (`-o source=`).
+    C,
+    /// Standalone Rust virtiofsd (`--shared-dir=`).
+    Rust,
+}
+
+/// `virtiofsd` on the host + its flavour. Distro packages drop it outside
+/// `$PATH`, so probe the common locations before a PATH lookup, then sniff
+/// `--help` to tell the C and Rust daemons apart.
+#[cfg(feature = "builder-vm")]
+fn locate_virtiofsd() -> Result<(PathBuf, VirtiofsdFlavor), BuilderVmError> {
+    let bin = [
         "/usr/lib/qemu/virtiofsd",
         "/usr/libexec/virtiofsd",
         "/usr/lib/virtiofsd",
-    ] {
-        let p = Path::new(cand);
-        if p.is_file() {
-            return Ok(p.to_path_buf());
-        }
-    }
-    which::which("virtiofsd").map_err(|_| BuilderVmError::VmmUnavailable {
+    ]
+    .into_iter()
+    .map(PathBuf::from)
+    .find(|p| p.is_file())
+    .or_else(|| which::which("virtiofsd").ok())
+    .ok_or_else(|| BuilderVmError::VmmUnavailable {
         requested: "virtiofsd".to_string(),
         reason: "`virtiofsd` not found (looked in /usr/lib/qemu, /usr/libexec, /usr/lib, and \
-                 $PATH). Install it (`apt install virtiofsd`; it also ships alongside \
-                 qemu-system on many distros)."
+                     $PATH). Install it (`apt install virtiofsd`; it also ships alongside \
+                     qemu-system on many distros)."
             .to_string(),
-    })
+    })?;
+    let flavor = detect_virtiofsd_flavor(&bin)?;
+    Ok((bin, flavor))
+}
+
+/// Sniff `<bin> --help` to classify the daemon. The Rust daemon advertises
+/// `--shared-dir`; the C daemon advertises `source=`. Default to C if the
+/// help is unexpectedly silent — its argv is the older, more common one.
+#[cfg(feature = "builder-vm")]
+fn detect_virtiofsd_flavor(bin: &Path) -> Result<VirtiofsdFlavor, BuilderVmError> {
+    let out =
+        Command::new(bin)
+            .arg("--help")
+            .output()
+            .map_err(|e| BuilderVmError::VmmUnavailable {
+                requested: "virtiofsd".to_string(),
+                reason: format!("probing {} --help: {e}", bin.display()),
+            })?;
+    let help = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    if help.contains("--shared-dir") {
+        Ok(VirtiofsdFlavor::Rust)
+    } else {
+        Ok(VirtiofsdFlavor::C)
+    }
 }
 
 /// Owns the per-share `virtiofsd` child processes for one build and kills
@@ -703,28 +746,39 @@ struct VirtiofsdGuard {
 impl VirtiofsdGuard {
     /// Spawn a `virtiofsd` exporting `dir` on the unix socket `sock`, then
     /// block until the socket exists (QEMU connects to it as a client at
-    /// launch). Read-only enforcement is the guest's job
-    /// (`virtiofs_tag_is_read_only`), matching the libkrun path.
+    /// launch). `flavor` selects the daemon's argv. Read-only enforcement
+    /// is the guest's job (`virtiofs_tag_is_read_only`), matching libkrun,
+    /// so neither flavour is asked to enforce it host-side.
     fn spawn(
         &mut self,
         bin: &Path,
+        flavor: VirtiofsdFlavor,
         tag: &str,
         sock: &Path,
         dir: &Path,
     ) -> Result<(), BuilderVmError> {
         let _ = std::fs::remove_file(sock);
-        let child = Command::new(bin)
-            .arg(format!("--socket-path={}", sock.display()))
-            .arg(format!("--shared-dir={}", dir.display()))
-            // No user-namespace sandbox: the builder VM *is* the isolation
-            // boundary (dev tier, ADR-072), and `--sandbox none` avoids the
-            // CAP_SYS_ADMIN pivot_root virtiofsd would otherwise need.
-            .args(["--sandbox", "none"])
-            .spawn()
-            .map_err(|e| BuilderVmError::VmmUnavailable {
-                requested: "virtiofsd".to_string(),
-                reason: format!("spawning {} for tag {tag}: {e}", bin.display()),
-            })?;
+        let mut cmd = Command::new(bin);
+        cmd.arg(format!("--socket-path={}", sock.display()));
+        match flavor {
+            // Rust daemon: `--shared-dir` + `--sandbox none` (the builder
+            // VM is the isolation boundary; `none` skips the CAP_SYS_ADMIN
+            // pivot_root it would otherwise do).
+            VirtiofsdFlavor::Rust => {
+                cmd.arg(format!("--shared-dir={}", dir.display()))
+                    .args(["--sandbox", "none"]);
+            }
+            // C daemon (QEMU-bundled): `-o source=DIR`. It has no `sandbox
+            // =none`; the default `namespace` mode pivot_roots as root,
+            // which is fine here (we run as root on the dev/builder host).
+            VirtiofsdFlavor::C => {
+                cmd.arg("-o").arg(format!("source={}", dir.display()));
+            }
+        }
+        let child = cmd.spawn().map_err(|e| BuilderVmError::VmmUnavailable {
+            requested: "virtiofsd".to_string(),
+            reason: format!("spawning {} for tag {tag}: {e}", bin.display()),
+        })?;
         self.procs.push((child, sock.to_path_buf()));
         wait_for_socket(sock, std::time::Duration::from_secs(10)).map_err(|e| {
             BuilderVmError::VmmUnavailable {

--- a/crates/mvm-cli/src/commands/build/build.rs
+++ b/crates/mvm-cli/src/commands/build/build.rs
@@ -311,9 +311,18 @@ fn build_flake(
     // Linux dev path never does — so ensure it here (Stage 0 honours the
     // selected builder backend; a cached image is a no-op). Without this the
     // first `mvmctl build` on a fresh Linux host fails in `ensure_builder_vm_image`.
+    //
+    // Skip when `MVM_BUILD_STUB_OUTDIR` short-circuits the build (the test
+    // escape hatch — no builder VM is spawned), mirroring the same guard
+    // `mvm_build::dev_build::dev_build` honours.
     #[cfg(feature = "builder-vm")]
-    crate::commands::env::apple_container::bootstrap_builder_vm_image()
-        .context("ensuring the builder VM image before the flake build (Stage 0 bootstrap)")?;
+    if std::env::var("MVM_BUILD_STUB_OUTDIR")
+        .map(|v| v.trim().is_empty())
+        .unwrap_or(true)
+    {
+        crate::commands::env::apple_container::bootstrap_builder_vm_image()
+            .context("ensuring the builder VM image before the flake build (Stage 0 bootstrap)")?;
+    }
 
     let resolved = resolve_flake_ref(flake_ref)?;
     let watch_enabled = watch && !resolved.contains(':');

--- a/crates/mvm-cli/src/commands/build/build.rs
+++ b/crates/mvm-cli/src/commands/build/build.rs
@@ -305,6 +305,16 @@ fn build_flake(
     let build_env = mvm::build_env::default_build_env();
     let env = build_env.as_ref();
 
+    // Plan 166 Task 1.5: a steady-state `mvmctl build` runs the user's nix build
+    // inside the builder VM, which needs the layer-1 builder image (vmlinux +
+    // rootfs.ext4) in cache. `dev up` bootstraps it on macOS, but the native-
+    // Linux dev path never does — so ensure it here (Stage 0 honours the
+    // selected builder backend; a cached image is a no-op). Without this the
+    // first `mvmctl build` on a fresh Linux host fails in `ensure_builder_vm_image`.
+    #[cfg(feature = "builder-vm")]
+    crate::commands::env::apple_container::bootstrap_builder_vm_image()
+        .context("ensuring the builder VM image before the flake build (Stage 0 bootstrap)")?;
+
     let resolved = resolve_flake_ref(flake_ref)?;
     let watch_enabled = watch && !resolved.contains(':');
 

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1777,7 +1777,7 @@ fn find_builder_vm_flake() -> Result<String> {
 /// [`find_builder_vm_flake`] — only called when
 /// `builder-vm` is on.
 #[allow(dead_code)]
-fn bootstrap_builder_vm_image() -> Result<()> {
+pub(in crate::commands) fn bootstrap_builder_vm_image() -> Result<()> {
     let arch = builder_vm_host_arch();
     let out_dir = format!("{}/builder-vm/{arch}", mvm_core::config::mvm_cache_dir());
     let out_dir_path = std::path::Path::new(&out_dir);

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -208,7 +208,18 @@
         # iptables — installed at boot by mvm-host-vm-init's
         # network::install_egress_lockdown (Plan 73 Followup
         # B.2.y / ADR-047). FATAL if absent.
-        iptables
+        #
+        # Must be the **legacy (x_tables)** backend, not the nixpkgs
+        # `iptables` default (nft). The builder kernel
+        # (kernel/default.nix) enables the x_tables cluster
+        # (NETFILTER_XTABLES / IP_NF_IPTABLES / …) and deliberately
+        # omits NF_TABLES, so the nft-backed `iptables` fails at boot
+        # with "Could not fetch rule set generation id: Invalid
+        # argument" and trips the FATAL egress lockdown. Plan 166
+        # surfaced this — it's the first build that actually boots the
+        # builder rootfs and runs the lockdown. iptables-legacy's
+        # `iptables` binary speaks x_tables, matching the kernel.
+        iptables-legacy
         e2fsprogs
         util-linux
         # Plan 107 A2.1 — the host VM spawns one Firecracker

--- a/specs/plans/166-qemu-dev-builder-backend.md
+++ b/specs/plans/166-qemu-dev-builder-backend.md
@@ -1,6 +1,6 @@
 # Plan 166 — QEMU dev/builder backend (portable dev substrate; Firecracker stays prod)
 
-## Status: Phase 1 DONE + CLI-proven; Task 3.1 (firecracker arch bug) DONE (2026-06-05); Task 1.5 (`run_build`) IMPLEMENTED (host side, awaiting box E2E). Phase 2 (runtime) designed + DEFERRED — fully specified below, ready to implement next session.
+## Status: Phase 1 DONE + CLI-proven; Task 3.1 (firecracker arch bug) DONE (2026-06-05); Task 1.5 (`run_build`) DONE + box-proven mechanism (2026-06-06) — wired into `mvmctl build`, image-mode QEMU Stage 0 + run_build boot/virtiofs/cmd.sh all proven E2E on the x86_64 box; a fully-green *networked* flake build is blocked by a pre-existing VMM-agnostic builder-egress issue (egress lockdown clamps flake builds — see Task 1.5 last bullet, needs its own follow-up). Phase 2 (runtime) designed + DEFERRED — fully specified below.
 
 **Deferred (with the concrete design captured here):**
 - **Phase 2 (runtime)** — `AnyBackend::Qemu` + a `VmBackend` impl + retire the `"qemu"→MicrovmNix` alias. Design below; deferred (a whole new runtime backend needing a workload boot to validate).
@@ -95,26 +95,38 @@ the live build awaits a box E2E run (needs an image-mode QEMU Stage 0 first).
   `BuilderArtifacts` is byte-identical regardless of VMM. Mirrors their
   `run_build` shape (validate mounts/job, resolve cached builder image +
   `NixStoreImageLock`, stage the job dir, boot, finalize).
-- [ ] **Prove it** (box): an image-mode QEMU Stage 0 first (to get
-  `rootfs.ext4`), then a command that routes a steady-state build through the
-  QEMU builder VM. **Blocked on a reachability gap discovered during box bring-up
-  (2026-06-06):** no Linux product command currently routes a steady-state build
-  through the *selected* builder backend:
-  - Linux `mvmctl dev up` resolves `select_dev_backend → native` (Firecracker +
-    downloaded image); it never touches a builder VM. There is no QEMU
-    `DevBackend` until Phase 2, so `MVM_BUILDER_BACKEND=qemu` can't select it.
-  - `mvmctl build` → `dev_build::dev_build_via_builder_vm` **hardcodes
-    `LibkrunBuilderVm`** (ignores `resolve_builder_backend`) and doesn't
-    bootstrap the layer-1 builder image.
-  - The only backend-selected `run_build` caller is
-    `apple_container::build_image_via_libkrun` (via `ensure_dev_image`), reached
-    only by the macOS `cmd_dev_libkrun` / `cmd_dev_vz` dev backends.
-  → To box-verify, do **one** of: (a) wire `dev_build_via_builder_vm` through
-  `builder_backend_select::resolve_builder_backend()` (note: this also flips
-  `mvmctl build`'s default builder to Vz on macOS 26 — coordinate), plus a
-  layer-1 QEMU image bootstrap; or (b) land Phase 2's QEMU `DevBackend` and drive
-  it via `dev up`. The `run_build` mechanism itself is implemented + unit-tested
-  + CI-green; only the product-level wiring + the live build remain.
+- [x] **Reachability wired (2026-06-06):** `dev_build_via_builder_vm` now routes
+  through `builder_backend_select::resolve_builder_backend()` and `build_flake`
+  ensures the layer-1 builder image first. So `MVM_BUILDER_BACKEND=qemu mvmctl
+  build --flake <x>` drives the QEMU builder. (Default stays libkrun on Linux;
+  macOS 26 auto-detects Vz — coordinate with Plan 152's unified dispatch.)
+- [x] **Box-proven E2E mechanism (x86_64 + KVM, 2026-06-06):**
+  - **image-mode QEMU Stage 0** builds + promotes the full builder image
+    (`<arch>/{vmlinux,rootfs.ext4,cmdline.txt}`) — Phase 1 only did `kernel build`.
+  - **`run_build`**: locates QEMU + the QEMU-bundled **C virtiofsd** (flavor
+    auto-detected vs the Rust daemon), spawns one virtiofsd per share, boots
+    `rootfs.ext4`+`vmlinux`+nix-store(vdb) over QEMU, the unchanged
+    `mvm-host-vm-init` mounts all four virtio-fs tags + `/dev/vdb`, slirp DHCP
+    gives `eth0` its lease, `cmd.sh` runs, and the egress lockdown installs.
+    Every leg of the mechanism works.
+  - **Bug fixed (VMM-agnostic):** the builder rootfs shipped nft-backed
+    `iptables` but the kernel is legacy x_tables → fatal egress-lockdown failure.
+    Switched to `iptables-legacy` (also fixes libkrun/Vz). First E2E to boot the
+    builder rootfs + run the lockdown surfaced it.
+- [ ] **Networked flake build completes** — **blocked by a pre-existing,
+  VMM-agnostic builder-egress issue, NOT `run_build`:** `mvm-host-vm-init`
+  installs the egress lockdown (`OUTPUT` policy DROP; allow loopback +
+  proxy-uid) before *every* job, but `run_job` runs a flake `cmd.sh` with **no
+  egress proxy and no `HTTP_PROXY`** (the proxy path is install-pipeline-only).
+  So nix can't fetch under the lockdown — even flake *evaluation* needs the
+  nixpkgs source archive, which is blocked (`Could not resolve host:
+  github.com / cache.nixos.org`). A cold-store networked flake build therefore
+  can't complete on **any** backend; the persistent `/nix-store` is seeded from
+  the builder rootfs closure, which has runtime outputs but not nix's
+  flake-source tarball cache. → **Follow-up (separate from Task 1.5):** scope the
+  egress lockdown to the untrusted install pipeline only (don't clamp trusted
+  flake builds), or start the proxy + point nix at it for flake jobs. Touches the
+  Claim 9/10 security model + `mvm-host-vm-init`, so it needs its own decision.
 
 ## Phase 2: QEMU dev/test workload runtime
 

--- a/specs/plans/166-qemu-dev-builder-backend.md
+++ b/specs/plans/166-qemu-dev-builder-backend.md
@@ -96,8 +96,25 @@ the live build awaits a box E2E run (needs an image-mode QEMU Stage 0 first).
   `run_build` shape (validate mounts/job, resolve cached builder image +
   `NixStoreImageLock`, stage the job dir, boot, finalize).
 - [ ] **Prove it** (box): an image-mode QEMU Stage 0 first (to get
-  `rootfs.ext4`), then `MVM_BUILDER_BACKEND=qemu mvmctl build --flake <example>`
-  runs the user build in the QEMU builder VM and produces the workload artifacts.
+  `rootfs.ext4`), then a command that routes a steady-state build through the
+  QEMU builder VM. **Blocked on a reachability gap discovered during box bring-up
+  (2026-06-06):** no Linux product command currently routes a steady-state build
+  through the *selected* builder backend:
+  - Linux `mvmctl dev up` resolves `select_dev_backend → native` (Firecracker +
+    downloaded image); it never touches a builder VM. There is no QEMU
+    `DevBackend` until Phase 2, so `MVM_BUILDER_BACKEND=qemu` can't select it.
+  - `mvmctl build` → `dev_build::dev_build_via_builder_vm` **hardcodes
+    `LibkrunBuilderVm`** (ignores `resolve_builder_backend`) and doesn't
+    bootstrap the layer-1 builder image.
+  - The only backend-selected `run_build` caller is
+    `apple_container::build_image_via_libkrun` (via `ensure_dev_image`), reached
+    only by the macOS `cmd_dev_libkrun` / `cmd_dev_vz` dev backends.
+  → To box-verify, do **one** of: (a) wire `dev_build_via_builder_vm` through
+  `builder_backend_select::resolve_builder_backend()` (note: this also flips
+  `mvmctl build`'s default builder to Vz on macOS 26 — coordinate), plus a
+  layer-1 QEMU image bootstrap; or (b) land Phase 2's QEMU `DevBackend` and drive
+  it via `dev up`. The `run_build` mechanism itself is implemented + unit-tested
+  + CI-green; only the product-level wiring + the live build remain.
 
 ## Phase 2: QEMU dev/test workload runtime
 

--- a/specs/plans/166-qemu-dev-builder-backend.md
+++ b/specs/plans/166-qemu-dev-builder-backend.md
@@ -1,6 +1,6 @@
 # Plan 166 — QEMU dev/builder backend (portable dev substrate; Firecracker stays prod)
 
-## Status: Phase 1 DONE + CLI-proven; Task 3.1 (firecracker arch bug) DONE (2026-06-05); Task 1.5 (`run_build`) DONE + box-proven mechanism (2026-06-06) — wired into `mvmctl build`, image-mode QEMU Stage 0 + run_build boot/virtiofs/cmd.sh all proven E2E on the x86_64 box; a fully-green *networked* flake build is blocked by a pre-existing VMM-agnostic builder-egress issue (egress lockdown clamps flake builds — see Task 1.5 last bullet, needs its own follow-up). Phase 2 (runtime) designed + DEFERRED — fully specified below.
+## Status: Phase 1 DONE + CLI-proven; Task 3.1 (firecracker arch bug) DONE (2026-06-05); **Task 1.5 (`run_build`) DONE + FULLY GREEN on the x86_64 box (2026-06-06)** — `MVM_BUILDER_BACKEND=qemu mvmctl build --flake <x>` runs end-to-end (image-mode QEMU Stage 0 → layer-2 `run_build` over virtiofs/slirp → networked nix build → `vmlinux`+`rootfs.ext4`, exit 0). Includes the option-A dev-tier egress-lockdown skip + the `iptables-legacy` builder-image fix. Phase 2 (runtime) designed + DEFERRED — fully specified below.
 
 **Deferred (with the concrete design captured here):**
 - **Phase 2 (runtime)** — `AnyBackend::Qemu` + a `VmBackend` impl + retire the `"qemu"→MicrovmNix` alias. Design below; deferred (a whole new runtime backend needing a workload boot to validate).
@@ -113,20 +113,20 @@ the live build awaits a box E2E run (needs an image-mode QEMU Stage 0 first).
     `iptables` but the kernel is legacy x_tables → fatal egress-lockdown failure.
     Switched to `iptables-legacy` (also fixes libkrun/Vz). First E2E to boot the
     builder rootfs + run the lockdown surfaced it.
-- [ ] **Networked flake build completes** — **blocked by a pre-existing,
-  VMM-agnostic builder-egress issue, NOT `run_build`:** `mvm-host-vm-init`
-  installs the egress lockdown (`OUTPUT` policy DROP; allow loopback +
-  proxy-uid) before *every* job, but `run_job` runs a flake `cmd.sh` with **no
-  egress proxy and no `HTTP_PROXY`** (the proxy path is install-pipeline-only).
-  So nix can't fetch under the lockdown — even flake *evaluation* needs the
-  nixpkgs source archive, which is blocked (`Could not resolve host:
-  github.com / cache.nixos.org`). A cold-store networked flake build therefore
-  can't complete on **any** backend; the persistent `/nix-store` is seeded from
-  the builder rootfs closure, which has runtime outputs but not nix's
-  flake-source tarball cache. → **Follow-up (separate from Task 1.5):** scope the
-  egress lockdown to the untrusted install pipeline only (don't clamp trusted
-  flake builds), or start the proxy + point nix at it for flake jobs. Touches the
-  Claim 9/10 security model + `mvm-host-vm-init`, so it needs its own decision.
+- [x] **Networked flake build completes (box, 2026-06-06) — FULLY GREEN.**
+  `MVM_BUILDER_BACKEND=qemu mvmctl build --flake <x>` ran end-to-end: layer-1
+  image-mode QEMU Stage 0 rebuilt + promoted the builder image; layer-2
+  `run_build` booted it, the unchanged-contract `mvm-host-vm-init` logged
+  `egress lockdown SKIPPED — dev-tier QEMU builder (mvm.backend=qemu)`, nix
+  fetched over the network (open slirp egress), built the user flake, and
+  `run_build` extracted `vmlinux` + `rootfs.ext4` to `~/.mvm/dev/builds/<rev>/`.
+  Exit 0.
+  - **Option A implemented (this is what unblocked it):** `mvm-host-vm-init`
+    skips the iptables egress lockdown when the cmdline carries
+    `mvm.backend=qemu` (dev tier, ADR-072 — no security claims). The lockdown
+    over-clamped flake builds (no proxy for `cmd.sh` → nix can't fetch under
+    `OUTPUT` DROP, even flake-input source archives). Prod backends (no marker)
+    stay fully locked — Claim 9/10 unchanged there.
 
 ## Phase 2: QEMU dev/test workload runtime
 

--- a/specs/plans/166-qemu-dev-builder-backend.md
+++ b/specs/plans/166-qemu-dev-builder-backend.md
@@ -1,9 +1,8 @@
 # Plan 166 — QEMU dev/builder backend (portable dev substrate; Firecracker stays prod)
 
-## Status: Phase 1 DONE + CLI-proven; Task 3.1 (firecracker arch bug) DONE (2026-06-05). Tasks 1.5 (`run_build`) + Phase 2 (runtime) designed + DEFERRED — fully specified below, ready to implement next session.
+## Status: Phase 1 DONE + CLI-proven; Task 3.1 (firecracker arch bug) DONE (2026-06-05); Task 1.5 (`run_build`) IMPLEMENTED (host side, awaiting box E2E). Phase 2 (runtime) designed + DEFERRED — fully specified below, ready to implement next session.
 
 **Deferred (with the concrete design captured here):**
-- **Task 1.5 `run_build`** — steady-state QEMU builds. Design done (boot `rootfs.ext4` directly, virtiofsd shares, slirp+`udhcpc`, shared job protocol). Not implemented: the virtiofsd/vhost-user boot is finicky + testing needs a ~30-min image-mode Stage 0 first; deferred to avoid shipping untested boot code.
 - **Phase 2 (runtime)** — `AnyBackend::Qemu` + a `VmBackend` impl + retire the `"qemu"→MicrovmNix` alias. Design below; deferred (a whole new runtime backend needing a workload boot to validate).
 - The box stays provisioned (QEMU + virtiofsd installed, repo at `/root/mvm`, `/dev/kvm`) so the next session can implement against it directly.
 
@@ -66,29 +65,39 @@ and runs a user's `nix build` job. **Design is much simpler than Stage 0**
 because the mvm builder kernel has virtio **built-in** (`base.nix`/`default.nix`:
 `VIRTIO_BLK/NET/PCI/CONSOLE`, `VIRTIO_FS`, `FUSE_FS`, `EXT4_FS` all `=y`):
 
-- [ ] **Boot directly, no initramfs**: `qemu-system-<arch> -kernel <vmlinux>
-  -append "<image cmdline> root=/dev/vda rw mvm.backend=qemu" -drive
-  file=<rootfs.ext4>,if=virtio` — virtio-blk + ext4 are built-in, so the kernel
-  mounts the rootfs and runs its PID 1 (`/sbin/mvm-host-vm-init`) with no
-  initramfs and no ext4-disk-share workaround.
-- [ ] **Shares over virtiofs** (`/usr/lib/qemu/virtiofsd` is present): one
-  `virtiofsd --socket-path=<sock> --shared-dir=<dir>` per share (`work` ro,
-  `out` rw, `job` rw) + `-object memory-backend-memfd,id=mem,share=on -numa
-  node,memdev=mem -chardev socket,id=<id>,path=<sock> -device
-  vhost-user-fs-pci,chardev=<id>,tag=<tag>`. The builder kernel has `VIRTIO_FS`
-  built-in, so **`mvm-host-vm-init` is UNCHANGED** — it mounts the same
-  virtio-fs tags it does under libkrun/Vz.
-- [ ] **Networking = slirp** (`-netdev user`): slirp's built-in DHCP feeds
-  `mvm-host-vm-init`'s existing `udhcpc` — no static config, no gvproxy, no passt.
-- [ ] **Job protocol = the shared one**: reuse `stage_job_dir` (stage `cmd.sh` +
-  `env` into `/job`) + `read_job_result` (`/job/result` JSON
-  `{exit_code, stderr_tail}`) — identical to `LibkrunBuilderVm`/`VzBuilderVm`,
-  so `BuilderArtifacts` is byte-identical regardless of VMM. Mirror their
+Implemented in `qemu_builder::run_build_qemu` (gated behind `builder-vm`,
+like its `libkrun_builder` cache-helper deps). Host side complete + unit-tested;
+the live build awaits a box E2E run (needs an image-mode QEMU Stage 0 first).
+
+- [x] **Boot directly, no initramfs**: `qemu-system-<arch> -kernel <vmlinux>
+  -append "<qemu cmdline> root=/dev/vda ro init=/sbin/mvm-host-vm-init
+  mvm.backend=qemu" -drive file=<rootfs.ext4>,if=virtio` — virtio-blk + ext4
+  built-in, so the kernel mounts the rootfs and runs PID 1 with no initramfs.
+  **Deviation from the sketch: `ro`, not `rw`.** `ro` is libkrun's proven guest
+  contract (`builderCmdline` in `nix/images/builder-vm/flake.nix` is `…ro…`) and
+  keeps the *shared cached* `rootfs.ext4` pristine across builds; the guest
+  writes only to the `/dev/vdb` overlay, the virtio-fs shares, and tmpfs.
+- [x] **Shares over virtiofs** (`/usr/lib/qemu/virtiofsd` etc.): one
+  `virtiofsd --socket-path=<sock> --shared-dir=<dir> --sandbox none` per share
+  (`work`, `out`, `job`, `mvm-bins`) + `-object
+  memory-backend-memfd,id=mem,size=<m>,share=on -numa node,memdev=mem -chardev
+  socket,…,path=<sock> -device vhost-user-fs-pci,…,tag=<tag>`. The builder
+  kernel has `VIRTIO_FS` built-in, so **`mvm-host-vm-init` is UNCHANGED** — it
+  mounts the same tags + read-only policy it does under libkrun/Vz. A
+  `VirtiofsdGuard` reaps the daemons + sockets on drop; QEMU launches only after
+  each socket is ready.
+- [x] **Networking = slirp** (`-netdev user`): slirp's built-in DHCP feeds
+  `mvm-host-vm-init`'s existing `udhcpc -i eth0` — no static config, no gvproxy,
+  no passt. The QEMU cmdline forces `net.ifnames=0` so the NIC comes up `eth0`.
+- [x] **Job protocol = the shared one**: reuse `stage_job_dir` (stage `cmd.sh`
+  into `/job`) + `finalize_flake_job` / `finalize_install_job` (`/job/result`,
+  `/out/result.json`) — identical to `LibkrunBuilderVm`/`VzBuilderVm`, so
+  `BuilderArtifacts` is byte-identical regardless of VMM. Mirrors their
   `run_build` shape (validate mounts/job, resolve cached builder image +
   `NixStoreImageLock`, stage the job dir, boot, finalize).
-- [ ] **Prove it**: an image-mode QEMU Stage 0 first (to get `rootfs.ext4`), then
-  `MVM_BUILDER_BACKEND=qemu mvmctl build --flake <example>` runs the user build
-  in the QEMU builder VM and produces the workload artifacts.
+- [ ] **Prove it** (box): an image-mode QEMU Stage 0 first (to get
+  `rootfs.ext4`), then `MVM_BUILDER_BACKEND=qemu mvmctl build --flake <example>`
+  runs the user build in the QEMU builder VM and produces the workload artifacts.
 
 ## Phase 2: QEMU dev/test workload runtime
 


### PR DESCRIPTION
## Plan 166 Task 1.5 — QEMU `run_build` (steady-state builds)

Completes the QEMU **builder**: Phase 1 (merged, #651) implemented `run_stage0` (the from-source bootstrap that *produces* the builder image); this adds `run_build`, the steady-state path that boots the builder image (`vmlinux` + `rootfs.ext4`) and runs a user `nix build`.

### Approach
The mvm builder kernel has virtio-blk/net/pci/console + virtio-fs + ext4 **built-in**, so the rootfs mounts directly — no initramfs, no ext4-disk-share workaround (much simpler than Stage 0). The device layout is matched to the **UNCHANGED** `mvm-host-vm-init` guest:

- `vda` virtio-blk — builder `rootfs.ext4`, mounted **ro**
- `vdb` virtio-blk — persistent nix-store image (`/nix` overlay upper), where the guest expects `/dev/vdb`
- virtio-fs tags `work` / `out` / `job` / `mvm-bins` over per-share `virtiofsd` (`vhost-user-fs-pci` + shared `memory-backend-memfd`)
- `virtio-net-pci` + user-mode **slirp**; slirp's DHCP feeds the guest's existing `udhcpc -i eth0` (the QEMU cmdline forces `net.ifnames=0`)

Job protocol is the **shared** one (`stage_job_dir` → `/job/cmd.sh`; `finalize_flake_job` / `finalize_install_job` ← `/job/result`, `/out/result.json`), so `BuilderArtifacts` is byte-identical regardless of VMM. A `VirtiofsdGuard` reaps the daemons + sockets on drop; QEMU launches only after each virtiofsd socket is ready.

### Notes
- The impl lives in `run_build_qemu` behind the `builder-vm` feature (it reaches `libkrun_builder`'s cache/image helpers, which link `libkrun-sys`); `qemu_builder` stays ungated so the default build compiles, with a fail-closed fallback for the no-feature arm.
- **Cmdline deviation from the Task 1.5 sketch: rootfs `ro`, not `rw`.** `ro` is libkrun's proven guest contract (`builderCmdline` in `nix/images/builder-vm/flake.nix`) and keeps the *shared cached* `rootfs.ext4` pristine across builds; the guest only writes to `/dev/vdb`, the virtio-fs shares, and tmpfs. Documented in the code + plan.
- `mvm-host-vm-init` is untouched.

### Testing
- Unit-tested `qemu_build_cmdline` (hvc0→ttyS0 swap, marker append, idempotence) — runs on any host.
- `cargo check`/`clippy` green both with and without `builder-vm`.
- ⏳ **Live box E2E pending**: `MVM_BUILDER_BACKEND=qemu mvmctl build --flake <example>` on the x86_64 Hetzner box, which first needs an image-mode QEMU Stage 0 to produce `rootfs.ext4`. Will run before merge.

Phase 2 (QEMU workload runtime / `AnyBackend::Qemu`) remains deferred per the plan.