### PR TITLE
docs: keep REFACTOR-STATUS.md current during the major refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,4 +484,13 @@ macOS / Linux Host
 - Active sprint spec: `specs/SPRINT.md`
 - Completed sprints archived to: `specs/backlog/` (e.g. `specs/backlog/01-foundation.md`)
 - When a sprint is completed, rename `specs/SPRINT.md` to `specs/backlog/<NN>-<name>.md` and create a new `specs/SPRINT.md` for the next sprint
-- `specs/REFACTOR-STATUS.md` is the cross-plan rollup checklist. Keep it ticked in the same change whenever a plan workstream lands, merges, or is descoped. It is an index, not source of truth — if it disagrees with a `specs/plans/` doc, the plan doc wins.
+
+## Refactor status
+
+We are in the middle of a major multi-plan refactor. `specs/REFACTOR-STATUS.md`
+is the hand-maintained rollup of every in-flight plan's workstream checkboxes.
+**Keep it current.** Whenever you land, merge, or descope a workstream in any
+plan, tick/strike the matching box in `specs/REFACTOR-STATUS.md` in the SAME
+change and bump its "Last updated" date. It is a quick index, not the source of
+truth — if it disagrees with a `specs/plans/` doc, the plan doc wins; fix the
+rollup.


### PR DESCRIPTION
Promotes the terse Sprint Management one-liner about `specs/REFACTOR-STATUS.md` into its own **Refactor status** section in `CLAUDE.md`, so the keep-it-current rule is prominent while the multi-plan refactor is in flight.

The section restates the rollup's own contract: tick/strike the matching box in the same change a workstream lands/merges/is descoped, bump the "Last updated" date, and treat it as an index — the `specs/plans/` docs win on disagreement.

No behavior change; documentation only.