### PR TITLE
docs(adr-073): complete the half-applied 072→073 renumber

### DIFF
--- a/specs/adrs/073-warm-snapshot-prior-art-adoption-boundary.md
+++ b/specs/adrs/073-warm-snapshot-prior-art-adoption-boundary.md
@@ -1,10 +1,11 @@
-# ADR-072 — Warm-snapshot prior art: adoption boundary
+# ADR-073 — Warm-snapshot prior art: adoption boundary
 
 **Status:** Proposed
 **Date:** 2026-06-05
-**Numbering:** 072 is next-after-highest in `specs/adrs/` (main tops at 071).
+**Numbering:** 073 is next-after-highest in `specs/adrs/` (main tops at 072 —
+`072-qemu-dev-builder-backend` landed first, so this was renumbered 072 → 073).
 `xtask check-spec-numbers` (a Lint gate) hard-fails on a duplicate integer prefix —
-re-confirm 072 is free against open PRs before merge and renumber if taken.
+re-confirm 073 is free against open PRs before merge and renumber if taken.
 
 ## Context
 

--- a/specs/plans/157-warmed-parent-recipes.md
+++ b/specs/plans/157-warmed-parent-recipes.md
@@ -59,12 +59,12 @@ useful.
 *commercial* macOS fast-boot sibling — the **pooled OCI-microVM runtime** (referred
 to obliquely per [[feedback_no_competitor_names_anywhere]]; trait key in auto-memory
 `reference_objc2_vz_external_references`; design boundary recorded in
-[ADR-072](../adrs/072-warm-snapshot-prior-art-adoption-boundary.md)) — bakes a warm
+[ADR-073](../adrs/073-warm-snapshot-prior-art-adoption-boundary.md)) — bakes a warm
 snapshot by running the workload *once during the bake* and capturing a snapshot
 whose **guest page cache is already populated**. That is a distinct lever from this
 plan's warmup, which primes **disk** state (`initdb` output into a warm overlay). Its
 hot-pool reuse model (a released worker kept dirty across cycles) is **refused** under
-mvm's one-guest-one-workload + claim-8 posture (ADR-072 §3); only the page-cache-at-
+mvm's one-guest-one-workload + claim-8 posture (ADR-073 §3); only the page-cache-at-
 freeze idea is adopted, as a Phase C follow-up below. The other thing it validates is
 that this whole warm-path direction is achievable on Apple Silicon (it hits ~10–50 ms
 boot, sub-100 ms cold restore) — we just have to reach it without surrendering the
@@ -274,7 +274,7 @@ recipe (it exercises the full disk + memory freeze).
 
 ## Deferred follow-ups
 
-- [ ] **Page-cache priming at freeze (ADR-072 §1).** Extend Task C1's freeze so the
+- [ ] **Page-cache priming at freeze (ADR-073 §1).** Extend Task C1's freeze so the
       memory snapshot captures a *warm guest page cache*, not just a quiesced one:
       before taking the snapshot, touch the entry's declared working set (a new
       optional `WarmupSpec` field, e.g. `prime_paths` / a prime command) so the
@@ -285,7 +285,7 @@ recipe (it exercises the full disk + memory freeze).
       disk-only anyway, Phase D). Sequences behind the same memory-snapshot substrate
       as Task C1 (Plan 123 Phase C / Plan 140). Plan 140's restore inherits the
       warmth for free. Borrowed *design-level only* from the pooled OCI-microVM
-      runtime's `with_warmup` (ADR-072) — no code adopted, and its hot-pool reuse is
+      runtime's `with_warmup` (ADR-073) — no code adopted, and its hot-pool reuse is
       explicitly **not** taken.
 
 ## Success criteria


### PR DESCRIPTION
## Why

PR #653 renumbered ADR-072 → ADR-073 (because `072-qemu-dev-builder-backend` had landed on `main` first). But the renumber commit captured a **half-applied** state: the file was *renamed* to `073-...md`, yet its internal heading + numbering note still said "ADR-072", and Plan 157 still carried `ADR-072` labels and linked to `../adrs/072-warm-snapshot-prior-art-adoption-boundary.md`.

On current `main` that path resolves to the **unrelated** `072-qemu-dev-builder-backend.md` — so Plan 157's cross-references were broken/misdirected. `check-spec-numbers` stayed green because it keys on the (unique) filename prefix, not heading text.

## What

Completes the renumber — the deterministic 072→073 fixups the original commit missed:
- ADR-073 heading + numbering note now say 073 (note records the qemu collision that forced the renumber).
- Plan 157's four `ADR-072` references and the link path → `073`.

Docs only; no code.