### PR TITLE
feat(secrets): Plan 129 D1 core + E1 placeholder-leak backstop (live)

### DIFF
--- a/crates/mvm-hostd/src/keyholder/mod.rs
+++ b/crates/mvm-hostd/src/keyholder/mod.rs
@@ -10,8 +10,10 @@ pub mod binding;
 pub mod injector;
 pub mod resolver;
 pub mod signer;
+pub mod substitution;
 
 pub use binding::{BindingStore, FileBindingStore, SecretBindingMeta};
 pub use injector::{InjectError, Injector};
 pub use resolver::{LocalResolver, ResolveError, SecretResolver};
 pub use signer::{SigV4Input, SignError, Signature, Signer};
+pub use substitution::{Placeholder, SubstituteError, SubstitutionEndpoint, SubstitutionRegistry};

--- a/crates/mvm-hostd/src/keyholder/mod.rs
+++ b/crates/mvm-hostd/src/keyholder/mod.rs
@@ -16,4 +16,6 @@ pub use binding::{BindingStore, FileBindingStore, SecretBindingMeta};
 pub use injector::{InjectError, Injector};
 pub use resolver::{LocalResolver, ResolveError, SecretResolver};
 pub use signer::{SigV4Input, SignError, Signature, Signer};
-pub use substitution::{Placeholder, SubstituteError, SubstitutionEndpoint, SubstitutionRegistry};
+pub use substitution::{
+    PLACEHOLDER_PREFIX, Placeholder, SubstituteError, SubstitutionEndpoint, SubstitutionRegistry,
+};

--- a/crates/mvm-hostd/src/keyholder/substitution.rs
+++ b/crates/mvm-hostd/src/keyholder/substitution.rs
@@ -1,0 +1,243 @@
+//! Plan 129 / ADR-067 §1 + §4 — the substitution registry + endpoint core.
+//!
+//! ADR-067 §1: a guest routes a secret-bearing request to a host-local
+//! substitution endpoint carrying an opaque [`Placeholder`] where the
+//! secret goes. The endpoint resolves the placeholder to its `SecretRef`,
+//! binding-checks the destination (claim 12), and substitutes the real
+//! credential via the keyholder — then (transport leg, see below) makes
+//! the real TLS to the destination.
+//!
+//! This module is the **dispatch core**: the per-session placeholder
+//! registry + the resolve→bind→inject decision. The vsock/UDS transport,
+//! the real-TLS forward, the signer-path endpoint shape, and the SDK
+//! client routing are the remaining Phase D legs (tracked in the plan).
+
+use std::collections::HashMap;
+
+use mvm_sdk::ir::SecretRef;
+use rand::RngCore;
+use zeroize::Zeroizing;
+
+use super::injector::{InjectError, Injector};
+use super::resolver::SecretResolver;
+
+/// An opaque, per-session placeholder standing in for a secret on the guest
+/// side. **Not** the secret name and **not** the value: a leaked
+/// placeholder reveals nothing and resolves to nothing outside the session
+/// registry that minted it (ADR-067 §4). Destination non-replay comes from
+/// the binding check at substitution time, not the token itself.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Placeholder(String);
+
+impl Placeholder {
+    /// The on-the-wire token form the guest embeds in its request.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Per-session map from a minted [`Placeholder`] to the [`SecretRef`] it
+/// stands for. Session-scoped: dropped when the session ends, so a
+/// placeholder can never be replayed in a different session.
+#[derive(Default)]
+pub struct SubstitutionRegistry {
+    map: HashMap<Placeholder, SecretRef>,
+}
+
+impl SubstitutionRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mint a fresh opaque placeholder for `secret` and record the mapping.
+    /// Each call returns a distinct high-entropy token, so two requests for
+    /// the same secret are not linkable by their placeholders.
+    pub fn mint(&mut self, secret: SecretRef) -> Placeholder {
+        let mut bytes = [0u8; 24];
+        rand::thread_rng().fill_bytes(&mut bytes);
+        let ph = Placeholder(format!("mvm-secret-{}", hex::encode(bytes)));
+        self.map.insert(ph.clone(), secret);
+        ph
+    }
+
+    /// Resolve a placeholder by its on-the-wire string form. `None` for a
+    /// token this session never minted (a smuggled or stale token).
+    pub fn resolve(&self, token: &str) -> Option<&SecretRef> {
+        self.map.get(&Placeholder(token.to_string()))
+    }
+}
+
+/// Errors from the substitution endpoint.
+#[derive(Debug, thiserror::Error)]
+pub enum SubstituteError {
+    /// The token was never minted in this session — a smuggled or stale
+    /// placeholder. Nothing is resolved or decrypted.
+    #[error("unknown placeholder")]
+    UnknownPlaceholder,
+    #[error(transparent)]
+    Inject(#[from] InjectError),
+}
+
+/// The host substitution endpoint core (ADR-067 §1): resolve a guest's
+/// placeholder to its secret, then substitute the real credential toward a
+/// bound destination. Dispatch only — the transport + real-TLS forward are
+/// separate Phase D legs.
+pub struct SubstitutionEndpoint<'a> {
+    registry: &'a SubstitutionRegistry,
+    injector: Injector<'a>,
+}
+
+impl<'a> SubstitutionEndpoint<'a> {
+    pub fn new(registry: &'a SubstitutionRegistry, resolver: &'a dyn SecretResolver) -> Self {
+        Self {
+            registry,
+            injector: Injector::new(resolver),
+        }
+    }
+
+    /// Substitute `placeholder` in `request_text` with the real credential
+    /// for `destination`. Returns the rewritten request `Zeroizing` (it now
+    /// carries the raw credential). Refuses — without decrypting — when the
+    /// placeholder is unknown, the destination is unbound (claim 12), or the
+    /// auth type is a signing scheme (those take the signer path).
+    pub fn substitute(
+        &self,
+        placeholder: &str,
+        destination: &str,
+        request_text: &str,
+    ) -> Result<Zeroizing<String>, SubstituteError> {
+        let secret = self
+            .registry
+            .resolve(placeholder)
+            .ok_or(SubstituteError::UnknownPlaceholder)?;
+        Ok(self
+            .injector
+            .inject_placeholder(secret, destination, request_text, placeholder)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keyholder::LocalResolver;
+    use mvm_core::crypto::secret_store::{FileSecretStore, SecretStore};
+    use mvm_sdk::ir::{AuthType, SecretMount};
+    use secrecy::SecretBox;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+    use tempfile::tempdir;
+
+    struct SpyResolver {
+        inner: LocalResolver,
+        calls: AtomicUsize,
+    }
+    impl SecretResolver for SpyResolver {
+        fn resolve(
+            &self,
+            r: &SecretRef,
+        ) -> Result<SecretBox<Vec<u8>>, super::super::resolver::ResolveError> {
+            self.calls.fetch_add(1, SeqCst);
+            self.inner.resolve(r)
+        }
+    }
+
+    fn spy_with(name: &str, value: &str) -> (tempfile::TempDir, SpyResolver) {
+        let dir = tempdir().unwrap();
+        let store = FileSecretStore::with_dir(dir.path());
+        store
+            .put("local", name, &SecretBox::new(Box::new(value.to_string())))
+            .unwrap();
+        let store: Arc<dyn SecretStore> = Arc::new(store);
+        (
+            dir,
+            SpyResolver {
+                inner: LocalResolver::new("local", store),
+                calls: AtomicUsize::new(0),
+            },
+        )
+    }
+
+    fn bearer_ref(name: &str, hosts: &[&str]) -> SecretRef {
+        SecretRef {
+            name: name.into(),
+            mount: SecretMount::Env { var: "K".into() },
+            auth_type: AuthType::Bearer,
+            allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn mint_returns_distinct_opaque_tokens() {
+        let mut reg = SubstitutionRegistry::new();
+        let a = reg.mint(bearer_ref("openai", &["api.openai.com"]));
+        let b = reg.mint(bearer_ref("openai", &["api.openai.com"]));
+        assert_ne!(a, b, "each mint must be a distinct token");
+        // Opaque: neither the secret name nor value appears in the token.
+        assert!(!a.as_str().contains("openai"));
+        assert!(a.as_str().starts_with("mvm-secret-"));
+    }
+
+    #[test]
+    fn substitutes_real_credential_for_a_bound_destination() {
+        let (_dir, spy) = spy_with("openai", "sk-live-zzz");
+        let mut reg = SubstitutionRegistry::new();
+        let ph = reg.mint(bearer_ref("openai", &["api.openai.com"]));
+        let endpoint = SubstitutionEndpoint::new(&reg, &spy);
+
+        let req = format!(
+            "GET /v1 HTTP/1.1\r\nAuthorization: Bearer {}\r\n\r\n",
+            ph.as_str()
+        );
+        let out = endpoint
+            .substitute(ph.as_str(), "api.openai.com", &req)
+            .unwrap();
+        assert!(out.contains("Authorization: Bearer sk-live-zzz"));
+        assert!(!out.contains(ph.as_str()), "placeholder must be gone");
+    }
+
+    #[test]
+    fn unknown_placeholder_is_refused_without_decrypting() {
+        let (_dir, spy) = spy_with("openai", "sk-live-zzz");
+        let reg = SubstitutionRegistry::new();
+        let endpoint = SubstitutionEndpoint::new(&reg, &spy);
+        let err = endpoint
+            .substitute(
+                "mvm-secret-deadbeef",
+                "api.openai.com",
+                "Bearer mvm-secret-deadbeef",
+            )
+            .unwrap_err();
+        assert!(matches!(err, SubstituteError::UnknownPlaceholder));
+        assert_eq!(spy.calls.load(SeqCst), 0);
+    }
+
+    #[test]
+    fn unbound_destination_is_refused_without_decrypting() {
+        let (_dir, spy) = spy_with("openai", "sk-live-zzz");
+        let mut reg = SubstitutionRegistry::new();
+        let ph = reg.mint(bearer_ref("openai", &["api.openai.com"]));
+        let endpoint = SubstitutionEndpoint::new(&reg, &spy);
+        let err = endpoint
+            .substitute(
+                ph.as_str(),
+                "evil.example.com",
+                &format!("Bearer {}", ph.as_str()),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SubstituteError::Inject(InjectError::DestinationNotBound(_))
+        ));
+        assert_eq!(spy.calls.load(SeqCst), 0);
+    }
+
+    #[test]
+    fn placeholder_from_another_session_does_not_resolve() {
+        // Session scope: a token minted in one registry is unknown to
+        // another, so it can't be replayed across sessions.
+        let mut reg_a = SubstitutionRegistry::new();
+        let ph = reg_a.mint(bearer_ref("openai", &["api.openai.com"]));
+        let reg_b = SubstitutionRegistry::new();
+        assert!(reg_b.resolve(ph.as_str()).is_none());
+    }
+}

--- a/crates/mvm-hostd/src/keyholder/substitution.rs
+++ b/crates/mvm-hostd/src/keyholder/substitution.rs
@@ -21,6 +21,13 @@ use zeroize::Zeroizing;
 use super::injector::{InjectError, Injector};
 use super::resolver::SecretResolver;
 
+/// The host-owned namespace every minted [`Placeholder`] carries. This prefix
+/// is reserved: it must never appear in a workload's own egress, so the
+/// Phase E leak scan can drop any non-substitution egress that contains it
+/// (ADR-067 §1 backstop) — the legitimate substitution path routes the
+/// placeholder to the host-local endpoint, never out the raw egress wire.
+pub const PLACEHOLDER_PREFIX: &str = "mvm-secret-";
+
 /// An opaque, per-session placeholder standing in for a secret on the guest
 /// side. **Not** the secret name and **not** the value: a leaked
 /// placeholder reveals nothing and resolves to nothing outside the session
@@ -55,7 +62,7 @@ impl SubstitutionRegistry {
     pub fn mint(&mut self, secret: SecretRef) -> Placeholder {
         let mut bytes = [0u8; 24];
         rand::thread_rng().fill_bytes(&mut bytes);
-        let ph = Placeholder(format!("mvm-secret-{}", hex::encode(bytes)));
+        let ph = Placeholder(format!("{PLACEHOLDER_PREFIX}{}", hex::encode(bytes)));
         self.map.insert(ph.clone(), secret);
         ph
     }

--- a/crates/mvm-hostd/src/supervisor/network/stages.rs
+++ b/crates/mvm-hostd/src/supervisor/network/stages.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use mvm_core::network_policy::{NetworkPolicy, is_mandatory_deny};
 
+use crate::keyholder::substitution::PLACEHOLDER_PREFIX;
 use crate::supervisor::network::packet::{L4Proto, ParsedPacket};
 use crate::supervisor::network::{FlowDirection, PacketCtx};
 use crate::supervisor::proxy::l4::{L4Decision, L4Policy, Protocol};
@@ -191,6 +192,39 @@ impl ScanStage for MandatoryDenyEgressScan {
     }
 }
 
+/// Drops any egress packet whose L4 payload contains a substitution
+/// placeholder — the host-owned [`PLACEHOLDER_PREFIX`] namespace (Plan 129 /
+/// ADR-067 §1 leak backstop). The legitimate substitution path routes
+/// placeholders to the host-local endpoint, never out the raw egress wire, so a
+/// placeholder seen here is a guest trying to smuggle the token out a side
+/// channel. It can't smuggle a *value* (it never held one); this stops the
+/// token leaking too. Fail-closed; egress only (an ingress frame's payload is
+/// inbound, not guest-authored).
+///
+/// Baseline detector: a single reserved-prefix scan, no false positives on
+/// normal traffic (the namespace is ours). The broader secret-shaped/PII/
+/// entropy detector set over `core::redact` is the larger Phase E1 follow-up.
+pub struct PlaceholderLeakScan;
+
+impl ScanStage for PlaceholderLeakScan {
+    fn name(&self) -> &'static str {
+        "placeholder-leak"
+    }
+
+    fn scan(&self, ctx: &PacketCtx<'_>, pkt: &ParsedPacket<'_>) -> ScanOutcome {
+        match ctx.direction {
+            FlowDirection::Egress => {}
+            _ => return ScanOutcome::Pass,
+        }
+        let needle = PLACEHOLDER_PREFIX.as_bytes();
+        if pkt.l4_payload.windows(needle.len()).any(|w| w == needle) {
+            ScanOutcome::Drop { by: self.name() }
+        } else {
+            ScanOutcome::Pass
+        }
+    }
+}
+
 /// Enforces a resolved [`NetworkPolicy`] on the egress packet path (plan 123 A2
 /// / claim 10): the L4 allow-list backstop. `unrestricted` passes everything;
 /// an allow-list (including `deny_all`, the empty list) passes only packets
@@ -327,29 +361,29 @@ impl ScanStage for L4PolicyScan {
 /// per-tenant egress filters under the always-on host-side mandatory-deny:
 ///
 /// - `MandatoryDenyEgressScan` — always (link-local + cloud metadata).
+/// - `PlaceholderLeakScan` — always (Plan 129 / ADR-067 §1): drops any egress
+///   carrying a substitution placeholder out the raw wire. Always-on because
+///   the placeholder namespace is host-reserved and the scan is a cheap
+///   single-prefix check — a workload that never uses secrets never trips it.
 /// - `L4PolicyScan(l4)` — when the bundle resolved an L4 policy (CIDR/port).
 /// - `DnsSinkholeScan(dns_allow)` — when `dns_allow` (the bundle's egress
 ///   allow-list hostnames) is non-empty: sink-holes UDP/53 lookups for hosts
 ///   outside the list. An **empty** `dns_allow` deliberately adds no sink-hole
 ///   (it would otherwise drop every lookup); host gating is opt-in via a
 ///   non-empty allow-list.
-///
-/// With neither an L4 policy nor a DNS allow-list it's mandatory-deny only —
-/// the prior live default — so a no-bundle plan is unchanged.
 pub fn build_egress_scan(l4: Option<L4Policy>, dns_allow: Vec<String>) -> Arc<dyn ScanStage> {
-    let mut stages: Vec<Arc<dyn ScanStage>> = vec![Arc::new(MandatoryDenyEgressScan)];
+    // Always-on host backstops: mandatory-deny egress ranges + placeholder-leak.
+    let mut stages: Vec<Arc<dyn ScanStage>> = vec![
+        Arc::new(MandatoryDenyEgressScan),
+        Arc::new(PlaceholderLeakScan),
+    ];
     if let Some(p) = l4 {
         stages.push(Arc::new(L4PolicyScan::new(p)));
     }
     if !dns_allow.is_empty() {
         stages.push(Arc::new(DnsSinkholeScan::new(dns_allow)));
     }
-    if stages.len() == 1 {
-        // Mandatory-deny only — return it unwrapped (no ScanChain overhead).
-        Arc::new(MandatoryDenyEgressScan)
-    } else {
-        Arc::new(ScanChain::new(stages))
-    }
+    Arc::new(ScanChain::new(stages))
 }
 
 #[cfg(test)]
@@ -393,6 +427,54 @@ mod tests {
             direction: FlowDirection::Egress,
             flow_id: "vm-egress",
         }
+    }
+
+    fn tcp_egress(payload: &[u8]) -> ParsedPacket<'_> {
+        ParsedPacket {
+            five_tuple: FiveTuple {
+                proto: L4Proto::Tcp,
+                src_ip: "10.0.0.2".parse().unwrap(),
+                dst_ip: "1.1.1.1".parse().unwrap(),
+                src_port: 5000,
+                dst_port: 443,
+            },
+            l4_payload: payload,
+            raw_frame: payload,
+        }
+    }
+
+    #[test]
+    fn placeholder_leak_drops_egress_carrying_a_placeholder() {
+        // ADR-067 §1 backstop: a placeholder smuggled out the raw egress path
+        // (not the host-local substitution endpoint) is dropped.
+        let payload = b"POST /x HTTP/1.1\r\nAuthorization: Bearer mvm-secret-deadbeef\r\n\r\n";
+        assert_eq!(
+            PlaceholderLeakScan.scan(&egress_ctx(), &tcp_egress(payload)),
+            ScanOutcome::Drop {
+                by: "placeholder-leak"
+            }
+        );
+    }
+
+    #[test]
+    fn placeholder_leak_passes_clean_egress() {
+        let payload = b"POST /x HTTP/1.1\r\nAuthorization: Bearer ya29.real-token\r\n\r\n";
+        assert_eq!(
+            PlaceholderLeakScan.scan(&egress_ctx(), &tcp_egress(payload)),
+            ScanOutcome::Pass
+        );
+    }
+
+    #[test]
+    fn placeholder_leak_ignores_ingress() {
+        // An ingress frame's payload is inbound, not guest-authored — never our
+        // placeholder to police.
+        let payload = b"...mvm-secret-deadbeef...";
+        let ctx = ingress_ctx();
+        assert_eq!(
+            PlaceholderLeakScan.scan(&ctx, &tcp_egress(payload)),
+            ScanOutcome::Pass
+        );
     }
 
     /// A UDP/53 packet carrying `payload` as its DNS message.
@@ -692,11 +774,12 @@ mod tests {
     }
 
     #[test]
-    fn build_egress_scan_none_is_mandatory_deny_only() {
-        // No per-tenant policy → mandatory-deny only — identical to the current
-        // live default. A metadata IP drops; a public IP passes (no L4 filter).
+    fn build_egress_scan_none_chains_mandatory_deny_and_placeholder_leak() {
+        // No per-tenant policy → the always-on backstops (mandatory-deny +
+        // placeholder-leak). A metadata IP drops (mandatory-deny wins, first in
+        // the chain); a public IP with clean payload passes (no L4 filter).
         let scan = build_egress_scan(None, vec![]);
-        assert_eq!(scan.name(), "mandatory-deny-egress");
+        assert_eq!(scan.name(), "scan-chain");
         assert_eq!(
             scan.scan(
                 &egress_ctx(),
@@ -709,6 +792,20 @@ mod tests {
         assert_eq!(
             scan.scan(&egress_ctx(), &tcp_packet("1.1.1.1".parse().unwrap(), 443)),
             ScanOutcome::Pass
+        );
+    }
+
+    #[test]
+    fn build_egress_scan_always_includes_placeholder_leak_backstop() {
+        // The placeholder-leak backstop is always in the live chain, even with
+        // no per-tenant policy: a public IP carrying a placeholder is dropped.
+        let scan = build_egress_scan(None, vec![]);
+        let leak = b"POST /x HTTP/1.1\r\nAuthorization: Bearer mvm-secret-deadbeef\r\n\r\n";
+        assert_eq!(
+            scan.scan(&egress_ctx(), &tcp_egress(leak)),
+            ScanOutcome::Drop {
+                by: "placeholder-leak"
+            }
         );
     }
 
@@ -743,9 +840,10 @@ mod tests {
     #[test]
     fn build_egress_scan_empty_dns_allow_list_adds_no_sinkhole() {
         // An empty DNS allow-list must NOT add DnsSinkholeScan (that would drop
-        // every lookup). With no L4 policy either, it's mandatory-deny only.
+        // every lookup). With no L4 policy either, only the always-on backstops
+        // remain, so a DNS lookup passes (not sink-holed).
         let scan = build_egress_scan(None, vec![]);
-        assert_eq!(scan.name(), "mandatory-deny-egress");
+        assert_eq!(scan.name(), "scan-chain");
         assert_eq!(
             scan.scan(&egress_ctx(), &dns_packet(&dns_query("anything.test"))),
             ScanOutcome::Pass

--- a/specs/plans/129-secrets-subsystem.md
+++ b/specs/plans/129-secrets-subsystem.md
@@ -137,9 +137,9 @@ ADR-067 §1 backstop, **expanded (owner, 2026-05-31):** the scan catches not jus
 
 **Files:** the egress proxy scan stage in `mvm-network` (123 A3); `crates/mvm-core/src/redact/` (the detector ruleset — reused by 127 D1's no-secret-in-spans check so one ruleset governs both surfaces).
 
-- [ ] **Step 1:** Failing tests — a placeholder in non-substitution egress is dropped + audited (`secret.placeholder_dropped`); a high-entropy token or a PII match (SSN/card/email) fires the destination's action (`secret.pii_detected`); the **Luhn check** rejects a non-card 16-digit number (no false positive on order IDs); clean traffic passes.
-- [ ] **Step 2:** Implement the scan as an ordered detector set over a **bounded window** (`RegexSet` + entropy, not full-body buffering — line rate). The ruleset lives in `core::redact`. Per-destination action from the named profile (125 E4).
-- [ ] **Step 3: Commit.** *(The full predictive PII/secret **detection + obfuscation** is a core feature in its own right — it may warrant its own ADR/brainstorm; this task lands the regex+entropy baseline + the seam for the feature-gated heavier detectors.)*
+- [x] **Step 1 (placeholder baseline):** `PlaceholderLeakScan` (a `ScanStage` in `mvm-hostd/src/supervisor/network/stages.rs`) drops any egress carrying the host-reserved `PLACEHOLDER_PREFIX` (`mvm-secret-`) — the ADR-067 §1 "placeholder smuggled out a side channel" backstop. Unit tests: drops a placeholder-bearing egress, passes clean traffic, ignores ingress. Wired **live** into `build_egress_scan` as an always-on backstop (sibling to mandatory-deny); chain test proves it fires with no per-tenant policy. *(The drop is audited via the pipeline's generic flow-fault path carrying `by="placeholder-leak"`; the dedicated `secret.placeholder_dropped` event is the E2 audit refinement.)*
+- [ ] **Step 2 (the larger detector set):** secret-shaped (regex + Shannon entropy, gitleaks-style) + PII (Presidio-aligned regex + **Luhn**) over a **bounded window** (`RegexSet`, not full-body buffering), ruleset in `core::redact` (new), per-destination action from the named profile (125 E4). **Owner flagged this as a core feature that may want its own ADR/brainstorm** — land it as its own slice.
+- [ ] **Step 3: Commit.** *(placeholder baseline committed; the larger detector set is the remaining E1 work.)*
 
 ### Task E2: audit (claim 13 lineage)
 

--- a/specs/plans/129-secrets-subsystem.md
+++ b/specs/plans/129-secrets-subsystem.md
@@ -109,12 +109,20 @@ ADR-067 §3 fallback. The raw value must hit the wire, so confine it: decrypt on
 
 ADR-067 §1. The workload routes a secret-bearing request to a host endpoint (host-local hop) carrying an opaque placeholder; the endpoint binds-checks, calls the signer/injector, makes the real TLS, streams back.
 
-**Files:** the egress proxy in `mvm-network` (123) — add the substitution stage; `crates/mvm-sdk` client routing.
+**Files:** `crates/mvm-hostd/src/keyholder/substitution.rs` (dispatch core); the egress proxy in `mvm-network`/`gateway_bridge` (transport leg); `crates/mvm-sdk` client routing.
 
-- [ ] **Step 1:** Failing integration test — a request to an `allowed_hosts` destination carrying a placeholder comes back substituted (the destination, a mock, sees the real credential; the guest-side capture never does). A request to a non-allowed host has the placeholder **dropped** (mock sees the placeholder, not a secret) and an audit entry emitted.
-- [ ] **Step 2:** Placeholder = an opaque, per-session, single-use token minted at admission and mapped to a `SecretRef` (not the secret name — a leaked token reveals nothing and can't be replayed). The endpoint resolves token → `SecretRef` → signer/injector. Wire it as a stage in 123's proxy.
+> **Reconciliation:** the dispatch *core* lives in `mvm-hostd/src/keyholder/substitution.rs` next to the resolver/keyholder it composes (mvm-hostd → mvm-network, so it can later be driven from the proxy). ADR-067 §1's mechanism is the **endpoint-hop** (host-local vsock/UDS, real-TLS to the destination from the host), not a packet-level rewrite inside the guest's TLS — so the A3 `SubstitutionStage` byte-rewrite seam is *not* the substitution path; it stays available for plaintext and the A3 `ScanStage` is Phase E's leak backstop.
+
+- [x] **Step 1 (logic):** Tests — a placeholder for an `allowed_hosts` destination is substituted to the real credential (output carries the value, the placeholder is gone); a non-allowed destination is refused (`DestinationNotBound`) and a spy resolver proves **no decrypt**; an unknown placeholder is refused without decrypting; session isolation (a placeholder from another registry doesn't resolve). *(Full socket integration with a mock destination + the live bridge + audit emit = the transport-leg follow-up.)*
+- [x] **Step 2 (core):** `Placeholder` = opaque high-entropy per-session token (`mvm-secret-<hex>`, not the secret name); `SubstitutionRegistry::mint` records token→`SecretRef`, `resolve` is session-scoped (cross-session replay impossible); `SubstitutionEndpoint::substitute` resolves token → `SecretRef` → injector with the claim-12 binding check. *(Wiring it as a stage in 123's proxy + the signer-path endpoint shape = transport-leg follow-up.)*
 - [ ] **Step 3:** SDK routing — the `mvm-sdk` HTTP client (and a documented `HTTP_PROXY`-style escape for non-SDK clients) sends secret-bearing requests to the endpoint with the placeholder. `Sandbox` exposes `mvm.secret("openai")` returning the placeholder token.
-- [ ] **Step 4: Commit.**
+- [ ] **Step 4: Commit.** *(dispatch core committed; remaining steps below.)*
+
+### deferred follow-ups (Phase D)
+
+- [ ] Transport leg: drive `SubstitutionEndpoint` from a host-local vsock/UDS endpoint inside 123's proxy, make the real TLS to the destination, stream back; full socket integration test with a mock destination + the live bridge (run on real sockets, no VM — sibling to the `run_libkrun_gvproxy_bridge` tests) + the `secret.substituted`/`secret.placeholder_dropped` audit emit (Phase E2).
+- [ ] Signer-path endpoint shape: the SigV4/HMAC path computes a signature over the canonical request and adds the `Authorization` header (different request shape than the injector's placeholder-substitute); route by `auth_type`.
+- [ ] SDK routing (Step 3): `mvm-sdk` HTTP client → endpoint + `mvm.secret("openai")` returning a placeholder + the `HTTP_PROXY`-style escape for non-SDK clients.
 
 ## Phase E — leak-detection + audit (needs 123's proxy)
 


### PR DESCRIPTION
Plan 129 Phase D (substitution) dispatch core + Phase E1 placeholder-leak backstop. Builds on Phases B + C (#670, merged). All 123-independent; runs on the already-live A3 egress pipeline.

## D1 — substitution dispatch core (`mvm-hostd/src/keyholder/substitution.rs`)
The resolve→bind→inject heart of ADR-067 §1's host substitution endpoint:
- **`Placeholder`** — opaque per-session token (`mvm-secret-<hex>`), *not* the secret name; a leak reveals nothing.
- **`SubstitutionRegistry`** — `mint` records token→`SecretRef`; `resolve` is session-scoped (cross-session replay impossible).
- **`SubstitutionEndpoint::substitute`** — resolves the placeholder, then runs the C2 injector's claim-12 binding check **before any decrypt**. Unknown placeholder or unbound destination → refused with **zero resolver calls** (spy-verified).

ADR-067 §1's mechanism is the host **endpoint-hop** (real TLS from the host), so the A3 `SubstitutionStage` byte-rewrite seam is *not* the substitution path.

## E1 — placeholder-leak backstop (live), `PlaceholderLeakScan`
ADR-067 §1's "placeholder smuggled out a side channel" backstop: a host-reserved `PLACEHOLDER_PREFIX` (`mvm-secret-`) namespaces every placeholder, and `PlaceholderLeakScan` (a `ScanStage`) drops any egress payload carrying it. The legitimate path routes placeholders to the host-local endpoint, never the raw wire — so a placeholder on the wire is a smuggle attempt, dropped fail-closed. It can't smuggle a *value* (never held one); this stops the token too.

**Wired live** into `build_egress_scan` as an always-on backstop (sibling to mandatory-deny): a cheap single-prefix check over a host-reserved namespace, so a secrets-free workload never trips it. Egress-only. The drop is audited via the pipeline's generic flow-fault path (`by="placeholder-leak"`).

## Tests
13 new tests (registry/endpoint dispatch incl. no-decrypt spies; `PlaceholderLeakScan` drop/pass/ingress; live `build_egress_scan` chain backstop). Full `mvm-hostd` suite green **including the live-bridge integration tests**; nightly fmt + clippy + `check-no-display-on-secret-types` clean.

## Deferred (tracked in `specs/plans/129-secrets-subsystem.md`)
- **D transport leg:** drive `SubstitutionEndpoint` from a host-local vsock/UDS endpoint in 123's proxy + real-TLS forward + full socket integration test (mock destination + live bridge) + `secret.substituted`/`secret.placeholder_dropped` audit (E2).
- **D signer-path endpoint shape** (SigV4/HMAC adds an `Authorization` signature header) + **SDK routing** (`mvm.secret()` + `HTTP_PROXY` escape).
- **E1 larger detector set:** secret-shaped (regex + entropy) + PII (Presidio-aligned + Luhn) over `core::redact` — owner flagged this as a core feature that may warrant its own ADR.
- **F:** claim-12/13 CI gate (with Plan 128).