### PR TITLE
docs: refer to external sandbox/VMM sibling projects obliquely (naming-policy sweep)

### DIFF
--- a/specs/plans/148-microvm-fork-fanout-and-branch.md
+++ b/specs/plans/148-microvm-fork-fanout-and-branch.md
@@ -1,4 +1,4 @@
-# Plan 148 — MicroVM fork fan-out + live BRANCH (forkd-inspired)
+# Plan 148 — MicroVM fork fan-out + live BRANCH (fork/snapshot-sibling-inspired)
 
 > Number 148 is the next free integer (145–147 are claimed: 145 app-deps-completion
 > on `main`, 146 cloud-hypervisor-tier1-parity, 147 portable-runnable-artifacts).
@@ -7,9 +7,11 @@
 
 ## Context
 
-[forkd](https://github.com/deeplethe/forkd) is the closest public sibling to mvm:
-Firecracker microVMs, Rust, AI-agent sandboxing, an explicit security posture. Its
-one genuinely novel mechanism is **fork fan-out** — pause a *warmed* parent, then
+The closest public sibling to mvm — a Rust Firecracker-microVM fork/snapshot tool
+for AI-agent sandboxing with an explicit security posture (referred to obliquely per
+[[feedback_no_competitor_names_anywhere]]; trait key in auto-memory
+`reference_external_sandbox_control_plane_oblique_key`) — has one genuinely novel
+mechanism: **fork fan-out** — pause a *warmed* parent, then
 spawn N children as separate Firecracker processes that `mmap` the parent's memory
 image `MAP_PRIVATE`, so the kernel does page-level copy-on-write and children share
 the parent's resident RAM until they diverge ("100 microVMs in 101 ms," full KVM
@@ -23,13 +25,12 @@ base `mem.bin`/`vmstate.bin` and per-instance deltas; `instance_wake`
 Firecracker UFFD/NBD/hugepages fast-resume substrate; Plan 140 closes the four
 restore-correctness gaps (seccomp, entropy reseed, clock resync, wake-admission).
 **What's missing is the fan-out: many children from one warm parent, and a
-live-branch of a running workload.** That is the forkd delta, and the agent
+live-branch of a running workload.** That is the sibling's delta, and the agent
 fan-out use case (parallel rollouts, code-interpreter swarms, SWE-bench evals) is
 squarely mvm/mvmd territory.
 
-**Decision up front — no vendored Firecracker.** forkd vendors a patched
-Firecracker (`forkd-v0.4-mem-backend-shared`) to expose `mmap MAP_SHARED` on a
-memfd-backed *live* parent. That collides with three standing principles: keep VMM
+**Decision up front — no vendored Firecracker.** The sibling vendors a patched
+Firecracker branch to expose `mmap MAP_SHARED` on a memfd-backed *live* parent. That collides with three standing principles: keep VMM
 specifics behind the backend trait (the trick is Firecracker/x86_64/Linux-only,
 with no libkrun/Vz/AppleContainer analogue); replace a problematic dep rather than
 maintain a fork against upstream; and don't pay a vendored-hypervisor tax for a win
@@ -131,14 +132,14 @@ entropy_seed }`), `crates/mvm-core` plan/audit (`synthesize_plan` / `admit_for_r
 ## Phase B — live BRANCH (bounded spike, go/no-go)
 
 Branching a **running** parent into divergent children inheriting in-flight state is
-forkd's speculative-branch feature and the one piece that wants a live shared-memory
+the sibling's speculative-branch feature and the one piece that wants a live shared-memory
 parent. This phase is investigation, not a vendoring commitment.
 
 ### Task B1: feasibility spike on stock Firecracker
 
 - [ ] **Step 1:** Measure stock Firecracker's pause → Diff-snapshot → resume window
       on a representative running workload (warmed deps, ~1–4 GiB RSS) at the dirty-
-      page volumes a mid-execution branch produces. forkd's own numbers: full-copy
+      page volumes a mid-execution branch produces. The sibling's own numbers: full-copy
       branch was 29.3 s, diff-snapshot dropped it to 205 ms, async UFFD_WP live mode
       to 56 ms. The question for us: **is upstream Firecracker's Diff snapshot
       pause-window acceptable** (children restore via Phase A's shared-base path from
@@ -199,7 +200,7 @@ parent. This phase is investigation, not a vendoring commitment.
 
 - **Why this isn't just Plan 123/140 again:** 123 C2 and 140 make *one* VM resume
   fast and correct. This plan makes *N* children share *one* base's resident RAM and
-  proves each diverges security-correctly — the fan-out forkd is built around. The
+  proves each diverges security-correctly — the fan-out the sibling is built around. The
   single-restore path is the prereq, not the feature.
 - **The honest win:** Phase A gives the "many-from-one" amortized-warmup benefit on
   stock Firecracker via page-cache sharing of a frozen base. The sub-ms `mmap`

--- a/specs/plans/157-warmed-parent-recipes.md
+++ b/specs/plans/157-warmed-parent-recipes.md
@@ -1,4 +1,4 @@
-# Plan 157 — Warmed parent recipes (forkd-inspired)
+# Plan 157 — Warmed parent recipes (fork/snapshot-sibling-inspired)
 
 > Number 157 is the next free integer (`main` tops out at 156: 156 binary-size-reduction,
 > 155 portable-runnable-artifacts, 154 cloud-hypervisor-tier1-parity). `xtask
@@ -7,33 +7,35 @@
 
 ## Context
 
-[forkd](https://github.com/deeplethe/forkd) is the closest public sibling to mvm
-(Firecracker microVMs, Rust, agent sandboxing, an explicit security posture). Its
-`recipes/` directory ships **rootfs recipes** — a per-environment `build.sh` plus a
-shared `scripts/build-rootfs.sh` — that turn a public OCI image into a **pre-warmed
-parent**. `recipes/postgres-fixture` is the canonical one: it runs `initdb`, starts
-the postmaster, emits a line-JSON ready handshake, then idles; `forkd snapshot`
-freezes that primed state and `forkd fork -n` fans out children that get a
-ready-to-query DB in ~10 ms instead of ~2 s.
+The closest public sibling to mvm — a Rust Firecracker-microVM fork/snapshot tool
+for agent sandboxing with an explicit security posture (referred to obliquely per
+[[feedback_no_competitor_names_anywhere]]; trait key in auto-memory
+`reference_external_sandbox_control_plane_oblique_key`) — ships **rootfs recipes** in
+its `recipes/` directory: a per-environment `build.sh` plus a shared
+`scripts/build-rootfs.sh` that turn a public OCI image into a **pre-warmed parent**.
+`recipes/postgres-fixture` is the canonical one: it runs `initdb`, starts the
+postmaster, emits a line-JSON ready handshake, then idles; its `snapshot` command
+freezes that primed state and `fork -n` fans out children that get a ready-to-query
+DB in ~10 ms instead of ~2 s.
 
 Two findings from reviewing those recipes set the scope of this plan.
 
 **1. The rootfs *mechanism* is not worth adopting — mvm already has the secure
-equivalent.** forkd's `scripts/build-rootfs.sh` is `docker pull` → `docker export | tar`
+equivalent.** That sibling's `scripts/build-rootfs.sh` is `docker pull` → `docker export | tar`
 → `mkfs.ext4 -d` on the host. That collides head-on with two standing mvm invariants:
 no Docker/containers anywhere near the image path, and ext4 is never materialized on
 the host (it runs in the builder VM — ADR-050). mvm already converts OCI → ext4 with
 `mvm_oci::unpack::unpack_layer` + `mvm_build::oci_to_rootfs::materialize_to_ext4` +
 `seal_with_verity`, pure-Rust, in the builder VM, with cosign + provenance + audit
 (claim 14, `specs/claims/claim-10-oci-image-provenance.md`). **Rebuilding that against
-forkd's shell pipeline is an explicit non-goal** — it would regress integrity.
+that shell pipeline is an explicit non-goal** — it would regress integrity.
 
-**2. forkd bakes warm state *into a writable rootfs*; mvm structurally can't — and
+**2. The sibling bakes warm state *into a writable rootfs*; mvm structurally can't — and
 that exposes a real gap.** mvm's workload rootfs is read-only, dm-verity'd, and
 provenance-pinned (claims 3 / 14). Mutable warm state — an initialized `initdb` data
 dir, a running postmaster, primed caches — cannot live inside a verity rootfs without
 throwing away the verity tree and the provenance chain. So a "warmed parent" in mvm
-necessarily decomposes into **three** layers where forkd has one:
+necessarily decomposes into **three** layers where that tool has one:
 
 | Layer | Holds | mvm home | Status |
 |---|---|---|---|
@@ -72,7 +74,7 @@ verity/provenance/audit chain.
 
 **Core decision, stated up front: mvm does not warm the rootfs.** A warmed parent is
 an immutable verity rootfs (already built) + a sealed warm overlay/volume (disk) + a
-memory snapshot (RAM). forkd's "bake into one writable rootfs" model is rejected as a
+memory snapshot (RAM). The sibling's "bake into one writable rootfs" model is rejected as a
 verity/provenance regression.
 
 **Prereqs / sequencing.** The disk-warm legs (Phases A, B, and the libkrun disk-only
@@ -260,14 +262,14 @@ silently degrade (matches Plan 148 / 123 posture).
 - Live BRANCH of a *running* parent — Plan 148 Phase B (a measured go/no-go, not a
   commitment).
 - Rebuilding the OCI → ext4 rootfs builder — already exists (`unpack_layer` +
-  `materialize_to_ext4` + `seal_with_verity`); explicitly **not** adopting forkd's
-  `scripts/build-rootfs.sh`.
+  `materialize_to_ext4` + `seal_with_verity`); explicitly **not** adopting that
+  sibling's `scripts/build-rootfs.sh`.
 
 ## Candidate recipes (target menu)
 
-Expressed as mvm catalog entries with a `WarmupSpec`, drawn from forkd's recipe set:
+Expressed as mvm catalog entries with a `WarmupSpec`, drawn from the sibling's recipe set:
 `postgres-fixture` (initdb + postmaster), `jupyter-kernel`, `node`, `code-interpreter`,
-`python-numpy`. Note forkd's own recipes are thin — `python-numpy` has *no* warmup
+`python-numpy`. Note the sibling's own recipes are thin — `python-numpy` has *no* warmup
 (just `apt install python3-numpy`); only `postgres-fixture` truly warms — so this is a
 **target list, not a borrowed design**. `postgres-fixture` is the natural first
 recipe (it exercises the full disk + memory freeze).


### PR DESCRIPTION
## What

A repo-wide sweep replacing direct names of external **sandbox / VMM sibling & prior-art projects** with trait-based **oblique** references, per the naming policy (`[[feedback_no_competitor_names_anywhere]]`). GitHub URLs/slugs dropped; the private real-name → oblique decode key lives in auto-memory, not the repo.

### Scrubbed
| Was | Now | Files |
|---|---|---|
| fork/snapshot sibling | "the closest public sibling — a Rust Firecracker-microVM fork/snapshot tool" | Plans 148, 157 |
| production CH sandbozer | "the reference cloud-hypervisor sandboxer" | Plan 154 (title + 27 refs) |
| removed predecessor sandbox | "the earlier external sandbox runtime" | SPRINT.md, Plans 74/77/83/117, backlog 42/85, ADR-048 |
| sandbox-wrapper CLI | "an external thin sandbox-wrapper CLI" (examples use generic `wrap`) | Plan 24, backlog 41 |
| Nix sandbox MCP server | "an external single-tool Nix sandbox MCP server" | Plan 32, ADR-003 |
| LLM jail tool | "an external LLM sandbox/jail tool" | Plan 60 |
| libkrun-based OCI sandbox | "an external libkrun-based OCI microVM sandbox" | Plan 15 |

### Kept (deliberately — not sandbox competitors)
- **OpenClaw** (a supported AI-agent *workload* mvm hosts, 55 files), **SafeClaw** (security-dashboard *reference material* for hardening that workload), **nix-openclaw** (OpenClaw's Nix packaging) — these are integration/workload names, covered by the "service/integration names are NOT competitors — keep them" carve-out.
- Infra: cloud-hypervisor, libkrun, bubblewrap, microvm.nix, runwasi, MCP, Firecracker.

## Scope

No technical content changes — every adoption/non-adoption decision and file reference is preserved; only external project names/URLs are genericized. Docs only; affected plans remain Proposed.

**Not included (flagged for a separate decision):** `kata-containers` appears in 3 files (Plan 20 — a factual note on Apple Container's kernel origin; Plan 15 — an ecosystem survey; backlog 13 — a GitHub-issue citation). Kata is on the banned-name list but these contexts are nuanced; leaving for explicit sign-off.