### PR TITLE
feat(secrets): Plan 129 Phases B + C — resolver, binding store, `secret set`, signing/injecting keyholder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,6 +3246,7 @@ dependencies = [
  "etherparse",
  "hex",
  "hickory-resolver",
+ "hmac",
  "ipnet",
  "landlock",
  "libc",

--- a/crates/mvm-cli/src/commands/ops/secret.rs
+++ b/crates/mvm-cli/src/commands/ops/secret.rs
@@ -1,10 +1,16 @@
-//! Plan 63 W4 — `mvmctl secret put/get/ls/rm` CLI surface.
+//! `mvmctl secret put/set/get/ls/rm` CLI surface (Plan 63 W4 + Plan 129 B2).
 //!
 //! Local CRUD for secret namespaces. Values never appear in
-//! logs, error chains, or process listings — `put` accepts the
+//! logs, error chains, or process listings — `put`/`set` accept the
 //! value via an interactive hidden prompt, stdin, flag, or file;
 //! `get` verifies that a secret exists but never prints the stored
 //! value.
+//!
+//! `set` (Plan 129 / ADR-067 §2) is `put` plus an egress binding: it
+//! records, in a parallel [`mvm_hostd::keyholder::FileBindingStore`], the
+//! auth-type and destination allow-list for a secret whose value the host
+//! egress proxy substitutes toward bound destinations only (never the
+//! guest). `ls` surfaces that binding (type + hosts) but never the value.
 //!
 //! ## Audit
 //!
@@ -23,7 +29,8 @@
 //!   file-backed secrets visible.
 //! - `FileSecretStore` everywhere else (CI Linux, headless hosts).
 //!
-//! Tests inject `FileSecretStore::with_dir` via [`run_with_store`].
+//! Tests inject `FileSecretStore::with_dir` + `FileBindingStore::with_dir`
+//! via [`run_with_stores`].
 
 use std::io::{IsTerminal, Read, Write};
 use std::path::PathBuf;
@@ -31,10 +38,12 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use chrono::Utc;
-use clap::{Args as ClapArgs, Subcommand};
+use clap::{Args as ClapArgs, Subcommand, ValueEnum};
 use mvm_core::crypto::secret_store::{self, SecretStore};
 use mvm_core::plan::TenantId;
+use mvm_hostd::keyholder::{BindingStore, FileBindingStore, SecretBindingMeta};
 use mvm_hostd::supervisor::{EventCategory, FileAuditSigner, Recorder};
+use mvm_sdk::ir::AuthType;
 use secrecy::SecretBox;
 
 use mvm_core::user_config::MvmConfig;
@@ -79,7 +88,38 @@ pub(in crate::commands) enum SecretAction {
         tenant: String,
     },
 
-    /// List secret names stored for a tenant.
+    /// Define a local secret with its egress binding (Plan 129 /
+    /// ADR-067 §2): store the value *and* record where the substituted
+    /// credential may go and how it authenticates. The value never
+    /// enters the guest — the host egress proxy substitutes it toward a
+    /// bound destination only. Value source as for `put` (interactive
+    /// prompt / piped stdin / `--value -` / `--value-file`); never pass
+    /// the value inline in scripts (it lands in the process table).
+    Set {
+        /// Name to store the secret under (alphanumeric + `_-`).
+        name: String,
+        /// Local namespace. Fleet tenant secrets are managed by mvmd.
+        #[arg(long, default_value = "local")]
+        tenant: String,
+        /// Destination the credential may reach (claim 12). Repeatable;
+        /// at least one required. `*.` subdomain wildcards supported.
+        #[arg(long = "host", required = true)]
+        hosts: Vec<String>,
+        /// How the credential authenticates outbound requests.
+        #[arg(long = "type", value_enum)]
+        auth_type: AuthTypeArg,
+        /// Inline value. Pass `-` to read from stdin (preferred when
+        /// scripting; avoids shell-history exposure).
+        #[arg(long, conflicts_with = "value_file")]
+        value: Option<String>,
+        /// Read value from a file on disk.
+        #[arg(long)]
+        value_file: Option<PathBuf>,
+    },
+
+    /// List secret names stored for a tenant. Bound secrets (defined via
+    /// `set`) also show their auth-type and destination allow-list;
+    /// never the value.
     Ls {
         #[arg(long, default_value = "local")]
         tenant: String,
@@ -93,14 +133,40 @@ pub(in crate::commands) enum SecretAction {
     },
 }
 
-pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
-    let store = secret_store::default_secret_store();
-    run_with_store(store.as_ref(), args)
+/// Clap mirror of [`mvm_sdk::ir::AuthType`] — kept local so the CLI owns
+/// the clap dependency and `mvm-sdk` (a build-time crate) does not.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::commands) enum AuthTypeArg {
+    Sigv4,
+    Hmac,
+    Bearer,
+    Basic,
 }
 
-/// Same dispatch as [`run`] but takes an injected store. Test
-/// seam for `FileSecretStore::with_dir(<tempdir>)`.
-pub(in crate::commands) fn run_with_store(store: &dyn SecretStore, args: Args) -> Result<()> {
+impl From<AuthTypeArg> for AuthType {
+    fn from(a: AuthTypeArg) -> Self {
+        match a {
+            AuthTypeArg::Sigv4 => AuthType::Sigv4,
+            AuthTypeArg::Hmac => AuthType::Hmac,
+            AuthTypeArg::Bearer => AuthType::Bearer,
+            AuthTypeArg::Basic => AuthType::Basic,
+        }
+    }
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    let store = secret_store::default_secret_store();
+    let bindings = FileBindingStore::default_location()?;
+    run_with_stores(store.as_ref(), &bindings, args)
+}
+
+/// Same dispatch as [`run`] but takes injected stores. Test seam for
+/// `FileSecretStore::with_dir(<tempdir>)` + `FileBindingStore::with_dir`.
+pub(in crate::commands) fn run_with_stores(
+    store: &dyn SecretStore,
+    bindings: &dyn BindingStore,
+    args: Args,
+) -> Result<()> {
     let audit = AuditLog::default()?.with_optional_recorder();
     match args.action {
         SecretAction::Put {
@@ -109,9 +175,29 @@ pub(in crate::commands) fn run_with_store(store: &dyn SecretStore, args: Args) -
             value,
             value_file,
         } => cmd_put(store, &audit, tenant, name, value, value_file),
+        SecretAction::Set {
+            name,
+            tenant,
+            hosts,
+            auth_type,
+            value,
+            value_file,
+        } => cmd_set(
+            store,
+            bindings,
+            &audit,
+            SetArgs {
+                tenant,
+                name,
+                hosts,
+                auth_type: auth_type.into(),
+                value,
+                value_file,
+            },
+        ),
         SecretAction::Get { name, tenant } => cmd_get(store, &audit, tenant, name),
-        SecretAction::Ls { tenant } => cmd_ls(store, &audit, tenant),
-        SecretAction::Rm { name, tenant } => cmd_rm(store, &audit, tenant, name),
+        SecretAction::Ls { tenant } => cmd_ls(store, bindings, &audit, tenant),
+        SecretAction::Rm { name, tenant } => cmd_rm(store, bindings, &audit, tenant, name),
     }
 }
 
@@ -138,6 +224,52 @@ fn cmd_put(
     Ok(())
 }
 
+/// The `secret set` inputs, bundled to keep [`cmd_set`] under the
+/// argument-count lint (never suppressed — see CLAUDE.md).
+struct SetArgs {
+    tenant: String,
+    name: String,
+    hosts: Vec<String>,
+    auth_type: AuthType,
+    value: Option<String>,
+    value_file: Option<PathBuf>,
+}
+
+fn cmd_set(
+    store: &dyn SecretStore,
+    bindings: &dyn BindingStore,
+    audit: &AuditLog,
+    set: SetArgs,
+) -> Result<()> {
+    let SetArgs {
+        tenant,
+        name,
+        hosts,
+        auth_type,
+        value,
+        value_file,
+    } = set;
+    let result = (|| -> Result<()> {
+        let raw = resolve_value(value, value_file, &name)?;
+        let secret = SecretBox::new(Box::new(raw));
+        store.put(&tenant, &name, &secret)?;
+        // Binding after value: if the value write fails we never record a
+        // binding for a secret that isn't there.
+        bindings.put(
+            &tenant,
+            &name,
+            &SecretBindingMeta {
+                auth_type,
+                allowed_hosts: hosts,
+            },
+        )
+    })();
+    audit.record("set", &tenant, &name, &result)?;
+    result?;
+    eprintln!("Defined secret '{name}' for tenant '{tenant}'.");
+    Ok(())
+}
+
 fn cmd_get(store: &dyn SecretStore, audit: &AuditLog, tenant: String, name: String) -> Result<()> {
     let result = store.get(&tenant, &name);
     audit.record("get", &tenant, &name, &result.as_ref().map(|_| ()))?;
@@ -146,7 +278,12 @@ fn cmd_get(store: &dyn SecretStore, audit: &AuditLog, tenant: String, name: Stri
     Ok(())
 }
 
-fn cmd_ls(store: &dyn SecretStore, audit: &AuditLog, tenant: String) -> Result<()> {
+fn cmd_ls(
+    store: &dyn SecretStore,
+    bindings: &dyn BindingStore,
+    audit: &AuditLog,
+    tenant: String,
+) -> Result<()> {
     let result = store.list(&tenant);
     audit.record("list", &tenant, "*", &result.as_ref().map(|_| ()))?;
     let names = result?;
@@ -155,18 +292,51 @@ fn cmd_ls(store: &dyn SecretStore, audit: &AuditLog, tenant: String) -> Result<(
         return Ok(());
     }
     for name in &names {
-        // Names ONLY. Never values. Avoid even the names' lengths
-        // being implicit value-length signals: the names are
-        // user-chosen identifiers, not derived from values.
-        println!("{name}");
+        // Name + (for bound secrets) auth-type and destination
+        // allow-list. Never the value, and never anything value-derived:
+        // the binding is operator-declared metadata.
+        let binding = bindings.get(&tenant, name)?;
+        println!("{}", ls_line(name, binding.as_ref()));
     }
     Ok(())
 }
 
-fn cmd_rm(store: &dyn SecretStore, audit: &AuditLog, tenant: String, name: String) -> Result<()> {
+/// Render one `secret ls` row. Pure so it is unit-testable without
+/// capturing stdout — and structurally incapable of leaking the value,
+/// which is never an input.
+fn ls_line(name: &str, binding: Option<&SecretBindingMeta>) -> String {
+    match binding {
+        Some(b) => format!(
+            "{name}\ttype={}\thosts={}",
+            auth_type_label(b.auth_type),
+            b.allowed_hosts.join(",")
+        ),
+        None => name.to_string(),
+    }
+}
+
+fn auth_type_label(t: AuthType) -> &'static str {
+    match t {
+        AuthType::Sigv4 => "sigv4",
+        AuthType::Hmac => "hmac",
+        AuthType::Bearer => "bearer",
+        AuthType::Basic => "basic",
+    }
+}
+
+fn cmd_rm(
+    store: &dyn SecretStore,
+    bindings: &dyn BindingStore,
+    audit: &AuditLog,
+    tenant: String,
+    name: String,
+) -> Result<()> {
     let result = store.delete(&tenant, &name);
     audit.record("delete", &tenant, &name, &result)?;
     result?;
+    // Drop the binding too so a re-`put` of the same name can't inherit a
+    // stale allow-list. Idempotent — absent binding is fine.
+    bindings.delete(&tenant, &name)?;
     eprintln!("Removed secret '{name}' for tenant '{tenant}'.");
     Ok(())
 }
@@ -427,6 +597,12 @@ mod tests {
         (tmp, AuditLog::with_path(path))
     }
 
+    fn temp_bindings() -> (tempfile::TempDir, FileBindingStore) {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileBindingStore::with_dir(tmp.path());
+        (tmp, store)
+    }
+
     fn read_audit(audit: &AuditLog) -> String {
         let path = audit.path.as_ref().expect("audit has path");
         std::fs::read_to_string(path).unwrap_or_default()
@@ -542,6 +718,7 @@ mod tests {
     fn cmd_rm_after_put_clears_name() {
         let tmp_store = tempfile::tempdir().unwrap();
         let store = FileSecretStore::with_dir(tmp_store.path());
+        let (_bind_dir, bindings) = temp_bindings();
         let (_audit_dir, audit) = temp_audit();
         cmd_put(
             &store,
@@ -552,8 +729,109 @@ mod tests {
             None,
         )
         .unwrap();
-        cmd_rm(&store, &audit, "acme".into(), "k".into()).unwrap();
+        cmd_rm(&store, &bindings, &audit, "acme".into(), "k".into()).unwrap();
         assert!(store.list("acme").unwrap().is_empty());
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Plan 129 B2 — `secret set` (value + egress binding) and `ls`
+    // ──────────────────────────────────────────────────────────────
+
+    fn set(
+        store: &dyn SecretStore,
+        bindings: &dyn BindingStore,
+        audit: &AuditLog,
+        name: &str,
+        hosts: &[&str],
+        auth_type: AuthType,
+        value: &str,
+    ) -> Result<()> {
+        cmd_set(
+            store,
+            bindings,
+            audit,
+            SetArgs {
+                tenant: "local".into(),
+                name: name.into(),
+                hosts: hosts.iter().map(|h| h.to_string()).collect(),
+                auth_type,
+                value: Some(value.into()),
+                value_file: None,
+            },
+        )
+    }
+
+    #[test]
+    fn cmd_set_stores_value_and_binding_without_leaking_value() {
+        let tmp_store = tempfile::tempdir().unwrap();
+        let store = FileSecretStore::with_dir(tmp_store.path());
+        let (bind_dir, bindings) = temp_bindings();
+        let (_audit_dir, audit) = temp_audit();
+
+        set(
+            &store,
+            &bindings,
+            &audit,
+            "openai",
+            &["api.openai.com"],
+            AuthType::Bearer,
+            "sk-live-zzz",
+        )
+        .unwrap();
+
+        // Value landed in the value store.
+        assert_eq!(store.list("local").unwrap(), vec!["openai"]);
+        // Binding landed with type + hosts.
+        let b = bindings.get("local", "openai").unwrap().unwrap();
+        assert_eq!(b.auth_type, AuthType::Bearer);
+        assert_eq!(b.allowed_hosts, vec!["api.openai.com"]);
+        // The binding sidecar carries metadata only — never the value.
+        let sidecar =
+            std::fs::read_to_string(bind_dir.path().join("local").join("openai.json")).unwrap();
+        assert!(
+            !sidecar.contains("sk-live-zzz"),
+            "binding sidecar must not contain the secret value: {sidecar}"
+        );
+    }
+
+    #[test]
+    fn ls_line_shows_type_and_hosts_for_a_bound_secret() {
+        let b = SecretBindingMeta {
+            auth_type: AuthType::Bearer,
+            allowed_hosts: vec!["api.openai.com".into(), "*.openai.com".into()],
+        };
+        let line = ls_line("openai", Some(&b));
+        assert!(line.starts_with("openai"));
+        assert!(line.contains("type=bearer"), "got: {line}");
+        assert!(
+            line.contains("hosts=api.openai.com,*.openai.com"),
+            "got: {line}"
+        );
+    }
+
+    #[test]
+    fn ls_line_for_a_value_only_secret_is_name_only() {
+        assert_eq!(ls_line("legacy", None), "legacy");
+    }
+
+    #[test]
+    fn cmd_rm_removes_binding_too() {
+        let tmp_store = tempfile::tempdir().unwrap();
+        let store = FileSecretStore::with_dir(tmp_store.path());
+        let (_bind_dir, bindings) = temp_bindings();
+        let (_audit_dir, audit) = temp_audit();
+        set(
+            &store,
+            &bindings,
+            &audit,
+            "openai",
+            &["api.openai.com"],
+            AuthType::Bearer,
+            "sk-live-zzz",
+        )
+        .unwrap();
+        cmd_rm(&store, &bindings, &audit, "local".into(), "openai".into()).unwrap();
+        assert!(bindings.get("local", "openai").unwrap().is_none());
     }
 
     #[test]

--- a/crates/mvm-hostd/Cargo.toml
+++ b/crates/mvm-hostd/Cargo.toml
@@ -63,6 +63,8 @@ serde_json.workspace = true
 # RFC 8785 JSON Canonicalization Scheme — audit-signer stable bytes-to-sign.
 serde_jcs = "0.1"
 sha2.workspace = true
+# Plan 129 keyholder — HMAC-SHA256 signer (webhook HMAC + AWS SigV4 key derivation).
+hmac.workspace = true
 # Plan 141 — hex digests for flow-byte-log record refs.
 hex.workspace = true
 thiserror = "1"

--- a/crates/mvm-hostd/src/keyholder/binding.rs
+++ b/crates/mvm-hostd/src/keyholder/binding.rs
@@ -1,0 +1,172 @@
+//! Plan 129 / ADR-067 §2 + §4 — local binding metadata for a named secret.
+//!
+//! `mvmctl secret set --host --type` records, per (tenant, name), the
+//! auth-type and the destination allow-list: the operator's local
+//! definition of *where* a secret may go and *how* it is used. The value
+//! itself lives in [`mvm_core::crypto::secret_store::SecretStore`]; this
+//! carries metadata only — **no secret bytes** — so `mvmctl secret ls`
+//! can show name/type/hosts without a `get`, and the keyholder
+//! (Phase C/D) can consult the binding it enforces against.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use mvm_core::config::mvm_data_dir_strict;
+use mvm_core::crypto::keystore::validate_shell_id;
+use mvm_sdk::ir::AuthType;
+use serde::{Deserialize, Serialize};
+
+/// Per-(tenant, name) binding metadata. No secret bytes — safe to print.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SecretBindingMeta {
+    /// How the keyholder uses the secret on egress (signer vs injector).
+    pub auth_type: AuthType,
+    /// Destinations the substituted credential may reach (claim 12).
+    /// `*.` subdomain wildcards per [`mvm_sdk::ir::host_matches`].
+    pub allowed_hosts: Vec<String>,
+}
+
+/// Storage for [`SecretBindingMeta`], keyed by (tenant, name). Parallel
+/// to the value store: the value lives in `SecretStore`, the binding here.
+pub trait BindingStore: Send + Sync {
+    fn put(&self, tenant: &str, name: &str, meta: &SecretBindingMeta) -> Result<()>;
+    /// `Ok(None)` when no binding is recorded — a secret stored via the
+    /// Plan 63 `put` path has a value but no egress binding.
+    fn get(&self, tenant: &str, name: &str) -> Result<Option<SecretBindingMeta>>;
+    /// Idempotent: removing an absent binding is not an error.
+    fn delete(&self, tenant: &str, name: &str) -> Result<()>;
+}
+
+/// File-backed binding store. Layout: `<base>/<tenant>/<name>.json`,
+/// per-file mode 0600, per-tenant dir mode 0700 — mirrors
+/// [`mvm_core::crypto::secret_store::FileSecretStore`]. Default base is
+/// `~/.mvm/secret-bindings/`.
+pub struct FileBindingStore {
+    base: PathBuf,
+}
+
+impl FileBindingStore {
+    pub fn with_dir(base: impl Into<PathBuf>) -> Self {
+        Self { base: base.into() }
+    }
+
+    /// `~/.mvm/secret-bindings/` (honors `MVM_DATA_DIR`).
+    pub fn default_location() -> Result<Self> {
+        Ok(Self {
+            base: mvm_data_dir_strict()?.join("secret-bindings"),
+        })
+    }
+
+    fn path(&self, tenant: &str, name: &str) -> Result<PathBuf> {
+        validate_shell_id(tenant).with_context(|| format!("invalid tenant id {tenant:?}"))?;
+        validate_shell_id(name).with_context(|| format!("invalid secret name {name:?}"))?;
+        Ok(self.base.join(tenant).join(format!("{name}.json")))
+    }
+}
+
+impl BindingStore for FileBindingStore {
+    fn put(&self, tenant: &str, name: &str, meta: &SecretBindingMeta) -> Result<()> {
+        let path = self.path(tenant, name)?;
+        let dir = path.parent().expect("path has tenant parent");
+        fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+        fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 0700 {}", dir.display()))?;
+        let json = serde_json::to_vec_pretty(meta).context("serializing binding metadata")?;
+        // Write 0600 then rename so a concurrent reader never sees a
+        // half-written file.
+        let tmp = path.with_extension("json.tmp");
+        let mut f = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp)
+            .with_context(|| format!("opening {}", tmp.display()))?;
+        f.write_all(&json)
+            .with_context(|| format!("writing {}", tmp.display()))?;
+        f.sync_all().ok();
+        fs::rename(&tmp, &path)
+            .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+        Ok(())
+    }
+
+    fn get(&self, tenant: &str, name: &str) -> Result<Option<SecretBindingMeta>> {
+        let path = self.path(tenant, name)?;
+        match fs::read(&path) {
+            Ok(bytes) => {
+                let meta = serde_json::from_slice(&bytes)
+                    .with_context(|| format!("parsing binding {}", path.display()))?;
+                Ok(Some(meta))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(anyhow::Error::from(e).context(format!("reading {}", path.display()))),
+        }
+    }
+
+    fn delete(&self, tenant: &str, name: &str) -> Result<()> {
+        let path = self.path(tenant, name)?;
+        match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(anyhow::Error::from(e).context(format!("removing {}", path.display()))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn meta() -> SecretBindingMeta {
+        SecretBindingMeta {
+            auth_type: AuthType::Bearer,
+            allowed_hosts: vec!["api.openai.com".into()],
+        }
+    }
+
+    #[test]
+    fn put_get_roundtrip() {
+        let dir = tempdir().unwrap();
+        let store = FileBindingStore::with_dir(dir.path());
+        store.put("local", "openai", &meta()).unwrap();
+        assert_eq!(store.get("local", "openai").unwrap(), Some(meta()));
+    }
+
+    #[test]
+    fn get_missing_is_none() {
+        let dir = tempdir().unwrap();
+        let store = FileBindingStore::with_dir(dir.path());
+        assert_eq!(store.get("local", "absent").unwrap(), None);
+    }
+
+    #[test]
+    fn delete_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let store = FileBindingStore::with_dir(dir.path());
+        store.put("local", "openai", &meta()).unwrap();
+        store.delete("local", "openai").unwrap();
+        assert_eq!(store.get("local", "openai").unwrap(), None);
+        store.delete("local", "openai").unwrap(); // second remove: no error
+    }
+
+    #[test]
+    fn binding_file_is_0600() {
+        let dir = tempdir().unwrap();
+        let store = FileBindingStore::with_dir(dir.path());
+        store.put("local", "openai", &meta()).unwrap();
+        let path = dir.path().join("local").join("openai.json");
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn rejects_unsafe_name() {
+        let dir = tempdir().unwrap();
+        let store = FileBindingStore::with_dir(dir.path());
+        assert!(store.put("local", "../escape", &meta()).is_err());
+    }
+}

--- a/crates/mvm-hostd/src/keyholder/binding.rs
+++ b/crates/mvm-hostd/src/keyholder/binding.rs
@@ -20,6 +20,9 @@ use mvm_sdk::ir::AuthType;
 use serde::{Deserialize, Serialize};
 
 /// Per-(tenant, name) binding metadata. No secret bytes — safe to print.
+// allow(secret-debug): metadata only — auth_type + allowed_hosts. The
+// secret value lives in `SecretStore`, never here; Debug prints the
+// destination policy, which `mvmctl secret ls` already shows in cleartext.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SecretBindingMeta {
     /// How the keyholder uses the secret on egress (signer vs injector).

--- a/crates/mvm-hostd/src/keyholder/injector.rs
+++ b/crates/mvm-hostd/src/keyholder/injector.rs
@@ -1,0 +1,192 @@
+//! Plan 129 / ADR-067 §3 — the injecting keyholder (bearer/basic fallback).
+//!
+//! For transmitted-value auth (bearer tokens, basic credentials) the raw
+//! value must reach the wire, so there is no "host never sees it" — and we
+//! don't overclaim. Instead we confine it: the value is decrypted only
+//! inside this component, substituted into the outbound bytes, and
+//! zeroized. The blast radius is one audited component scoped to the
+//! secret's destinations.
+//!
+//! claim 12: the destination allow-list is checked **before** the value is
+//! resolved, so an out-of-policy request never triggers a decrypt.
+
+use mvm_sdk::ir::{AuthType, SecretRef, host_matches};
+use secrecy::ExposeSecret;
+use zeroize::Zeroizing;
+
+use super::resolver::{ResolveError, SecretResolver};
+
+/// Errors from the injecting keyholder.
+#[derive(Debug, thiserror::Error)]
+pub enum InjectError {
+    #[error(transparent)]
+    Resolve(#[from] ResolveError),
+    /// The injector handles only transmitted-value schemes; sigv4/hmac go
+    /// to the signer (whose key never leaves it).
+    #[error("injector handles bearer/basic only, not {0:?}; use the signer")]
+    WrongAuthType(AuthType),
+    /// The destination is not in the secret's `allowed_hosts`. Returned
+    /// **before** any decrypt (claim 12).
+    #[error("destination `{0}` is not in the secret's allowed_hosts")]
+    DestinationNotBound(String),
+    /// The stored value is not UTF-8 — bearer/basic credentials are text.
+    #[error("secret value is not valid UTF-8")]
+    NonUtf8Value,
+}
+
+/// The injecting keyholder. Borrows a [`SecretResolver`] for the value
+/// source.
+pub struct Injector<'a> {
+    resolver: &'a dyn SecretResolver,
+}
+
+impl<'a> Injector<'a> {
+    pub fn new(resolver: &'a dyn SecretResolver) -> Self {
+        Self { resolver }
+    }
+
+    /// Substitute `placeholder` in `text` with the secret's resolved value,
+    /// for an outbound request to `destination`. The result is a zeroizing
+    /// buffer because it carries the raw credential. Refuses — without
+    /// decrypting — if `destination` is not bound or the auth type is a
+    /// signing scheme.
+    pub fn inject_placeholder(
+        &self,
+        r: &SecretRef,
+        destination: &str,
+        text: &str,
+        placeholder: &str,
+    ) -> Result<Zeroizing<String>, InjectError> {
+        // Both guards run BEFORE resolve, so a wrong-scheme or out-of-policy
+        // request never triggers a decrypt (claim 12).
+        match r.auth_type {
+            AuthType::Bearer | AuthType::Basic => {}
+            other => return Err(InjectError::WrongAuthType(other)),
+        }
+        if !r.allowed_hosts.iter().any(|p| host_matches(p, destination)) {
+            return Err(InjectError::DestinationNotBound(destination.to_string()));
+        }
+        let value = self.resolver.resolve(r)?;
+        let value =
+            std::str::from_utf8(value.expose_secret()).map_err(|_| InjectError::NonUtf8Value)?;
+        // The output carries the raw credential — hand it back zeroizing so
+        // the caller's copy wipes on drop.
+        Ok(Zeroizing::new(text.replace(placeholder, value)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keyholder::LocalResolver;
+    use mvm_core::crypto::secret_store::{FileSecretStore, SecretStore};
+    use mvm_sdk::ir::SecretMount;
+    use secrecy::SecretBox;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+    use tempfile::tempdir;
+
+    /// Wraps a real resolver and counts `resolve` calls so a test can prove
+    /// the injector never decrypted for an out-of-policy destination.
+    struct SpyResolver {
+        inner: LocalResolver,
+        calls: AtomicUsize,
+    }
+    impl SecretResolver for SpyResolver {
+        fn resolve(&self, r: &SecretRef) -> Result<SecretBox<Vec<u8>>, ResolveError> {
+            self.calls.fetch_add(1, SeqCst);
+            self.inner.resolve(r)
+        }
+    }
+
+    fn spy_with(name: &str, value: &str) -> (tempfile::TempDir, SpyResolver) {
+        let dir = tempdir().unwrap();
+        let store = FileSecretStore::with_dir(dir.path());
+        store
+            .put("local", name, &SecretBox::new(Box::new(value.to_string())))
+            .unwrap();
+        let store: Arc<dyn SecretStore> = Arc::new(store);
+        (
+            dir,
+            SpyResolver {
+                inner: LocalResolver::new("local", store),
+                calls: AtomicUsize::new(0),
+            },
+        )
+    }
+
+    fn secret_ref(name: &str, auth_type: AuthType, hosts: &[&str]) -> SecretRef {
+        SecretRef {
+            name: name.into(),
+            mount: SecretMount::Env { var: "K".into() },
+            auth_type,
+            allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn substitutes_value_for_a_bound_destination() {
+        let (_dir, spy) = spy_with("api", "sk-tok");
+        let injector = Injector::new(&spy);
+        let out = injector
+            .inject_placeholder(
+                &secret_ref("api", AuthType::Bearer, &["api.openai.com"]),
+                "api.openai.com",
+                "Authorization: Bearer %TOK%",
+                "%TOK%",
+            )
+            .unwrap();
+        assert_eq!(&*out, "Authorization: Bearer sk-tok");
+    }
+
+    #[test]
+    fn refuses_unbound_destination_without_decrypting() {
+        let (_dir, spy) = spy_with("api", "sk-tok");
+        let injector = Injector::new(&spy);
+        let err = injector
+            .inject_placeholder(
+                &secret_ref("api", AuthType::Bearer, &["api.openai.com"]),
+                "evil.example.com",
+                "Authorization: Bearer %TOK%",
+                "%TOK%",
+            )
+            .unwrap_err();
+        assert!(matches!(err, InjectError::DestinationNotBound(_)));
+        assert_eq!(
+            spy.calls.load(SeqCst),
+            0,
+            "must not resolve/decrypt for an unbound destination"
+        );
+    }
+
+    #[test]
+    fn honors_wildcard_host_binding() {
+        let (_dir, spy) = spy_with("api", "sk-tok");
+        let injector = Injector::new(&spy);
+        let out = injector
+            .inject_placeholder(
+                &secret_ref("api", AuthType::Bearer, &["*.openai.com"]),
+                "api.openai.com",
+                "Bearer %TOK%",
+                "%TOK%",
+            )
+            .unwrap();
+        assert_eq!(&*out, "Bearer sk-tok");
+    }
+
+    #[test]
+    fn rejects_signing_auth_type_without_decrypting() {
+        let (_dir, spy) = spy_with("api", "sk-tok");
+        let injector = Injector::new(&spy);
+        let err = injector
+            .inject_placeholder(
+                &secret_ref("api", AuthType::Sigv4, &["api.openai.com"]),
+                "api.openai.com",
+                "Bearer %TOK%",
+                "%TOK%",
+            )
+            .unwrap_err();
+        assert!(matches!(err, InjectError::WrongAuthType(AuthType::Sigv4)));
+        assert_eq!(spy.calls.load(SeqCst), 0);
+    }
+}

--- a/crates/mvm-hostd/src/keyholder/mod.rs
+++ b/crates/mvm-hostd/src/keyholder/mod.rs
@@ -7,9 +7,11 @@
 //! ever handing it to the guest (claims 12/13).
 
 pub mod binding;
+pub mod injector;
 pub mod resolver;
 pub mod signer;
 
 pub use binding::{BindingStore, FileBindingStore, SecretBindingMeta};
+pub use injector::{InjectError, Injector};
 pub use resolver::{LocalResolver, ResolveError, SecretResolver};
 pub use signer::{SigV4Input, SignError, Signature, Signer};

--- a/crates/mvm-hostd/src/keyholder/mod.rs
+++ b/crates/mvm-hostd/src/keyholder/mod.rs
@@ -6,6 +6,8 @@
 //! adds the signer/injector that uses a resolved value on egress without
 //! ever handing it to the guest (claims 12/13).
 
+pub mod binding;
 pub mod resolver;
 
+pub use binding::{BindingStore, FileBindingStore, SecretBindingMeta};
 pub use resolver::{LocalResolver, ResolveError, SecretResolver};

--- a/crates/mvm-hostd/src/keyholder/mod.rs
+++ b/crates/mvm-hostd/src/keyholder/mod.rs
@@ -8,6 +8,8 @@
 
 pub mod binding;
 pub mod resolver;
+pub mod signer;
 
 pub use binding::{BindingStore, FileBindingStore, SecretBindingMeta};
 pub use resolver::{LocalResolver, ResolveError, SecretResolver};
+pub use signer::{SigV4Input, SignError, Signature, Signer};

--- a/crates/mvm-hostd/src/keyholder/mod.rs
+++ b/crates/mvm-hostd/src/keyholder/mod.rs
@@ -1,0 +1,11 @@
+//! Host-side secret keyholder (Plan 129 / ADR-067).
+//!
+//! The keyholder owns the boundary where a workload's `SecretRef`
+//! becomes a real credential. Phase B is the value source: the
+//! [`SecretResolver`] trait + the single-host [`LocalResolver`]. Phase C
+//! adds the signer/injector that uses a resolved value on egress without
+//! ever handing it to the guest (claims 12/13).
+
+pub mod resolver;
+
+pub use resolver::{LocalResolver, ResolveError, SecretResolver};

--- a/crates/mvm-hostd/src/keyholder/resolver.rs
+++ b/crates/mvm-hostd/src/keyholder/resolver.rs
@@ -1,0 +1,144 @@
+//! Plan 129 / ADR-067 §2 — the `SecretResolver` trait + `LocalResolver`.
+//!
+//! A resolver maps a workload's [`SecretRef`] (by name) to its raw
+//! credential value, handed back in a zeroizing `SecretBox`. The value
+//! source is swappable: [`LocalResolver`] reads the single-host
+//! [`SecretStore`] (the `mvmctl secret set` backend) so the standalone
+//! demo needs no `mvmd`; the fleet resolver is a separate mvmd plan.
+//!
+//! Raw bytes never widen past this boundary — the value lands in a
+//! `SecretBox<Vec<u8>>` that zeroizes on drop, and the keyholder
+//! (Phase C) consumes it on egress without copying it into the guest.
+
+use std::sync::Arc;
+
+use mvm_core::crypto::secret_store::SecretStore;
+use mvm_sdk::ir::SecretRef;
+use secrecy::{ExposeSecret, SecretBox};
+
+/// Errors from resolving a [`SecretRef`] to its stored value.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolveError {
+    /// The ref carries no `allowed_hosts` — an unbound secret must never
+    /// resolve (claim 12, fail-closed). Validation rejects this earlier
+    /// (`SecretWithoutBinding`); this is the resolver's own backstop.
+    #[error("secret `{name}` has no destination binding")]
+    Unbound { name: String },
+    /// The store had no value for the ref, or the backend failed.
+    #[error("secret `{name}` could not be resolved: {source}")]
+    Backend {
+        name: String,
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+/// Resolves a workload [`SecretRef`] to its raw credential value.
+///
+/// One trait, swappable value source. The returned `SecretBox`
+/// zeroizes on drop; callers must not copy the exposed bytes into a
+/// longer-lived buffer.
+pub trait SecretResolver: Send + Sync {
+    fn resolve(&self, r: &SecretRef) -> Result<SecretBox<Vec<u8>>, ResolveError>;
+}
+
+/// Single-host resolver over the local [`SecretStore`] (the
+/// `mvmctl secret set` backend). The fleet resolver lives in mvmd.
+pub struct LocalResolver {
+    tenant: String,
+    store: Arc<dyn SecretStore>,
+}
+
+impl LocalResolver {
+    pub fn new(tenant: impl Into<String>, store: Arc<dyn SecretStore>) -> Self {
+        Self {
+            tenant: tenant.into(),
+            store,
+        }
+    }
+}
+
+impl SecretResolver for LocalResolver {
+    fn resolve(&self, r: &SecretRef) -> Result<SecretBox<Vec<u8>>, ResolveError> {
+        if r.allowed_hosts.is_empty() {
+            return Err(ResolveError::Unbound {
+                name: r.name.clone(),
+            });
+        }
+        let value =
+            self.store
+                .get(&self.tenant, &r.name)
+                .map_err(|source| ResolveError::Backend {
+                    name: r.name.clone(),
+                    source,
+                })?;
+        // `SecretStore` yields `SecretBox<String>`; re-box as bytes so the
+        // keyholder treats every credential uniformly. The String buffer
+        // zeroizes when `value` drops at end of scope; the new Vec is owned
+        // by the returned box and zeroizes on its drop.
+        Ok(SecretBox::new(Box::new(
+            value.expose_secret().as_bytes().to_vec(),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::crypto::secret_store::FileSecretStore;
+    use mvm_sdk::ir::{AuthType, SecretMount};
+    use tempfile::tempdir;
+
+    fn bearer_ref(name: &str, hosts: &[&str]) -> SecretRef {
+        SecretRef {
+            name: name.into(),
+            mount: SecretMount::Env {
+                var: "API_KEY".into(),
+            },
+            auth_type: AuthType::Bearer,
+            allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+        }
+    }
+
+    fn store_with(
+        tenant: &str,
+        name: &str,
+        value: &str,
+    ) -> (tempfile::TempDir, Arc<dyn SecretStore>) {
+        let dir = tempdir().unwrap();
+        let store = FileSecretStore::with_dir(dir.path());
+        store
+            .put(tenant, name, &SecretBox::new(Box::new(value.to_string())))
+            .unwrap();
+        (dir, Arc::new(store))
+    }
+
+    #[test]
+    fn local_resolver_returns_zeroizing_value_for_a_known_ref() {
+        let (_dir, store) = store_with("local", "openai", "sk-live-xxx");
+        let resolver = LocalResolver::new("local", store);
+        let secret = resolver
+            .resolve(&bearer_ref("openai", &["api.openai.com"]))
+            .unwrap();
+        assert_eq!(secret.expose_secret().as_slice(), b"sk-live-xxx");
+    }
+
+    #[test]
+    fn local_resolver_rejects_unbound_ref() {
+        let (_dir, store) = store_with("local", "openai", "sk-live-xxx");
+        let resolver = LocalResolver::new("local", store);
+        let err = resolver.resolve(&bearer_ref("openai", &[])).unwrap_err();
+        assert!(matches!(err, ResolveError::Unbound { .. }));
+    }
+
+    #[test]
+    fn local_resolver_reports_missing_secret_as_backend_error() {
+        let dir = tempdir().unwrap();
+        let store: Arc<dyn SecretStore> = Arc::new(FileSecretStore::with_dir(dir.path()));
+        let resolver = LocalResolver::new("local", store);
+        let err = resolver
+            .resolve(&bearer_ref("absent", &["api.openai.com"]))
+            .unwrap_err();
+        assert!(matches!(err, ResolveError::Backend { .. }));
+    }
+}

--- a/crates/mvm-hostd/src/keyholder/signer.rs
+++ b/crates/mvm-hostd/src/keyholder/signer.rs
@@ -1,0 +1,263 @@
+//! Plan 129 / ADR-067 §3 — the signing keyholder (gold path).
+//!
+//! For signing-based auth (AWS SigV4, HMAC webhooks) the secret key never
+//! goes on the wire: the signer resolves the key into confined memory,
+//! computes a signature over a caller-prepared canonical request, and
+//! zeroizes. The returned [`Signature`] carries the digest only — no key
+//! material — so a leaked signature reveals nothing about the key.
+//!
+//! Software-first, hardware-optional (ADR-067 §3): the default path is
+//! pure software (key encrypted at rest, decrypted only here, wiped after
+//! use). A Secure Enclave / TPM, when present, strengthens this to "host
+//! never sees the key" through the *same* interface — no DX change.
+
+use hmac::{Hmac, Mac};
+use mvm_sdk::ir::{AuthType, SecretRef};
+use secrecy::ExposeSecret;
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+use super::resolver::{ResolveError, SecretResolver};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// A computed signature, hex-encoded. Carries **no** key material.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signature {
+    pub hex: String,
+}
+
+/// Errors from the signing keyholder.
+#[derive(Debug, thiserror::Error)]
+pub enum SignError {
+    #[error(transparent)]
+    Resolve(#[from] ResolveError),
+    /// The signer handles only signing schemes; bearer/basic go to the
+    /// injector. Guards against a caller routing a transmitted-value
+    /// secret through the key-never-leaves path.
+    #[error("signer handles sigv4/hmac only, not {0:?}; use the injector")]
+    WrongAuthType(AuthType),
+}
+
+/// Inputs for an AWS SigV4 signature. The caller prepares the canonical
+/// request — the signer signs, it does not build requests.
+pub struct SigV4Input {
+    pub canonical_request: String,
+    /// `yyyymmddThhmmssZ`.
+    pub amz_date: String,
+    /// `yyyymmdd` — the credential-scope date.
+    pub date_stamp: String,
+    pub region: String,
+    pub service: String,
+}
+
+impl SigV4Input {
+    /// `<date>/<region>/<service>/aws4_request` — public, for the caller's
+    /// `Authorization` header.
+    pub fn credential_scope(&self) -> String {
+        format!(
+            "{}/{}/{}/aws4_request",
+            self.date_stamp, self.region, self.service
+        )
+    }
+
+    fn string_to_sign(&self) -> String {
+        let hashed = hex::encode(Sha256::digest(self.canonical_request.as_bytes()));
+        format!(
+            "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+            self.amz_date,
+            self.credential_scope(),
+            hashed
+        )
+    }
+}
+
+/// The signing keyholder. Borrows a [`SecretResolver`] for the key source.
+pub struct Signer<'a> {
+    resolver: &'a dyn SecretResolver,
+}
+
+impl<'a> Signer<'a> {
+    pub fn new(resolver: &'a dyn SecretResolver) -> Self {
+        Self { resolver }
+    }
+
+    /// HMAC-SHA256 over `payload` (webhook signing). The key is resolved,
+    /// used, and zeroized within this call.
+    pub fn sign_hmac(&self, r: &SecretRef, payload: &[u8]) -> Result<Signature, SignError> {
+        if r.auth_type != AuthType::Hmac {
+            return Err(SignError::WrongAuthType(r.auth_type));
+        }
+        let key = self.resolver.resolve(r)?;
+        let sig = hmac_sha256(key.expose_secret(), payload);
+        // `key` (SecretBox) and `sig` (Zeroizing) wipe on drop at scope end.
+        Ok(Signature {
+            hex: hex::encode(&*sig),
+        })
+    }
+
+    /// AWS SigV4 signature. The key is resolved, the signing key derived
+    /// in zeroizing buffers, and all of it wiped on return.
+    pub fn sign_sigv4(&self, r: &SecretRef, input: &SigV4Input) -> Result<Signature, SignError> {
+        if r.auth_type != AuthType::Sigv4 {
+            return Err(SignError::WrongAuthType(r.auth_type));
+        }
+        let key = self.resolver.resolve(r)?;
+        let signing_key = derive_sigv4_signing_key(
+            key.expose_secret(),
+            &input.date_stamp,
+            &input.region,
+            &input.service,
+        );
+        let sig = hmac_sha256(&signing_key, input.string_to_sign().as_bytes());
+        Ok(Signature {
+            hex: hex::encode(&*sig),
+        })
+    }
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Zeroizing<Vec<u8>> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts a key of any length");
+    mac.update(data);
+    Zeroizing::new(mac.finalize().into_bytes().to_vec())
+}
+
+/// AWS SigV4 four-step signing-key derivation. Every intermediate is a
+/// zeroizing buffer so no derived key lingers on the heap after the sign.
+fn derive_sigv4_signing_key(
+    secret: &[u8],
+    date_stamp: &str,
+    region: &str,
+    service: &str,
+) -> Zeroizing<Vec<u8>> {
+    let mut seed = Zeroizing::new(Vec::with_capacity(4 + secret.len()));
+    seed.extend_from_slice(b"AWS4");
+    seed.extend_from_slice(secret);
+    let k_date = hmac_sha256(&seed, date_stamp.as_bytes());
+    let k_region = hmac_sha256(&k_date, region.as_bytes());
+    let k_service = hmac_sha256(&k_region, service.as_bytes());
+    hmac_sha256(&k_service, b"aws4_request")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keyholder::LocalResolver;
+    use mvm_core::crypto::secret_store::{FileSecretStore, SecretStore};
+    use mvm_sdk::ir::SecretMount;
+    use secrecy::SecretBox;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    fn resolver_with(name: &str, value: &str) -> (tempfile::TempDir, LocalResolver) {
+        let dir = tempdir().unwrap();
+        let store = FileSecretStore::with_dir(dir.path());
+        store
+            .put("local", name, &SecretBox::new(Box::new(value.to_string())))
+            .unwrap();
+        let store: Arc<dyn SecretStore> = Arc::new(store);
+        (dir, LocalResolver::new("local", store))
+    }
+
+    fn secret_ref(name: &str, auth_type: AuthType, hosts: &[&str]) -> SecretRef {
+        SecretRef {
+            name: name.into(),
+            mount: SecretMount::Env { var: "K".into() },
+            auth_type,
+            allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn hmac_matches_rfc4231_case2() {
+        // RFC 4231 §4.3: key="Jefe", data="what do ya want for nothing?".
+        let (_dir, resolver) = resolver_with("webhook", "Jefe");
+        let signer = Signer::new(&resolver);
+        let sig = signer
+            .sign_hmac(
+                &secret_ref("webhook", AuthType::Hmac, &["hooks.example.com"]),
+                b"what do ya want for nothing?",
+            )
+            .unwrap();
+        assert_eq!(
+            sig.hex,
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+    }
+
+    #[test]
+    fn sigv4_matches_aws_get_vanilla_vector() {
+        // aws-sig-v4-test-suite `get-vanilla`: the published signature for
+        // the canonical example. Proves the full derive + string-to-sign.
+        let (_dir, resolver) = resolver_with("aws", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY");
+        let signer = Signer::new(&resolver);
+        let input = SigV4Input {
+            canonical_request: "GET\n/\n\nhost:example.amazonaws.com\n\
+                 x-amz-date:20150830T123600Z\n\nhost;x-amz-date\n\
+                 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                .to_string(),
+            amz_date: "20150830T123600Z".into(),
+            date_stamp: "20150830".into(),
+            region: "us-east-1".into(),
+            service: "service".into(),
+        };
+        let sig = signer
+            .sign_sigv4(
+                &secret_ref("aws", AuthType::Sigv4, &["example.amazonaws.com"]),
+                &input,
+            )
+            .unwrap();
+        assert_eq!(
+            sig.hex,
+            "5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"
+        );
+    }
+
+    #[test]
+    fn sign_hmac_rejects_non_hmac_auth_type() {
+        let (_dir, resolver) = resolver_with("aws", "k");
+        let signer = Signer::new(&resolver);
+        let err = signer
+            .sign_hmac(
+                &secret_ref("aws", AuthType::Sigv4, &["api.example.com"]),
+                b"x",
+            )
+            .unwrap_err();
+        assert!(matches!(err, SignError::WrongAuthType(AuthType::Sigv4)));
+    }
+
+    #[test]
+    fn sign_sigv4_rejects_non_sigv4_auth_type() {
+        let (_dir, resolver) = resolver_with("webhook", "k");
+        let signer = Signer::new(&resolver);
+        let input = SigV4Input {
+            canonical_request: "GET\n/\n\n\n\n".into(),
+            amz_date: "20150830T123600Z".into(),
+            date_stamp: "20150830".into(),
+            region: "us-east-1".into(),
+            service: "service".into(),
+        };
+        let err = signer
+            .sign_sigv4(
+                &secret_ref("webhook", AuthType::Bearer, &["api.example.com"]),
+                &input,
+            )
+            .unwrap_err();
+        assert!(matches!(err, SignError::WrongAuthType(AuthType::Bearer)));
+    }
+
+    #[test]
+    fn unbound_secret_never_signs() {
+        // The resolver's claim-12 backstop: an empty allow-list refuses to
+        // resolve, so the signer can't sign for an unbound secret.
+        let (_dir, resolver) = resolver_with("webhook", "Jefe");
+        let signer = Signer::new(&resolver);
+        let err = signer
+            .sign_hmac(&secret_ref("webhook", AuthType::Hmac, &[]), b"x")
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SignError::Resolve(ResolveError::Unbound { .. })
+        ));
+    }
+}

--- a/crates/mvm-hostd/src/lib.rs
+++ b/crates/mvm-hostd/src/lib.rs
@@ -25,4 +25,8 @@ pub mod broker;
 pub mod framing;
 pub mod host_signer;
 pub mod jailer;
+/// Secret keyholder (Plan 129 / ADR-067) — the `SecretRef` → credential
+/// boundary. Phase B: the [`keyholder::SecretResolver`] trait + the
+/// single-host [`keyholder::LocalResolver`].
+pub mod keyholder;
 pub mod supervisor;

--- a/specs/plans/129-secrets-subsystem.md
+++ b/specs/plans/129-secrets-subsystem.md
@@ -51,23 +51,15 @@ ADR-067 §4. The reference must say *how* the secret is used (so the keyholder p
 
 ### Task B1: the `SecretResolver` trait + `Local` impl
 
-ADR-067 §2. One trait, value source swappable. `Local` is the existing `KeyProvider` (OS keyring).
+ADR-067 §2. One trait, value source swappable. `Local` reads the existing named-secret store.
 
-**Files:** `crates/mvm-core/src/secret/resolver.rs` (new); reuse `keystore.rs`'s `KeyProvider`.
+**Files:** `crates/mvm-hostd/src/keyholder/resolver.rs` (new) + `keyholder/mod.rs`.
 
-- [ ] **Step 1:** Failing test — `LocalResolver` resolves a `SecretRef` whose value was set in the OS keyring (use the in-memory/file `KeyProvider` backend in test), and returns the value in a `SecretBox` (zeroize on drop).
-  ```rust
-  #[test]
-  fn local_resolver_returns_zeroizing_value_for_a_known_ref() {
-      let store = KeyProvider::file_backed(tmp());          // existing backend
-      store.set("openai", b"sk-live-xxx").unwrap();
-      let r = LocalResolver::new(store);
-      let secret = r.resolve(&secret_ref("openai", AuthType::Bearer, &["api.openai.com"])).unwrap();
-      assert_eq!(secret.expose(), b"sk-live-xxx"); // SecretBox<Vec<u8>>, zeroized on drop
-  }
-  ```
-- [ ] **Step 2:** Define `trait SecretResolver { fn resolve(&self, r: &SecretRef) -> Result<SecretBox<Vec<u8>>, ResolveError>; }`; implement `LocalResolver` over `KeyProvider`. The `mvmd` resolver is a separate mvmd plan; leave a `// resolver: mvmd impl lives in mvmd` note, not a stub.
-- [ ] **Step 3: Commit.**
+> **Reconciliation (post-plan-121):** the plan first named `crates/mvm-core/src/secret/resolver.rs` over `KeyProvider`. Two corrections: (1) `KeyProvider` (keystore.rs) is the *single* per-tenant master DEK — the actual named-secret backend is `SecretStore` (`mvm_core::crypto::secret_store`, the `mvmctl secret put/ls` backend); (2) `SecretRef` now lives in `mvm-sdk::ir`, and `mvm-core` is *below* `mvm-sdk`, so a resolver taking `&SecretRef` cannot live in mvm-core. `mvm-hostd` deps both `mvm-sdk` (SecretRef) and `mvm-core` (SecretStore) and is the admit-time/keyholder home — the resolver lives there, sibling to the Phase C keyholder.
+
+- [x] **Step 1:** Failing test — `LocalResolver` resolves a `SecretRef` whose value was set in the file-backed `SecretStore`, returns it in a `SecretBox<Vec<u8>>` (zeroize on drop); plus an unbound-ref backstop and a missing-secret error path.
+- [x] **Step 2:** Define `trait SecretResolver { fn resolve(&self, r: &SecretRef) -> Result<SecretBox<Vec<u8>>, ResolveError>; }`; implement `LocalResolver` over `SecretStore`. `ResolveError::Unbound` is the fail-closed claim-12 backstop (empty `allowed_hosts` never resolves). The `mvmd` resolver is a separate mvmd plan.
+- [x] **Step 3: Commit.**
 
 ### Task B2: `mvmctl secret set` (the standalone-mvm DX)
 

--- a/specs/plans/129-secrets-subsystem.md
+++ b/specs/plans/129-secrets-subsystem.md
@@ -75,26 +75,33 @@ ADR-067 §2 — the local define path so the demo needs no `mvmd`.
 
 ## Phase C — keyholder (123-independent)
 
+> **Reconciliation:** both live under `crates/mvm-hostd/src/keyholder/` (`signer.rs`, `injector.rs`), not the plan's standalone `secret_signer/`/`secret_injector/` — ADR-067 §3 literally calls signer+injector "the keyholder, split by auth-type", so they sit with the resolver + binding store under one cohesive module. Both take a `&dyn SecretResolver`. The separate-process moat (a `[[bin]]` under the jailer) is **deferred** — see "deferred follow-ups" below; the in-process lib is what D/E wire against, and the jailer wrap is orthogonal to the signing/injecting logic.
+
 ### Task C1: the signer (signing-based: SigV4, HMAC)
 
 ADR-067 §3 gold path. The signer takes a canonical request + a `SecretRef`, returns a signature; the key never leaves it. Hardware-sealed when a Secure Enclave/TPM is present, else a jailed software signer — **same interface**.
 
-**Files:** `crates/mvm-hostd/src/secret_signer/` (new module + a `[[bin]]` per the §3 separate-process model); reuse `core::subprocess`.
+**Files:** `crates/mvm-hostd/src/keyholder/signer.rs`.
 
-- [ ] **Step 1:** Failing test — given a SigV4 canonical request and a stored signing key, the signer returns a signature that verifies, and the key bytes never appear in the returned struct or the signer's public surface (assert the response type has no key field; `check-no-display-on-secret-types` covers Debug).
-- [ ] **Step 2:** Implement SigV4 + HMAC signing (existing `hmac`/`sha2`); key loaded via the resolver into the signer's confined memory (software path) or referenced by handle (hardware path — `keyring` → Secure Enclave on macOS). Zeroize after. Run under the jailer (ADR-066 §3).
-- [ ] **Step 3:** Hardware-optional test — with no Secure Enclave, the software path runs and zeroizes (assert the key is wiped post-sign); with a sealed handle present, signing uses it. No hardware required for the suite to pass.
-- [ ] **Step 4: Commit.**
+- [x] **Step 1:** Tests — `Signer::sign_hmac`/`sign_sigv4` return a signature; `Signature` has no key field (no key on the public surface; `check-no-display-on-secret-types` covers Debug). Verified against **published vectors**: RFC 4231 HMAC-SHA256 case 2 + aws-sig-v4-test-suite `get-vanilla`.
+- [x] **Step 2:** SigV4 + HMAC over existing `hmac`/`sha2`; key resolved into confined memory; derived SigV4 keys live in `Zeroizing` buffers (no intermediate lingers); the resolved value is a `SecretBox` that wipes on drop. Wrong auth type (bearer/basic) refused → signer is signing-only. (Hardware-sealed handle + jailer wrap: deferred follow-up.)
+- [x] **Step 3:** Software path runs with no hardware (the default; all tests exercise it). Sealed-handle path is the deferred hardware follow-up.
+- [x] **Step 4: Commit.**
 
 ### Task C2: the injector (bearer / basic)
 
 ADR-067 §3 fallback. The raw value must hit the wire, so confine it: decrypt only inside the injector, inject into the request, zeroize. Honest — not "never seen", but minimal + audited.
 
-**Files:** `crates/mvm-hostd/src/secret_injector/` (new).
+**Files:** `crates/mvm-hostd/src/keyholder/injector.rs`.
 
-- [ ] **Step 1:** Failing test — the injector replaces a placeholder in a request header with the resolved value and zeroizes its copy; on a destination not in `allowed_hosts` it refuses (returns `DestinationNotBound`, claim 12) and never decrypts.
-- [ ] **Step 2:** Implement: check `allowed_hosts` *before* resolving (no decrypt for an unbound destination), inject, zeroize. Encrypted at rest via 122's DEK/KEK.
-- [ ] **Step 3: Commit.**
+- [x] **Step 1:** Tests — `Injector::inject_placeholder` substitutes the resolved value into the outbound text and returns it `Zeroizing` (wipes on drop); a destination not in `allowed_hosts` returns `DestinationNotBound` (claim 12) and a spy resolver proves **no decrypt** happened; a signing auth type returns `WrongAuthType`, also without decrypting.
+- [x] **Step 2:** `allowed_hosts` (and auth-type) checked *before* resolve — no decrypt for an unbound destination; `*.` wildcard binding honored via `host_matches`. (Encrypted-at-rest via 122's DEK/KEK is the value store's concern.)
+- [x] **Step 3: Commit.**
+
+### deferred follow-ups (Phase C)
+
+- [ ] Separate-process moat: run the signer + injector as jailed `[[bin]]`s (ADR-066 §3 / `core::subprocess`) so a compromised signer can't read the supervisor's address space. The in-process lib is correct and tested; this is a confinement hardening, sequenced with the broker subprocess model.
+- [ ] Hardware-sealed signing path: load the SigV4/HMAC key by handle from the OS keyring → Secure Enclave on macOS, so the host never sees the plaintext key. Same `Signer` interface; the software path is the no-hardware default already shipped.
 
 ## Phase D — substitution endpoint + SDK routing (needs 123's proxy)
 

--- a/specs/plans/129-secrets-subsystem.md
+++ b/specs/plans/129-secrets-subsystem.md
@@ -65,11 +65,13 @@ ADR-067 §2. One trait, value source swappable. `Local` reads the existing named
 
 ADR-067 §2 — the local define path so the demo needs no `mvmd`.
 
-**Files:** `crates/mvm-cli/src/commands/secret.rs` (new); wire into `commands/mod.rs`.
+**Files:** extended `crates/mvm-cli/src/commands/ops/secret.rs` + new `crates/mvm-hostd/src/keyholder/binding.rs`.
 
-- [ ] **Step 1:** Failing CLI test — `mvmctl secret set openai --host api.openai.com --type bearer` (value from stdin or `--value-stdin`, never argv — it would hit the process table) stores it, and `mvmctl secret ls` shows the name + hosts + type, **never the value**.
-- [ ] **Step 2:** Implement over `LocalResolver`/`KeyProvider`; the value is read from stdin and zeroized; `ls` redacts. A `set` for a `--type sigv4` secret stores the signing key for the signer (Phase C).
-- [ ] **Step 3: Commit.**
+> **Reconciliation:** the plan named a *new* `commands/secret.rs`, but a `secret` clap command already exists (`commands/ops/secret.rs`, Plan 63 `put/get/ls/rm`) — a second one would collide, so `set` is added to that enum. Binding metadata (auth-type + allowed-hosts) needs storage separate from the value (`SecretStore` is value-only); it lives in a parallel `FileBindingStore` in `mvm-hostd` (where `AuthType` from mvm-sdk + `SecretStore` from mvm-core are both visible, and the Phase C/D keyholder can reuse it). `rm` now drops the binding too.
+
+- [x] **Step 1:** CLI tests — `cmd_set` stores value (`SecretStore`) + binding (`FileBindingStore`) and the binding sidecar never contains the value; `ls_line` shows name + `type=` + `hosts=` for a bound secret, name-only for a value-only (Plan 63) secret; `rm` removes the binding.
+- [x] **Step 2:** `mvmctl secret set <name> --host <h>… --type <sigv4|hmac|bearer|basic>` (value via prompt/stdin/`--value -`/`--value-file`, never argv); value through the existing zeroizing path; `ls` reads the binding store, redacts the value. (The Phase C signing-key-for-sigv4 store is wired in Phase C.)
+- [x] **Step 3: Commit.**
 
 ## Phase C — keyholder (123-independent)
 

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -490,6 +490,7 @@ fn audit_posture_emits_entries_reference_known_audit_kinds() {
         "SecretGet",
         "SecretPut",
         "SecretRm",
+        "SecretSet",
         "SandboxGc",
         "SessionStart",
         "SlotPrune",

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -135,6 +135,7 @@ const VOLUME_SUB: &[(&str, AuditPosture)] = &[
 
 const SECRET_SUB: &[(&str, AuditPosture)] = &[
     ("put", AuditPosture::Emits("SecretPut")),
+    ("set", AuditPosture::Emits("SecretSet")),
     ("get", AuditPosture::Emits("SecretGet")),
     ("ls", AuditPosture::ReadOnly),
     ("rm", AuditPosture::Emits("SecretRm")),


### PR DESCRIPTION
Plan 129 Phases B + C (Secrets subsystem / egress substitution) — the **local keyholder**: everything needed to resolve a `SecretRef` to a credential and use it on egress, with the value never reaching the guest. All 123-independent; builds on Phase A (#666, merged). No external wiring yet (that's D/E/F), so this is one cohesive `mvm-hostd/src/keyholder/` module.

## Phase B — resolver + local-define DX
- **B1 `SecretResolver` + `LocalResolver`** (`keyholder/resolver.rs`): `SecretRef` → zeroizing `SecretBox<Vec<u8>>` over the single-host `SecretStore`. Empty `allowed_hosts` → `ResolveError::Unbound` (fail-closed claim-12 backstop).
- **B2 `FileBindingStore`** (`keyholder/binding.rs`) + **`mvmctl secret set`**: `set <name> --host <h>… --type <sigv4|hmac|bearer|basic>` stores the value (existing zeroizing `SecretStore` path) **and** the egress binding (auth-type + allow-list) in a parallel metadata store (no bytes; 0600/0700). `ls` shows the binding (type + hosts) for bound secrets, name-only for value-only Plan 63 secrets; `rm` drops the binding too. Value never enters argv/sidecar/guest.

## Phase C — keyholder (signing + injecting), ADR-067 §3
- **C1 signer** (`keyholder/signer.rs`): `sign_hmac` / `sign_sigv4`. Key resolved into confined memory, signed, zeroized; derived SigV4 keys in `Zeroizing` buffers; `Signature` carries the digest only (no key field). Verified against **published vectors** (RFC 4231 HMAC case 2; aws-sig-v4-test-suite `get-vanilla`). Software-first; wrong auth type (bearer/basic) refused.
- **C2 injector** (`keyholder/injector.rs`): `inject_placeholder` substitutes the resolved value into outbound text for a **bound** destination, returning it `Zeroizing`. claim 12: auth-type + `allowed_hosts` checked **before** resolve — a spy resolver proves an out-of-policy or wrong-scheme request triggers **no decrypt**. `*.` wildcard bindings honored.

## Reconciliations vs the plan text (pre-plan-121 / pre-Plan-63-CLI)
- Keyholder (resolver, binding, signer, injector) lives in **mvm-hostd** (`SecretRef` is in mvm-sdk post-121; mvm-core sits below it; mvm-hostd deps both and is the admit-time home). ADR-067 §3 calls signer+injector "the keyholder", so they're one module, not standalone `secret_signer/`/`secret_injector/`.
- Value backend is **`SecretStore`**, not `KeyProvider` (the latter is the per-tenant master DEK).
- `set` extends the **existing** `commands/ops/secret.rs` (a new `secret` command would collide).

## Deferred (tracked in `specs/plans/129-secrets-subsystem.md`)
- Separate-process jailer moat for signer/injector (`[[bin]]`, ADR-066 §3) — the in-process lib is what D/E wire against; the jailer wrap is orthogonal hardening.
- Hardware-sealed signing path (keyring → Secure Enclave) — same interface; software path is the shipped default.
- Phases D (substitution endpoint → A3 `SubstitutionStage`), E (leak-scan → `ScanStage`), F (claim 12/13 CI gate).

## Tests
30 new tests across resolver / binding / signer / injector / CLI. Affected-crate suites green (`mvm-hostd` 1626, `mvm-cli`, `mvm-core`, `mvm-sdk`); nightly fmt + clippy + `check-no-display-on-secret-types` clean.