### PR TITLE
feat(secrets): Plan 129 E2 — secret.substituted/placeholder_dropped audit (claim 13)

### DIFF
--- a/crates/mvm-hostd/src/keyholder/substitution.rs
+++ b/crates/mvm-hostd/src/keyholder/substitution.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use mvm_sdk::ir::SecretRef;
+use mvm_sdk::ir::{AuthType, SecretRef};
 use rand::RngCore;
 use zeroize::Zeroizing;
 
@@ -120,6 +120,15 @@ impl<'a> SubstitutionEndpoint<'a> {
             registry,
             injector: Injector::new(resolver),
         }
+    }
+
+    /// The `(secret name, auth-type)` a placeholder resolves to — for audit
+    /// labelling. `None` for an unknown placeholder. No value is touched, so
+    /// this is safe to call without triggering a decrypt.
+    pub fn resolve_meta(&self, placeholder: &str) -> Option<(String, AuthType)> {
+        self.registry
+            .resolve(placeholder)
+            .map(|r| (r.name.clone(), r.auth_type))
     }
 
     /// Substitute `placeholder` in `request_text` with the real credential

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -72,6 +72,9 @@ pub mod pii_redactor;
 pub mod policy_tool_gate;
 pub mod proxy;
 pub mod reaper;
+/// Plan 129 / ADR-067 §4 + claim 13 — chain-signed `secret.substituted` /
+/// `secret.placeholder_dropped` audit events (metadata only, never the value).
+pub mod secret_audit;
 pub mod secrets_scanner;
 /// Plan 129 / ADR-067 §1 — host substitution endpoint request preparation
 /// (placeholder → real credential, binding-checked). The forward leg + the

--- a/crates/mvm-hostd/src/supervisor/secret_audit.rs
+++ b/crates/mvm-hostd/src/supervisor/secret_audit.rs
@@ -1,0 +1,136 @@
+//! Plan 129 / ADR-067 §4 + claim 13 — chain-signed audit for egress secrets.
+//!
+//! Two events, both in the `Secret` category, both carrying **metadata only** —
+//! the secret name, the destination, the auth-type — and **never the value**.
+//! This is claim 13's "no raw secret value crosses the audit chain": the label
+//! set is fixed and value-free, so a chain reader (or a leaked chain file)
+//! learns *where* a secret went, never *what* it is. The entries ride the same
+//! chain-signed stream as the claim-8 plan events, so `verify_audit_chain`
+//! (surfaced by `mvmctl audit verify`) detects any tampering.
+
+use mvm_sdk::ir::AuthType;
+
+use crate::supervisor::audit_recorder::{EventCategory, Recorder, RecorderError};
+
+fn auth_type_label(t: AuthType) -> &'static str {
+    match t {
+        AuthType::Sigv4 => "sigv4",
+        AuthType::Hmac => "hmac",
+        AuthType::Bearer => "bearer",
+        AuthType::Basic => "basic",
+    }
+}
+
+/// Emit `secret.substituted { name, destination, auth_type }` — one per secret
+/// the endpoint substituted into an outbound request. Metadata only (claim 13).
+pub async fn emit_secret_substituted(
+    recorder: &Recorder,
+    secret_name: &str,
+    destination: &str,
+    auth_type: AuthType,
+) -> Result<(), RecorderError> {
+    recorder
+        .record_unbound(
+            EventCategory::Secret,
+            "secret.substituted",
+            [
+                ("name".to_string(), secret_name.to_string()),
+                ("destination".to_string(), destination.to_string()),
+                (
+                    "auth_type".to_string(),
+                    auth_type_label(auth_type).to_string(),
+                ),
+            ],
+        )
+        .await
+}
+
+/// Emit `secret.placeholder_dropped { destination }` — a placeholder smuggled
+/// onto the raw egress wire was dropped (the E1 backstop). Metadata only.
+pub async fn emit_secret_placeholder_dropped(
+    recorder: &Recorder,
+    destination: &str,
+) -> Result<(), RecorderError> {
+    recorder
+        .record_unbound(
+            EventCategory::Secret,
+            "secret.placeholder_dropped",
+            [("destination".to_string(), destination.to_string())],
+        )
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::supervisor::audit_file::{FileAuditSigner, verify_audit_chain};
+    use ed25519_dalek::SigningKey;
+    use mvm_core::plan::TenantId;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    fn recorder_at(file: &std::path::Path) -> (Recorder, ed25519_dalek::VerifyingKey) {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let vk = signing.verifying_key();
+        let signer = FileAuditSigner::open_file(signing, file).unwrap();
+        (
+            Recorder::new(Arc::new(signer), TenantId("local".into())),
+            vk,
+        )
+    }
+
+    #[tokio::test]
+    async fn substituted_event_is_metadata_only_and_chain_verifies() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("audit.jsonl");
+        let (recorder, vk) = recorder_at(&file);
+
+        emit_secret_substituted(&recorder, "openai", "api.openai.com", AuthType::Bearer)
+            .await
+            .unwrap();
+
+        let chain = std::fs::read_to_string(&file).unwrap();
+        assert!(chain.contains("secret.substituted"));
+        assert!(chain.contains("openai"));
+        assert!(chain.contains("api.openai.com"));
+        assert!(chain.contains("bearer"));
+        // claim 13: the value never appears in the chain.
+        assert!(
+            !chain.contains("sk-live"),
+            "audit chain must not carry the secret value: {chain}"
+        );
+
+        assert_eq!(verify_audit_chain(&file, &vk).unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_tampered_entry_fails_verification() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("audit.jsonl");
+        let (recorder, vk) = recorder_at(&file);
+        emit_secret_substituted(&recorder, "openai", "api.openai.com", AuthType::Bearer)
+            .await
+            .unwrap();
+
+        // Flip the destination label after signing.
+        let tampered = std::fs::read_to_string(&file)
+            .unwrap()
+            .replace("api.openai.com", "evil.example.com");
+        std::fs::write(&file, tampered).unwrap();
+        assert!(verify_audit_chain(&file, &vk).is_err());
+    }
+
+    #[tokio::test]
+    async fn placeholder_dropped_event_records_destination() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("audit.jsonl");
+        let (recorder, vk) = recorder_at(&file);
+        emit_secret_placeholder_dropped(&recorder, "evil.example.com")
+            .await
+            .unwrap();
+        let chain = std::fs::read_to_string(&file).unwrap();
+        assert!(chain.contains("secret.placeholder_dropped"));
+        assert!(chain.contains("evil.example.com"));
+        assert_eq!(verify_audit_chain(&file, &vk).unwrap(), 1);
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -24,6 +24,7 @@ use url::Url;
 
 use mvm_core::crypto::secret_store::SecretStore;
 use mvm_core::plan::SecretBinding;
+use mvm_sdk::ir::AuthType;
 
 use crate::framing::{FrameError, read_json_frame, write_json_frame};
 use crate::keyholder::{
@@ -31,6 +32,8 @@ use crate::keyholder::{
     SubstituteError, SubstitutionEndpoint, SubstitutionRegistry, assemble_registry,
     find_placeholder,
 };
+use crate::supervisor::audit_recorder::Recorder;
+use crate::supervisor::secret_audit::emit_secret_substituted;
 use crate::supervisor::tools::http_hardening::hardened_client_builder;
 
 /// 16 MiB cap on a single routed request/response frame.
@@ -231,6 +234,9 @@ pub struct SubstitutionService {
     registry: Arc<SubstitutionRegistry>,
     resolver: Arc<dyn SecretResolver>,
     forwarder: Arc<dyn Forwarder>,
+    /// Optional chain-signed audit recorder. When set, each substitution emits
+    /// a `secret.substituted` entry (metadata only — claim 13).
+    recorder: Option<Recorder>,
 }
 
 impl SubstitutionService {
@@ -243,7 +249,15 @@ impl SubstitutionService {
             registry,
             resolver,
             forwarder,
+            recorder: None,
         }
+    }
+
+    /// Attach a chain-signed audit recorder; each substitution then emits a
+    /// `secret.substituted` entry (metadata only — claim 13).
+    pub fn with_recorder(mut self, recorder: Recorder) -> Self {
+        self.recorder = Some(recorder);
+        self
     }
 
     /// Assemble a ready-to-serve service from an admitted plan's secret
@@ -312,6 +326,16 @@ impl SubstitutionService {
         // after admission minted its placeholders.
         let registry: &SubstitutionRegistry = &self.registry;
         let endpoint = SubstitutionEndpoint::new(registry, self.resolver.as_ref());
+        // Capture audit metadata (name + auth-type per substituted secret, and
+        // the destination) before `prepare_request` consumes `req`. resolve_meta
+        // touches no value, so this is claim-13 safe.
+        let destination = destination_host(&req.url).ok();
+        let substituted: Vec<(String, AuthType)> = req
+            .headers
+            .iter()
+            .filter_map(|(_, v)| find_placeholder(v))
+            .filter_map(|ph| endpoint.resolve_meta(ph))
+            .collect();
         let prepared = match prepare_request(&endpoint, req) {
             Ok(p) => p,
             Err(e) => {
@@ -321,14 +345,36 @@ impl SubstitutionService {
             }
         };
         match self.forwarder.forward(prepared).await {
-            Ok(r) => WireResponse::Ok {
-                status: r.status,
-                headers: r.headers,
-                body_b64: B64.encode(r.body),
-            },
+            Ok(r) => {
+                self.audit_substitutions(&substituted, destination.as_deref())
+                    .await;
+                WireResponse::Ok {
+                    status: r.status,
+                    headers: r.headers,
+                    body_b64: B64.encode(r.body),
+                }
+            }
             Err(e) => WireResponse::Refused {
                 message: e.to_string(),
             },
+        }
+    }
+
+    /// Emit one `secret.substituted` audit entry per substituted secret (claim
+    /// 13 — metadata only). Best-effort: an audit failure is logged, never
+    /// fails the request. No-op when no recorder is wired.
+    async fn audit_substitutions(
+        &self,
+        substituted: &[(String, AuthType)],
+        destination: Option<&str>,
+    ) {
+        let (Some(recorder), Some(dest)) = (&self.recorder, destination) else {
+            return;
+        };
+        for (name, auth_type) in substituted {
+            if let Err(e) = emit_secret_substituted(recorder, name, dest, *auth_type).await {
+                tracing::warn!(error = %e, secret = %name, "secret.substituted audit emit failed");
+            }
         }
     }
 }
@@ -607,6 +653,69 @@ mod server_tests {
         assert!(matches!(resp, WireResponse::Refused { .. }));
         // claim 12: an unbound destination never reaches the forward leg.
         assert!(forwarder.seen.lock().unwrap().is_none());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn emits_secret_substituted_audit_on_success() {
+        use crate::supervisor::audit_file::FileAuditSigner;
+        use crate::supervisor::audit_recorder::Recorder;
+        use ed25519_dalek::SigningKey;
+        use mvm_core::plan::TenantId;
+
+        let dir = tempdir().unwrap();
+        let store = FileSecretStore::with_dir(dir.path().join("secrets"));
+        store
+            .put(
+                "local",
+                "openai",
+                &SecretBox::new(Box::new("sk-live-zzz".to_string())),
+            )
+            .unwrap();
+        let resolver: Arc<dyn SecretResolver> =
+            Arc::new(LocalResolver::new("local", Arc::new(store)));
+        let mut reg = SubstitutionRegistry::new();
+        let ph = reg
+            .mint(bearer_ref("openai", &["api.openai.com"]))
+            .as_str()
+            .to_string();
+        let forwarder = Arc::new(MockForwarder {
+            seen: Mutex::new(None),
+        });
+
+        let chain = dir.path().join("audit.jsonl");
+        let signer =
+            FileAuditSigner::open_file(SigningKey::from_bytes(&[9u8; 32]), &chain).unwrap();
+        let recorder = Recorder::new(Arc::new(signer), TenantId("local".into()));
+
+        let service = Arc::new(
+            SubstitutionService::new(Arc::new(reg), resolver, forwarder).with_recorder(recorder),
+        );
+        let sock = dir.path().join("subst.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = tokio::spawn(Arc::clone(&service).serve(listener));
+
+        let mut client = UnixStream::connect(&sock).await.unwrap();
+        let wire = WireRequest {
+            method: "POST".into(),
+            url: "https://api.openai.com/v1".into(),
+            headers: vec![("authorization".into(), format!("Bearer {ph}"))],
+            body_b64: String::new(),
+        };
+        write_json_frame(&mut client, &wire).await.unwrap();
+        // The audit emit completes before the Ok response is written, so the
+        // chain entry is on disk by the time we read the reply.
+        let _resp: WireResponse = read_json_frame(&mut client, MAX_FRAME_BYTES).await.unwrap();
+
+        let logged = std::fs::read_to_string(&chain).unwrap();
+        assert!(logged.contains("secret.substituted"), "got: {logged}");
+        assert!(logged.contains("openai"));
+        assert!(logged.contains("api.openai.com"));
+        // claim 13: the value never reaches the audit chain.
+        assert!(
+            !logged.contains("sk-live-zzz"),
+            "audit chain must not carry the secret value: {logged}"
+        );
         server.abort();
     }
 }

--- a/specs/plans/129-secrets-subsystem.md
+++ b/specs/plans/129-secrets-subsystem.md
@@ -154,10 +154,12 @@ ADR-067 §1 backstop, **expanded (owner, 2026-05-31):** the scan catches not jus
 
 ### Task E2: audit (claim 13 lineage)
 
-**Files:** the chain-signed audit emitter (`mvm-hostd` / `audit_chain`).
+**Files:** `mvm-hostd/src/supervisor/secret_audit.rs` (emit helpers) + `substitution_proxy.rs` (wiring).
 
-- [ ] **Step 1:** Failing tests — every substitution emits `secret.substituted { name, destination, auth_type }`; the audit chain **carries no secret bytes** (assert no entry contains the value); `verify_audit_chain` passes; a tampered entry fails.
-- [ ] **Step 2:** Emit the entries; reuse the claim-8 chain. Commit.
+- [x] **Step 1:** Tests — `emit_secret_substituted` writes `secret.substituted { name, destination, auth_type }` to the chain-signed stream; the chain **carries no secret value** (asserted); `verify_audit_chain` passes; a tampered entry fails verification. `emit_secret_placeholder_dropped` records `secret.placeholder_dropped { destination }`. Plus an end-to-end test: a successful substitution over the UDS endpoint emits `secret.substituted` (value absent from the chain).
+- [x] **Step 2:** Both events emit via `Recorder::record_unbound(EventCategory::Secret, …)` (same claim-8 chain). `secret.substituted` is wired **live** into `SubstitutionService` (optional `Recorder` via `with_recorder`; `resolve_meta` supplies name+auth-type without touching the value; best-effort, never fails the request). Committed.
+
+> **Deferred:** wiring `secret.placeholder_dropped` into the live packet pipeline (the drop is already audited via the generic `gateway.flow_observer_fault` with `by="placeholder-leak"`; the dedicated event is a refinement, landed with the #1b bin-glue pass).
 
 ## Phase F — the claim-12/13 gate (with 128)
 


### PR DESCRIPTION
Plan 129 Phase E2 — the chain-signed audit lineage for egress secrets (claim 13). Builds on the merged transport leg (#677) + lifecycle assembly (#680).

## What lands
- **`supervisor/secret_audit.rs`** — `emit_secret_substituted { name, destination, auth_type }` + `emit_secret_placeholder_dropped { destination }`, both via `Recorder::record_unbound(EventCategory::Secret, …)` (the same claim-8 chain). **Metadata only — never the value** (claim 13).
- **Live wiring** of `secret.substituted` into `SubstitutionService`: an optional `Recorder` (`with_recorder`) + `SubstitutionEndpoint::resolve_meta` (name+auth-type, no value touched) let the endpoint emit one entry per substituted secret after a successful forward — best-effort, never fails the request.

## Tests
- `secret.substituted` chain entry carries the labels but **not** the value; `verify_audit_chain` passes; a **tampered entry fails** verification.
- `secret.placeholder_dropped` records the destination.
- End-to-end over the UDS endpoint: a successful substitution emits `secret.substituted`, value absent from the chain.

6 new tests. Full `mvm-hostd` suite green; nightly fmt + clippy + `check-no-display-on-secret-types` clean; workspace `--all-targets` build clean.

## Deferred (tracked in the plan)
- `secret.placeholder_dropped` wiring into the live packet pipeline — the drop is already audited via the generic `gateway.flow_observer_fault` (`by="placeholder-leak"`); the dedicated event lands with the #1b bin-glue pass.