### PR TITLE
build(xtask): gate man-page deps behind a `man` feature

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -193,6 +193,13 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace --all-targets
 
+      - name: xtask man-page tests
+        # gen-man lives behind xtask's off-by-default `man` feature (it pulls
+        # mvm-cli + its heavy build.rs out of the default xtask graph), so the
+        # workspace run above skips its tests. Exercise the man-page path here;
+        # the mvm-cli rlib it links was already built by the workspace run.
+        run: cargo nextest run -p xtask --features man
+
       # Plan 98 Phase 3 §3.4 — Linux auto-detect assertion. The
       # `auto_detect_default_for(false)` arm covers macOS 13-25, Linux,
       # and Windows; pinning it here ensures the Linux path keeps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,13 @@ jobs:
         # explicitly so the gated surface stays covered.
         run: cargo nextest run -p mvm-core --features hostd-transport
 
+      - name: xtask man-page tests
+        # gen-man lives behind xtask's off-by-default `man` feature (it pulls
+        # mvm-cli + its heavy build.rs out of the default xtask graph), so the
+        # workspace run above skips its tests. Exercise the man-page path here;
+        # the mvm-cli rlib it links was already built by the workspace run.
+        run: cargo nextest run -p xtask --features man
+
       - name: Run doctests
         # nextest does not run doctests; gate them separately.
         run: cargo test --workspace --doc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,9 @@ jobs:
 
       - name: Generate man pages
         shell: bash
-        run: cargo run --package xtask -- gen-man --output-dir man/
+        # gen-man lives behind xtask's off-by-default `man` feature (it pulls
+        # mvm-cli + its heavy build.rs); release is the only caller.
+        run: cargo run --package xtask --features man -- gen-man --output-dir man/
 
       - name: Package binary and generate checksums
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7107,7 +7107,6 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_mangen",
- "mvm-build",
  "mvm-cli",
  "regex",
  "serde",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,15 +6,24 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-clap.workspace = true
-clap_mangen.workspace = true
-mvm-build.workspace = true
-mvm-cli.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
+
+# Man-page generation only. mvm-cli sits at the top of the workspace tree
+# and its build.rs cross-compiles the embedded host-vm binaries via zig, so
+# pulling it into the default xtask build makes every `cargo run -p xtask`
+# (every CI lint lane + the check-sync test's nested invocation) pay that
+# tax. Gate it behind an off-by-default feature so only `gen-man` — invoked
+# solely by release.yml — drags in the heavy graph.
+clap = { workspace = true, optional = true }
+clap_mangen = { workspace = true, optional = true }
+mvm-cli = { workspace = true, optional = true }
+
+[features]
+man = ["dep:clap", "dep:clap_mangen", "dep:mvm-cli"]
 
 [dev-dependencies]
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,11 @@
-use anyhow::{Context, Result};
-use std::path::{Path, PathBuf};
+use anyhow::Result;
+use std::path::PathBuf;
+
+// Only the gen-man path (gated behind `man`) uses these.
+#[cfg(feature = "man")]
+use anyhow::Context;
+#[cfg(feature = "man")]
+use std::path::Path;
 
 mod build_dev_image;
 mod check_adr_coverage;
@@ -20,8 +26,21 @@ fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     match args.get(1).map(|s| s.as_str()) {
         Some("gen-man") => {
-            let output_dir = parse_output_dir(&args).unwrap_or_else(default_man_dir);
-            gen_man(&output_dir)
+            #[cfg(feature = "man")]
+            {
+                let output_dir = parse_output_dir(&args).unwrap_or_else(default_man_dir);
+                gen_man(&output_dir)
+            }
+            // Man-page generation pulls mvm-cli (and its heavy build.rs), so it
+            // lives behind the off-by-default `man` feature. release.yml is the
+            // only caller and builds with `--features man`.
+            #[cfg(not(feature = "man"))]
+            {
+                let _ = &args;
+                anyhow::bail!(
+                    "gen-man requires the `man` feature: cargo run -p xtask --features man -- gen-man"
+                )
+            }
         }
         Some("check-adr-coverage") => {
             let workspace = workspace_root();
@@ -88,7 +107,7 @@ fn main() -> Result<()> {
             eprintln!("Usage: cargo xtask <task>");
             eprintln!("Available tasks:");
             eprintln!(
-                "  gen-man [--output-dir DIR]              Generate man pages into DIR (default: man/)"
+                "  gen-man [--output-dir DIR]              Generate man pages into DIR (default: man/) — build with --features man"
             );
             eprintln!(
                 "  check-adr-coverage                      Report ADRs with no code references"
@@ -153,6 +172,7 @@ fn workspace_root() -> PathBuf {
         .unwrap_or(manifest)
 }
 
+#[cfg(feature = "man")]
 fn parse_output_dir(args: &[String]) -> Option<PathBuf> {
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
@@ -163,10 +183,12 @@ fn parse_output_dir(args: &[String]) -> Option<PathBuf> {
     None
 }
 
+#[cfg(feature = "man")]
 fn default_man_dir() -> PathBuf {
     workspace_root().join("man")
 }
 
+#[cfg(feature = "man")]
 pub fn gen_man(output_dir: &Path) -> Result<()> {
     std::fs::create_dir_all(output_dir).with_context(|| {
         format!(
@@ -186,6 +208,7 @@ pub fn gen_man(output_dir: &Path) -> Result<()> {
 ///
 /// Top-level page: `<cmd_name>.1`
 /// Subcommand pages: `<cmd_name>-<sub>.1`
+#[cfg(feature = "man")]
 fn generate_man_pages(cmd: &clap::Command, output_dir: &Path) -> Result<()> {
     let cmd_name = cmd.get_name().to_string();
 
@@ -201,6 +224,7 @@ fn generate_man_pages(cmd: &clap::Command, output_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "man")]
 fn write_man_page(cmd: &clap::Command, path: &Path) -> Result<()> {
     let mut file = std::fs::File::create(path)
         .with_context(|| format!("Failed to create {}", path.display()))?;
@@ -211,7 +235,8 @@ fn write_man_page(cmd: &clap::Command, path: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
+// All tests here exercise gen-man, which only exists under the `man` feature.
+#[cfg(all(test, feature = "man"))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Why

`xtask_check_sync_passes_on_main` was hitting **>120s on GitHub Actions**. The test shells out to `cargo run -p xtask -- check-mvm-host-binaries-sync` at runtime, and `xtask` depended on `mvm-cli` — the top of the 15-crate workspace tree, whose `build.rs` zig-cross-compiles the embedded host-vm binaries. So that nested invocation (and *every* CI lint lane that runs `cargo run -p xtask`) had to link the whole graph and re-run the zig step.

The sync check — and all the other `check-*` / `perf` / `gen-stubs` / `build-dev-image` commands — need none of that. Only `gen-man` does.

## What

- **`xtask/Cargo.toml`**: `mvm-cli`, `clap`, `clap_mangen` are now `optional`, behind a new off-by-default `man` feature. **Removed `mvm-build`** entirely — it was an unused dependency (only a doc-comment reference).
- **`xtask/src/main.rs`**: `#[cfg(feature = "man")]` on the `gen-man` arm, the man-page functions/helpers/imports, and the man tests. Default `gen-man` bails with a clear hint to rebuild with `--features man`.
- **`release.yml`**: the sole `gen-man` caller now builds `--features man`.
- **`ci.yml` + `ci-full.yml`**: dedicated `cargo nextest run -p xtask --features man` step so the `gen_man` tests stay covered (cheap there — the `mvm-cli` rlib is already built by the workspace run).

Default `xtask` now links a tiny binary; the man-page path keeps its heavy tree, isolated to the one place that needs it.

## Verification

- `cargo tree -p xtask` (default): no mvm-cli / mvm-build / clap; `--features man`: mvm-cli + clap_mangen present.
- nightly fmt, default clippy, and `--features man` clippy all clean.
- `cargo test -p xtask --features man`: 108 pass (incl. both `gen_man` tests).
- `xtask_check_sync_passes_on_main` now links + runs in **<1s** from a cold xtask build (whole 107-test xtask suite: 4.6s cold).
- `gen-man` without the feature bails with the rebuild hint.