### PR TITLE
docs(spike): Vz page-cache-priming spike — design, runbook, findings

### DIFF
--- a/specs/notes/2026-06-05-vz-page-cache-priming-spike-plan.md
+++ b/specs/notes/2026-06-05-vz-page-cache-priming-spike-plan.md
@@ -1,0 +1,338 @@
+# Vz Page-Cache Priming Spike — Implementation Plan (runbook)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:executing-plans to run
+> this task-by-task. This is a **measurement runbook**, not a TDD feature build — the
+> per-step "verify" is an observed command output or an abort gate, not a unit test.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Get a real number on whether a warm guest page cache speeds first-read after
+a **Vz workload** snapshot restore — to decide the fate of the Plan 157 page-cache-priming
+follow-up (ADR-073 §1).
+
+**Architecture:** Boot a fat dev-shell **workload** microVM on `VzBackend`, snapshot-save
+it twice (once with the working set pre-read = *primed*, once untouched = *cold*),
+restore each, and time the first read of the working set via `mvmctl console --command`.
+The builder/dev VM appears in exactly one step — building the measurement image — and is
+never the thing measured. Everything else is workload-on-Vz.
+
+**Tech stack:** `mvmctl` CLI (`up --hypervisor vz`, `snapshot save/restore`, `console
+--command`), the codesigned Swift `mvm-vz-supervisor`, a copied dev-shell Nix flake.
+
+**Design source:** `specs/notes/2026-06-05-vz-page-cache-priming-spike.md` (read its
+Security constraints + Success threshold sections — they are the decision criteria).
+
+---
+
+## Environment & lifecycle (do once, up front)
+
+- **Isolation:** all builder + workload state goes to scratch dirs so nothing races the
+  shared persistent builder or parallel sessions:
+  ```bash
+  export MVM_CACHE_DIR="$HOME/.cache/mvm-spike-pagecache"
+  export MVM_DATA_DIR="$HOME/.mvm-spike-pagecache"
+  mkdir -p "$MVM_CACHE_DIR" "$MVM_DATA_DIR"
+  ```
+  These persist across the spike's builds (warm nix store for the image build + any B/C
+  rebuild), then are removed at teardown (Task 9).
+- **Worktree:** run from a dedicated git worktree (the spike branch is already
+  `spike/vz-page-cache-priming`); the design + this plan live there.
+- **Scratch dir for snapshots/results:**
+  ```bash
+  export SPIKE="$HOME/spike-pagecache"; mkdir -p "$SPIKE"
+  ```
+
+---
+
+## Task 0: Build the Vz supervisor + mvmctl
+
+**Files:** none created. Builds existing crates.
+
+- [ ] **Step 1: Build the codesigned Swift supervisor** (Vz refuses an unsigned/missing one)
+
+```bash
+crates/mvm-vz-supervisor/tools/build.sh release
+export MVM_VZ_SUPERVISOR_PATH="$(pwd)/crates/mvm-vz-supervisor/.build/$(uname -m)-apple-macosx/release/mvm-vz-supervisor"
+test -x "$MVM_VZ_SUPERVISOR_PATH" && echo "supervisor OK: $MVM_VZ_SUPERVISOR_PATH"
+```
+Expected: prints `supervisor OK: …`. If the path differs, `find crates/mvm-vz-supervisor/.build -name mvm-vz-supervisor -type f`.
+
+- [ ] **Step 2: Build mvmctl release**
+
+```bash
+cargo build --release --bin mvmctl
+export MVMCTL="$(pwd)/target/release/mvmctl"
+"$MVMCTL" --version
+```
+Expected: prints a version. Use `$MVMCTL` for all subsequent commands so we run the build we just made.
+
+- [ ] **Step 3: Confirm host tier**
+
+```bash
+sw_vers   # expect ProductVersion 26.x (macOS 26+), arch arm64 (uname -m = arm64)
+```
+Expected: macOS 26+ on arm64 — required for `macos_supports_vz_snapshots()` (macOS 14+) and the Vz default tier. If `< 14`, **abort**: Vz snapshots are unavailable.
+
+---
+
+## Task 1 (GATE): Boot a trivial dev workload on Vz, confirm it stays alive + console works
+
+This is the **cheap feasibility gate** — prove the Vz workload path + console exec work
+*before* spending a fat image build. Uses the in-repo busybox dev image.
+
+**Files:** none.
+
+- [ ] **Step 1: Boot the busybox dev image on Vz, detached**
+
+```bash
+"$MVMCTL" up --flake 'nix/images/default-tenant#dev' \
+  --hypervisor vz --accept-tier2-isolation \
+  --name spike-probe --cpus 2 --memory 1G --detach
+```
+Expected: builds (first time, via the isolated builder) then reports the VM started. Note: first build is cold and may take minutes.
+
+- [ ] **Step 2: Confirm it stays alive >60s** (the workload PID 1 idles — the dev-VM init-EOF quirk does NOT apply to workloads)
+
+```bash
+sleep 60
+"$MVMCTL" ps 2>/dev/null || "$MVMCTL" list 2>/dev/null   # whichever lists running VMs
+```
+Expected: `spike-probe` still listed as running. **Abort gate:** if it died ~5s after boot, the workload-on-Vz path has a liveness bug — stop, capture `"$MVMCTL" console spike-probe --command 'true'` error + `<vm_state_dir>/console.log`, and report. Do not proceed.
+
+- [ ] **Step 3: Confirm `console --command` returns guest stdout**
+
+```bash
+"$MVMCTL" console spike-probe --command 'echo SPIKE_OK; uname -a'
+```
+Expected: prints `SPIKE_OK` + a Linux uname line (proves the vsock `Exec` path + dev-shell `accessible=true`). **Abort gate:** if it refuses (sealed image) or hangs, stop and report — without console exec there is no measurement channel.
+
+- [ ] **Step 4: Tear down the probe**
+
+```bash
+"$MVMCTL" stop spike-probe 2>/dev/null; "$MVMCTL" rm spike-probe 2>/dev/null || true
+```
+
+---
+
+## Task 2 (GATE): Snapshot save/restore round-trip on the trivial guest
+
+Prove the Vz snapshot mechanism works end-to-end *before* the fat build. Re-boot the
+busybox dev image, save, stop, restore, confirm console still works post-restore.
+
+**Files:** snapshot blob under `$SPIKE`.
+
+- [ ] **Step 1: Boot + save**
+
+```bash
+"$MVMCTL" up --flake 'nix/images/default-tenant#dev' --hypervisor vz \
+  --accept-tier2-isolation --name spike-snap --cpus 2 --memory 1G --detach
+sleep 20
+"$MVMCTL" snapshot save spike-snap --path "$SPIKE/probe.vzsnap" --hypervisor vz
+ls -la "$SPIKE/probe.vzsnap"
+```
+Expected: snapshot save succeeds; blob exists (non-zero size). Emits a `vm.snapshot_saved` audit entry.
+
+- [ ] **Step 2: Stop, then restore** (restore requires the VM not be running)
+
+```bash
+"$MVMCTL" stop spike-snap
+"$MVMCTL" snapshot restore spike-snap --path "$SPIKE/probe.vzsnap" --hypervisor vz
+sleep 5
+"$MVMCTL" console spike-snap --command 'echo RESTORED_OK'
+```
+Expected: restore succeeds; console prints `RESTORED_OK`. **Abort gate:** if restore fails or the restored guest is unreachable, stop and report — this is the core mechanism the spike depends on.
+
+- [ ] **Step 3: Tear down**
+
+```bash
+"$MVMCTL" stop spike-snap 2>/dev/null; "$MVMCTL" rm spike-snap 2>/dev/null; rm -f "$SPIKE/probe.vzsnap" || true
+```
+
+> Both gates green → the mechanism works; invest in the fat image. Either gate red →
+> stop here; the spike's blocker is the Vz workload/snapshot path, not page-cache priming.
+
+---
+
+## Task 3: Build the measurement image (fat dev-shell flake)
+
+The busybox image's `/nix/store` is too thin to be a working set. Copy the working
+default-tenant flake and add a fat, representative closure (python + numpy — also sets
+up scope B). The builder builds it once.
+
+**Files:**
+- Create: `$SPIKE/flake/` (copy of `nix/images/default-tenant/`)
+- Modify: `$SPIKE/flake/flake.nix` (the `packages` line)
+
+- [ ] **Step 1: Copy the flake**
+
+```bash
+cp -R nix/images/default-tenant "$SPIKE/flake"
+```
+
+- [ ] **Step 2: Fatten the dev variant's package set**
+
+In `$SPIKE/flake/flake.nix`, change the `packages` line (currently line ~101):
+```nix
+            packages = [ pkgs.busybox ];
+```
+to:
+```nix
+            packages = [ pkgs.busybox (pkgs.python3.withPackages (ps: [ ps.numpy ])) ];
+```
+(This adds a ~200 MB closure to the rootfs — the working set — and gives scope B a real `import numpy`.)
+
+- [ ] **Step 3: Build + boot the fat dev image on Vz**
+
+```bash
+"$MVMCTL" up --flake "$SPIKE/flake#dev" --hypervisor vz \
+  --accept-tier2-isolation --name spike-fat --cpus 4 --memory 4G --detach
+```
+Expected: cold build (slower — fetches the python/numpy closure through the isolated builder), then VM starts. Confirm alive: `sleep 30; "$MVMCTL" console spike-fat --command 'echo FAT_OK; du -sh /nix/store'`.
+Expected: `FAT_OK` + a `/nix/store` size in the hundreds of MB.
+
+- [ ] **Step 4: Pick the working set + record its size + a baseline read time**
+
+```bash
+"$MVMCTL" console spike-fat --command \
+  'WS=$(ls -d /nix/store/*python3*-env 2>/dev/null | head -1 || ls -d /nix/store/*numpy* | head -1); echo "WS=$WS"; du -sh "$WS"; sync; time sh -c "find $WS -type f -exec cat {} + >/dev/null"'
+```
+Expected: prints `WS=/nix/store/…`, a size (tens–hundreds of MB), and a `real` time. **Record `WS` and this warm baseline.** If `WS` read is <~50 ms, it's too small to measure — widen to the whole store: `WS=/nix/store`.
+
+- [ ] **Step 5: Tear down the boot-build VM** (we re-boot fresh for each A/B arm)
+
+```bash
+"$MVMCTL" stop spike-fat 2>/dev/null; "$MVMCTL" rm spike-fat 2>/dev/null || true
+```
+
+---
+
+## Task 4: Primed snapshot
+
+**Files:** `$SPIKE/primed.vzsnap`
+
+- [ ] **Step 1: Boot fresh, prime the working set, save**
+
+```bash
+WS="<the WS path recorded in Task 3 Step 4>"
+"$MVMCTL" up --flake "$SPIKE/flake#dev" --hypervisor vz --accept-tier2-isolation \
+  --name spike-primed --cpus 4 --memory 4G --detach
+sleep 20
+# prime: read the working set into the guest page cache
+"$MVMCTL" console spike-primed --command "find $WS -type f -exec cat {} + >/dev/null; echo PRIMED"
+"$MVMCTL" snapshot save spike-primed --path "$SPIKE/primed.vzsnap" --hypervisor vz
+"$MVMCTL" stop spike-primed
+```
+Expected: prints `PRIMED`; snapshot saved (non-zero blob).
+
+---
+
+## Task 5: Cold snapshot
+
+**Files:** `$SPIKE/cold.vzsnap`
+
+- [ ] **Step 1: Boot fresh, do NOT touch the working set, save**
+
+```bash
+"$MVMCTL" up --flake "$SPIKE/flake#dev" --hypervisor vz --accept-tier2-isolation \
+  --name spike-cold --cpus 4 --memory 4G --detach
+sleep 20
+# deliberately do NOT read WS — leave its pages cold
+"$MVMCTL" snapshot save spike-cold --path "$SPIKE/cold.vzsnap" --hypervisor vz
+"$MVMCTL" stop spike-cold
+```
+Expected: snapshot saved (non-zero blob). (Boot reads /init + the agent, never WS, so WS stays cold.)
+
+---
+
+## Task 6: Measure — restore each, time the first read, ≥5 trials
+
+**Files:** `$SPIKE/results.tsv`
+
+- [ ] **Step 1: Primed trials**
+
+```bash
+WS="<recorded WS path>"
+echo -e "arm\ttrial\treal_seconds" > "$SPIKE/results.tsv"
+for i in 1 2 3 4 5; do
+  "$MVMCTL" snapshot restore spike-primed --path "$SPIKE/primed.vzsnap" --hypervisor vz
+  sleep 3
+  t=$("$MVMCTL" console spike-primed --command \
+      "S=\$(date +%s.%N); find $WS -type f -exec cat {} + >/dev/null; E=\$(date +%s.%N); echo \$(echo \"\$E - \$S\" | bc)")
+  echo -e "primed\t$i\t$t" | tee -a "$SPIKE/results.tsv"
+  "$MVMCTL" stop spike-primed
+done
+```
+Expected: 5 `primed` rows with `real_seconds`. (Times the read *inside* the guest with `date +%s.%N`, avoiding PTY round-trip noise in the number itself.)
+
+- [ ] **Step 2: Cold trials**
+
+```bash
+for i in 1 2 3 4 5; do
+  "$MVMCTL" snapshot restore spike-cold --path "$SPIKE/cold.vzsnap" --hypervisor vz
+  sleep 3
+  t=$("$MVMCTL" console spike-cold --command \
+      "S=\$(date +%s.%N); find $WS -type f -exec cat {} + >/dev/null; E=\$(date +%s.%N); echo \$(echo \"\$E - \$S\" | bc)")
+  echo -e "cold\t$i\t$t" | tee -a "$SPIKE/results.tsv"
+  "$MVMCTL" stop spike-cold
+done
+```
+Expected: 5 `cold` rows. Each cold restore starts from the same untouched-WS snapshot, so every cold trial faults WS from the virtual disk anew.
+
+> Note the host-page-cache confound (design doc): across cold trials the *host's* cache
+> for the rootfs image warms up, which may shrink the cold cost over trials. Record the
+> per-trial values (don't just average) so the trend is visible.
+
+---
+
+## Task 7: Analyze + decide (apply the two gates)
+
+**Files:** append a "Results" section to `specs/notes/2026-06-05-vz-page-cache-priming-spike.md`.
+
+- [ ] **Step 1: Summarize**
+
+```bash
+awk -F'\t' 'NR>1{a[$1]=a[$1]" "$3} END{for(k in a)print k": "a[k]}' "$SPIKE/results.tsv"
+```
+Compute per-arm median + min/max.
+
+- [ ] **Step 2: Apply the thresholds** (from the design doc Success threshold):
+  - **Robustness:** does primed clearly separate from cold (slowest primed ≤ fastest cold, or medians clearly apart with no overlap)?
+  - **Materiality:** is the median saving on the order of ≥100 ms?
+  - **Verdict:** both pass → *mechanism viable, proceed to B/C*. Either fails → *kill the Plan 157 follow-up*.
+
+- [ ] **Step 3: Write the Results section** into the design note — the per-trial table, medians, the host-cache trend, and the explicit verdict (proceed-to-B/C **or** kill, with the one-line reason). Commit:
+
+```bash
+git add specs/notes/2026-06-05-vz-page-cache-priming-spike.md
+git commit -m "docs(spike): Vz page-cache priming results + verdict"
+```
+
+---
+
+## Task 8: Decision handoff (no code either way)
+
+- [ ] **Step 1:** If **proceed**: open a short note recommending scope B (`python -c "import numpy"` on the *same* fat image — it's already built) to quote a realistic number, and flag that the actual feature work is still gated behind Plan 140 + Plan 123-C (ADR-073 sequencing). If **kill**: note that the Plan 157 follow-up `- [ ]` should be struck (or annotated "measured no benefit on Vz, <date>"), and propose that doc edit as a follow-up PR.
+
+---
+
+## Task 9: Teardown
+
+- [ ] **Step 1: Remove VMs, snapshots, scratch, and the isolated builder**
+
+```bash
+for n in spike-probe spike-snap spike-fat spike-primed spike-cold; do
+  "$MVMCTL" stop "$n" 2>/dev/null; "$MVMCTL" rm "$n" 2>/dev/null
+done
+"$MVMCTL" dev down 2>/dev/null || true            # shut down the job-specific builder
+rm -rf "$SPIKE" "$MVM_CACHE_DIR" "$MVM_DATA_DIR"   # never touched the shared persistent builder
+```
+Expected: scratch gone; the user's shared `~/.cache/mvm` / `~/.mvm` untouched (we only ever used the `*-spike-pagecache` dirs).
+
+- [ ] **Step 2:** Decide whether the design note + results land on `main` (recommended — it's the durable decision record) via a small PR, independent of the throwaway spike branch.
+
+---
+
+## Out of scope (carried from the design)
+
+- Implementing page-cache priming or any freeze/restore change.
+- Firecracker / cloud-hypervisor measurement (different snapshot mechanism — only if Vz shows a signal worth generalizing).
+- Scope B/C execution (gated on Task 7 verdict).

--- a/specs/notes/2026-06-05-vz-page-cache-priming-spike.md
+++ b/specs/notes/2026-06-05-vz-page-cache-priming-spike.md
@@ -1,0 +1,144 @@
+# Spike — Vz page-cache priming: does a warm cache speed first-read after restore?
+
+**Date:** 2026-06-05
+**Status:** Design (awaiting review) — throwaway measurement spike, nothing ships.
+**Feeds:** [ADR-073](../adrs/073-warm-snapshot-prior-art-adoption-boundary.md) §1 +
+the Plan 157 "page-cache priming at freeze" deferred follow-up.
+
+## Goal — the one decision this feeds
+
+Answer with a real number on *our* stack: after a Vz (`Virtualization.framework`)
+snapshot restore, does a **warm guest page cache** produce a meaningfully faster
+first read of the working set than a **cold** one?
+
+- **Clear gain** → the Plan 157 page-cache-priming follow-up is justified; proceed
+  to a sized/realistic measurement (B/C below).
+- **No gain / lost in noise** → **delete** the follow-up. We don't build it.
+
+The premise today is borrowed from a commercial sibling's docs (ADR-073's "pooled
+OCI-microVM runtime", `with_warmup`, "~7× on rustc-class"). This converts that
+assumption into evidence we own.
+
+## Background (why this is the cheap first move)
+
+Page-cache priming sits at the *top* of a dependency chain, not the bottom:
+
+```
+page-cache priming
+  needs → Plan 157 Phase C (memory-snapshot freeze)
+            needs → Plan 123 Phase C (FC fast-resume) + Plan 140 (restore correctness)
+```
+
+Building that whole stack on the strength of a competitor's number is backwards.
+Vz already has working `snapshot save`/`restore` CLI (macOS 14+), so we can measure
+the *page-cache* variable in isolation **today**, without building any of it.
+
+## Experiment — the A/B (existing CLI only, scope A)
+
+Vz `saveMachineStateTo` serializes the **entire guest RAM** (page cache included) and
+`restoreMachineStateFrom` loads it back. So priming *is* captured in the snapshot; the
+question is whether that warm cache beats a cold one **net of Vz's restore overhead**.
+
+1. Boot a long-lived `dev-shell` workload on Vz (PID 1 idles; agent serves the vsock
+   console — the Plan 120 init-EOF exit is already fixed).
+2. **Primed run:** read the working set in-guest via `mvmctl console <vm> --command
+   '<read>'`, then `mvmctl snapshot save <vm> --path primed.vzsnap`.
+3. **Cold run:** fresh boot, *don't* touch the working set, `mvmctl snapshot save
+   <vm> --path cold.vzsnap`.
+4. **Measure:** `mvmctl snapshot restore` each, then time the first read of the
+   working set via `console --command`. N trials each (≥5); compare distributions, not
+   single runs — we want an obvious gap, not a precise figure.
+
+### Working set — read existing immutable rootfs, no image surgery
+
+Use a large `/nix/store` subtree the boot path never touches as the working set:
+
+```sh
+time sh -c 'find /nix/store/<subtree> -type f -exec cat {} + >/dev/null'
+```
+
+Rationale: it's block-backed (rootfs ext4 on virtio-blk, so a cold read genuinely
+faults from the virtual disk), naturally cold (boot doesn't read it, so no root
+`drop_caches` needed), and it's *also the most representative* thing — "warm the
+binaries/libs the workload will read" is exactly what priming buys. A tmpfs file would
+be useless here (tmpfs is always RAM-resident — no cold/primed distinction).
+
+### Success threshold (judgment, stated up front)
+
+A gain worth pursuing should be **obvious**: primed first-read consistently ≥~2× faster,
+or saving on the order of hundreds of ms on the working set, across trials. A
+difference under ~20% or inside trial-to-trial noise = no signal = kill the follow-up.
+
+## Security constraints (carried into the eventual feature)
+
+The spike is security-neutral (see below), but it nails down the scope the *feature*
+must obey, so record it here:
+
+- **Prime the immutable root volume (rootfs) only.** The rootfs is read-only,
+  verity'd, secret-free by design. It is the *only* thing priming touches. A primed
+  page cache becomes part of a snapshot that forked children (Plan 157 / 148) all
+  restore from, so priming anything mutable or sensitive would share it across every
+  fork — a claim-1 / claim-11 confidentiality leak.
+- **Secrets are never in any volume — root or data.** They arrive as destination-bound,
+  signed credentials over the host broker (`host.secrets.v1`, claims 12/13), never as
+  raw bytes in the guest. So there is no secret-in-volume for a primed cache to leak.
+- **Other (data / app-dep) volumes may be mounted, but are never primed into a shared
+  base.** Mutable per-tenant data must not be baked into a snapshot N children share;
+  each fork gets its own volume disposition (Plan 157 / 140 per-instance freshness).
+
+Net constraint, one line: **priming = read-only immutable rootfs, never volumes,
+never secrets.** The spike's working-set choice (`/nix/store` reads) already obeys it.
+
+## Why the spike itself has no security impact
+
+- Changes no production code; merges nothing; throwaway worktree torn down after.
+- Runs entirely in the **dev tier** — a `dev-shell` image is required for the console
+  `Exec` path. That is the explicitly non-hardened tier
+  (`feedback_dev_vm_vs_prod_security_tiers`); it does **not** touch **claim 4**
+  (`prod-agent-no-exec`, which asserts `do_exec` is absent from *prod* builds), and
+  this path is never presented as evidence about prod.
+- `snapshot save/restore` already emit `vm.snapshot_saved` / `vm.snapshot_restored`
+  audit-chain entries — the actions aren't covert.
+- No network — claim 10 / egress posture untouched.
+- Honest caveat: it measures perf on a restore path that still has Plan 140's four
+  correctness gaps (seccomp-off-on-restore, no entropy reseed, no clock resync, no
+  wake admission). Fine for a latency number on a dev guest; it's why the result is
+  "is the perf worth pursuing," not "restore is ready."
+
+## Environment / isolation
+
+- Run in a **git worktree** with `MVM_CACHE_DIR` / `MVM_DATA_DIR` pointed at scratch
+  dirs, so the shared nix-store flock can't race parallel sessions
+  (`project_dev_host_runs_builder_via_vz`).
+- Build the codesigned `mvm-vz-supervisor` via `crates/mvm-vz-supervisor/tools/build.sh`
+  (or set `MVM_VZ_SUPERVISOR_PATH`) — Vz refuses an unsigned/missing supervisor
+  (`reference_mvm_vz_supervisor_separate_swiftpm_binary`).
+
+## Deliverable
+
+A results section appended to this note: the trial numbers, the verdict (proceed to
+B/C, or kill the follow-up), and any surprises (esp. the host-page-cache confound
+below). No code merged; snapshots/images discarded.
+
+## Confound we note, not fight
+
+The **host's** page cache for the rootfs disk image can make even a "cold" guest read
+fast and mask the benefit. That's part of the truth about this backend, so the results
+state it plainly rather than trying to defeat it (e.g. we won't purge host cache between
+runs — a real deployment wouldn't either).
+
+## Feasibility items to resolve in the plan (not blockers)
+
+1. Which ready **dev-shell Vz-bootable workload image** to use, vs. building one (a
+   single Vz builder run on this Mac). Prefer an existing example image if one boots on
+   Vz with the agent.
+2. Confirm `console --command` returns the timing output cleanly from a one-shot exec
+   (vs. needing the raw `Exec` vsock RPC — that would be scope B, out of bounds for A).
+
+## Out of scope
+
+- Implementing page-cache priming, or any change to the freeze/restore path.
+- Firecracker / cloud-hypervisor (different snapshot mechanism — measure later if Vz
+  shows a signal worth generalizing).
+- B (realistic workload, e.g. `python -c "import numpy"`) and C (synthetic + realistic)
+  — gated on A showing a signal.

--- a/specs/notes/2026-06-05-vz-page-cache-priming-spike.md
+++ b/specs/notes/2026-06-05-vz-page-cache-priming-spike.md
@@ -65,9 +65,21 @@ be useless here (tmpfs is always RAM-resident — no cold/primed distinction).
 
 ### Success threshold (judgment, stated up front)
 
-A gain worth pursuing should be **obvious**: primed first-read consistently ≥~2× faster,
-or saving on the order of hundreds of ms on the working set, across trials. A
-difference under ~20% or inside trial-to-trial noise = no signal = kill the follow-up.
+A's job is narrow — prove the *mechanism* yields a robust, material signal on Vz at
+all; the "worth the engineering cost" magnitude call is B/C's job. Avoid a raw
+multiplier (a 2× over single-digit ms is meaningless; a 1.3× over seconds may matter).
+Two gates instead:
+
+- **Robustness (primary):** ≥5 trials each. Primed and cold first-read distributions
+  must clearly separate — slowest primed run ≤ fastest cold run (full separation), or
+  primed median clearly lower with no meaningful overlap. If they interleave → noise →
+  **kill**.
+- **Materiality (secondary):** median saving on the order of **≥100 ms** — comparable
+  to or larger than the Vz restore time itself. A robust-but-5 ms gap is real but not
+  worth a feature.
+
+Pass both → mechanism viable → run B/C to quote the real-world number. Fail either →
+kill the Plan 157 follow-up.
 
 ## Security constraints (carried into the eventual feature)
 

--- a/specs/notes/2026-06-05-vz-page-cache-priming-spike.md
+++ b/specs/notes/2026-06-05-vz-page-cache-priming-spike.md
@@ -216,3 +216,30 @@ not the throwaway afternoon the spike assumed. The decision the spike was meant 
 inform (justify or kill the Plan 157 follow-up) is therefore **deferred**, with the
 honest new datum that *the Vz workload path itself needs plumbing* — relevant to the
 broader Vz warm-path effort (Plan 152 / 159), not just to page-cache priming.
+
+## Update — 2026-06-07 (A+B fixed; a third bug surfaced)
+
+Bugs A and B were fixed properly (TDD) in **PR #674**; the spike still can't run because
+fixing B exposed a deeper third bug.
+
+- **Bug A — FIXED + E2E-validated.** Root cause refined: the Vz backend
+  (`build_supervisor_config`) *unconditionally* requested the bridge
+  (`events_ingest_socket_path: Some(...)`), while `spawn_vz_drainer` only binds that
+  socket for admitted workloads (`plan_json` + `tenant_id`) — which the default
+  `up --dev` / `up --flake` path doesn't set (the in-VM bridge is `MVM_GATEWAY_BRIDGE`-
+  gated, off by default; a Plan 138 libkrun workaround). Fix: gate the bridge *request*
+  on the same condition as the drainer (no shim, no Swift change). E2E: `up --dev
+  --hypervisor vz` now boots — `console.log` ~5501 bytes, agent listening.
+- **Bug B — FIXED (the transport-selection gap).** `VzTransport` +
+  `vm_vz_vsock_dir` / `vm_vz_vsock_port_socket` helpers, wired into both pickers.
+  `console` now selects the Vz transport and connects to the right socket.
+- **Bug C — OPEN, [issue #673](https://github.com/tinylabscom/mvm/issues/673).** B's fix
+  makes `console` reach the socket, exposing that the Vz vsock **proxy**
+  (`VsockProxy.swift` — accept → `connect(toPort:)` → bidirectional `DispatchIO` pump,
+  *implemented*) **connects but hangs** with no agent round-trip (`console --command`
+  exit 124, no output). This is the remaining blocker for `console`-on-Vz E2E and for
+  this spike's measurement channel.
+
+**Net:** the page-cache number is still unmeasured — now gated on Bug C (#673), or on
+running the measurement on Firecracker/Linux-KVM instead. The Plan 157 follow-up stays
+deferred (no data to justify or kill it).

--- a/specs/notes/2026-06-05-vz-page-cache-priming-spike.md
+++ b/specs/notes/2026-06-05-vz-page-cache-priming-spike.md
@@ -164,3 +164,55 @@ runs — a real deployment wouldn't either).
   shows a signal worth generalizing).
 - B (realistic workload, e.g. `python -c "import numpy"`) and C (synthetic + realistic)
   — gated on A showing a signal.
+
+## Execution findings — 2026-06-05 (BLOCKED: page-cache number NOT measured)
+
+The spike could not produce a number. It did not fail at the page-cache question — it
+ran aground on **two pre-existing host-side gaps in the Vz *workload* path**, plus one
+correction. The "cheap today on Vz" premise is invalidated: the Vz workload runtime is
+half-plumbed and needs real fixes before it can host this measurement.
+
+**Correction — Vz snapshot restore IS implemented** (an earlier investigation wrongly
+called it unimplemented from a stale doc comment). Verified in source: `snap_restore`
+(`crates/mvm-cli/src/commands/vm/pause.rs:385`) reads the persisted supervisor config,
+flips to `StartupMode::Restore`, spawns the supervisor, emits `vm.snapshot_restored`;
+Swift `restoreStart` (`crates/mvm-vz-supervisor/.../Supervisor.swift:377`) does the real
+two-step `restoreMachineStateFrom(url:)` + `resume()`. The stale "NOT YET IMPLEMENTED"
+comment at `pause.rs:187` and the deferred *live control-socket* `RESTORE` command are
+different things. Restore was never exercised E2E here (blocked below), but it is wired.
+
+**Bug A — `up --dev --hypervisor vz` kills the supervisor before the guest boots.**
+The Swift supervisor's `makeBridgedGvproxyDevice` (`Network.swift:179`, claim-10 gvproxy
+flow-audit bridge) does a **mandatory fatal `connect()`** to
+`…/audit/gateway-events-<name>.sock`. The legacy `up --dev` path leaves `plan_json`
+unset on `VmStartConfig`, so `spawn_vz_drainer` (`vz.rs:1161`) skips the `mvm-vz-drainer`
+that would bind that socket → `connect()` fails `errno=2` → `exit()` before VM
+construction (`console.log` 0 bytes, no kernel output). The guest image is *correct*
+(Plan 162 idle `/init` present, `variant=dev`); the death is entirely host-side and
+pre-boot. **Confirmed sole boot blocker** via a no-code shim (pre-bind the socket with
+`socat UNIX-LISTEN:…/gateway-events-<name>.sock` before `up`): with the socket bound the
+supervisor lives, the kernel boots, and `mvm-guest-agent` reaches "listening on vsock
+port 5252". So the fix is good to go. Fix options: make the Swift bridge tolerate a
+missing/absent ingest socket (skip/fallback), or thread `plan_json` into the `up --dev`
+path so the drainer binds it first.
+
+**Bug B — `mvmctl console` cannot reach a Vz *workload* (the measurement channel).**
+`pick_console_transport` (`crates/mvm-cli/src/commands/vm/console.rs:31`) knows only
+four transports — apple_container, a *fixed* dev-VM proxy path (`mvm-dev`), libkrun, and
+firecracker. There is **no Vz-workload transport**. A Vz workload's agent proxy socket
+lives at `vms/<name>/vsock/vsock-5252.sock`, which none of those construct, so `console
+<name>` ignores the name, falls through to the fixed dev path, and errors as `mvm-dev`.
+This blocks the spike's only measurement channel (timed in-guest read via
+`console --command`).
+
+**Runbook command corrections** (for whoever resumes): the CLI does **not** split
+`--flake '…#dev'` (whole string is a literal path) — the bundled dev image is selected
+by `up --dev`; lifecycle verbs are `up` / `down <name>` / `ls` (no `ps`/`stop`/`rm`).
+
+**Verdict.** The page-cache-priming question on Vz is **still open** — unmeasured. To
+measure it on Vz, two real fixes land first (Bug A: events-ingest tolerance; Bug B: a Vz
+console/agent transport). Both are legitimate Vz-workload-path work but are *substrate*,
+not the throwaway afternoon the spike assumed. The decision the spike was meant to
+inform (justify or kill the Plan 157 follow-up) is therefore **deferred**, with the
+honest new datum that *the Vz workload path itself needs plumbing* — relevant to the
+broader Vz warm-path effort (Plan 152 / 159), not just to page-cache priming.

--- a/specs/notes/2026-06-05-vz-page-cache-priming-spike.md
+++ b/specs/notes/2026-06-05-vz-page-cache-priming-spike.md
@@ -49,19 +49,29 @@ question is whether that warm cache beats a cold one **net of Vz's restore overh
    working set via `console --command`. N trials each (≥5); compare distributions, not
    single runs — we want an obvious gap, not a precise figure.
 
-### Working set — read existing immutable rootfs, no image surgery
+### Working set — a fat closure on the immutable rootfs
 
-Use a large `/nix/store` subtree the boot path never touches as the working set:
+The in-repo default dev image (`nix/images/default-tenant#dev`) is **busybox-only** — its
+`/nix/store` is too thin to be a working set. So the builder builds *one* fatter dev
+variant (add a `python3 + numpy` closure, ~200 MB) and the working set is a subtree of
+that closure in `/nix/store`:
 
 ```sh
-time sh -c 'find /nix/store/<subtree> -type f -exec cat {} + >/dev/null'
+time sh -c 'find /nix/store/<closure-subtree> -type f -exec cat {} + >/dev/null'
 ```
 
-Rationale: it's block-backed (rootfs ext4 on virtio-blk, so a cold read genuinely
-faults from the virtual disk), naturally cold (boot doesn't read it, so no root
-`drop_caches` needed), and it's *also the most representative* thing — "warm the
-binaries/libs the workload will read" is exactly what priming buys. A tmpfs file would
-be useless here (tmpfs is always RAM-resident — no cold/primed distinction).
+Rationale: block-backed (rootfs ext4 on virtio-blk, so a cold read genuinely faults from
+the virtual disk), naturally cold (boot reads `/init` + the agent, never the closure, so
+no root `drop_caches`), it sits on the **immutable rootfs** — so it already obeys the
+"prime the rootfs only, never volumes/secrets" constraint — and it's the *most
+representative* thing ("warm the binaries/libs the workload reads"). The same image's
+`python -c "import numpy"` is scope B, so one build serves both. A tmpfs file would be
+useless (always RAM-resident — no cold/primed distinction).
+
+The builder that produces this image is **job-specific and isolated** (`MVM_CACHE_DIR` /
+`MVM_DATA_DIR` at scratch paths), kept persistent across the spike's builds for a warm
+store, then shut down + removed at teardown — the shared persistent builder is never
+touched. It is build tooling only; never measured or snapshotted.
 
 ### Success threshold (judgment, stated up front)
 


### PR DESCRIPTION
Docs only — the decision record for the Vz page-cache-priming spike (referenced by ADR-073 §1 and the Plan 157 deferred follow-up). Two new files under `specs/notes/`; no code.

## What's here

- **Design** (`2026-06-05-vz-page-cache-priming-spike.md`) — the A/B measurement (does a warm guest page cache speed first-read after a Vz snapshot restore?), the working set, the security constraints (prime the immutable rootfs only — never volumes/secrets), the success threshold, and the **execution findings**.
- **Runbook** (`…-spike-plan.md`) — the phased measurement procedure with abort gates.

## Outcome (recorded in the findings section)

The page-cache number was **not** measured — the spike surfaced that the Vz *workload* path was half-plumbed. Net:

- **Bug A** (`up --dev --hypervisor vz` boot crash) — fixed in #674 (merged).
- **Bug B** (`console` had no Vz transport) — fixed in #674 (merged).
- **Bug C** (Vz vsock-proxy connects but hangs) — open as #673; the remaining blocker for console-on-Vz E2E and for this spike's measurement channel.
- Correction recorded: Vz snapshot **restore is implemented** (an earlier "unimplemented" reading was a stale doc comment).

The Plan 157 page-cache follow-up stays **deferred** (no data to justify or kill it); measuring it is now gated on #673 or a Firecracker/Linux-KVM run.

> Branch is behind `main` but adds only these two new files (no conflicts).