### PR TITLE
feat(plan-169): backend-agnostic proc/diff agent RPC

### DIFF
--- a/crates/mvm-backend/src/mock_guest_agent.rs
+++ b/crates/mvm-backend/src/mock_guest_agent.rs
@@ -21,8 +21,8 @@
 //!   `ProcKill`) return the matching success variant of [`ProcResult`].
 //!   `ProcStart` mints a deterministic `proc-<N>` token from an atomic
 //!   counter.
-//! - **Read-only verbs** (`FsRead`, `FsStat`, `FsList`, `ProcList`,
-//!   `ProcWait`) return empty / zero-state responses — they exist to
+//! - **Read-only verbs** (`FsRead`, `FsStat`, `FsList`, `FsDiff`,
+//!   `ProcList`, `ProcWait`) return empty / zero-state responses — they exist to
 //!   keep the wire surface complete for the pinned no-emit tests in
 //!   plan 66 W4, not to model real filesystem / proc state.
 //! - **Everything else** comes back as `GuestResponse::Error` so a
@@ -363,6 +363,14 @@ fn dispatch(req: GuestRequest, next_token: &AtomicU64) -> GuestResponse {
             GuestResponse::ProcWaitEvent(ProcWaitEvent::Exit { code: 0 })
         }
 
+        // ── Filesystem diff (Plan 169) ──────────────────────────────
+        // Mock VMs have no overlay to walk; report no changes so
+        // `mvmctl diff --hypervisor mock` succeeds rather than hitting
+        // the loud catch-all.
+        GuestRequest::FsDiff => GuestResponse::FsDiffResult {
+            changes: Vec::new(),
+        },
+
         // ── Catch-all: every other verb fails loud ──────────────────
         other => GuestResponse::Error {
             message: format!(
@@ -376,9 +384,19 @@ fn dispatch(req: GuestRequest, next_token: &AtomicU64) -> GuestResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mvm_guest::vsock::{send_fs_request, send_proc_request};
+    use mvm_guest::vsock::{
+        connect_to, query_fs_diff_on, send_fs_request, send_proc_request, send_proc_request_on,
+        send_proc_wait_on, vsock_uds_path,
+    };
     use std::collections::BTreeMap;
     use tempfile::TempDir;
+
+    /// Connect a CONNECT-handshaked stream to a running mock agent —
+    /// the same shape `mvm::vsock_transport::for_vm(...).connect(...)`
+    /// hands the backend-agnostic `*_on` helpers (Plan 169).
+    fn connect_stream(dir: &TempDir) -> std::os::unix::net::UnixStream {
+        connect_to(&vsock_uds_path(&dir.path().to_string_lossy()), 5).expect("connect mock stream")
+    }
 
     fn make_vm_dir() -> TempDir {
         tempfile::tempdir().expect("tempdir")
@@ -547,5 +565,44 @@ mod tests {
             (FsResult::Write { bytes_written: 1 }, FsResult::Write { bytes_written: 2 }) => {}
             other => panic!("expected 1-byte / 2-byte writes, got {other:?}"),
         }
+    }
+
+    // ── Plan 169: stream-based `*_on` entry points round-trip ────────
+    // These drive the new backend-agnostic helpers directly on a
+    // CONNECT-handshaked stream (what `vsock_transport::for_vm` yields
+    // for QEMU/libkrun), instead of the dir-based wrappers.
+
+    #[test]
+    fn send_proc_request_on_round_trips_proc_list() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+        let mut stream = connect_stream(&dir);
+        let result = send_proc_request_on(&mut stream, GuestRequest::ProcList).expect("proc list");
+        match result {
+            ProcResult::List { processes } => assert!(processes.is_empty()),
+            other => panic!("expected List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn send_proc_wait_on_streams_to_terminal_event() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+        let mut stream = connect_stream(&dir);
+        let terminal =
+            send_proc_wait_on(&mut stream, "proc-1", None, |_| {}).expect("proc wait stream");
+        assert!(matches!(terminal, ProcWaitEvent::Exit { code: 0 }));
+    }
+
+    #[test]
+    fn query_fs_diff_on_round_trips_empty_changes() {
+        let dir = make_vm_dir();
+        let agent = MockGuestAgent::start(dir.path()).expect("start agent");
+        let _ = &agent;
+        let mut stream = connect_stream(&dir);
+        let changes = query_fs_diff_on(&mut stream).expect("fs diff");
+        assert!(changes.is_empty());
     }
 }

--- a/crates/mvm-cli/src/commands/vm/diff.rs
+++ b/crates/mvm-cli/src/commands/vm/diff.rs
@@ -5,9 +5,9 @@ use clap::Args as ClapArgs;
 
 use crate::ui;
 
-use mvm_backend::microvm;
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
+use mvm_guest::vsock::FsChange;
 
 use super::Cli;
 use super::shared::{clap_vm_name, human_bytes};
@@ -25,8 +25,7 @@ pub(in crate::commands) struct Args {
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
     validate_vm_name(&args.name).with_context(|| format!("Invalid VM name: {:?}", args.name))?;
 
-    let instance_dir = microvm::resolve_running_vm_dir(&args.name)?;
-    let changes = mvm_guest::vsock::query_fs_diff(&instance_dir)?;
+    let changes = fs_diff(&args.name)?;
 
     if args.json {
         println!("{}", serde_json::to_string_pretty(&changes)?);
@@ -54,4 +53,19 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     }
 
     Ok(())
+}
+
+/// Fetch the guest fs-diff over the backend-aware transport (Plan 169).
+/// Like `fs::fs_request`, the `--hypervisor mock` fast path stays ahead of
+/// the `vsock_transport::for_vm` probe — which resolves the right socket per
+/// VMM (Firecracker's `v.sock`, or the per-port UNIX socket libkrun/QEMU
+/// expose) but is unaware of the in-memory mock backend.
+fn fs_diff(name: &str) -> Result<Vec<FsChange>> {
+    let mock_dir = mvm_backend::MockBackend::vm_dir(name);
+    if mock_dir.join("runtime").join("v.sock").exists() {
+        return mvm_guest::vsock::query_fs_diff(&mock_dir.to_string_lossy());
+    }
+    let mut stream =
+        mvm::vsock_transport::for_vm(name)?.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+    mvm_guest::vsock::query_fs_diff_on(&mut stream)
 }

--- a/crates/mvm-cli/src/commands/vm/proc.rs
+++ b/crates/mvm-cli/src/commands/vm/proc.rs
@@ -12,7 +12,6 @@ use clap::{Args as ClapArgs, Subcommand};
 use std::collections::BTreeMap;
 use std::io::Write;
 
-use mvm_backend::microvm;
 use mvm_core::naming::validate_vm_name;
 use mvm_core::user_config::MvmConfig;
 use mvm_guest::vsock::{GuestRequest, ProcResult, ProcWaitEvent};
@@ -124,19 +123,45 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     }
 }
 
-fn instance_dir_for(name: &str) -> Result<String> {
+/// Send a non-streaming proc-control RPC to `name`'s guest agent over the
+/// backend-aware transport (Plan 169). Like `fs::fs_request`, the
+/// `--hypervisor mock` fast path (a mock agent at the VM dir's
+/// `runtime/v.sock`) stays ahead of the `vsock_transport::for_vm` probe,
+/// which resolves the right socket per VMM (Firecracker's `v.sock`, or the
+/// per-port UNIX socket libkrun/QEMU expose) but is unaware of the in-memory
+/// mock backend.
+fn proc_request(name: &str, req: GuestRequest) -> Result<ProcResult> {
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
-    // Plan 66 W3: if a mock VM is registered at
-    // `<mvm_data_dir>/mock-vms/<name>/runtime/v.sock`, route to it
-    // directly. The check is filesystem-based — production code
-    // never reaches the mock-vms path because `MockBackend` only
-    // populates it under `--hypervisor mock`. Falls through to the
-    // Lima-era resolver when no mock is in play.
     let mock_dir = mvm_backend::MockBackend::vm_dir(name);
     if mock_dir.join("runtime").join("v.sock").exists() {
-        return Ok(mock_dir.to_string_lossy().into_owned());
+        return mvm_guest::vsock::send_proc_request(&mock_dir.to_string_lossy(), req);
     }
-    microvm::resolve_running_vm_dir(name)
+    let mut stream =
+        mvm::vsock_transport::for_vm(name)?.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+    mvm_guest::vsock::send_proc_request_on(&mut stream, req)
+}
+
+/// Stream a `ProcWait` for `name`'s guest agent over the backend-aware
+/// transport (Plan 169), same mock-vs-`for_vm` resolution as [`proc_request`].
+fn proc_wait<F: FnMut(&ProcWaitEvent)>(
+    name: &str,
+    token: &str,
+    timeout: Option<u64>,
+    on_event: F,
+) -> Result<ProcWaitEvent> {
+    validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
+    let mock_dir = mvm_backend::MockBackend::vm_dir(name);
+    if mock_dir.join("runtime").join("v.sock").exists() {
+        return mvm_guest::vsock::send_proc_wait(
+            &mock_dir.to_string_lossy(),
+            token,
+            timeout,
+            on_event,
+        );
+    }
+    let mut stream =
+        mvm::vsock_transport::for_vm(name)?.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+    mvm_guest::vsock::send_proc_wait_on(&mut stream, token, timeout, on_event)
 }
 
 fn unwrap_proc(result: ProcResult) -> Result<ProcResult> {
@@ -164,7 +189,6 @@ fn cmd_start(name: &str, argv: &[String], envs: &[String], cwd: Option<&str>) ->
     if argv.is_empty() {
         bail!("argv cannot be empty");
     }
-    let dir = instance_dir_for(name)?;
     let env = parse_envs(envs)?;
     let req = GuestRequest::ProcStart {
         argv: argv.to_vec(),
@@ -175,7 +199,7 @@ fn cmd_start(name: &str, argv: &[String], envs: &[String], cwd: Option<&str>) ->
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_proc(mvm_guest::vsock::send_proc_request(&dir, req)?)?;
+    let result = unwrap_proc(proc_request(name, req)?)?;
     match result {
         ProcResult::Started { pid_token } => {
             println!("{pid_token}");
@@ -187,13 +211,9 @@ fn cmd_start(name: &str, argv: &[String], envs: &[String], cwd: Option<&str>) ->
 }
 
 fn cmd_ls(name: &str, json: bool) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &GuestRequest::ProcList);
-    let result = unwrap_proc(mvm_guest::vsock::send_proc_request(
-        &dir,
-        GuestRequest::ProcList,
-    )?)?;
+    let result = unwrap_proc(proc_request(name, GuestRequest::ProcList)?)?;
     match result {
         ProcResult::List { processes } => {
             if json {
@@ -224,14 +244,13 @@ fn cmd_ls(name: &str, json: bool) -> Result<()> {
 }
 
 fn cmd_signal(name: &str, token: &str, signum: i32) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     let req = GuestRequest::ProcSignal {
         pid_token: token.to_string(),
         signum,
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_proc(mvm_guest::vsock::send_proc_request(&dir, req)?)?;
+    let result = unwrap_proc(proc_request(name, req)?)?;
     match result {
         ProcResult::Signaled => {
             mvm_core::audit_emit!(VmProcSignal, vm: name, "token={token} signum={signum}");
@@ -242,13 +261,12 @@ fn cmd_signal(name: &str, token: &str, signum: i32) -> Result<()> {
 }
 
 fn cmd_kill(name: &str, token: &str) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     let req = GuestRequest::ProcKill {
         pid_token: token.to_string(),
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_proc(mvm_guest::vsock::send_proc_request(&dir, req)?)?;
+    let result = unwrap_proc(proc_request(name, req)?)?;
     match result {
         ProcResult::Killed => {
             mvm_core::audit_emit!(Kill, vm: name, "scope=guest_proc token={token}");
@@ -260,7 +278,6 @@ fn cmd_kill(name: &str, token: &str) -> Result<()> {
 
 fn cmd_stdin(name: &str, token: &str, content: Option<String>) -> Result<()> {
     use std::io::Read;
-    let dir = instance_dir_for(name)?;
     let bytes = match content {
         Some(s) => s.into_bytes(),
         None => {
@@ -275,7 +292,7 @@ fn cmd_stdin(name: &str, token: &str, content: Option<String>) -> Result<()> {
     };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(name, &req);
-    let result = unwrap_proc(mvm_guest::vsock::send_proc_request(&dir, req)?)?;
+    let result = unwrap_proc(proc_request(name, req)?)?;
     match result {
         ProcResult::InputAccepted { bytes_accepted } => {
             eprintln!("accepted {bytes_accepted} bytes");
@@ -287,9 +304,8 @@ fn cmd_stdin(name: &str, token: &str, content: Option<String>) -> Result<()> {
 }
 
 fn cmd_wait(name: &str, token: &str, timeout: Option<u64>) -> Result<()> {
-    let dir = instance_dir_for(name)?;
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit. The
-    // `send_proc_wait` helper constructs the wire-format
+    // `proc_wait` helper constructs the wire-format
     // ProcWait internally; we synthesize an equivalent request
     // here purely so the audit kind_name lines up with what the
     // guest receives.
@@ -302,7 +318,7 @@ fn cmd_wait(name: &str, token: &str, timeout: Option<u64>) -> Result<()> {
     );
     let mut stdout = std::io::stdout().lock();
     let mut stderr = std::io::stderr().lock();
-    let terminal = mvm_guest::vsock::send_proc_wait(&dir, token, timeout, |ev| match ev {
+    let terminal = proc_wait(name, token, timeout, |ev| match ev {
         ProcWaitEvent::Stdout { chunk } => {
             let _ = stdout.write_all(chunk);
             let _ = stdout.flush();

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -2313,22 +2313,25 @@ pub fn exec_at(
 /// the diff.
 pub fn query_fs_diff(instance_dir: &str) -> Result<Vec<FsChange>> {
     let mut stream = connect(instance_dir, DEFAULT_TIMEOUT_SECS)?;
-    let resp = send_request(&mut stream, &GuestRequest::FsDiff)?;
-
-    match resp {
-        GuestResponse::FsDiffResult { changes } => Ok(changes),
-        GuestResponse::Error { message } => {
-            bail!("Guest fs-diff error: {}", message);
-        }
-        _ => bail!("Unexpected response to FsDiff"),
-    }
+    query_fs_diff_on(&mut stream)
 }
 
 /// Query filesystem diff at a specific UDS path.
 pub fn query_fs_diff_at(vsock_uds_path: &str) -> Result<Vec<FsChange>> {
     let mut stream = connect_to(vsock_uds_path, DEFAULT_TIMEOUT_SECS)?;
-    let resp = send_request(&mut stream, &GuestRequest::FsDiff)?;
+    query_fs_diff_on(&mut stream)
+}
 
+/// Query filesystem diff on an already-connected stream. Backend-agnostic
+/// entry point for `mvmctl diff` — the stream comes from
+/// `mvm::vsock_transport::for_vm(name)` so the verb works against any VMM
+/// (Plan 169). `FsDiff` is part of the filesystem RPC surface, so this drives
+/// the plan 74 W1 hello prelude requiring `FilesystemRpc` exactly like
+/// [`send_fs_request_on`] — the dir-based wrappers used to skip the hello,
+/// which a hard-cutover agent (ADR-053) would reject.
+pub fn query_fs_diff_on(stream: &mut UnixStream) -> Result<Vec<FsChange>> {
+    require_capabilities(stream, &[GuestCapability::FilesystemRpc])?;
+    let resp = send_request(stream, &GuestRequest::FsDiff)?;
     match resp {
         GuestResponse::FsDiffResult { changes } => Ok(changes),
         GuestResponse::Error { message } => {
@@ -2340,8 +2343,20 @@ pub fn query_fs_diff_at(vsock_uds_path: &str) -> Result<Vec<FsChange>> {
 
 /// Dispatch a non-streaming process-control request to a running
 /// VM and return the `ProcResult`. Single-frame surface — the
-/// streaming `ProcWait` verb has its own helper below.
+/// streaming `ProcWait` verb has its own helper below. Dir-based
+/// wrapper over [`send_proc_request_on`] for callers that still pass
+/// an instance dir (mvmd, mock).
 pub fn send_proc_request(instance_dir: &str, req: GuestRequest) -> Result<ProcResult> {
+    let mut stream = connect(instance_dir, DEFAULT_TIMEOUT_SECS)?;
+    send_proc_request_on(&mut stream, req)
+}
+
+/// Dispatch a non-streaming process-control verb on an already-connected
+/// stream and return the `ProcResult`. The backend-agnostic entry point:
+/// the host CLI obtains the stream from `mvm::vsock_transport::for_vm(name)`
+/// so `mvmctl proc` works regardless of which VMM launched the VM
+/// (Plan 169). `send_proc_request` is the dir-based wrapper over this.
+pub fn send_proc_request_on(stream: &mut UnixStream, req: GuestRequest) -> Result<ProcResult> {
     debug_assert!(matches!(
         req,
         GuestRequest::ProcStart { .. }
@@ -2350,9 +2365,8 @@ pub fn send_proc_request(instance_dir: &str, req: GuestRequest) -> Result<ProcRe
             | GuestRequest::ProcSendInput { .. }
             | GuestRequest::ProcKill { .. }
     ));
-    let mut stream = connect(instance_dir, DEFAULT_TIMEOUT_SECS)?;
-    require_capabilities(&mut stream, &[GuestCapability::ProcessRpc])?;
-    let resp = send_request(&mut stream, &req)?;
+    require_capabilities(stream, &[GuestCapability::ProcessRpc])?;
+    let resp = send_request(stream, &req)?;
     match resp {
         GuestResponse::ProcResult(r) => Ok(r),
         GuestResponse::Error { message } => {
@@ -2364,22 +2378,36 @@ pub fn send_proc_request(instance_dir: &str, req: GuestRequest) -> Result<ProcRe
 
 /// Stream `ProcWait` events for `pid_token`. Calls `on_event` for
 /// every non-terminal frame and returns the terminal event. Mirrors
-/// the host shape of `send_run_entrypoint`.
+/// the host shape of `send_run_entrypoint`. Dir-based wrapper over
+/// [`send_proc_wait_on`].
 pub fn send_proc_wait<F: FnMut(&ProcWaitEvent)>(
     instance_dir: &str,
     pid_token: &str,
     timeout_secs: Option<u64>,
-    mut on_event: F,
+    on_event: F,
 ) -> Result<ProcWaitEvent> {
     let mut stream = connect(instance_dir, DEFAULT_TIMEOUT_SECS)?;
-    require_capabilities(&mut stream, &[GuestCapability::ProcessRpc])?;
+    send_proc_wait_on(&mut stream, pid_token, timeout_secs, on_event)
+}
+
+/// Stream `ProcWait` events on an already-connected stream. Backend-agnostic
+/// entry point for `mvmctl proc wait` — the stream comes from
+/// `mvm::vsock_transport::for_vm(name)` so the verb works against any VMM
+/// (Plan 169). Mirrors the host shape of [`send_run_entrypoint`].
+pub fn send_proc_wait_on<F: FnMut(&ProcWaitEvent)>(
+    stream: &mut UnixStream,
+    pid_token: &str,
+    timeout_secs: Option<u64>,
+    mut on_event: F,
+) -> Result<ProcWaitEvent> {
+    require_capabilities(stream, &[GuestCapability::ProcessRpc])?;
     let req = GuestRequest::ProcWait {
         pid_token: pid_token.to_string(),
         timeout_secs,
     };
-    write_frame(&mut stream, &req)?;
+    write_frame(stream, &req)?;
     loop {
-        let resp: GuestResponse = read_frame(&mut stream)?;
+        let resp: GuestResponse = read_frame(stream)?;
         match resp {
             GuestResponse::ProcWaitEvent(ev) => {
                 if ev.is_terminal() {

--- a/specs/plans/169-agent-rpc-backend-agnostic-transport.md
+++ b/specs/plans/169-agent-rpc-backend-agnostic-transport.md
@@ -1,6 +1,6 @@
 # Plan 169 — Backend-agnostic agent-RPC transport (`fs`/`proc`/`exec`/`cp`/`diff`)
 
-## Status: IN PROGRESS (2026-06-07). `fs` + `cp` migrated + box-verified on QEMU; `proc`/`exec`/`diff` remaining. Surfaced by Plan 166 Phase 2 box verification.
+## Status: DONE (2026-06-07). All verbs (`fs`/`proc`/`exec`/`cp`/`diff`) migrated to the backend-aware transport + box-verified on QEMU. `fs`+`cp` landed in PR #681; `proc`/`exec`/`diff` in this slice. Surfaced by Plan 166 Phase 2 box verification.
 
 > **Cross-backend, not QEMU-specific.** The QEMU workload runtime (Plan 166
 > Phase 2, PR #671/#675) is the trigger, but the gap is in the shared
@@ -56,33 +56,48 @@ bridge socket), then drive the stream-based primitives.
 
 - [x] **`mvm-guest::vsock`**: `send_fs_request_on(stream, req)` added; dir-based
   `send_fs_request` delegates to it (FC/mock/mvmd dir callers unchanged).
-  (`send_proc_request_on` / `send_proc_wait_on` / `send_run_entrypoint_on`
-  still to add for the proc/exec slice.)
+  Proc/diff slice: `send_proc_request_on` / `send_proc_wait_on` /
+  `query_fs_diff_on` added the same way (dir-based `send_proc_request` /
+  `send_proc_wait` / `query_fs_diff` / `query_fs_diff_at` delegate). No
+  `send_run_entrypoint_on` was needed — `send_run_entrypoint` is already
+  stream-based. `query_fs_diff_on` adds the plan 74 W1 hello prelude
+  (`require_capabilities(FilesystemRpc)`) the old dir-based diff helpers
+  skipped — a hard-cutover agent (ADR-053) rejected the un-helloed `FsDiff`,
+  so `mvmctl diff` was latently broken on **every** backend, not just QEMU.
 - [x] **`mvmctl fs`**: `fs_request(name, req)` helper routes through
   `for_vm(name)?.connect(GUEST_AGENT_PORT)?` + `send_fs_request_on`, keeping
   the mock fast path ahead of the probe. All 7 verbs migrated; the dead
   `instance_dir_for`/`microvm` import dropped.
 - [x] **`mvmctl cp`**: routed through `fs::fs_request`.
-- [ ] **`mvmctl proc`**: add `send_proc_request_on` / `send_proc_wait_on`;
-  route `proc.rs` (its own `instance_dir_for`) through `for_vm`.
-- [ ] **`mvmctl exec` / `invoke`**: route `send_run_entrypoint` through
-  `for_vm` (confirm exec's current mechanism first).
-- [ ] **`mvmctl diff`**: route `query_fs_diff` through `for_vm` (or its
-  `_at` variant fed by the resolved socket path).
-- [ ] Keep the mock-VM fast path (`MockBackend::vm_dir/.../runtime/v.sock`)
-  working — `for_vm` doesn't know mock; either add a mock probe to `for_vm`
-  or keep the mock check ahead of the `for_vm` call in each command.
+- [x] **`mvmctl proc`**: added `send_proc_request_on` / `send_proc_wait_on`;
+  `proc.rs` now has `proc_request` / `proc_wait` helpers (mock fast path →
+  `for_vm`), dropping its own `instance_dir_for` + the `microvm` import.
+- [x] **`mvmctl exec` / `invoke`**: already backend-agnostic — `invoke.rs`'s
+  `dispatch_inner` drives `for_vm(...).connect()` + the stream-based
+  `send_run_entrypoint`. Confirmed it predates this plan; no change needed.
+  (`mvmctl exec`/`run` is the transient-VM runner and never speaks agent RPC.)
+- [x] **`mvmctl diff`**: `diff.rs` now has an `fs_diff` helper routing through
+  `for_vm` + `query_fs_diff_on` (mock fast path ahead of the probe).
+- [x] Keep the mock-VM fast path (`MockBackend::vm_dir/.../runtime/v.sock`)
+  working — kept the mock check ahead of the `for_vm` call in `proc_request` /
+  `proc_wait` / `fs_diff`, mirroring `fs::fs_request`. Added an `FsDiff` arm
+  to the mock guest agent so `mvmctl diff --hypervisor mock` succeeds.
 
 ## Verification
 
-- [ ] Unit: `for_vm` selects the libkrun/QEMU socket for a marker-resolved
-  VM; the `*_on` framing round-trips against a mock stream.
-- [ ] Box (x86_64): `mvmctl up --hypervisor qemu` then `fs ls` / `fs read` /
-  `proc list` / `cp` succeed against the live QEMU workload (agent over the
-  `__qemu-vsock-bridge`).
-- [ ] Regression: the same verbs still work against Firecracker + mock
-  (`--hypervisor mock`) + the mvmd dir-based callers compile unchanged.
-- [ ] `cargo nextest` + clippy + nightly fmt + `check-spec-numbers`.
+- [x] Unit: the `*_on` framing round-trips against a mock stream —
+  `send_proc_request_on` / `send_proc_wait_on` / `query_fs_diff_on` tests in
+  `mvm-backend::mock_guest_agent` drive a CONNECT-handshaked stream (the shape
+  `for_vm(...).connect(...)` yields). The dir-based wrappers (which delegate to
+  the `*_on` entry points) keep their existing round-trip tests.
+- [ ] Box (x86_64): `mvmctl up --hypervisor qemu` then `proc list` /
+  `proc start`+`proc wait` / `diff` / an `exec` succeed against the live QEMU
+  workload (agent over the `__qemu-vsock-bridge`). (Pending box run.)
+- [x] Regression: the same verbs still work against Firecracker + mock
+  (`--hypervisor mock`); the mvmd dir-based callers (`send_proc_request`,
+  `query_fs_diff`) compile unchanged — they now delegate to the `*_on` forms.
+- [x] `cargo nextest` (proc/diff slice) + clippy `-D warnings` + nightly fmt +
+  `check-spec-numbers`.
 
 ## Non-goals
 

--- a/specs/plans/169-agent-rpc-backend-agnostic-transport.md
+++ b/specs/plans/169-agent-rpc-backend-agnostic-transport.md
@@ -90,9 +90,16 @@ bridge socket), then drive the stream-based primitives.
   `mvm-backend::mock_guest_agent` drive a CONNECT-handshaked stream (the shape
   `for_vm(...).connect(...)` yields). The dir-based wrappers (which delegate to
   the `*_on` entry points) keep their existing round-trip tests.
-- [ ] Box (x86_64): `mvmctl up --hypervisor qemu` then `proc list` /
-  `proc start`+`proc wait` / `diff` / an `exec` succeed against the live QEMU
-  workload (agent over the `__qemu-vsock-bridge`). (Pending box run.)
+- [x] Box (x86_64): `mvmctl up --flake … --hypervisor qemu` booted
+  `mushy-house`; `mvmctl diff` and `mvmctl fs ls` returned real results
+  (full round-trips over the QEMU `vsock-5252.sock` bridge), and
+  `mvmctl proc ls/start/wait` reached the agent and returned a typed
+  `UnsupportedInProduction` (this e2e flake's agent is built without
+  `dev-shell`, so proc handlers are compiled out — orthogonal to transport).
+  The FC-style `…/runtime/v.sock` path is **absent** for the QEMU VM, so the
+  pre-migration resolver would have failed with "Vsock socket not found"; only
+  `vsock_transport::for_vm` finds the live `vsock-5252.sock`. This is the
+  end-to-end proof the transport migration works.
 - [x] Regression: the same verbs still work against Firecracker + mock
   (`--hypervisor mock`); the mvmd dir-based callers (`send_proc_request`,
   `query_fs_diff`) compile unchanged — they now delegate to the `*_on` forms.


### PR DESCRIPTION
Completes Plan 169 — the remaining `proc`, `exec`/`invoke`, and `diff` verbs of the backend-agnostic agent-RPC transport (`fs`/`cp` landed in #681).

## Problem
`mvmctl proc` and `mvmctl diff` resolved the guest vsock socket the **Firecracker** way (`instance_dir → <dir>/runtime/v.sock`), so they failed against QEMU/libkrun workloads whose agent is a per-port UNIX socket. They now route through the same backend-aware `mvm::vsock_transport::for_vm` that `wait`/`boot-report` (and `invoke`) already use.

## Changes
- **`mvm-guest::vsock`**: add stream-based `send_proc_request_on` / `send_proc_wait_on` / `query_fs_diff_on`; the dir-based `send_proc_request` / `send_proc_wait` / `query_fs_diff[_at]` now delegate to them (FC/mock/mvmd dir callers unchanged). `query_fs_diff_on` adds the plan 74 W1 hello prelude the old dir-based diff helpers **skipped** — a hard-cutover agent (ADR-053) rejected the un-helloed `FsDiff`, so `mvmctl diff` was latently broken on *every* backend.
- **`mvmctl proc`**: `proc_request` / `proc_wait` helpers (mock fast path → `for_vm`); dropped `proc.rs`'s own `instance_dir_for` + the `microvm` import.
- **`mvmctl diff`**: `fs_diff` helper through `for_vm` + `query_fs_diff_on`.
- **`mvmctl exec`/`invoke`**: already backend-agnostic (`invoke.rs::dispatch_inner`) — confirmed, no change. (`mvmctl exec`/`run` is the transient-VM runner, not agent RPC.)
- **mock guest agent**: add an `FsDiff` arm + stream-based `*_on` round-trip tests.

No new RPCs or wire-format changes — pure transport-resolution.

## Verification
- Unit: `*_on` round-trip tests in `mvm-backend::mock_guest_agent` (CONNECT-handshaked stream); dir-based wrappers keep their existing tests. `cargo clippy -D warnings`, nightly fmt, `check-spec-numbers`, `audit_total_coverage` all green locally.
- Box (x86_64 QEMU): booted a workload; `diff` + `fs ls` returned real round-trip results over the QEMU `vsock-5252.sock`; `proc ls/start/wait` reached the agent and returned a typed `UnsupportedInProduction` (e2e flake's agent built without `dev-shell` — proc handlers compiled out, orthogonal to transport). The FC-style `…/runtime/v.sock` is **absent** for the QEMU VM, so the pre-migration resolver would have failed with "Vsock socket not found"; only `for_vm` finds the live socket.