### PR TITLE
docs(adr-073,plan-157): scope page-cache priming to the immutable rootfs

### DIFF
--- a/specs/adrs/073-warm-snapshot-prior-art-adoption-boundary.md
+++ b/specs/adrs/073-warm-snapshot-prior-art-adoption-boundary.md
@@ -79,6 +79,18 @@ it makes a *signed, sealed, single-workload* snapshot boot faster without touchi
 isolation, provenance, or the audit chain. The warmth lives in the snapshot the
 freeze already produces and admits.
 
+**Scope constraint — prime the immutable rootfs only, never volumes, never secrets.**
+A primed page cache becomes part of the memory snapshot that forked children
+(Plan 157 / 148) all restore from, so priming anything mutable or sensitive would
+share it across every fork — a claim-1 / claim-11 confidentiality leak. Priming is
+therefore confined to the read-only, verity'd **root volume** (binaries/libs); the
+declared working set must resolve inside it. Mounted data / app-dep volumes are never
+primed into the shared base (each fork gets its own per-instance volume disposition),
+and secrets never live in any volume to begin with — they arrive as destination-bound
+signed credentials over the host broker (`host.secrets.v1`, claims 12/13), never as
+raw bytes in the guest. The freeze step must reject a `prime_paths` that escapes the
+rootfs.
+
 ### 2. Adopt (as a data point, no direction change) — HVF-direct as a reference for the Rust-native VZ path
 
 The runtime's HVF-direct design demonstrates that driving the hypervisor a layer

--- a/specs/plans/157-warmed-parent-recipes.md
+++ b/specs/plans/157-warmed-parent-recipes.md
@@ -286,7 +286,11 @@ recipe (it exercises the full disk + memory freeze).
       as Task C1 (Plan 123 Phase C / Plan 140). Plan 140's restore inherits the
       warmth for free. Borrowed *design-level only* from the pooled OCI-microVM
       runtime's `with_warmup` (ADR-073) — no code adopted, and its hot-pool reuse is
-      explicitly **not** taken.
+      explicitly **not** taken. **Scope (ADR-073 §1):** `prime_paths` resolves inside
+      the immutable verity'd **root volume** only — never mounted data/app-dep volumes,
+      never secrets (which never live in a volume anyway; claims 12/13). The primed
+      cache is shared across every fork, so priming mutable/sensitive state would leak
+      it (claim 1 / 11); the freeze step rejects a working set that escapes the rootfs.
 
 ## Success criteria
 


### PR DESCRIPTION
Records the security constraint surfaced while scoping the Vz page-cache-priming spike (`specs/notes/2026-06-05-vz-page-cache-priming-spike.md`).

A primed page cache becomes part of the memory snapshot that forked children all restore from, so priming must be confined to the **read-only, verity'd root volume** (binaries/libs):
- never mounted **data/app-dep volumes** (each fork gets its own per-instance disposition — claim 1/11);
- never **secrets**, which never live in any volume anyway (broker-delivered signed creds — claims 12/13).

The freeze step must reject a `prime_paths` that escapes the rootfs.

Adds the constraint to **ADR-073 §1** and the **Plan 157** deferred follow-up. Docs only.