### PR TITLE
fix(vz): unblock up --dev --hypervisor vz boot + give console a Vz transport

### DIFF
--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -1050,7 +1050,19 @@ fn build_supervisor_config(
         network: Some(vz::NetworkConfig::Gvproxy {
             socket_path: gvproxy.socket_path.to_string_lossy().into_owned(),
             mac: host_gvproxy::derive_mac(&config.name),
-            events_ingest_socket_path: Some(events_ingest_socket_path(&config.name)),
+            // Only request the claim-10 audit bridge when the drainer will
+            // actually bind the ingest socket — i.e. an admitted workload
+            // (plan_json + tenant_id), the same gate as `spawn_vz_drainer`.
+            // Without admission the drainer is skipped; requesting the bridge
+            // anyway makes the Swift supervisor's mandatory connect() fail
+            // (errno=2) and the VM die before boot — the `up --dev
+            // --hypervisor vz` crash. None → Swift takes the plain gvproxy
+            // attachment (no bridge), mirroring libkrun's legacy path.
+            events_ingest_socket_path: if config.plan_json.is_some() && config.tenant_id.is_some() {
+                Some(events_ingest_socket_path(&config.name))
+            } else {
+                None
+            },
         }),
         balloon: Some(vz::BalloonConfig {
             enabled: true,
@@ -1548,6 +1560,12 @@ mod tests {
         };
         cfg.kernel_path = Some("/abs/vmlinux".into());
         cfg.rootfs_path = "/abs/rootfs.ext4".into();
+        // Admitted workload: plan_json + tenant_id present, so the drainer
+        // runs and the bridge is requested (the events_ingest assertion
+        // below). The no-admission branch is covered separately by
+        // `build_supervisor_config_omits_events_ingest_without_admission`.
+        cfg.plan_json = Some("{}".into());
+        cfg.tenant_id = Some("local".into());
         let state_dir = Path::new("/tmp/vz-smoke-state");
         // Plan 102 W6.A.5 — build_supervisor_config now takes
         // HostGvproxyInfo (the host-side gvproxy lifecycle's
@@ -1594,10 +1612,46 @@ mod tests {
                 );
                 assert!(
                     events_ingest_socket_path.is_some(),
-                    "events_ingest_socket_path should be populated for W6.A.5 Vz bridge"
+                    "events_ingest_socket_path should be populated for an admitted workload (W6.A.5 Vz bridge)"
                 );
             }
             None => panic!("network should be Some(Gvproxy {{ .. }}) after W6.A.5"),
+        }
+    }
+
+    #[test]
+    fn build_supervisor_config_omits_events_ingest_without_admission() {
+        // No plan_json/tenant_id — the default `up --dev` / no-bridge path.
+        // `spawn_vz_drainer` is skipped for this case, so nothing binds the
+        // events-ingest socket. The Vz bridge must therefore NOT request it,
+        // or the Swift supervisor's mandatory connect() fails errno=2 and the
+        // VM dies before boot (the `up --dev --hypervisor vz` crash). Gate the
+        // request on the same condition as the drainer.
+        let mut cfg = VmStartConfig {
+            name: "no-admit".into(),
+            cpus: 1,
+            memory_mib: 512,
+            ..Default::default()
+        };
+        cfg.kernel_path = Some("/abs/vmlinux".into());
+        cfg.rootfs_path = "/abs/rootfs.ext4".into();
+        assert!(cfg.plan_json.is_none() && cfg.tenant_id.is_none());
+        let state_dir = Path::new("/tmp/vz-no-admit-state");
+        let gvproxy_info = host_gvproxy::HostGvproxyInfo {
+            socket_path: state_dir.join("gvproxy.sock"),
+            pid: 0,
+        };
+        let built =
+            build_supervisor_config(&cfg, "/abs/vmlinux", state_dir, &gvproxy_info).expect("build");
+        match built.network {
+            Some(vz::NetworkConfig::Gvproxy {
+                events_ingest_socket_path,
+                ..
+            }) => assert!(
+                events_ingest_socket_path.is_none(),
+                "events_ingest must be None without admission (no drainer binds it); got {events_ingest_socket_path:?}"
+            ),
+            None => panic!("network should be Some(Gvproxy {{ .. }})"),
         }
     }
 

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -8,7 +8,7 @@ use clap::Args as ClapArgs;
 
 use mvm::vsock_transport::{
     AppleContainerTransport, FirecrackerTransport, LibkrunTransport, VsockProxyTransport,
-    VsockTransport,
+    VsockTransport, VzTransport,
 };
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
@@ -22,7 +22,8 @@ use crate::ui;
 /// 1. In-process Apple Container (zero-copy `VZVirtioSocketDevice` stream).
 /// 2. Dev-mode mode-0700 proxy socket (cross-process daemon dispatch).
 /// 3. libkrun per-port Unix socket.
-/// 4. Firecracker UDS multiplexer (fleet/production path).
+/// 4. Vz per-port Unix socket (`<vm_state_dir>/vsock/vsock-<port>.sock`).
+/// 5. Firecracker UDS multiplexer (fleet/production path).
 ///
 /// The Apple Container probe consumes one stream and drops it; the
 /// returned `Arc<dyn VsockTransport>` is then used for every real
@@ -44,6 +45,13 @@ fn pick_console_transport(name: &str) -> Result<Arc<dyn VsockTransport>> {
     let libkrun = LibkrunTransport::for_vm(name);
     if libkrun.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
         return Ok(Arc::new(libkrun));
+    }
+    // Vz workloads expose the agent at `<vm_state_dir>/vsock/vsock-<port>.sock`
+    // (one subdir deeper than libkrun); without this probe `console` fell
+    // through to the firecracker fallback and mis-resolved to `mvm-dev`.
+    let vz = VzTransport::for_vm(name);
+    if vz.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
+        return Ok(Arc::new(vz));
     }
     Ok(Arc::new(FirecrackerTransport::for_vm(name)?))
 }
@@ -422,6 +430,37 @@ mod accessible_gate_tests {
             match prev {
                 Some(v) => std::env::set_var("HOME", v),
                 None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn pick_console_transport_selects_vz_when_only_vz_socket_present() {
+        use std::os::unix::net::UnixListener;
+        // Regression for the "console can't reach a Vz workload" gap: with a
+        // Vz workload's vsock socket present (and no apple-container / dev-proxy
+        // / libkrun / firecracker surface), the picker must select the Vz
+        // transport instead of erroring out on the firecracker fallback.
+        let _g = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var_os("MVM_DATA_DIR");
+        unsafe { std::env::set_var("MVM_DATA_DIR", tmp.path()) };
+
+        let name = "vz-console-probe";
+        let sock =
+            mvm_core::config::vm_vz_vsock_port_socket(name, mvm_guest::vsock::GUEST_AGENT_PORT);
+        std::fs::create_dir_all(sock.parent().unwrap()).unwrap();
+        let _listener = UnixListener::bind(&sock).unwrap();
+
+        let transport = pick_console_transport(name).expect("picker should find the vz transport");
+        transport
+            .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+            .expect("selected transport should connect to the vz socket");
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MVM_DATA_DIR", v),
+                None => std::env::remove_var("MVM_DATA_DIR"),
             }
         }
     }

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -364,6 +364,24 @@ pub fn vm_vsock_proxy_socket(name: &str) -> std::path::PathBuf {
     vm_state_dir(name).join("vsock.sock")
 }
 
+/// The directory the Vz supervisor nests its per-port vsock listener
+/// sockets under: `<vm_state_dir>/vsock`. Unlike libkrun (which binds
+/// `<vm_state_dir>/vsock-<port>.sock` directly), the Vz `VsockProxy`
+/// listens inside this subdir. Single source of truth for the subdir so
+/// `mvm-backend`'s supervisor config and the host-side `VzTransport`
+/// can't drift (the #582 lesson, applied to Vz).
+pub fn vm_vz_vsock_dir(name: &str) -> std::path::PathBuf {
+    vm_state_dir(name).join("vsock")
+}
+
+/// Vz's per-port vsock listener socket: `<vm_state_dir>/vsock/vsock-<port>.sock`.
+/// The Vz supervisor listens here and forwards to the guest's vsock port, so a
+/// host client connects directly with no port handshake (same shape as libkrun,
+/// one subdir deeper). Pairs with [`vm_vz_vsock_dir`] + [`vsock_socket_filename`].
+pub fn vm_vz_vsock_port_socket(name: &str, port: u32) -> std::path::PathBuf {
+    vm_vz_vsock_dir(name).join(vsock_socket_filename(port))
+}
+
 /// libkrun supervisor pid file: `<vm_state_dir>/libkrun.pid`.
 pub fn vm_libkrun_pid(name: &str) -> std::path::PathBuf {
     vm_state_dir(name).join("libkrun.pid")
@@ -731,6 +749,17 @@ mod tests {
         assert_eq!(
             vm_vsock_proxy_socket("foo"),
             std::path::PathBuf::from("/custom/data/vms/foo/vsock.sock")
+        );
+        // Vz nests its per-port listener under a `vsock/` subdir (vz.rs
+        // builds `<state_dir>/vsock`); the console VzTransport must derive
+        // the same path so they can't drift.
+        assert_eq!(
+            vm_vz_vsock_port_socket("foo", 5252),
+            std::path::PathBuf::from("/custom/data/vms/foo/vsock/vsock-5252.sock")
+        );
+        assert_eq!(
+            vm_vz_vsock_dir("foo").join(vsock_socket_filename(5252)),
+            vm_vz_vsock_port_socket("foo", 5252)
         );
         // The dev-VM connect resolver (mvm-backend) and the console transport
         // (mvm) both build the libkrun socket as state-dir + shared filename,

--- a/crates/mvm/src/vsock_transport.rs
+++ b/crates/mvm/src/vsock_transport.rs
@@ -109,6 +109,42 @@ impl VsockTransport for LibkrunTransport {
     }
 }
 
+/// Connects through the Vz supervisor's per-port vsock listener.
+///
+/// `VzBackend` starts the Swift supervisor with a `VsockProxy` that
+/// listens under `<vm_state_dir>/vsock/` and forwards each connection to
+/// the guest's vsock port, so a host client connects directly with no
+/// port handshake — the libkrun shape, one subdir deeper. The path is the
+/// single-source-of-truth [`mvm_core::config::vm_vz_vsock_port_socket`].
+pub struct VzTransport {
+    socket_dir: PathBuf,
+}
+
+impl VzTransport {
+    pub fn new(socket_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            socket_dir: socket_dir.into(),
+        }
+    }
+
+    pub fn for_vm(vm_name: &str) -> Self {
+        Self::new(mvm_core::config::vm_vz_vsock_dir(vm_name))
+    }
+
+    fn socket_path(&self, port: u32) -> PathBuf {
+        self.socket_dir
+            .join(mvm_core::config::vsock_socket_filename(port))
+    }
+}
+
+impl VsockTransport for VzTransport {
+    fn connect(&self, port: u32) -> Result<UnixStream> {
+        let path = self.socket_path(port);
+        UnixStream::connect(&path)
+            .with_context(|| format!("Failed to connect to Vz vsock at {}", path.display()))
+    }
+}
+
 /// Connects through Apple's `Virtualization.framework` vsock device.
 ///
 /// `mvm_backend::providers::apple_container::vsock_connect` consults the framework's
@@ -243,6 +279,10 @@ pub fn for_vm(vm_name: &str) -> Result<Box<dyn VsockTransport>> {
     if libkrun.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
         return Ok(Box::new(libkrun));
     }
+    let vz = VzTransport::for_vm(vm_name);
+    if vz.connect(mvm_guest::vsock::GUEST_AGENT_PORT).is_ok() {
+        return Ok(Box::new(vz));
+    }
     let fc = FirecrackerTransport::for_vm(vm_name)
         .with_context(|| format!("no vsock transport found for VM {:?}", vm_name))?;
     Ok(Box::new(fc))
@@ -298,6 +338,58 @@ mod tests {
             msg.contains("/tmp/no-such-libkrun-vm"),
             "error didn't mention socket dir: {msg}"
         );
+    }
+
+    #[test]
+    fn vz_transport_connects_to_socket_in_its_dir() {
+        use std::os::unix::net::UnixListener;
+        // Vz's supervisor listens on `<vsock_dir>/vsock-<port>.sock`; a host
+        // client connects directly (no port handshake), same shape as libkrun.
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir
+            .path()
+            .join(mvm_core::config::vsock_socket_filename(5252));
+        let _listener = UnixListener::bind(&sock).unwrap();
+        let t = VzTransport::new(dir.path());
+        t.connect(5252).expect("vz transport should connect");
+    }
+
+    #[test]
+    fn vz_transport_for_vm_targets_vsock_subdir() {
+        // for_vm must point at `<vm_state_dir>/vsock/` (Vz nests one subdir
+        // deeper than libkrun's `<vm_state_dir>/`), and the error names the
+        // backend so console failures are diagnosable.
+        let t = VzTransport::for_vm("no-such-vz-vm");
+        let err = t
+            .connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+            .expect_err("should fail to connect")
+            .to_string();
+        assert!(
+            err.contains("Vz vsock") && err.contains("/vsock/vsock-5252.sock"),
+            "error didn't show the vz vsock-subdir path: {err}"
+        );
+    }
+
+    #[test]
+    fn for_vm_selects_vz_when_only_vz_socket_present() {
+        use std::os::unix::net::UnixListener;
+        // With a Vz workload's socket present (and no apple-container/libkrun/
+        // firecracker surface), the picker must select the Vz transport rather
+        // than falling through to the firecracker error. Regression for the
+        // "console can't reach a Vz workload" gap.
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("MVM_DATA_DIR", dir.path()) };
+        let name = "vz-picker-probe";
+        let sock =
+            mvm_core::config::vm_vz_vsock_port_socket(name, mvm_guest::vsock::GUEST_AGENT_PORT);
+        std::fs::create_dir_all(sock.parent().unwrap()).unwrap();
+        let _listener = UnixListener::bind(&sock).unwrap();
+
+        let t = for_vm(name).expect("picker should find the vz transport");
+        t.connect(mvm_guest::vsock::GUEST_AGENT_PORT)
+            .expect("selected transport should connect to the vz socket");
+
+        unsafe { std::env::remove_var("MVM_DATA_DIR") };
     }
 
     #[test]


### PR DESCRIPTION
Two pre-existing host-side bugs in the **Vz workload path**, found while scoping a Vz measurement spike. Both fixed with TDD.

## Bug A — `up --dev --hypervisor vz` crashes before boot ✅ (E2E-validated)

`build_supervisor_config` unconditionally set `NetworkConfig::Gvproxy.events_ingest_socket_path: Some(...)` (the claim-10 audit bridge), so the Swift supervisor's **mandatory** `connect()` to that socket ran even when `spawn_vz_drainer` was skipped — which it is on the default `up --dev` path (no `plan_json`/`tenant_id`; the in-VM bridge is `MVM_GATEWAY_BRIDGE`-gated by design, a Plan 138 workaround). The socket was never bound → `connect()` `errno=2` → supervisor `exit()` before VM construction → 0-byte `console.log`.

**Fix:** gate `events_ingest_socket_path` on the same condition as the drainer (`plan_json` + `tenant_id`). Unadmitted → `None` → Swift takes the plain gvproxy attachment (mirrors libkrun's legacy path); admitted → bridge requested, drainer binds, `connect()` succeeds (flow audit active).

**E2E proof:** with the fix, `up --dev --hypervisor vz` boots — `console.log` ~5501 bytes, agent reaches `listening on vsock port 5252` (vs the 0-byte crash before).

## Bug B — `mvmctl console` had no Vz-workload transport ✅

`pick_console_transport` (and `vsock_transport::for_vm`) only knew apple-container / dev-proxy / libkrun / firecracker, so a Vz workload's agent — socket at `<vm_state_dir>/vsock/vsock-<port>.sock`, one subdir deeper than libkrun — was unreachable; `console` mis-resolved to `mvm-dev` and errored.

**Fix:** add `VzTransport` + centralized `vm_vz_vsock_dir` / `vm_vz_vsock_port_socket` helpers (single source of truth vs. the supervisor config, the #582 lesson), wired into both pickers.

## Tests (TDD, red→green)

- `mvm-core`: `vm_vz_vsock_port_socket` path derivation.
- `mvm`: `VzTransport` connect + `for_vm` vsock-subdir targeting + picker selection.
- `mvm-cli`: console picker selects Vz (reproduces the exact `mvm-dev` failure).
- `mvm-backend`: `build_supervisor_config_omits_events_ingest_without_admission` (the crash repro) + the existing mapping test now exercises the admitted branch.

`cargo clippy -D warnings` clean on all four crates; nightly `fmt`.

## Out of scope — follow-up #673

E2E console exec on Vz still **hangs** after this PR: Bug B makes `console` reach the right socket, which *exposes* a deeper Vz vsock-**proxy** data-path issue (connects, then no agent round-trip). Filed as #673. Bug A is fully working E2E; Bug B fixes the transport-selection gap it was scoped to.