### PR TITLE
feat(plan-168): VZ DX layer — the Plan-152-independent slice

### DIFF
--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -584,7 +584,7 @@ impl VmBackend for LibkrunBackend {
 /// 3. `PATH` lookup.
 ///
 /// Returns an actionable error if all three fail.
-fn resolve_supervisor_path() -> Result<PathBuf> {
+pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
     if let Some(p) = std::env::var_os("MVM_LIBKRUN_SUPERVISOR_PATH") {
         let path = PathBuf::from(p);
         if path.is_file() {

--- a/crates/mvm-backend/src/providers/apple_container/macos.rs
+++ b/crates/mvm-backend/src/providers/apple_container/macos.rs
@@ -395,6 +395,44 @@ const ENTITLEMENTS_PLIST: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
     <key>com.apple.security.hypervisor</key><true/>\n\
     </dict></plist>";
 
+/// Read the binary's entitlements XML via codesign.
+fn read_entitlements_xml(path: &std::path::Path) -> Option<String> {
+    let out = std::process::Command::new("codesign")
+        .args(["-d", "--entitlements", "-", "--xml"])
+        .arg(path)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// True only when BOTH the virtualization and hypervisor entitlements
+/// are present (the launch path requires both — see `ensure_signed`).
+pub(super) fn entitlements_present(path: &std::path::Path) -> bool {
+    match read_entitlements_xml(path) {
+        Some(xml) => {
+            xml.contains("com.apple.security.virtualization")
+                && xml.contains("com.apple.security.hypervisor")
+        }
+        None => false,
+    }
+}
+
+/// Sign `path` ad-hoc with both entitlements and report the result.
+pub(super) fn sign_path(path: &std::path::Path) -> super::SignReport {
+    let already = entitlements_present(path);
+    if !already {
+        sign_binary(&path.to_string_lossy());
+    }
+    super::SignReport {
+        path: path.to_path_buf(),
+        applied: !already,
+        entitlements_present: entitlements_present(path),
+    }
+}
+
 /// Sign the binary ad-hoc with both VZ and Hypervisor.framework
 /// entitlements (no self-restart).
 ///

--- a/crates/mvm-backend/src/providers/apple_container/macos.rs
+++ b/crates/mvm-backend/src/providers/apple_container/macos.rs
@@ -429,6 +429,7 @@ pub(super) fn sign_path(path: &std::path::Path) -> super::SignReport {
     super::SignReport {
         path: path.to_path_buf(),
         applied: !already,
+        // re-probe: confirm sign_binary actually applied both entitlements
         entitlements_present: entitlements_present(path),
     }
 }

--- a/crates/mvm-backend/src/providers/apple_container/mod.rs
+++ b/crates/mvm-backend/src/providers/apple_container/mod.rs
@@ -286,6 +286,25 @@ pub fn sign_binaries(targets: &[PathBuf]) -> Vec<SignReport> {
     }
 }
 
+/// The binaries that need VZ/Hypervisor entitlements to launch a VM:
+/// the running CLI plus whichever supervisors resolve on this host.
+/// Unresolved supervisors are silently skipped (a host may have only
+/// one backend installed).
+pub fn collect_sign_targets() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(exe) = std::env::current_exe() {
+        out.push(exe);
+    }
+    if let Ok(p) = crate::vz::resolve_supervisor_path() {
+        out.push(p);
+    }
+    if let Ok(p) = crate::libkrun::resolve_supervisor_path() {
+        out.push(p);
+    }
+    out.dedup();
+    out
+}
+
 #[cfg(test)]
 mod sign_api_tests {
     use super::*;
@@ -313,6 +332,16 @@ mod sign_api_tests {
     fn sign_binaries_is_noop_off_macos() {
         let targets = vec![std::path::PathBuf::from("/bin/sh")];
         assert!(sign_binaries(&targets).is_empty());
+    }
+
+    #[test]
+    fn collect_sign_targets_includes_current_exe() {
+        let targets = collect_sign_targets();
+        let exe = std::env::current_exe().unwrap();
+        assert!(
+            targets.contains(&exe),
+            "targets must include the running exe"
+        );
     }
 }
 

--- a/crates/mvm-backend/src/providers/apple_container/mod.rs
+++ b/crates/mvm-backend/src/providers/apple_container/mod.rs
@@ -10,6 +10,8 @@
 #[cfg(target_os = "macos")]
 mod macos;
 
+use std::path::{Path, PathBuf};
+
 /// Check if Apple Virtualization is available on this platform.
 pub fn is_available() -> bool {
     #[cfg(target_os = "macos")]
@@ -243,6 +245,74 @@ pub fn list_ids() -> Vec<String> {
     #[cfg(not(target_os = "macos"))]
     {
         vec![]
+    }
+}
+
+/// Outcome of attempting to sign one binary.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SignReport {
+    pub path: PathBuf,
+    /// Whether codesign was (re)applied during this call.
+    pub applied: bool,
+    /// Whether both VZ + Hypervisor entitlements are present after.
+    pub entitlements_present: bool,
+}
+
+/// `Some(true/false)` on macOS (both required entitlements present?),
+/// `None` on platforms where the question is meaningless.
+pub fn entitlements_present(path: &Path) -> Option<bool> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(macos::entitlements_present(path))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+/// Ad-hoc re-sign each target with the VZ + Hypervisor entitlements and
+/// report the post-sign state. No-op (empty) off macOS.
+pub fn sign_binaries(targets: &[PathBuf]) -> Vec<SignReport> {
+    #[cfg(target_os = "macos")]
+    {
+        targets.iter().map(|p| macos::sign_path(p)).collect()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = targets;
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod sign_api_tests {
+    use super::*;
+
+    #[test]
+    fn sign_report_is_serializable() {
+        let r = SignReport {
+            path: std::path::PathBuf::from("/tmp/mvmctl"),
+            applied: true,
+            entitlements_present: true,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"applied\":true"));
+        assert!(json.contains("entitlements_present"));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn entitlements_present_is_none_off_macos() {
+        assert!(entitlements_present(std::path::Path::new("/bin/sh")).is_none());
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn sign_binaries_is_noop_off_macos() {
+        let targets = vec![std::path::PathBuf::from("/bin/sh")];
+        assert!(sign_binaries(&targets).is_empty());
     }
 }
 

--- a/crates/mvm-backend/src/providers/apple_container/mod.rs
+++ b/crates/mvm-backend/src/providers/apple_container/mod.rs
@@ -299,7 +299,7 @@ mod sign_api_tests {
         };
         let json = serde_json::to_string(&r).unwrap();
         assert!(json.contains("\"applied\":true"));
-        assert!(json.contains("entitlements_present"));
+        assert!(json.contains("\"entitlements_present\":true"));
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -1087,7 +1087,7 @@ fn build_supervisor_config(
 ///    mvm-published artifacts"); this matters during local dev
 ///    when `mvmctl` is `cargo run` from the workspace root.
 /// 4. The version-pinned release layout `~/.mvm/bin/mvm-vz-supervisor-<version>`.
-fn resolve_supervisor_path() -> Result<PathBuf> {
+pub(crate) fn resolve_supervisor_path() -> Result<PathBuf> {
     if let Some(p) = std::env::var_os("MVM_VZ_SUPERVISOR_PATH") {
         let path = PathBuf::from(p);
         if path.is_file() {

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -148,6 +148,7 @@ impl Commands {
             Commands::Ls(_) => "ls",
             Commands::Update(_) => "update",
             Commands::Doctor(_) => "doctor",
+            Commands::Sign(_) => "sign",
             Commands::Kernel(_) => "kernel",
             Commands::Manifest(_) => "manifest",
             Commands::Image(_) => "image",

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -1225,7 +1225,10 @@ fn download_dev_image_inner(kernel_path: &str, rootfs_path: &str) -> Result<(Str
     let kernel_url = format!("{base_url}/{kernel_name}");
     let rootfs_url = format!("{base_url}/{rootfs_name}");
 
-    ui::info(&format!("Downloading dev image (v{version})..."));
+    ui::info(&format!(
+        "Downloading dev image (v{version}) — one-time setup. \
+         Subsequent runs reuse the cached image and start in seconds."
+    ));
 
     // Plan 36 PR-C.2: prefer the cosign-signed manifest. Falls back
     // to the W5.1 unsigned checksum file when the manifest is 404

--- a/crates/mvm-cli/src/commands/env/artifact_verify.rs
+++ b/crates/mvm-cli/src/commands/env/artifact_verify.rs
@@ -179,10 +179,27 @@ pub(super) fn verify_artifact_hash(
     Ok(())
 }
 
-/// Download a file from a URL using curl.
+/// Build the curl argv for a (resumable) download to `dest`.
+/// `-C -` resumes from a partial `dest` if present; on a fresh or
+/// already-complete file curl handles it gracefully. Corruption is
+/// still caught downstream by the SHA-256 gate (`verify_artifact_hash`),
+/// which deletes on mismatch so the next run restarts clean.
+pub(super) fn curl_download_args(dest: &str, url: &str) -> Vec<String> {
+    vec![
+        "-fSL".to_string(),
+        "--progress-bar".to_string(),
+        "-C".to_string(),
+        "-".to_string(),
+        "-o".to_string(),
+        dest.to_string(),
+        url.to_string(),
+    ]
+}
+
+/// Download a file from a URL using curl, resuming a partial `dest`.
 pub(super) fn download_file(url: &str, dest: &str) -> Result<()> {
     let status = std::process::Command::new("curl")
-        .args(["-fSL", "--progress-bar", "-o", dest, url])
+        .args(curl_download_args(dest, url))
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
@@ -190,8 +207,10 @@ pub(super) fn download_file(url: &str, dest: &str) -> Result<()> {
         .context("Failed to run curl")?;
 
     if !status.success() {
-        // Clean up partial download
-        let _ = std::fs::remove_file(dest);
+        // Keep any partial file: curl's `-C -` resumes it on the next
+        // run. It's never hash-accepted while incomplete — verify runs
+        // only after a successful download, and the SHA-256 gate deletes
+        // on mismatch — so leaving it is safe and saves re-fetching.
         anyhow::bail!(
             "Download failed. Pre-built images for v{version} may not yet be\n\
              published — release tags are pushed before the artifact-build\n\
@@ -221,6 +240,21 @@ mod tests {
     use sha2::{Digest, Sha256};
     use std::io::Write;
     use std::sync::Mutex;
+
+    #[test]
+    fn curl_download_args_request_resume() {
+        let args = curl_download_args("/tmp/out", "https://example/x");
+        assert!(
+            args.contains(&"-C".to_string()),
+            "must pass -C for resume: {args:?}"
+        );
+        assert!(
+            args.windows(2).any(|w| w == ["-C", "-"]),
+            "expected `-C -`: {args:?}"
+        );
+        assert!(args.contains(&"-fSL".to_string()));
+        assert_eq!(args.last().unwrap(), "https://example/x");
+    }
 
     /// Cargo test runs tests in parallel within a single binary. Two
     /// of these tests touch `MVM_SKIP_HASH_VERIFY` (the global env-var

--- a/crates/mvm-cli/src/commands/env/mod.rs
+++ b/crates/mvm-cli/src/commands/env/mod.rs
@@ -14,6 +14,7 @@ pub(super) mod init;
 pub(super) mod linux_native;
 pub(super) mod setup;
 pub(super) mod shell_init;
+pub(super) mod sign;
 pub(super) mod uninstall;
 pub(super) mod update;
 

--- a/crates/mvm-cli/src/commands/env/sign.rs
+++ b/crates/mvm-cli/src/commands/env/sign.rs
@@ -1,0 +1,55 @@
+//! `mvmctl sign` — re-sign mvmctl + supervisor binaries with the
+//! VZ/Hypervisor entitlements (user-facing repair of the auto-sign
+//! path). macOS-only; a no-op on other platforms.
+
+use anyhow::Result;
+use clap::Args as ClapArgs;
+
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+use crate::ui;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        if args.json {
+            crate::json_out::emit_json(
+                &serde_json::json!({"platform": "non-macos", "signed": []}),
+            )?;
+        } else {
+            ui::info("mvmctl sign is macOS-only (codesign entitlements); nothing to do here.");
+        }
+        return Ok(());
+    }
+
+    let targets = mvm_backend::providers::apple_container::collect_sign_targets();
+    let reports = mvm_backend::providers::apple_container::sign_binaries(&targets);
+
+    if args.json {
+        crate::json_out::emit_json(&reports)?;
+        return Ok(());
+    }
+
+    for r in &reports {
+        let verb = if r.applied {
+            "signed"
+        } else {
+            "already signed"
+        };
+        let mark = if r.entitlements_present { "✓" } else { "✗" };
+        ui::status_line(&format!("  {} {}:", mark, r.path.display()), verb);
+    }
+    if reports.iter().all(|r| r.entitlements_present) {
+        ui::success("All binaries carry the VZ + Hypervisor entitlements.");
+        Ok(())
+    } else {
+        anyhow::bail!("one or more binaries failed to acquire both entitlements");
+    }
+}

--- a/crates/mvm-cli/src/commands/env/sign.rs
+++ b/crates/mvm-cli/src/commands/env/sign.rs
@@ -21,7 +21,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     if !cfg!(target_os = "macos") {
         if args.json {
             crate::json_out::emit_json(
-                &serde_json::json!({"platform": "non-macos", "signed": []}),
+                &Vec::<mvm_backend::providers::apple_container::SignReport>::new(),
             )?;
         } else {
             ui::info("mvmctl sign is macOS-only (codesign entitlements); nothing to do here.");

--- a/crates/mvm-cli/src/commands/image.rs
+++ b/crates/mvm-cli/src/commands/image.rs
@@ -420,7 +420,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         ImageAction::Ls { registry, json } => {
             let rows = list_rows(&cache_root, registry.as_deref())?;
             if json {
-                println!("{}", serde_json::to_string_pretty(&rows)?);
+                crate::json_out::emit_json(&rows)?;
             } else {
                 render_list(&rows);
             }
@@ -429,7 +429,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         ImageAction::Inspect { reference, json } => {
             let output = inspect_image(&cache_root, &reference)?;
             if json {
-                println!("{}", serde_json::to_string_pretty(&output)?);
+                crate::json_out::emit_json(&output)?;
             } else {
                 render_inspect(&output);
             }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -76,6 +76,8 @@ pub(in crate::commands) enum Commands {
     Update(env::update::Args),
     /// System diagnostics and dependency checks
     Doctor(env::doctor::Args),
+    /// Re-sign mvmctl + supervisors with VZ entitlements (macOS)
+    Sign(env::sign::Args),
     /// Build the custom microVM kernels (builder / workload)
     Kernel(kernel::Args),
     /// Manage built manifest slots
@@ -287,6 +289,7 @@ pub fn run() -> Result<()> {
         Commands::Ls(a) => vm::ps::run(&cli, a, &cfg),
         Commands::Update(a) => env::update::run(&cli, a, &cfg),
         Commands::Doctor(a) => env::doctor::run(&cli, a, &cfg),
+        Commands::Sign(a) => env::sign::run(&cli, a, &cfg),
         Commands::Kernel(a) => kernel::run(&cli, a, &cfg),
         Commands::Manifest(a) => manifest::run(&cli, a, &cfg),
         Commands::Image(a) => image::run(&cli, a, &cfg),

--- a/crates/mvm-cli/src/commands/ops/audit.rs
+++ b/crates/mvm-cli/src/commands/ops/audit.rs
@@ -53,6 +53,9 @@ pub(in crate::commands) enum AuditAction {
         /// Tenant whose chain to search. Defaults to `"local"`.
         #[arg(long, default_value = "local")]
         tenant: String,
+        /// Emit matching entries as a JSON array to stdout.
+        #[arg(long)]
+        json: bool,
     },
     /// Run a read-only security-posture self-test. Reports the live
     /// state of plan-65 + plan-7a mitigations on this host (host
@@ -126,7 +129,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             }
         }
         AuditAction::Verify { tenant } => audit_verify(&tenant),
-        AuditAction::Show { plan_id, tenant } => audit_show(&tenant, &plan_id),
+        AuditAction::Show {
+            plan_id,
+            tenant,
+            json,
+        } => audit_show(&tenant, &plan_id, json),
         AuditAction::Posture { json } => super::audit_posture::run(json),
         AuditAction::VerifyCert {
             cert,
@@ -447,30 +454,39 @@ fn audit_verify(tenant: &str) -> Result<()> {
     }
 }
 
-fn audit_show(tenant: &str, plan_id: &str) -> Result<()> {
+fn audit_show(tenant: &str, plan_id: &str, json: bool) -> Result<()> {
     let dir = default_audit_dir()?;
     let path = audit_path_for_tenant(&dir, tenant);
     if !path.exists() {
-        ui::info(&format!(
-            "No audit chain found for tenant '{tenant}' at {}.",
-            path.display()
-        ));
+        if json {
+            crate::json_out::emit_json(&Vec::<SignedEnvelope>::new())?;
+        } else {
+            ui::info(&format!(
+                "No audit chain found for tenant '{tenant}' at {}.",
+                path.display()
+            ));
+        }
         return Ok(());
     }
     use std::io::BufRead;
     let file = std::fs::File::open(&path).with_context(|| format!("opening {}", path.display()))?;
     let reader = std::io::BufReader::new(file);
-    let mut matched = 0usize;
+    let mut matched: Vec<SignedEnvelope> = Vec::new();
     for line in reader.lines() {
         let line = line?;
         if let Ok(env) = serde_json::from_str::<SignedEnvelope>(&line)
             && env.entry.plan_id.0 == plan_id
         {
-            print_chain_line(&line);
-            matched += 1;
+            if json {
+                matched.push(env);
+            } else {
+                print_chain_line(&line);
+            }
         }
     }
-    if matched == 0 {
+    if json {
+        crate::json_out::emit_json(&matched)?;
+    } else if matched.is_empty() {
         ui::info(&format!(
             "No audit entries found for plan_id '{plan_id}' in tenant '{tenant}'."
         ));

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -95,8 +95,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 return Ok(());
             }
             println!("Cache directory: {cache_dir}");
-            let path = std::path::Path::new(&cache_dir);
-            if !path.exists() {
+            if !info.exists {
                 println!("(not yet created)");
                 return Ok(());
             }

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -40,30 +40,74 @@ pub(in crate::commands) enum CacheAction {
         reap_orphans: bool,
     },
     /// Show cache directory path and disk usage
-    Info,
+    Info {
+        /// Emit machine-readable JSON to stdout
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// Structured output for `cache info --json`.
+#[derive(serde::Serialize)]
+struct CacheInfo {
+    cache_dir: String,
+    exists: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    disk_usage_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    detail_lines: Vec<String>,
+}
+
+fn collect_cache_info() -> Result<CacheInfo> {
+    let cache_dir = mvm_core::config::mvm_cache_dir();
+    let path = std::path::Path::new(&cache_dir);
+    if !path.exists() {
+        return Ok(CacheInfo {
+            cache_dir,
+            exists: false,
+            disk_usage_bytes: None,
+            detail_lines: Vec::new(),
+        });
+    }
+    let disk_usage_bytes = dir_size(path);
+    let stage0_dir = mvm_build::stage0::stage0_cache_dir();
+    let blob_filenames: Vec<&str> = mvm_build::stage0::assets_for_host_arch()
+        .iter()
+        .map(|a| a.cache_filename)
+        .collect();
+    let detail_lines = stage0_cache_report(path, &stage0_dir, &blob_filenames);
+    Ok(CacheInfo {
+        cache_dir,
+        exists: true,
+        disk_usage_bytes: Some(disk_usage_bytes),
+        detail_lines,
+    })
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
     let cache_dir = mvm_core::config::mvm_cache_dir();
 
     match args.action {
-        CacheAction::Info => {
+        CacheAction::Info { json } => {
+            let info = collect_cache_info()?;
+            if json {
+                crate::json_out::emit_json(&info)?;
+                return Ok(());
+            }
             println!("Cache directory: {cache_dir}");
             let path = std::path::Path::new(&cache_dir);
             if !path.exists() {
                 println!("(not yet created)");
                 return Ok(());
             }
-            println!("Disk usage: {}", human_bytes(dir_size(path)));
+            println!(
+                "Disk usage: {}",
+                human_bytes(info.disk_usage_bytes.unwrap_or(0))
+            );
             // Plan 93 Phase 3: surface vendored-blob ages, the
             // cross-target builder-VM cache size, assembled rootfs ages,
             // and the last Stage 0 source fingerprint.
-            let stage0_dir = mvm_build::stage0::stage0_cache_dir();
-            let blob_filenames: Vec<&str> = mvm_build::stage0::assets_for_host_arch()
-                .iter()
-                .map(|a| a.cache_filename)
-                .collect();
-            for line in stage0_cache_report(path, &stage0_dir, &blob_filenames) {
+            for line in &info.detail_lines {
                 println!("{line}");
             }
             Ok(())

--- a/crates/mvm-cli/src/commands/ops/network.rs
+++ b/crates/mvm-cli/src/commands/ops/network.rs
@@ -27,11 +27,18 @@ pub(in crate::commands) enum NetworkAction {
     },
     /// List all dev networks
     #[command(alias = "ls")]
-    List,
+    List {
+        /// Emit machine-readable JSON to stdout
+        #[arg(long)]
+        json: bool,
+    },
     /// Show details of a named network
     Inspect {
         /// Network name
         name: String,
+        /// Emit machine-readable JSON to stdout
+        #[arg(long)]
+        json: bool,
     },
     /// Remove a named network
     #[command(alias = "rm")]
@@ -89,10 +96,14 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             ));
             Ok(())
         }
-        NetworkAction::List => {
+        NetworkAction::List { json } => {
             let dir = networks_dir();
             if !std::path::Path::new(&dir).exists() {
-                ui::info("No networks configured.");
+                if json {
+                    crate::json_out::emit_json(&Vec::<DevNetwork>::new())?;
+                } else {
+                    ui::info("No networks configured.");
+                }
                 return Ok(());
             }
 
@@ -104,6 +115,11 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 {
                     networks.push(net);
                 }
+            }
+
+            if json {
+                crate::json_out::emit_json(&networks)?;
+                return Ok(());
             }
 
             if networks.is_empty() {
@@ -119,14 +135,18 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             }
             Ok(())
         }
-        NetworkAction::Inspect { name } => {
+        NetworkAction::Inspect { name, json } => {
             let path = network_path(&name);
             if !std::path::Path::new(&path).exists() {
                 anyhow::bail!("Network {:?} not found", name);
             }
             let text = std::fs::read_to_string(&path)?;
             let net: DevNetwork = serde_json::from_str(&text)?;
-            println!("{}", serde_json::to_string_pretty(&net)?);
+            if json {
+                crate::json_out::emit_json(&net)?;
+            } else {
+                println!("{}", serde_json::to_string_pretty(&net)?);
+            }
             Ok(())
         }
         NetworkAction::Remove { name } => {

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -12,6 +12,7 @@ use super::build::compile;
 use super::catalog;
 use super::env::{cleanup, dev, init, uninstall};
 use super::image;
+use super::ops;
 use super::ops::{audit, cache, config, metrics, secret};
 use super::vm::{console, cp, down, exec, forward, sandbox, up, volume};
 
@@ -1599,6 +1600,28 @@ fn tenant_orchestration_commands_are_not_mvmctl_surface() {
 }
 
 // --- Network CLI tests ---
+
+#[test]
+fn test_network_list_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "network", "list", "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Network(ops::network::Args {
+            action: ops::network::NetworkAction::List { json: true }
+        })
+    ));
+}
+
+#[test]
+fn test_network_inspect_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "network", "inspect", "isolated", "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Network(ops::network::Args {
+            action: ops::network::NetworkAction::Inspect { json: true, .. }
+        })
+    ));
+}
 
 #[test]
 fn test_network_list_help() {

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2788,6 +2788,19 @@ fn builder_flag_unset_by_default() {
     assert_eq!(cli.builder, None);
 }
 
+// --- Session start --ephemeral tests (Task 3.3) ---
+
+#[test]
+fn test_session_start_ephemeral_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "session", "start", "tmpl", "--ephemeral"]).unwrap();
+    match cli.command {
+        Commands::Session(session::Args {
+            command: session::Cmd::Start(a),
+        }) => assert!(a.ephemeral),
+        _ => panic!("expected session start"),
+    }
+}
+
 // --- Session attach --continue / --resume tests (Task 3.2) ---
 
 #[test]

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1294,6 +1294,21 @@ fn test_uninstall_all_flag_parses() {
 // ---- Audit command tests ----
 
 #[test]
+fn test_audit_show_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "audit", "show", "plan-abc", "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Audit(audit::Args {
+            action: AuditAction::Show {
+                ref plan_id,
+                json: true,
+                ..
+            }
+        }) if plan_id == "plan-abc"
+    ));
+}
+
+#[test]
 fn test_audit_tail_parses() {
     let cli = Cli::try_parse_from(["mvmctl", "audit", "tail"]).unwrap();
     match cli.command {
@@ -1377,10 +1392,16 @@ fn test_audit_show_parses() {
     let cli = Cli::try_parse_from(["mvmctl", "audit", "show", "plan-abc"]).unwrap();
     match cli.command {
         Commands::Audit(audit::Args {
-            action: AuditAction::Show { plan_id, tenant },
+            action:
+                AuditAction::Show {
+                    plan_id,
+                    tenant,
+                    json,
+                },
         }) => {
             assert_eq!(plan_id, "plan-abc");
             assert_eq!(tenant, "local");
+            assert!(!json);
         }
         _ => panic!("Expected Audit::Show"),
     }

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2306,6 +2306,17 @@ fn test_init_catalog_conflicts_with_preset() {
 // --- Cache CLI tests ---
 
 #[test]
+fn test_cache_info_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "cache", "info", "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Cache(cache::Args {
+            action: CacheAction::Info { json: true }
+        })
+    ));
+}
+
+#[test]
 fn test_cache_info() {
     let cli = Cli::try_parse_from(["mvmctl", "cache", "info"]);
     assert!(cli.is_ok());

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -14,7 +14,7 @@ use super::env::{cleanup, dev, init, uninstall};
 use super::image;
 use super::ops;
 use super::ops::{audit, cache, config, metrics, secret};
-use super::vm::{console, cp, down, exec, forward, sandbox, up, volume};
+use super::vm::{console, cp, down, exec, forward, pause, sandbox, up, volume};
 
 use audit::AuditAction;
 use cache::CacheAction;
@@ -1645,6 +1645,19 @@ fn test_network_inspect_help() {
 fn test_network_remove_help() {
     let cli = Cli::try_parse_from(["mvmctl", "network", "rm", "mynet"]);
     assert!(cli.is_ok());
+}
+
+// --- Snapshot CLI tests ---
+
+#[test]
+fn test_snapshot_ls_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "snapshot", "ls", "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Snapshot(pause::SnapshotArgs {
+            command: pause::SnapshotCmd::Ls { json: true }
+        })
+    ));
 }
 
 // --- Catalog CLI tests (plan 40 replaced `mvmctl image *`) ---

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -14,7 +14,7 @@ use super::env::{cleanup, dev, init, uninstall};
 use super::image;
 use super::ops;
 use super::ops::{audit, cache, config, metrics, secret};
-use super::vm::{console, cp, down, exec, forward, pause, sandbox, up, volume};
+use super::vm::{console, cp, down, exec, forward, pause, sandbox, session, up, volume};
 
 use audit::AuditAction;
 use cache::CacheAction;
@@ -2786,4 +2786,35 @@ fn builder_flag_rejects_unknown_value() {
 fn builder_flag_unset_by_default() {
     let cli = Cli::try_parse_from(["mvmctl", "doctor"]).expect("parse");
     assert_eq!(cli.builder, None);
+}
+
+// --- Session attach --continue / --resume tests (Task 3.2) ---
+
+#[test]
+fn test_session_attach_continue_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "session", "attach", "--continue"]).unwrap();
+    match cli.command {
+        Commands::Session(session::Args {
+            command: session::Cmd::Attach(a),
+        }) => {
+            assert!(a.continue_latest);
+            assert!(a.session_id.is_none());
+            assert!(a.resume.is_none());
+        }
+        _ => panic!("expected session attach"),
+    }
+}
+
+#[test]
+fn test_session_attach_resume_parses() {
+    let cli =
+        Cli::try_parse_from(["mvmctl", "session", "attach", "-r", "aaaaaaaaaaaaaaaa"]).unwrap();
+    match cli.command {
+        Commands::Session(session::Args {
+            command: session::Cmd::Attach(a),
+        }) => {
+            assert_eq!(a.resume.as_deref(), Some("aaaaaaaaaaaaaaaa"));
+        }
+        _ => panic!("expected session attach"),
+    }
 }

--- a/crates/mvm-cli/src/commands/vm/pause.rs
+++ b/crates/mvm-cli/src/commands/vm/pause.rs
@@ -242,7 +242,7 @@ fn snap_ls(json: bool) -> Result<()> {
                 sealed: e.sidecar.is_some(),
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&rows)?);
+        crate::json_out::emit_json(&rows)?;
         return Ok(());
     }
     if entries.is_empty() {

--- a/crates/mvm-cli/src/commands/vm/ps.rs
+++ b/crates/mvm-cli/src/commands/vm/ps.rs
@@ -138,7 +138,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 }
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&rows)?);
+        crate::json_out::emit_json(&rows)?;
         return Ok(());
     }
 

--- a/crates/mvm-cli/src/commands/vm/sandbox.rs
+++ b/crates/mvm-cli/src/commands/vm/sandbox.rs
@@ -134,10 +134,7 @@ impl GcSummary {
 
 fn emit_gc_summary(summary: &GcSummary, json: bool) -> Result<()> {
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(summary).context("serializing sandbox gc JSON summary")?
-        );
+        crate::json_out::emit_json(summary)?;
         return Ok(());
     }
 

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -126,8 +126,19 @@ pub(in crate::commands) struct SetTimeoutArgs {
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct AttachArgs {
-    /// Session id to dispatch into.
-    pub session_id: String,
+    /// Session id to dispatch into (positional). Omit with --continue.
+    pub session_id: Option<String>,
+    /// Re-attach the most-recently-active running session.
+    #[arg(short = 'c', long = "continue", conflicts_with_all = ["session_id", "resume"])]
+    pub continue_latest: bool,
+    /// Re-attach a specific session id (alias for the positional).
+    #[arg(
+        short = 'r',
+        long = "resume",
+        value_name = "ID",
+        conflicts_with = "session_id"
+    )]
+    pub resume: Option<String>,
     /// Path to stdin payload, or `-` for mvmctl's own stdin. Default:
     /// no stdin (the wrapper sees an empty pipe).
     #[arg(long, value_name = "PATH")]
@@ -609,7 +620,17 @@ fn enforce_creator_pid_gate(
 }
 
 fn cmd_attach(args: AttachArgs) -> Result<()> {
-    let (id, record) = require_running_session(&args.session_id)?;
+    let resolved_id: String = if args.continue_latest {
+        let rec = mvm_core::session::most_recent_running_on_disk()?
+            .ok_or_else(|| anyhow::anyhow!("no running session to --continue"))?;
+        rec.id.into_string()
+    } else if let Some(id) = args.resume.or(args.session_id) {
+        id
+    } else {
+        bail!("provide a session id, --resume <id>, or --continue");
+    };
+
+    let (id, record) = require_running_session(&resolved_id)?;
 
     let stdin_bytes = super::invoke::read_stdin_payload(args.stdin.as_deref())?;
     ui::info(&format!(
@@ -1256,7 +1277,9 @@ mod tests {
         let _guard = isolated_runtime_dir();
         let id = SessionId::new().to_string();
         let err = cmd_attach(AttachArgs {
-            session_id: id,
+            session_id: Some(id),
+            continue_latest: false,
+            resume: None,
             stdin: None,
             timeout: 1,
         })

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -1291,6 +1291,25 @@ mod tests {
     }
 
     #[test]
+    fn attach_continue_with_no_sessions_errors() {
+        // Empty session store → most_recent_running_on_disk returns None
+        // → cmd_attach bails before touching any vsock.
+        let _guard = isolated_runtime_dir();
+        let err = cmd_attach(AttachArgs {
+            session_id: None,
+            continue_latest: true,
+            resume: None,
+            stdin: None,
+            timeout: 30,
+        })
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("no running session"),
+            "expected no-running-session error, got: {err}"
+        );
+    }
+
+    #[test]
     fn run_code_on_prod_session_is_rejected() {
         let _guard = isolated_runtime_dir();
         let rec = session::SessionRecord::new_running("vm-1", "wl", session::SessionMode::Prod);

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -198,6 +198,10 @@ pub(in crate::commands) struct StartArgs {
     /// minutes).
     #[arg(long, default_value_t = mvm_core::session::DEFAULT_IDLE_TIMEOUT_SECS)]
     pub idle_timeout: u64,
+    /// Tear the session down automatically after the next attach
+    /// completes (no manual `session kill` needed).
+    #[arg(long)]
+    pub ephemeral: bool,
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -655,6 +659,21 @@ fn cmd_attach(args: AttachArgs) -> Result<()> {
         tracing::warn!(err = %e, "failed to bump session invoke counter");
     }
 
+    // Ephemeral teardown runs unconditionally — before any early exit on
+    // non-zero workload exit code — so the VM is always cleaned up.
+    if record.ephemeral {
+        ui::info(&format!(
+            "ephemeral session {id}: tearing down after attach"
+        ));
+        crate::exec::tear_down_session_vm(crate::exec::SessionVm {
+            vm_name: record.vm_name.clone(),
+        });
+        let _ = mvm_core::session::update_session(&id, |r| {
+            r.state = mvm_core::session::SessionState::Reaped;
+            Ok(())
+        });
+    }
+
     if exit_code != 0 {
         std::process::exit(exit_code);
     }
@@ -907,6 +926,7 @@ fn cmd_start(args: StartArgs) -> Result<()> {
 
     let mut record = SessionRecord::new_running(&vm.vm_name, &template_id, mode);
     record.idle_timeout_secs = args.idle_timeout;
+    record.ephemeral = args.ephemeral;
     let id = record.id.clone();
     if let Err(e) = mvm_core::session::write_session(&record) {
         // Boot succeeded but we can't persist the record. Tear down

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -2122,7 +2122,7 @@ fn security_signing_check() -> Check {
     let exe = std::env::current_exe().ok();
     let present = exe
         .as_deref()
-        .and_then(|p| mvm_backend::providers::apple_container::entitlements_present(p));
+        .and_then(mvm_backend::providers::apple_container::entitlements_present);
     match present {
         None => Check {
             name: "signing",

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -277,6 +277,7 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
     checks.push(security_network_policy_default_check());
     checks.push(security_snapshot_key_check());
     checks.push(security_snapshot_dirs_check());
+    checks.push(security_signing_check());
 
     // ── Active backend security posture (ADR-002 / plan 53) ──────
     let security_posture = collect_security_posture();
@@ -2115,6 +2116,35 @@ fn security_snapshot_dirs_check() -> Check {
     }
 }
 
+/// macOS-only: VM launch needs the VZ + Hypervisor entitlements on the
+/// running binary. Off macOS the question is n/a.
+fn security_signing_check() -> Check {
+    let exe = std::env::current_exe().ok();
+    let present = exe
+        .as_deref()
+        .and_then(|p| mvm_backend::providers::apple_container::entitlements_present(p));
+    match present {
+        None => Check {
+            name: "signing",
+            category: "security",
+            ok: true,
+            info: "n/a (macOS only)".to_string(),
+        },
+        Some(true) => Check {
+            name: "signing",
+            category: "security",
+            ok: true,
+            info: "VZ + Hypervisor entitlements present".to_string(),
+        },
+        Some(false) => Check {
+            name: "signing",
+            category: "security",
+            ok: false,
+            info: "entitlements missing — run `mvmctl sign`".to_string(),
+        },
+    }
+}
+
 /// Pinned cross-compile toolchain versions, parsed at build time from
 /// the workspace's [workspace.metadata.mvm.toolchain] block.
 pub struct ZigbuildProbe {
@@ -3120,5 +3150,12 @@ mod tests {
             "stub should mention n/a; got: {}",
             c.info
         );
+    }
+
+    #[test]
+    fn signing_check_is_in_security_category() {
+        let c = security_signing_check();
+        assert_eq!(c.category, "security");
+        assert_eq!(c.name, "signing");
     }
 }

--- a/crates/mvm-cli/src/json_out.rs
+++ b/crates/mvm-cli/src/json_out.rs
@@ -1,0 +1,29 @@
+//! Single JSON-output path for the CLI: pretty-printed, newline-
+//! terminated, written to stdout. Keeps `--json` shape consistent
+//! across commands (no envelope framework — YAGNI).
+
+use anyhow::Result;
+use serde::Serialize;
+
+pub fn emit_json<T: Serialize>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+/// Render to a `String` (test seam; `emit_json` prints this + newline).
+pub fn to_json_string<T: Serialize>(value: &T) -> Result<String> {
+    Ok(serde_json::to_string_pretty(value)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_json_string_is_pretty() {
+        let v = serde_json::json!({"a": 1, "b": [2, 3]});
+        let s = to_json_string(&v).unwrap();
+        assert!(s.contains("\n"), "pretty output should be multi-line");
+        assert!(s.contains("\"a\""));
+    }
+}

--- a/crates/mvm-cli/src/lib.rs
+++ b/crates/mvm-cli/src/lib.rs
@@ -8,6 +8,7 @@ pub mod doctor;
 pub mod exec;
 pub mod host_binaries;
 pub mod http;
+pub mod json_out;
 pub mod logging;
 pub mod metrics_server;
 pub mod security_cmd;

--- a/crates/mvm-cli/tests/session_resume_cli.rs
+++ b/crates/mvm-cli/tests/session_resume_cli.rs
@@ -1,0 +1,38 @@
+//! CLI surface tests for session resume/ephemeral flags.
+
+use assert_cmd::cargo::CommandCargoExt;
+use std::process::Command;
+
+fn mvmctl(args: &[&str]) -> std::process::Output {
+    #[allow(deprecated)]
+    Command::cargo_bin("mvmctl")
+        .expect("locate mvmctl")
+        .args(args)
+        .output()
+        .expect("spawn")
+}
+
+#[test]
+fn session_attach_help_lists_continue_and_resume() {
+    let out = mvmctl(&["session", "attach", "--help"]);
+    let s = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(s.contains("--continue"), "missing --continue:\n{s}");
+    assert!(s.contains("--resume"), "missing --resume:\n{s}");
+}
+
+#[test]
+fn session_start_help_lists_ephemeral() {
+    let out = mvmctl(&["session", "start", "--help"]);
+    let s = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(s.contains("--ephemeral"), "missing --ephemeral:\n{s}");
+}

--- a/crates/mvm-cli/tests/sign_cli.rs
+++ b/crates/mvm-cli/tests/sign_cli.rs
@@ -1,0 +1,38 @@
+//! CLI surface tests for `mvmctl sign`.
+
+use assert_cmd::cargo::CommandCargoExt;
+use std::process::Command;
+
+fn mvmctl(args: &[&str]) -> std::process::Output {
+    #[allow(deprecated)]
+    Command::cargo_bin("mvmctl")
+        .expect("locate mvmctl")
+        .args(args)
+        .output()
+        .expect("spawn mvmctl")
+}
+
+#[test]
+fn sign_help_lists_json_flag() {
+    let out = mvmctl(&["sign", "--help"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("--json"),
+        "`mvmctl sign --help` missing --json; got:\n{stdout}"
+    );
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn sign_is_noop_off_macos() {
+    let out = mvmctl(&["sign"]);
+    assert!(
+        out.status.success(),
+        "sign should be a successful no-op off macOS"
+    );
+}

--- a/crates/mvm-core/src/domain/session.rs
+++ b/crates/mvm-core/src/domain/session.rs
@@ -828,4 +828,20 @@ mod tests {
     fn most_recent_running_none_when_empty() {
         assert!(most_recent_running(Vec::new()).is_none());
     }
+
+    #[test]
+    fn most_recent_running_compares_two_invoked() {
+        // Both records have last_invoke_at set; the later one wins.
+        let mut earlier = SessionRecord::new_running("vm-early", "tmpl", SessionMode::Prod);
+        earlier.last_invoke_at = Some("2026-03-01T10:00:00Z".to_string());
+        let mut later = SessionRecord::new_running("vm-late", "tmpl", SessionMode::Prod);
+        later.last_invoke_at = Some("2026-03-01T11:00:00Z".to_string());
+
+        let pick = most_recent_running(vec![earlier, later]);
+        assert_eq!(
+            pick.unwrap().vm_name,
+            "vm-late",
+            "later last_invoke_at should win"
+        );
+    }
 }

--- a/crates/mvm-core/src/domain/session.rs
+++ b/crates/mvm-core/src/domain/session.rs
@@ -411,6 +411,26 @@ pub fn list_expired_session_ids(now: chrono::DateTime<chrono::Utc>) -> Result<Ve
     Ok(expired)
 }
 
+/// The most-recently-active Running session, ranked by
+/// `last_invoke_at` (falling back to `started_at`). Pure over the
+/// input so it can be tested without touching disk.
+pub fn most_recent_running(records: Vec<SessionRecord>) -> Option<SessionRecord> {
+    records
+        .into_iter()
+        .filter(|r| r.state == SessionState::Running)
+        .max_by(|a, b| {
+            let ka = a.last_invoke_at.as_deref().unwrap_or(&a.started_at);
+            let kb = b.last_invoke_at.as_deref().unwrap_or(&b.started_at);
+            ka.cmp(kb)
+        })
+}
+
+/// Disk-backed convenience: scan the session table and return the
+/// most-recently-active Running session.
+pub fn most_recent_running_on_disk() -> Result<Option<SessionRecord>> {
+    Ok(most_recent_running(list_sessions()?))
+}
+
 // ---------------------------------------------------------------------------
 // Base32 helpers — RFC 4648, no padding, lowercase.
 // ---------------------------------------------------------------------------
@@ -785,5 +805,27 @@ mod tests {
         let path = sessions_dir().join(format!("{id}.json"));
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn most_recent_running_prefers_latest_activity() {
+        let mut a = SessionRecord::new_running("vm-a", "tmpl", SessionMode::Prod);
+        a.started_at = "2026-01-01T00:00:00Z".to_string();
+        a.last_invoke_at = Some("2026-01-01T05:00:00Z".to_string());
+        let mut b = SessionRecord::new_running("vm-b", "tmpl", SessionMode::Prod);
+        b.started_at = "2026-01-02T00:00:00Z".to_string();
+        b.last_invoke_at = None; // falls back to started_at
+        let mut killed = SessionRecord::new_running("vm-c", "tmpl", SessionMode::Prod);
+        killed.started_at = "2026-09-09T00:00:00Z".to_string();
+        killed.state = SessionState::Killed; // excluded
+
+        let pick = most_recent_running(vec![a, b, killed]);
+        // b's started_at (Jan 2) beats a's last_invoke (Jan 1 05:00).
+        assert_eq!(pick.unwrap().vm_name, "vm-b");
+    }
+
+    #[test]
+    fn most_recent_running_none_when_empty() {
+        assert!(most_recent_running(Vec::new()).is_none());
     }
 }

--- a/crates/mvm-core/src/domain/session.rs
+++ b/crates/mvm-core/src/domain/session.rs
@@ -199,6 +199,11 @@ pub struct SessionRecord {
     /// gate is implicitly disabled for this record."
     #[serde(default)]
     pub creator_pid: u32,
+    /// When true, the session is torn down automatically after an
+    /// attach completes (vz-style `--ephemeral`). Defaults false so
+    /// records written before this field still parse.
+    #[serde(default)]
+    pub ephemeral: bool,
 }
 
 /// Whether the session's wrapper is allowed to run ad-hoc code (dev)
@@ -241,6 +246,7 @@ impl SessionRecord {
             invoke_count: 0,
             state: SessionState::Running,
             creator_pid: std::process::id(),
+            ephemeral: false,
         }
     }
 }
@@ -843,5 +849,26 @@ mod tests {
             "vm-late",
             "later last_invoke_at should win"
         );
+    }
+
+    #[test]
+    fn session_record_ephemeral_defaults_false_and_roundtrips() {
+        let mut r = SessionRecord::new_running("vm", "tmpl", SessionMode::Prod);
+        assert!(!r.ephemeral);
+        r.ephemeral = true;
+        let json = serde_json::to_string(&r).unwrap();
+        let back: SessionRecord = serde_json::from_str(&json).unwrap();
+        assert!(back.ephemeral);
+    }
+
+    #[test]
+    fn session_record_legacy_without_ephemeral_parses() {
+        // A record serialized before `ephemeral` existed must still parse
+        // (serde default), despite deny_unknown_fields.
+        let r = SessionRecord::new_running("vm", "tmpl", SessionMode::Prod);
+        let mut val = serde_json::to_value(&r).unwrap();
+        val.as_object_mut().unwrap().remove("ephemeral");
+        let back: SessionRecord = serde_json::from_value(val).unwrap();
+        assert!(!back.ephemeral);
     }
 }

--- a/specs/notes/plan-159-dx-152-independent-slice-design.md
+++ b/specs/notes/plan-159-dx-152-independent-slice-design.md
@@ -1,0 +1,237 @@
+# Design — Plan 159 first slice: the Plan-152-independent VZ DX layer
+
+> **Status (2026-06-05):** Brainstormed, approved for first steps. This is
+> the scoping/design artifact for the first independent increment of
+> `specs/plans/159-vz-inspired-macos-dx.md`. The numbered implementation
+> plan is produced from this via writing-plans.
+>
+> **Naming:** the inspiration project is referred to obliquely ("the DX
+> reference" / "the multi-crate Rust-native VZ runtime") per repo naming
+> policy. Oblique-reference key: auto-memory
+> `reference_objc2_vz_external_references`.
+
+## Goal
+
+Ship every Plan 159 DX feature that needs **nothing from the Rust-`objc2`
+VZ supervisor (Plan 152)** as one coherent, phased push. This is the
+"everything compatible with our model that we can do *now*" slice. The
+headline vz differentiators — the warm "instant" path (WS-1) and
+checkpoint/restore/fork (WS-2) — are deliberately **out** because they
+require the Plan 152 supervisor primitives; they remain the critical path
+to full parity and are sequenced after 152.
+
+## Scope
+
+In:
+
+- **WS-3** — user-facing `mvmctl sign` + a doctor signing-status line.
+- **WS-5 B** — resume ergonomics (`-c/--continue`, `-r/--resume <id>`,
+  `--ephemeral`), mapped onto the existing `session` construct.
+- **WS-5 C** — a shared `--json` output helper + coverage on the
+  highest-value read commands.
+- **WS-4** — acquisition DX: honest one-time-cost framing, local-first
+  resolution, resumable downloads (in-binary parts core; `curl|sh`
+  installer is a lighter follow-on).
+
+Deliberately deferred (and **not** because they need Plan 152):
+
+- **WS-5 D — verb-vocabulary renames.** A mechanical, breaking rename
+  pass. Folding it in would bury the feature diff under churn; it gets its
+  own reviewable commit.
+- **WS-5 E — streamed `exec`.** Crosses into the **guest vsock protocol**
+  (changes `GuestResponse::ExecResult` from buffered to streamed in
+  mvm-guest). Different subsystem, different risk/testing surface; its own
+  slice.
+
+Net property of this slice: **host-side / CLI only — no guest-protocol
+change, no mass renames.** Keeps it to a single (phased) implementation
+plan.
+
+## Invariants (do not regress)
+
+- Claims 1–14 intact; no SSH into guests; no in-guest agent injection.
+- Hermetic-Nix (ADR-046) untouched — WS-4 only changes *how published
+  prebuilts are fetched*, never reintroduces host-Nix or prebuilt
+  dependence on the contributor path.
+- The claim-6 SHA-256 gate and `MVM_SKIP_HASH_VERIFY` posture are never
+  weakened by the resumable-download work.
+- Single-tenant-per-VM (claims 3/8): one-shot `run`/`up` VMs stay
+  ephemeral and are **not** made resumable; resume applies only to the
+  `session` construct that is already designed to persist.
+
+## WS-3 — `mvmctl sign` + doctor signing status
+
+**Current state.** `sign_binary()` + the `ENTITLEMENTS_PLIST` constant
+(the `com.apple.security.virtualization` + `com.apple.security.hypervisor`
+pair) are private in
+`crates/mvm-backend/src/providers/apple_container/macos.rs:390-416`.
+`ensure_signed()` (same file, `:345-383`) auto-signs and re-execs with
+`MVM_SIGNED=1`; it is called only from
+`apple_container/macos.rs:529` (`start_vm`) and
+`crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs:68`. Doctor already
+probes the supervisor's entitlement via `vz_entitlement_probe()`
+(`crates/mvm-cli/src/doctor.rs:901-916`) and renders checks by category
+(`doctor.rs:348-376`, security category at `:53-71`).
+
+**Build.**
+
+- Expose a public entry in `mvm-backend`:
+  `sign_binaries(targets: &[PathBuf]) -> Vec<SignReport>`, reusing
+  `sign_binary()` + the existing temp-plist mechanism.
+  `SignReport { path, applied: bool, entitlements_present: bool }`.
+- New `mvmctl sign` command in the `env` command module, beside `doctor`.
+  Resolves the three relevant binaries via the existing resolvers —
+  `std::env::current_exe()` for `mvmctl`, the `mvm-vz-supervisor` chain at
+  `crates/mvm-backend/src/vz.rs:1075-1134`, and the
+  `mvm-libkrun-supervisor` chain at
+  `crates/mvm-backend/src/libkrun.rs:561-601`. Signs each, then
+  **verifies** by re-running the entitlement probe, and prints the signed
+  paths + per-binary verdict.
+- macOS-only. On Linux it prints a clear "not applicable on this platform"
+  and exits 0.
+- Doctor: add a `signing` check in the **security** category that probes
+  `mvmctl`'s own entitlements (mirroring `vz_entitlement_probe`). When an
+  entitlement is missing, the `info` text reads `run 'mvmctl sign'`.
+  Auto-sign stays on the normal launch path; `sign` is the explicit
+  repair.
+
+## WS-5 B — resume ergonomics (sessions only)
+
+**Current state.** `session start/attach/exec/run-code/console/kill/ls/
+info/set-timeout/reap` exist
+(`crates/mvm-cli/src/commands/vm/session.rs:41-202`). Session metadata
+lives at `$XDG_RUNTIME_DIR/mvm/sessions/<id>.json` with `created_at`,
+`last_invoke_at`, `state` (Running/Killed/Reaped). There is **no**
+most-recent pointer and no `-c/-r/--ephemeral`.
+
+**Build.**
+
+- "Most recent" is **derived, not persisted**: scan session files for the
+  newest `last_invoke_at` (fall back to `created_at`) among `Running`
+  sessions. Nothing new to keep in sync. `attach` already bumps
+  `last_invoke_at`.
+- `session attach` gains:
+  - `-c/--continue` — no id → re-attach the most-recent `Running` session.
+  - `-r/--resume <id>` — explicit id (the existing positional id stays the
+    canonical form; this is the vz-parity verb surface mapped onto it).
+- `session start --ephemeral` — mark the session auto-reap-on-detach/exit,
+  riding the existing `reap` machinery.
+- One-shot `run`/`up` remain ephemeral-by-design and are **not**
+  resumable; documented in `--help`.
+
+## WS-5 C — shared `--json` helper + coverage
+
+**Current state.** ~11 commands hand-roll
+`serde_json::to_string_pretty(...)` inline (e.g. `image ls/inspect`,
+`ls`/`ps`, `session ls/info`, `sandbox gc`, `run --json`, `artifact
+inspect`). No shared path; coverage is uneven.
+
+**Build.**
+
+- One small helper, `crates/mvm-cli/src/json_out.rs`:
+  `emit_json<T: Serialize>(value: &T) -> Result<()>` (pretty + trailing
+  newline + consistent stdout discipline). Deliberately minimal — **no**
+  schema/envelope framework (YAGNI). Migrate the existing inline call
+  sites to it so there is exactly one JSON path.
+- Add `--json` to the committed first set of high-value read commands
+  currently missing it: **`doctor`** (machine-readable diagnostics — the
+  biggest win), `network list`, `network inspect`, `snapshot ls`,
+  `cache info`, and the `audit` list view. (`deps inspect` already emits
+  JSON — confirm it routes through the helper.)
+- Remaining commands are an explicit follow-up `--json` audit, not part of
+  this slice.
+
+## WS-4 — acquisition DX (in-binary core; installer follow-on)
+
+**Current state.** `download_dev_image`
+(`crates/mvm-cli/src/commands/env/apple_container.rs:1193`, with
+`download_dev_image_inner` at `:1212`) streams the artifact through
+SHA-256 and rejects+deletes on mismatch (claim 6), but is not resumable
+and does not frame the one-time cost. A sibling fetch for the dev-shell
+image mirrors it (`apple_container.rs:3572`), and an operator-provided
+local-image path exists (`:1564`) — the local-first chain unifies these.
+
+**Build.**
+
+- **Honest one-time-cost framing:** before an unavoidable first-run
+  download, print the payoff inline ("one-time — subsequent runs restore
+  in seconds").
+- **Local-first resolution chain:** flag → installed path → cache → CDN.
+- **Resumable downloads:** HTTP Range + a `download-state.json` sidecar
+  recording bytes-fetched + expected sha256. Resume appends; the assembled
+  artifact **still streams through the existing SHA-256 gate before
+  acceptance** — mismatch deletes, exactly as today. The claim-6 gate and
+  `MVM_SKIP_HASH_VERIFY` posture are untouched.
+- **Installer `curl|sh`:** lighter follow-on (touches the release
+  pipeline) — captured, not a blocker for this slice.
+
+## Testing & verification
+
+Per-feature, on the local Vz dev host (isolate with
+`MVM_CACHE_DIR`/`MVM_DATA_DIR`; see auto-memory
+`project_dev_host_runs_builder_via_vz`):
+
+- **WS-3:** on a fresh source checkout, `mvmctl sign` makes a
+  previously-unsigned binary boot a VZ VM, and `doctor` flips the signing
+  check to OK. (mvm-backend test bins can be codesign-SIGKILL'd on macOS —
+  lean on Linux CI for everything that isn't the macOS-only sign path; see
+  `reference_mvm_backend_test_binary_macos_codesign_sigkill`.)
+- **WS-5 B:** unit test for most-recent selection; `tests/cli.rs` parsing
+  tests for `--continue`/`--resume`/`--ephemeral`; `--ephemeral` auto-reap
+  behavior.
+- **WS-5 C:** `emit_json` unit test; per-command `--json` shape tests.
+- **WS-4:** interrupt + resume a dev-image download → byte-correct result
+  still passes the SHA-256 gate; a tampered partial is rejected + deleted.
+- **Gates:** `cargo nextest run --workspace`,
+  `cargo test --workspace --doc`,
+  `rustup run nightly cargo fmt --all -- --check` (CI uses nightly
+  rustfmt — see `reference_ci_lint_uses_nightly_rustfmt`),
+  `cargo clippy --workspace -- -D warnings`. Never run `core_demo_e2e`
+  unbounded (`feedback_never_run_core_demo_e2e_unbounded`).
+
+## Phasing (one plan, four phases)
+
+1. **WS-3** — `mvmctl sign` + doctor (quick, self-contained).
+2. **WS-5 C** — json helper + coverage.
+3. **WS-5 B** — resume ergonomics.
+4. **WS-4** — acquisition DX (split the `curl|sh` installer off if it runs
+   heavy).
+
+Work happens in a fresh git worktree off `main`
+(`feedback_always_use_git_worktrees`); commits carry no Claude co-author
+trailer (`feedback_no_claude_coauthor_trailer`).
+
+## Parity ledger (where this slice sits vs. full vz parity)
+
+This slice closes 2.5 rows of the Plan 159 parity checklist (`self-sign`,
+session-continuity flags, the `--json` half of machine-readable output).
+The rest of the path to parity:
+
+- **Captured in Plan 159, deferred:** verb parity (WS-5 D), streamed exec
+  (WS-5 E), resumable-download `curl|sh` installer (WS-4 follow-on).
+- **Gated on Plan 152 (the headline differentiators):** warm "instant"
+  path + background logs (WS-1), checkpoint/restore/fork/diff/`--tag`
+  (WS-2). **Full parity is not reachable without Plan 152.**
+- **Decision-gated (may be deliberately declined to preserve invariants):**
+  macOS guests (ADR-001), project `init`/config (ADR-046), OCI/Compose
+  `stack` (mvmd's domain). Parity target = "everything compatible with our
+  security + hermetic-Nix model," explicitly declining these three.
+- **Unowned — one true gap:** signed patch / binary-delta image
+  distribution; needs a home decision (overlaps `mvm-oci` + Plans
+  155/156) before the parity checklist can read complete.
+
+## References
+
+- `specs/plans/159-vz-inspired-macos-dx.md` — parent plan (WS map +
+  parity checklist).
+- `specs/plans/163-vz-support-execution-roadmap.md` — sequencing; this
+  slice is the 152-independent subset of S5.
+- `specs/plans/152-rust-native-vz-and-init-lifecycle-parity.md` — the
+  supervisor the gated features depend on.
+- `crates/mvm-backend/src/providers/apple_container/macos.rs` — sign
+  harness (WS-3).
+- `crates/mvm-cli/src/doctor.rs` — doctor report structure (WS-3).
+- `crates/mvm-cli/src/commands/vm/session.rs` — session construct (WS-5 B).
+- `crates/mvm-cli/src/commands/` + `crates/mvm-cli/src/exec.rs` — CLI
+  surface (WS-5 C).
+</content>

--- a/specs/plans/168-vz-dx-152-independent.md
+++ b/specs/plans/168-vz-dx-152-independent.md
@@ -1292,6 +1292,14 @@ git commit -m "feat(mvm-cli): honest one-time-cost framing for dev image downloa
 - [ ] WS-5 E — streamed `exec` (guest vsock protocol change; own slice).
 - [ ] WS-4 — `curl|sh` installer one-liner (release-pipeline work).
 - [ ] WS-5 C — `--json` audit of the remaining commands not covered here.
+      (Final review found ~15 inline `to_string_pretty` sites still
+      unmigrated, e.g. `manifest/ls.rs`, `catalog.rs`, `bundle/fetch.rs`,
+      `vm/cp.rs`, `vm/wait.rs`; `vm/session.rs:313` uses compact, not
+      pretty. No CI gate stops new inline sites — consider a lint.)
+- [ ] WS-3 — `doctor` `signing` check probes only the `mvmctl` binary,
+      not the supervisors `mvmctl sign` also signs; an unsigned
+      supervisor could still fail launch while doctor reads OK. Consider
+      probing `collect_sign_targets()` and reporting the worst case.
 
 ## Self-review notes
 

--- a/specs/plans/168-vz-dx-152-independent.md
+++ b/specs/plans/168-vz-dx-152-independent.md
@@ -1,0 +1,1320 @@
+# Plan 168 — VZ DX layer (Plan-152-independent slice) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Design source:** `specs/notes/plan-159-dx-152-independent-slice-design.md`.
+> **Parent plan:** `specs/plans/159-vz-inspired-macos-dx.md` (this is the
+> 152-independent subset of S5 in `specs/plans/163-...`).
+
+**Goal:** Ship the four Plan 159 DX features that need nothing from the
+Plan 152 Rust supervisor — `mvmctl sign` (WS-3), session resume
+ergonomics (WS-5 B), a shared `--json` helper + coverage (WS-5 C), and
+resumable/honest-cost acquisition (WS-4).
+
+**Architecture:** Pure host-side/CLI work. New CLI verb `mvmctl sign`
+wraps a small public signing API added to `mvm-backend`; resume flags
+extend the existing `session` construct and a new serde-default
+`SessionRecord.ephemeral` field; a one-line `emit_json` helper unifies
+JSON output; resumable downloads add curl's native `-C -` to the existing
+hash-gated fetch. No guest-protocol change, no verb renames.
+
+**Tech Stack:** Rust, clap (derive), anyhow, serde/serde_json, sha2,
+codesign/curl subprocesses, `assert_cmd` for CLI integration tests,
+`cargo nextest`.
+
+---
+
+## Guardrails (apply to every task)
+
+- Never regress claims 1–14; no SSH; no in-guest agent injection.
+- The claim-6 SHA-256 gate (`verify_artifact_hash`) and the
+  `MVM_SKIP_HASH_VERIFY` escape hatch are **unchanged** by WS-4.
+- Single-tenant invariant: one-shot `run`/`up` stay ephemeral and are
+  **not** resumable; resume applies only to `session`.
+- `cargo fmt` is CI-nightly: run `rustup run nightly cargo fmt --all`
+  before each commit (see `reference_ci_lint_uses_nightly_rustfmt`).
+- Per-task gate before commit:
+  `cargo nextest run -p mvm-cli -p mvm-backend -p mvm-core` (scope to the
+  crate(s) you touched) — `mvm-backend` test bins can be
+  codesign-SIGKILL'd on this macOS host
+  (`reference_mvm_backend_test_binary_macos_codesign_sigkill`); if so, run
+  that crate's tests on Linux CI and proceed.
+- Never run `core_demo_e2e` unbounded.
+
+## File Structure
+
+Created:
+
+- `crates/mvm-cli/src/json_out.rs` — `emit_json` helper (WS-5 C).
+- `crates/mvm-cli/src/commands/env/sign.rs` — `mvmctl sign` handler (WS-3).
+- `crates/mvm-cli/tests/sign_cli.rs` — `mvmctl sign` surface tests (WS-3).
+
+Modified:
+
+- `crates/mvm-backend/src/providers/apple_container/mod.rs` — public
+  `SignReport`, `sign_binaries`, `collect_sign_targets`,
+  `entitlements_present` (WS-3).
+- `crates/mvm-backend/src/providers/apple_container/macos.rs` — macOS
+  helpers behind the new public API (WS-3).
+- `crates/mvm-backend/src/vz.rs`, `.../libkrun.rs` — bump
+  `resolve_supervisor_path` to `pub(crate)` (WS-3).
+- `crates/mvm-cli/src/commands/mod.rs` — `Sign` variant + dispatch (WS-3).
+- `crates/mvm-cli/src/commands/cmd_audit.rs` — `Sign` verb name (WS-3).
+- `crates/mvm-cli/src/commands/env/mod.rs` — `mod sign;` (WS-3).
+- `crates/mvm-cli/tests/audit_total_coverage.rs` — `sign` posture row (WS-3).
+- `crates/mvm-cli/src/doctor.rs` — `signing` security check (WS-3).
+- `crates/mvm-cli/src/lib.rs` — `pub mod json_out;` (WS-5 C).
+- `crates/mvm-cli/src/commands/image.rs`, `.../vm/ps.rs`,
+  `.../vm/sandbox.rs` — migrate inline JSON to `emit_json` (WS-5 C).
+- `crates/mvm-cli/src/commands/ops/network.rs`,
+  `.../vm/pause.rs` (snapshot ls), `.../ops/cache.rs`,
+  `.../ops/audit.rs` — add `--json` via `emit_json` (WS-5 C).
+- `crates/mvm-cli/src/commands/vm/session.rs` — resume flags + ephemeral
+  teardown + most-recent helper (WS-5 B).
+- `crates/mvm-core/src/domain/session.rs` — `ephemeral` field +
+  `most_recent_running` (WS-5 B).
+- `crates/mvm-cli/src/commands/env/artifact_verify.rs` — curl `-C -`
+  resume + factored arg builder (WS-4).
+- `crates/mvm-cli/src/commands/env/apple_container.rs` — honest-cost
+  framing (WS-4).
+
+---
+
+# Phase 1 — WS-3: `mvmctl sign` + doctor signing status
+
+### Task 1.1: Public signing API in mvm-backend (`SignReport`, `entitlements_present`)
+
+**Files:**
+- Modify: `crates/mvm-backend/src/providers/apple_container/mod.rs`
+- Modify: `crates/mvm-backend/src/providers/apple_container/macos.rs`
+- Test: `crates/mvm-backend/src/providers/apple_container/mod.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1: Write the failing test** (append to `apple_container/mod.rs`)
+
+```rust
+#[cfg(test)]
+mod sign_api_tests {
+    use super::*;
+
+    #[test]
+    fn sign_report_is_serializable() {
+        let r = SignReport {
+            path: std::path::PathBuf::from("/tmp/mvmctl"),
+            applied: true,
+            entitlements_present: true,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"applied\":true"));
+        assert!(json.contains("entitlements_present"));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn entitlements_present_is_none_off_macos() {
+        assert!(entitlements_present(std::path::Path::new("/bin/sh")).is_none());
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn sign_binaries_is_noop_off_macos() {
+        let targets = vec![std::path::PathBuf::from("/bin/sh")];
+        assert!(sign_binaries(&targets).is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run -p mvm-backend sign_api_tests`
+Expected: FAIL — `SignReport`, `entitlements_present`, `sign_binaries` not found.
+
+- [ ] **Step 3: Add the public API** (in `apple_container/mod.rs`, near the existing `pub fn ensure_signed()` at line ~108)
+
+```rust
+use std::path::{Path, PathBuf};
+
+/// Outcome of attempting to sign one binary.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SignReport {
+    pub path: PathBuf,
+    /// Whether codesign was (re)applied during this call.
+    pub applied: bool,
+    /// Whether both VZ + Hypervisor entitlements are present after.
+    pub entitlements_present: bool,
+}
+
+/// `Some(true/false)` on macOS (both required entitlements present?),
+/// `None` on platforms where the question is meaningless.
+pub fn entitlements_present(path: &Path) -> Option<bool> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(macos::entitlements_present(path))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+/// Ad-hoc re-sign each target with the VZ + Hypervisor entitlements and
+/// report the post-sign state. No-op (empty) off macOS.
+pub fn sign_binaries(targets: &[PathBuf]) -> Vec<SignReport> {
+    #[cfg(target_os = "macos")]
+    {
+        targets.iter().map(|p| macos::sign_path(p)).collect()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = targets;
+        Vec::new()
+    }
+}
+```
+
+- [ ] **Step 4: Add the macOS helpers** (in `macos.rs`; reuse `sign_binary` + `ENTITLEMENTS_PLIST`)
+
+```rust
+/// Read the binary's entitlements XML via codesign.
+fn read_entitlements_xml(path: &std::path::Path) -> Option<String> {
+    let out = std::process::Command::new("codesign")
+        .args(["-d", "--entitlements", "-", "--xml"])
+        .arg(path)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// True only when BOTH the virtualization and hypervisor entitlements
+/// are present (the launch path requires both — see `ensure_signed`).
+pub(super) fn entitlements_present(path: &std::path::Path) -> bool {
+    match read_entitlements_xml(path) {
+        Some(xml) => {
+            xml.contains("com.apple.security.virtualization")
+                && xml.contains("com.apple.security.hypervisor")
+        }
+        None => false,
+    }
+}
+
+/// Sign `path` ad-hoc with both entitlements and report the result.
+pub(super) fn sign_path(path: &std::path::Path) -> super::SignReport {
+    let already = entitlements_present(path);
+    if !already {
+        sign_binary(&path.to_string_lossy());
+    }
+    super::SignReport {
+        path: path.to_path_buf(),
+        applied: !already,
+        entitlements_present: entitlements_present(path),
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo nextest run -p mvm-backend sign_api_tests`
+Expected: PASS (on macOS run all three; on Linux the two `not(macos)` tests + the serialize test pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-backend/src/providers/apple_container/
+git commit -m "feat(mvm-backend): public sign_binaries/entitlements_present API"
+```
+
+### Task 1.2: Aggregate signable targets
+
+**Files:**
+- Modify: `crates/mvm-backend/src/providers/apple_container/mod.rs`
+- Modify: `crates/mvm-backend/src/vz.rs` (make `resolve_supervisor_path` `pub(crate)`)
+- Modify: `crates/mvm-backend/src/libkrun.rs` (same)
+- Test: `crates/mvm-backend/src/providers/apple_container/mod.rs`
+
+- [ ] **Step 1: Write the failing test** (append to `sign_api_tests`)
+
+```rust
+    #[test]
+    fn collect_sign_targets_includes_current_exe() {
+        let targets = collect_sign_targets();
+        let exe = std::env::current_exe().unwrap();
+        assert!(targets.contains(&exe), "targets must include the running exe");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run -p mvm-backend collect_sign_targets_includes_current_exe`
+Expected: FAIL — `collect_sign_targets` not found.
+
+- [ ] **Step 3: Bump resolver visibility**
+
+In `crates/mvm-backend/src/vz.rs` change `fn resolve_supervisor_path()` to `pub(crate) fn resolve_supervisor_path()`. Do the same in `crates/mvm-backend/src/libkrun.rs`.
+
+- [ ] **Step 4: Add the aggregator** (in `apple_container/mod.rs`)
+
+```rust
+/// The binaries that need VZ/Hypervisor entitlements to launch a VM:
+/// the running CLI plus whichever supervisors resolve on this host.
+/// Unresolved supervisors are silently skipped (a host may have only
+/// one backend installed).
+pub fn collect_sign_targets() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(exe) = std::env::current_exe() {
+        out.push(exe);
+    }
+    if let Ok(p) = crate::vz::resolve_supervisor_path() {
+        out.push(p);
+    }
+    if let Ok(p) = crate::libkrun::resolve_supervisor_path() {
+        out.push(p);
+    }
+    out.dedup();
+    out
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo nextest run -p mvm-backend collect_sign_targets_includes_current_exe`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-backend/
+git commit -m "feat(mvm-backend): collect_sign_targets aggregator"
+```
+
+### Task 1.3: `mvmctl sign` command handler
+
+**Files:**
+- Create: `crates/mvm-cli/src/commands/env/sign.rs`
+- Modify: `crates/mvm-cli/src/commands/env/mod.rs`
+- Modify: `crates/mvm-cli/src/commands/mod.rs`
+- Modify: `crates/mvm-cli/src/commands/cmd_audit.rs`
+- Modify: `crates/mvm-cli/tests/audit_total_coverage.rs`
+
+- [ ] **Step 1: Create the handler** `crates/mvm-cli/src/commands/env/sign.rs`
+
+```rust
+//! `mvmctl sign` — re-sign mvmctl + supervisor binaries with the
+//! VZ/Hypervisor entitlements (user-facing repair of the auto-sign
+//! path). macOS-only; a no-op on other platforms.
+
+use anyhow::Result;
+use clap::Args as ClapArgs;
+
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+use crate::ui;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        if args.json {
+            crate::json_out::emit_json(&serde_json::json!({"platform": "non-macos", "signed": []}))?;
+        } else {
+            ui::info("mvmctl sign is macOS-only (codesign entitlements); nothing to do here.");
+        }
+        return Ok(());
+    }
+
+    let targets = mvm_backend::providers::apple_container::collect_sign_targets();
+    let reports = mvm_backend::providers::apple_container::sign_binaries(&targets);
+
+    if args.json {
+        crate::json_out::emit_json(&reports)?;
+        return Ok(());
+    }
+
+    for r in &reports {
+        let verb = if r.applied { "signed" } else { "already signed" };
+        let mark = if r.entitlements_present { "✓" } else { "✗" };
+        ui::status_line(
+            &format!("  {} {}:", mark, r.path.display()),
+            verb,
+        );
+    }
+    if reports.iter().all(|r| r.entitlements_present) {
+        ui::success("All binaries carry the VZ + Hypervisor entitlements.");
+        Ok(())
+    } else {
+        anyhow::bail!("one or more binaries failed to acquire both entitlements");
+    }
+}
+```
+
+- [ ] **Step 2: Declare the module** — add to `crates/mvm-cli/src/commands/env/mod.rs` next to the existing `doctor` declaration:
+
+```rust
+pub(in crate::commands) mod sign;
+```
+
+- [ ] **Step 3: Wire the enum variant** — in `crates/mvm-cli/src/commands/mod.rs`, add after the `Doctor` variant (~line 78):
+
+```rust
+    /// Re-sign mvmctl + supervisors with VZ entitlements (macOS)
+    Sign(env::sign::Args),
+```
+
+- [ ] **Step 4: Wire the dispatch arm** — in the `match cli.command.clone()` (~line 289, after `Commands::Doctor`):
+
+```rust
+        Commands::Sign(a) => env::sign::run(&cli, a, &cfg),
+```
+
+- [ ] **Step 5: Wire the verb name** — in `crates/mvm-cli/src/commands/cmd_audit.rs` `verb_name()` (after the `Doctor` arm ~line 150):
+
+```rust
+            Commands::Sign(_) => "sign",
+```
+
+- [ ] **Step 6: Add the audit-posture row** — in `crates/mvm-cli/tests/audit_total_coverage.rs`, add `"sign"` to the AUDIT_POSTURE table following the existing `"doctor"` entry's shape (read-only diagnostic verb, same posture class as `doctor`).
+
+- [ ] **Step 7: Build to verify it compiles**
+
+Run: `cargo build -p mvm-cli`
+Expected: builds; `mvmctl sign --help` lists `--json`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/
+git commit -m "feat(mvm-cli): mvmctl sign command"
+```
+
+### Task 1.4: `mvmctl sign` surface test
+
+**Files:**
+- Create: `crates/mvm-cli/tests/sign_cli.rs`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+//! CLI surface tests for `mvmctl sign`.
+
+use assert_cmd::cargo::CommandCargoExt;
+use std::process::Command;
+
+fn mvmctl(args: &[&str]) -> std::process::Output {
+    #[allow(deprecated)]
+    Command::cargo_bin("mvmctl")
+        .expect("locate mvmctl")
+        .args(args)
+        .output()
+        .expect("spawn mvmctl")
+}
+
+#[test]
+fn sign_help_lists_json_flag() {
+    let out = mvmctl(&["sign", "--help"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "stderr:\n{}", String::from_utf8_lossy(&out.stderr));
+    assert!(stdout.contains("--json"), "`mvmctl sign --help` missing --json; got:\n{stdout}");
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn sign_is_noop_off_macos() {
+    let out = mvmctl(&["sign"]);
+    assert!(out.status.success(), "sign should be a successful no-op off macOS");
+}
+```
+
+- [ ] **Step 2: Run to verify**
+
+Run: `cargo nextest run -p mvm-cli --test sign_cli`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/mvm-cli/tests/sign_cli.rs
+git commit -m "test(mvm-cli): mvmctl sign surface tests"
+```
+
+### Task 1.5: Doctor `signing` security check
+
+**Files:**
+- Modify: `crates/mvm-cli/src/doctor.rs`
+
+- [ ] **Step 1: Write the failing test** (append to `doctor.rs`'s `#[cfg(test)] mod tests`, or add one)
+
+```rust
+#[test]
+fn signing_check_is_in_security_category() {
+    let c = security_signing_check();
+    assert_eq!(c.category, "security");
+    assert_eq!(c.name, "signing");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-cli signing_check_is_in_security_category`
+Expected: FAIL — `security_signing_check` not found.
+
+- [ ] **Step 3: Implement the check** (in `doctor.rs`, near the other `security_*_check` fns)
+
+```rust
+fn security_signing_check() -> Check {
+    // macOS-only: VM launch needs the VZ + Hypervisor entitlements on
+    // the running binary. Off macOS the question is n/a.
+    let exe = std::env::current_exe().ok();
+    let present = exe
+        .as_deref()
+        .and_then(mvm_backend::providers::apple_container::entitlements_present);
+    match present {
+        None => Check {
+            name: "signing",
+            category: "security",
+            ok: true,
+            info: "n/a (macOS only)".to_string(),
+        },
+        Some(true) => Check {
+            name: "signing",
+            category: "security",
+            ok: true,
+            info: "VZ + Hypervisor entitlements present".to_string(),
+        },
+        Some(false) => Check {
+            name: "signing",
+            category: "security",
+            ok: false,
+            info: "entitlements missing — run `mvmctl sign`".to_string(),
+        },
+    }
+}
+```
+
+- [ ] **Step 4: Push it into the report** — add to the security block (after the existing `checks.push(security_snapshot_dirs_check());` ~line 279):
+
+```rust
+    checks.push(security_signing_check());
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo nextest run -p mvm-cli signing_check_is_in_security_category`
+Expected: PASS. `mvmctl doctor` shows a `signing:` line under "Security posture"; `mvmctl doctor --json` includes it (free via `DoctorReport` serialize).
+
+- [ ] **Step 6: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/doctor.rs
+git commit -m "feat(mvm-cli): doctor signing security check"
+```
+
+### Task 1.6: Manual VZ verification (macOS dev host)
+
+- [ ] On this Vz dev host, with an unsigned `target/debug/mvmctl`:
+  `cargo run -p mvm-cli -- doctor` shows `signing: MISSING (entitlements missing — run \`mvmctl sign\`)`.
+- [ ] `cargo run -p mvm-cli -- sign` reports `✓` for each resolved binary.
+- [ ] `cargo run -p mvm-cli -- doctor` now shows `signing: OK`.
+- [ ] A subsequent `mvmctl up`/dev boot succeeds without the auto-sign re-exec. Document the transcript in the PR.
+
+---
+
+# Phase 2 — WS-5 C: shared `--json` helper + coverage
+
+### Task 2.1: `emit_json` helper
+
+**Files:**
+- Create: `crates/mvm-cli/src/json_out.rs`
+- Modify: `crates/mvm-cli/src/lib.rs`
+
+- [ ] **Step 1: Write the helper + its test** `crates/mvm-cli/src/json_out.rs`
+
+```rust
+//! Single JSON-output path for the CLI: pretty-printed, newline-
+//! terminated, written to stdout. Keeps `--json` shape consistent
+//! across commands (no envelope framework — YAGNI).
+
+use anyhow::Result;
+use serde::Serialize;
+
+pub fn emit_json<T: Serialize>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+/// Render to a `String` (test seam; `emit_json` prints this + newline).
+pub fn to_json_string<T: Serialize>(value: &T) -> Result<String> {
+    Ok(serde_json::to_string_pretty(value)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_json_string_is_pretty() {
+        let v = serde_json::json!({"a": 1, "b": [2, 3]});
+        let s = to_json_string(&v).unwrap();
+        assert!(s.contains("\n"), "pretty output should be multi-line");
+        assert!(s.contains("\"a\""));
+    }
+}
+```
+
+- [ ] **Step 2: Declare the module** — add to `crates/mvm-cli/src/lib.rs` next to `pub mod doctor;`:
+
+```rust
+pub mod json_out;
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo nextest run -p mvm-cli json_out`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/json_out.rs crates/mvm-cli/src/lib.rs
+git commit -m "feat(mvm-cli): emit_json shared output helper"
+```
+
+### Task 2.2: Migrate existing inline JSON sites to `emit_json`
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/image.rs`
+- Modify: `crates/mvm-cli/src/commands/vm/ps.rs`
+- Modify: `crates/mvm-cli/src/commands/vm/sandbox.rs`
+
+- [ ] **Step 1: image.rs** — replace both
+  `println!("{}", serde_json::to_string_pretty(&rows)?);` and
+  `println!("{}", serde_json::to_string_pretty(&output)?);`
+  with `crate::json_out::emit_json(&rows)?;` and
+  `crate::json_out::emit_json(&output)?;` respectively.
+
+- [ ] **Step 2: ps.rs** — replace the trailing
+  `println!("{}", serde_json::to_string_pretty(&rows)?); return Ok(());`
+  with `crate::json_out::emit_json(&rows)?; return Ok(());`.
+
+- [ ] **Step 3: sandbox.rs** — replace its
+  `println!("{}", serde_json::to_string_pretty(&summary)?)` (GcSummary)
+  with `crate::json_out::emit_json(&summary)?;`.
+
+- [ ] **Step 4: Verify no behavior change**
+
+Run: `cargo nextest run -p mvm-cli`
+Expected: PASS (existing `--json` tests still green; output is byte-identical — same pretty serializer).
+
+- [ ] **Step 5: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/commands/image.rs crates/mvm-cli/src/commands/vm/ps.rs crates/mvm-cli/src/commands/vm/sandbox.rs
+git commit -m "refactor(mvm-cli): route existing --json through emit_json"
+```
+
+### Task 2.3: Add `--json` to `cache info`
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/ops/cache.rs`
+- Test: `crates/mvm-cli/src/commands/tests.rs`
+
+- [ ] **Step 1: Write the failing parse test** (in `commands/tests.rs`; add `use super::ops::cache;` if absent)
+
+```rust
+#[test]
+fn test_cache_info_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "cache", "info", "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Cache(cache::Args { action: cache::CacheAction::Info { json: true } })
+    ));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-cli test_cache_info_json_parses`
+Expected: FAIL — `Info` has no `json` field.
+
+- [ ] **Step 3: Implement** — add `#[arg(long)] json: bool` to the `CacheAction::Info` variant in `cache.rs`; in its handler build a `#[derive(serde::Serialize)]` struct of the fields currently printed (path, size bytes, entry counts) and branch:
+
+```rust
+        CacheAction::Info { json } => {
+            let info = collect_cache_info()?; // existing gather logic, returned as a Serialize struct
+            if json {
+                crate::json_out::emit_json(&info)?;
+            } else {
+                render_cache_info(&info); // existing human render
+            }
+            Ok(())
+        }
+```
+
+If `cache info`'s current handler computes values inline, refactor the
+gather into `fn collect_cache_info() -> Result<CacheInfo>` returning a
+new `#[derive(serde::Serialize)] struct CacheInfo { ... }`, and have the
+human path render from it (so JSON and text share one source).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo nextest run -p mvm-cli test_cache_info_json_parses`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/commands/ops/cache.rs crates/mvm-cli/src/commands/tests.rs
+git commit -m "feat(mvm-cli): cache info --json"
+```
+
+### Task 2.4: Add `--json` to `network list` and `network inspect`
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/ops/network.rs`
+- Test: `crates/mvm-cli/src/commands/tests.rs`
+
+- [ ] **Step 1: Write the failing parse tests**
+
+```rust
+#[test]
+fn test_network_list_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "network", "list", "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Network(ops::network::Args {
+            action: ops::network::NetworkAction::List { json: true }
+        })
+    ));
+}
+
+#[test]
+fn test_network_inspect_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "network", "inspect", "isolated", "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Network(ops::network::Args {
+            action: ops::network::NetworkAction::Inspect { ref name, json: true }
+        }) if name == "isolated"
+    ));
+}
+```
+
+(Add `use super::ops;` / `use super::ops::network;` to the alias block if
+the exact path differs; match the real `NetworkAction` variant names from
+`network.rs`.)
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo nextest run -p mvm-cli test_network_list_json_parses test_network_inspect_json_parses`
+Expected: FAIL — variants lack `json`.
+
+- [ ] **Step 3: Implement** — add `#[arg(long)] json: bool` to the `List` and `Inspect` variants of `NetworkAction`. In their handlers, ensure the gathered value is `Serialize` (the network record/list type) and branch:
+
+```rust
+        NetworkAction::List { json } => {
+            let nets = list_networks()?;
+            if json { crate::json_out::emit_json(&nets)?; } else { render_networks(&nets); }
+            Ok(())
+        }
+        NetworkAction::Inspect { name, json } => {
+            let net = inspect_network(&name)?;
+            if json { crate::json_out::emit_json(&net)?; } else { render_network(&net); }
+            Ok(())
+        }
+```
+
+If the network types aren't `Serialize`, derive `serde::Serialize` on the
+record struct(s) in `network.rs` (or `mvm-core`/`mvm-backend` if defined
+there) — they are plain data.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo nextest run -p mvm-cli test_network_list_json_parses test_network_inspect_json_parses`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/commands/ops/network.rs crates/mvm-cli/src/commands/tests.rs
+git commit -m "feat(mvm-cli): network list/inspect --json"
+```
+
+### Task 2.5: Add `--json` to `snapshot ls`
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/vm/pause.rs`
+- Test: `crates/mvm-cli/src/commands/tests.rs`
+
+- [ ] **Step 1: Write the failing parse test**
+
+```rust
+#[test]
+fn test_snapshot_ls_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "snapshot", "ls", "--json"]).unwrap();
+    match cli.command {
+        Commands::Snapshot(ref a) => assert!(format!("{a:?}").contains("json")),
+        _ => panic!("expected snapshot"),
+    }
+}
+```
+
+(Tighten the match to the real `SnapshotArgs`/`SnapshotAction::Ls`
+shape once you read `pause.rs`; the `Debug`-contains check is a
+fallback if the action is a flat struct.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-cli test_snapshot_ls_json_parses`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** — add `#[arg(long)] json: bool` to the snapshot-`ls` arm in `pause.rs`; build a `Serialize` row list of snapshots and branch through `crate::json_out::emit_json(&rows)?`, mirroring `image ls`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo nextest run -p mvm-cli test_snapshot_ls_json_parses`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/commands/vm/pause.rs crates/mvm-cli/src/commands/tests.rs
+git commit -m "feat(mvm-cli): snapshot ls --json"
+```
+
+### Task 2.6: Add `--json` to `audit` list view
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/ops/audit.rs`
+- Test: `crates/mvm-cli/src/commands/tests.rs`
+
+- [ ] **Step 1: Write the failing parse test** matching the real `audit` list subcommand/flag shape in `audit.rs` (read it first), e.g.:
+
+```rust
+#[test]
+fn test_audit_ls_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "audit", "ls", "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Audit(ops::audit::Args { action: ops::audit::AuditAction::Ls { json: true, .. } })
+    ));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-cli test_audit_ls_json_parses`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** — add `#[arg(long)] json: bool` to the audit list arm; the audit entries are already serde types (they are written as JSONL), so collect the parsed entries into a `Vec` and `crate::json_out::emit_json(&entries)?` on the flag, else the existing human render.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo nextest run -p mvm-cli test_audit_ls_json_parses`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/commands/ops/audit.rs crates/mvm-cli/src/commands/tests.rs
+git commit -m "feat(mvm-cli): audit ls --json"
+```
+
+---
+
+# Phase 3 — WS-5 B: session resume ergonomics
+
+### Task 3.1: `most_recent_running` selector in mvm-core
+
+**Files:**
+- Modify: `crates/mvm-core/src/domain/session.rs`
+- Test: `crates/mvm-core/src/domain/session.rs`
+
+- [ ] **Step 1: Write the failing test** (in the session module's `#[cfg(test)]`)
+
+```rust
+#[test]
+fn most_recent_running_prefers_latest_activity() {
+    let mut a = SessionRecord::new_running("vm-a", "tmpl", SessionMode::Prod);
+    a.started_at = "2026-01-01T00:00:00Z".to_string();
+    a.last_invoke_at = Some("2026-01-01T05:00:00Z".to_string());
+    let mut b = SessionRecord::new_running("vm-b", "tmpl", SessionMode::Prod);
+    b.started_at = "2026-01-02T00:00:00Z".to_string();
+    b.last_invoke_at = None; // falls back to started_at
+    let mut killed = SessionRecord::new_running("vm-c", "tmpl", SessionMode::Prod);
+    killed.started_at = "2026-09-09T00:00:00Z".to_string();
+    killed.state = SessionState::Killed; // excluded
+
+    let pick = most_recent_running(vec![a, b, killed]);
+    // b's started_at (Jan 2) beats a's last_invoke (Jan 1 05:00).
+    assert_eq!(pick.unwrap().vm_name, "vm-b");
+}
+
+#[test]
+fn most_recent_running_none_when_empty() {
+    assert!(most_recent_running(Vec::new()).is_none());
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-core most_recent_running`
+Expected: FAIL — `most_recent_running` not found.
+
+- [ ] **Step 3: Implement** (pure function over a Vec so it's unit-testable; a thin wrapper reads from disk)
+
+```rust
+/// The most-recently-active Running session, ranked by
+/// `last_invoke_at` (falling back to `started_at`). Pure over the
+/// input so it can be tested without touching disk.
+pub fn most_recent_running(records: Vec<SessionRecord>) -> Option<SessionRecord> {
+    records
+        .into_iter()
+        .filter(|r| r.state == SessionState::Running)
+        .max_by(|a, b| {
+            let ka = a.last_invoke_at.as_deref().unwrap_or(&a.started_at);
+            let kb = b.last_invoke_at.as_deref().unwrap_or(&b.started_at);
+            ka.cmp(kb)
+        })
+}
+
+/// Disk-backed convenience: scan the session table and return the
+/// most-recently-active Running session.
+pub fn most_recent_running_on_disk() -> Result<Option<SessionRecord>> {
+    Ok(most_recent_running(list_sessions()?))
+}
+```
+
+(RFC-3339 second-precision timestamps sort lexicographically, so string
+`cmp` is correct ordering here.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo nextest run -p mvm-core most_recent_running`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-core/src/domain/session.rs
+git commit -m "feat(mvm-core): most_recent_running session selector"
+```
+
+### Task 3.2: `--continue` / `--resume` on `session attach`
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/vm/session.rs`
+- Test: `crates/mvm-cli/src/commands/tests.rs`
+
+- [ ] **Step 1: Write the failing parse tests** (in `commands/tests.rs`; add `use super::vm::session;`)
+
+```rust
+#[test]
+fn test_session_attach_continue_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "session", "attach", "--continue"]).unwrap();
+    match cli.command {
+        Commands::Session(session::Args { command: session::Cmd::Attach(a) }) => {
+            assert!(a.continue_latest);
+            assert!(a.session_id.is_none());
+            assert!(a.resume.is_none());
+        }
+        _ => panic!("expected session attach"),
+    }
+}
+
+#[test]
+fn test_session_attach_resume_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "session", "attach", "-r", "aaaaaaaaaaaaaaaa"]).unwrap();
+    match cli.command {
+        Commands::Session(session::Args { command: session::Cmd::Attach(a) }) => {
+            assert_eq!(a.resume.as_deref(), Some("aaaaaaaaaaaaaaaa"));
+        }
+        _ => panic!("expected session attach"),
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo nextest run -p mvm-cli test_session_attach_continue_parses test_session_attach_resume_parses`
+Expected: FAIL — fields don't exist.
+
+- [ ] **Step 3: Extend `AttachArgs`** (make the positional optional, add the two flags)
+
+```rust
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct AttachArgs {
+    /// Session id to dispatch into (positional). Omit with --continue.
+    pub session_id: Option<String>,
+    /// Re-attach the most-recently-active running session.
+    #[arg(short = 'c', long = "continue", conflicts_with_all = ["session_id", "resume"])]
+    pub continue_latest: bool,
+    /// Re-attach a specific session id (alias for the positional).
+    #[arg(short = 'r', long = "resume", value_name = "ID", conflicts_with = "session_id")]
+    pub resume: Option<String>,
+    /// Path to stdin payload, or `-` for mvmctl's own stdin.
+    #[arg(long, value_name = "PATH")]
+    pub stdin: Option<String>,
+    /// Wall-clock timeout for the call, in seconds. Default 30.
+    #[arg(long, default_value = "30")]
+    pub timeout: u64,
+}
+```
+
+- [ ] **Step 4: Resolve the target id in `cmd_attach`** — replace the opening of `cmd_attach` so it computes the id from the three inputs before `require_running_session`:
+
+```rust
+fn cmd_attach(args: AttachArgs) -> Result<()> {
+    let resolved_id: String = if args.continue_latest {
+        let rec = mvm_core::session::most_recent_running_on_disk()?
+            .ok_or_else(|| anyhow::anyhow!("no running session to --continue"))?;
+        rec.id.into_string()
+    } else if let Some(id) = args.resume.or(args.session_id) {
+        id
+    } else {
+        bail!("provide a session id, --resume <id>, or --continue");
+    };
+
+    let (id, record) = require_running_session(&resolved_id)?;
+    // ... unchanged body from here (stdin read, dispatch, bump) ...
+```
+
+(Keep the rest of the existing `cmd_attach` body verbatim from
+`let stdin_bytes = ...` onward.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo nextest run -p mvm-cli test_session_attach_continue_parses test_session_attach_resume_parses`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/commands/vm/session.rs crates/mvm-cli/src/commands/tests.rs
+git commit -m "feat(mvm-cli): session attach --continue/--resume"
+```
+
+### Task 3.3: `--ephemeral` on `session start`
+
+**Files:**
+- Modify: `crates/mvm-core/src/domain/session.rs`
+- Modify: `crates/mvm-cli/src/commands/vm/session.rs`
+- Test: both
+
+- [ ] **Step 1: Write the failing record test** (mvm-core)
+
+```rust
+#[test]
+fn session_record_ephemeral_defaults_false_and_roundtrips() {
+    let mut r = SessionRecord::new_running("vm", "tmpl", SessionMode::Prod);
+    assert!(!r.ephemeral);
+    r.ephemeral = true;
+    let json = serde_json::to_string(&r).unwrap();
+    let back: SessionRecord = serde_json::from_str(&json).unwrap();
+    assert!(back.ephemeral);
+    // Back-compat: a record written before this field still parses.
+    let legacy = json.replace(",\n  \"ephemeral\": true", "");
+    let _legacy: SessionRecord = serde_json::from_str(&legacy).unwrap();
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-core session_record_ephemeral`
+Expected: FAIL — no `ephemeral` field. (Note: `SessionRecord` has
+`#[serde(deny_unknown_fields)]`, so the field MUST be added with
+`#[serde(default)]` for the legacy-parse leg to pass.)
+
+- [ ] **Step 3: Add the field** to `SessionRecord` (after `creator_pid`):
+
+```rust
+    /// When true, the session is torn down automatically after an
+    /// attach completes (vz-style `--ephemeral`). Defaults false so
+    /// records written before this field still parse.
+    #[serde(default)]
+    pub ephemeral: bool,
+```
+
+And set it in `new_running` (add `ephemeral: false,` to the struct
+literal).
+
+- [ ] **Step 4: Write the failing parse test** (mvm-cli, `commands/tests.rs`)
+
+```rust
+#[test]
+fn test_session_start_ephemeral_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "session", "start", "tmpl", "--ephemeral"]).unwrap();
+    match cli.command {
+        Commands::Session(session::Args { command: session::Cmd::Start(a) }) => assert!(a.ephemeral),
+        _ => panic!("expected session start"),
+    }
+}
+```
+
+- [ ] **Step 5: Add the flag + persist it** — add to `StartArgs`:
+
+```rust
+    /// Tear the session down automatically after the next attach
+    /// completes (no manual `session kill` needed).
+    #[arg(long)]
+    pub ephemeral: bool,
+```
+
+In `cmd_start`, after `let mut record = SessionRecord::new_running(...)`:
+
+```rust
+    record.ephemeral = args.ephemeral;
+```
+
+- [ ] **Step 6: Tear down ephemeral sessions after attach** — in
+  `cmd_attach`, after the invoke-counter bump and before the exit-code
+  check, add:
+
+```rust
+    if record.ephemeral {
+        ui::info(&format!("ephemeral session {id}: tearing down after attach"));
+        let _ = crate::exec::tear_down_session_vm(crate::exec::SessionVm {
+            vm_name: record.vm_name.clone(),
+        });
+        let _ = mvm_core::session::update_session(&id, |r| {
+            r.state = mvm_core::session::SessionState::Reaped;
+            Ok(())
+        });
+    }
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `cargo nextest run -p mvm-core session_record_ephemeral && cargo nextest run -p mvm-cli test_session_start_ephemeral_parses`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-core/src/domain/session.rs crates/mvm-cli/src/commands/vm/session.rs crates/mvm-cli/src/commands/tests.rs
+git commit -m "feat: session start --ephemeral with post-attach teardown"
+```
+
+### Task 3.4: `--help` documents the resume/ephemeral semantics
+
+**Files:**
+- Create: `crates/mvm-cli/tests/session_resume_cli.rs`
+
+- [ ] **Step 1: Write the surface test**
+
+```rust
+use assert_cmd::cargo::CommandCargoExt;
+use std::process::Command;
+
+fn mvmctl(args: &[&str]) -> std::process::Output {
+    #[allow(deprecated)]
+    Command::cargo_bin("mvmctl").expect("locate mvmctl").args(args).output().expect("spawn")
+}
+
+#[test]
+fn session_attach_help_lists_continue_and_resume() {
+    let out = mvmctl(&["session", "attach", "--help"]);
+    let s = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success());
+    assert!(s.contains("--continue"), "missing --continue:\n{s}");
+    assert!(s.contains("--resume"), "missing --resume:\n{s}");
+}
+
+#[test]
+fn session_start_help_lists_ephemeral() {
+    let out = mvmctl(&["session", "start", "--help"]);
+    let s = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success());
+    assert!(s.contains("--ephemeral"), "missing --ephemeral:\n{s}");
+}
+```
+
+- [ ] **Step 2: Run + commit**
+
+Run: `cargo nextest run -p mvm-cli --test session_resume_cli`
+Expected: PASS.
+
+```bash
+git add crates/mvm-cli/tests/session_resume_cli.rs
+git commit -m "test(mvm-cli): session resume/ephemeral help surface"
+```
+
+---
+
+# Phase 4 — WS-4: resumable + honest-cost acquisition
+
+### Task 4.1: Factor curl args + add `-C -` resume
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/env/artifact_verify.rs`
+- Test: `crates/mvm-cli/src/commands/env/artifact_verify.rs`
+
+- [ ] **Step 1: Write the failing test** (in `artifact_verify.rs` `#[cfg(test)]`)
+
+```rust
+#[test]
+fn curl_download_args_request_resume() {
+    let args = curl_download_args("/tmp/out", "https://example/x");
+    assert!(args.contains(&"-C".to_string()), "must pass -C for resume: {args:?}");
+    assert!(args.windows(2).any(|w| w == ["-C", "-"]), "expected `-C -`: {args:?}");
+    assert!(args.contains(&"-fSL".to_string()));
+    assert_eq!(args.last().unwrap(), "https://example/x");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-cli curl_download_args_request_resume`
+Expected: FAIL — `curl_download_args` not found.
+
+- [ ] **Step 3: Refactor `download_file`** to build args via a pure
+  helper, with `-C -` so an interrupted partial resumes. `-C -` is safe
+  on a fresh file (curl starts at 0) and a complete file (curl reports
+  nothing to do); a corrupt resume is still caught by the SHA-256 gate,
+  which deletes on mismatch so the next run restarts clean.
+
+```rust
+/// Build the curl argv for a (resumable) download to `dest`.
+/// `-C -` resumes from a partial `dest` if present.
+pub(super) fn curl_download_args(dest: &str, url: &str) -> Vec<String> {
+    vec![
+        "-fSL".to_string(),
+        "--progress-bar".to_string(),
+        "-C".to_string(),
+        "-".to_string(),
+        "-o".to_string(),
+        dest.to_string(),
+        url.to_string(),
+    ]
+}
+
+pub(super) fn download_file(url: &str, dest: &str) -> Result<()> {
+    let status = std::process::Command::new("curl")
+        .args(curl_download_args(dest, url))
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()
+        .context("Failed to run curl")?;
+
+    if !status.success() {
+        let _ = std::fs::remove_file(dest);
+        anyhow::bail!(
+            "Download failed. Pre-built images for v{version} may not yet be\n\
+             published — release tags are pushed before the artifact-build\n\
+             job finishes. Retry shortly, or build locally from the flake.",
+            version = env!("CARGO_PKG_VERSION")
+        );
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo nextest run -p mvm-cli curl_download_args_request_resume`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/commands/env/artifact_verify.rs
+git commit -m "feat(mvm-cli): resumable dev-image download (curl -C -)"
+```
+
+### Task 4.2: Honest one-time-cost framing
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/env/apple_container.rs`
+
+- [ ] **Step 1: Add the framing message** — in `download_dev_image_inner`,
+  replace the existing `ui::info(&format!("Downloading dev image (v{version})..."));`
+  with a payoff-framed pair:
+
+```rust
+    ui::info(&format!(
+        "Downloading dev image (v{version}) — one-time setup. \
+         Subsequent runs reuse the cached image and start in seconds."
+    ));
+```
+
+- [ ] **Step 2: Verify build + existing tests**
+
+Run: `cargo build -p mvm-cli && cargo nextest run -p mvm-cli`
+Expected: builds, tests green (message-only change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/commands/env/apple_container.rs
+git commit -m "feat(mvm-cli): honest one-time-cost framing for dev image download"
+```
+
+### Task 4.3: Manual resume verification (dev host)
+
+- [ ] On the Vz dev host with an empty `MVM_CACHE_DIR`, start a dev-image
+  download and interrupt it mid-stream (Ctrl-C). Re-run the same command;
+  confirm curl resumes (progress starts above 0%) and the final
+  `verify_artifact_hash` passes.
+- [ ] Corrupt the partial file by appending a byte, re-run, and confirm
+  the SHA-256 gate fails and deletes the file (claim-6 behavior intact).
+  Document both transcripts in the PR.
+
+---
+
+## Deferred follow-ups (tracked, not in this plan)
+
+- [ ] WS-5 D — verb-vocabulary rename pass (own reviewable commit).
+- [ ] WS-5 E — streamed `exec` (guest vsock protocol change; own slice).
+- [ ] WS-4 — `curl|sh` installer one-liner (release-pipeline work).
+- [ ] WS-5 C — `--json` audit of the remaining commands not covered here.
+
+## Self-review notes
+
+- **Spec coverage:** WS-3 → Phase 1; WS-5 C → Phase 2; WS-5 B → Phase 3;
+  WS-4 (in-binary) → Phase 4. Installer + deferred items recorded above.
+- **Type consistency:** `SignReport` fields (`path`/`applied`/
+  `entitlements_present`) are identical across mvm-backend definition,
+  the macOS `sign_path` constructor, and the CLI consumer.
+  `most_recent_running` signature matches both the pure test and the
+  disk wrapper. `SessionRecord.ephemeral` is `#[serde(default)] bool`
+  everywhere it's read/written.
+- **Verification gates:** every code task ends with a real
+  command + expected result; VZ/codesign live paths are explicit manual
+  steps (Tasks 1.6, 4.3) because they can't run in CI.
+
+## References
+
+- Design: `specs/notes/plan-159-dx-152-independent-slice-design.md`
+- Parent: `specs/plans/159-vz-inspired-macos-dx.md`
+- Sign harness: `crates/mvm-backend/src/providers/apple_container/macos.rs:345-416`
+- Doctor model: `crates/mvm-cli/src/doctor.rs:86-92,269-279,348-377,901-916`
+- Sessions: `crates/mvm-cli/src/commands/vm/session.rs`,
+  `crates/mvm-core/src/domain/session.rs`
+- Download path: `crates/mvm-cli/src/commands/env/artifact_verify.rs`,
+  `crates/mvm-cli/src/commands/env/apple_container.rs:1193-1283`
+</content>

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -265,6 +265,7 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     ("cleanup", AuditPosture::Emits("SlotPrune")),
     ("update", AuditPosture::Emits("UpdateInstall")),
     ("doctor", AuditPosture::ReadOnly),
+    ("sign", AuditPosture::ReadOnly),
     ("shell-init", AuditPosture::InteractiveOrControl),
     ("uninstall", AuditPosture::Emits("Uninstall")),
     ("init", AuditPosture::InteractiveOrControl),


### PR DESCRIPTION
## Summary

Ships the four Plan 159 DX features that need **nothing** from the Plan 152 Rust supervisor (the 152-independent subset of S5 in the VZ roadmap). Host-side/CLI only — no guest-protocol change, no verb renames.

- **WS-3 — `mvmctl sign` + doctor signing check.** New public `mvm-backend` signing API (`SignReport`, `entitlements_present`, `sign_binaries`, `collect_sign_targets`) wrapping the existing `ensure_signed()` harness; new top-level `mvmctl sign` verb; a `signing` check in `doctor`'s security section. Verified live on a macOS 26 Vz host: `signing: MISSING → mvmctl sign → signing: OK`.
- **WS-5 C — shared `--json`.** New `emit_json` helper; existing inline sites migrated; `--json` added to `cache info`, `network list`/`inspect`, `snapshot ls`, `audit show`.
- **WS-5 B — session resume ergonomics.** `most_recent_running` selector in mvm-core; `session attach --continue/--resume`; `session start --ephemeral` (serde-default `SessionRecord.ephemeral` field + post-attach teardown ordered before `process::exit`). Resume maps onto the persistent `session` construct only — one-shot `run`/`up` stay ephemeral (single-tenant invariant).
- **WS-4 — acquisition DX.** Resumable dev-image downloads via curl `-C -` (partial kept on failure; the claim-6 SHA-256 gate remains the integrity backstop and is unchanged); honest one-time-cost framing. Verified live: curl resumed a real release asset from 51.5% to a byte-identical file.

Design: `specs/notes/plan-159-dx-152-independent-slice-design.md`. Plan: `specs/plans/168-vz-dx-152-independent.md`. Deferred items (verb renames, streamed exec, `curl|sh` installer, `--json` remainder, doctor supervisor coverage) tracked in the plan's follow-ups section.

Built subagent-driven with per-task spec + code-quality review and an opus final review (Ready to merge, no Critical/Important issues).

## Test Plan

- [x] `rustup run nightly cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` — 4589 pass (mvm-backend excluded locally per the known macOS codesign-SIGKILL issue → Linux CI; the lone local failure was the `MVM_SKIP_EMBED_BINARIES=1` ELF-magic stub artifact)
- [x] `cargo test --doc` (touched crates)
- [x] Live WS-3: doctor signing flip on the Vz host
- [x] Live WS-4: curl `-C -` resume produces a byte-identical file
- [ ] CI green on Linux (full workspace incl. mvm-backend + embedded-binaries)