### PR TITLE
feat(plan-159 WS-5 E): truly streamed exec (ExecEvent, progressive)

### DIFF
--- a/crates/mvm-backend/src/base/linux_env.rs
+++ b/crates/mvm-backend/src/base/linux_env.rs
@@ -186,35 +186,32 @@ impl AppleContainerEnv {
         let mut stream = self.connect_with_auto_start()?;
 
         let wrapped = format!("{SUDO_SHIM}\n{script}");
-        let resp = mvm_guest::vsock::send_request(
+        let mut out_buf: Vec<u8> = Vec::new();
+        let mut err_buf: Vec<u8> = Vec::new();
+        // Plan 159 WS-5 E: accumulate streamed ExecEvent chunks.
+        let terminal = mvm_guest::vsock::send_exec_streaming(
             &mut stream,
-            &mvm_guest::vsock::GuestRequest::Exec {
-                command: wrapped,
-                stdin: None,
-                timeout_secs: Some(timeout_secs),
+            &wrapped,
+            None,
+            timeout_secs,
+            |event| match event {
+                mvm_guest::vsock::ExecEvent::Stdout { chunk } => out_buf.extend_from_slice(chunk),
+                mvm_guest::vsock::ExecEvent::Stderr { chunk } => err_buf.extend_from_slice(chunk),
+                _ => {}
             },
         )
         .with_context(|| format!("Failed to execute command in dev VM '{}'", self.vm_id))?;
 
-        match resp {
-            mvm_guest::vsock::GuestResponse::ExecResult {
-                exit_code,
-                stdout,
-                stderr,
-            } => {
+        match terminal {
+            mvm_guest::vsock::ExecEvent::Exit { code } => {
                 use std::os::unix::process::ExitStatusExt;
                 Ok(Output {
-                    status: std::process::ExitStatus::from_raw(exit_code << 8),
-                    stdout: stdout.into_bytes(),
-                    stderr: stderr.into_bytes(),
+                    status: std::process::ExitStatus::from_raw(code << 8),
+                    stdout: out_buf,
+                    stderr: err_buf,
                 })
             }
-            mvm_guest::vsock::GuestResponse::Error { message } => {
-                anyhow::bail!("Dev VM exec error: {message}");
-            }
-            other => {
-                anyhow::bail!("Unexpected response from dev VM: {other:?}");
-            }
+            other => anyhow::bail!("unexpected terminal exec event from dev VM: {other:?}"),
         }
     }
 }

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -461,17 +461,28 @@ pub(super) fn cmd_dev_apple_container_status() -> Result<()> {
             mvm_guest::vsock::GUEST_AGENT_PORT,
         )
     {
-        let req = mvm_guest::vsock::GuestRequest::Exec {
-            command: "uname -r".to_string(),
-            stdin: None,
-            timeout_secs: Some(5),
-        };
         // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
-        super::super::shared::emit_vsock_rpc_audit(DEV_VM_NAME, &req);
-        if let Ok(mvm_guest::vsock::GuestResponse::ExecResult { stdout, .. }) =
-            mvm_guest::vsock::send_request(&mut stream, &req)
+        super::super::shared::emit_vsock_rpc_audit(
+            DEV_VM_NAME,
+            &mvm_guest::vsock::GuestRequest::Exec {
+                command: "uname -r".to_string(),
+                stdin: None,
+                timeout_secs: Some(5),
+            },
+        );
+        // Best-effort kernel probe via streaming exec (Plan 159 WS-5 E).
+        let mut out_buf: Vec<u8> = Vec::new();
+        if mvm_guest::vsock::send_exec_streaming(&mut stream, "uname -r", None, 5, |event| {
+            if let mvm_guest::vsock::ExecEvent::Stdout { chunk } = event {
+                out_buf.extend_from_slice(chunk);
+            }
+        })
+        .is_ok()
         {
-            ui::info(&format!("  Kernel:  {}", stdout.trim()));
+            ui::info(&format!(
+                "  Kernel:  {}",
+                String::from_utf8_lossy(&out_buf).trim()
+            ));
         }
     }
 

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -101,40 +101,44 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     if let Some(cmd) = command {
         let transport = pick_console_transport(name)?;
         let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
-        // ADR-053 / plan 74 W1: hard cutover requires hello before any
-        // operational request. One-shot `Exec` is a dev-shell request
-        // not covered by the closed `GuestCapability` enum, so request
-        // no specific capability — the hello alone unblocks dispatch.
-        let _ = mvm_guest::vsock::negotiate_protocol(&mut stream, Vec::new())?;
-        let req = mvm_guest::vsock::GuestRequest::Exec {
-            command: cmd.to_string(),
-            stdin: None,
-            timeout_secs: Some(30),
-        };
-        // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
-        super::shared::emit_vsock_rpc_audit(name, &req);
-        let resp = mvm_guest::vsock::send_request(&mut stream, &req)?;
-        match resp {
-            mvm_guest::vsock::GuestResponse::ExecResult {
-                exit_code,
-                stdout,
-                stderr,
-            } => {
-                if !stdout.is_empty() {
-                    print!("{stdout}");
+        // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit (verb=exec).
+        super::shared::emit_vsock_rpc_audit(
+            name,
+            &mvm_guest::vsock::GuestRequest::Exec {
+                command: cmd.to_string(),
+                stdin: None,
+                timeout_secs: Some(30),
+            },
+        );
+        // send_exec_streaming does the protocol hello internally (Plan 159 WS-5 E).
+        use std::io::Write as _;
+        let terminal = mvm_guest::vsock::send_exec_streaming(
+            &mut stream,
+            cmd,
+            None,
+            30,
+            |event| match event {
+                mvm_guest::vsock::ExecEvent::Stdout { chunk } => {
+                    let mut so = std::io::stdout();
+                    let _ = so.write_all(chunk);
+                    let _ = so.flush();
                 }
-                if !stderr.is_empty() {
-                    eprint!("{stderr}");
+                mvm_guest::vsock::ExecEvent::Stderr { chunk } => {
+                    let mut se = std::io::stderr();
+                    let _ = se.write_all(chunk);
+                    let _ = se.flush();
                 }
-                if exit_code != 0 {
-                    std::process::exit(exit_code);
+                _ => {}
+            },
+        )?;
+        match terminal {
+            mvm_guest::vsock::ExecEvent::Exit { code } => {
+                if code != 0 {
+                    std::process::exit(code);
                 }
                 Ok(())
             }
-            mvm_guest::vsock::GuestResponse::Error { message } => {
-                anyhow::bail!("Console exec error: {message}")
-            }
-            other => anyhow::bail!("Unexpected response: {other:?}"),
+            other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
         }
     } else {
         // Interactive PTY session

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -765,21 +765,23 @@ fn dispatch_run_code(
     let req = mvm_guest::vsock::GuestRequest::RunCode { code, timeout_secs };
     // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit.
     super::shared::emit_vsock_rpc_audit(&record.vm_name, &req);
-    let resp = mvm_guest::vsock::send_request(&mut stream, &req)?;
-    let (exit_code, stdout, stderr) = match resp {
-        mvm_guest::vsock::GuestResponse::ExecResult {
-            exit_code,
-            stdout,
-            stderr,
-        } => (exit_code, stdout, stderr),
-        mvm_guest::vsock::GuestResponse::Error { message } => {
-            bail!("guest run-code error: {message}")
+    // RunCode now streams ExecEvent frames (Plan 159 WS-5 E). The hello +
+    // request write above mirror the old send_request path; read_exec_stream
+    // takes over from here.
+    mvm_guest::vsock::write_frame(&mut stream, &req)?;
+    let terminal = mvm_guest::vsock::read_exec_stream(&mut stream, |event| match event {
+        mvm_guest::vsock::ExecEvent::Stdout { chunk } => {
+            let _ = std::io::stdout().write_all(chunk);
         }
-        other => bail!("unexpected response to RunCode: {other:?}"),
+        mvm_guest::vsock::ExecEvent::Stderr { chunk } => {
+            let _ = std::io::stderr().write_all(chunk);
+        }
+        _ => {}
+    })?;
+    let exit_code = match terminal {
+        mvm_guest::vsock::ExecEvent::Exit { code } => code,
+        other => bail!("unexpected terminal exec event: {other:?}"),
     };
-
-    let _ = std::io::stdout().write_all(stdout.as_bytes());
-    let _ = std::io::stderr().write_all(stderr.as_bytes());
 
     if let Err(e) = session::update_session(id, |r| {
         r.invoke_count = r.invoke_count.saturating_add(1);

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -771,10 +771,14 @@ fn dispatch_run_code(
     mvm_guest::vsock::write_frame(&mut stream, &req)?;
     let terminal = mvm_guest::vsock::read_exec_stream(&mut stream, |event| match event {
         mvm_guest::vsock::ExecEvent::Stdout { chunk } => {
-            let _ = std::io::stdout().write_all(chunk);
+            let mut so = std::io::stdout();
+            let _ = so.write_all(chunk);
+            let _ = so.flush();
         }
         mvm_guest::vsock::ExecEvent::Stderr { chunk } => {
-            let _ = std::io::stderr().write_all(chunk);
+            let mut se = std::io::stderr();
+            let _ = se.write_all(chunk);
+            let _ = se.flush();
         }
         _ => {}
     })?;

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -940,6 +940,16 @@ pub fn dispatch_in_session(vm: &SessionVm, code: String, timeout_secs: u64) -> R
     let wrapper = build_guest_wrapper(&req, &[]);
     let transport = vsock_transport::for_vm(&vm.vm_name)?;
     let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+    // Plan 74 W2 — inbound vsock RPC audit. Mirrors run_in_guest's emit;
+    // was lost when this function migrated from send_request to
+    // send_exec_streaming.
+    let verb = "exec";
+    mvm_core::audit_emit!(
+        NetworkPolicyAllow,
+        vm: &vm.vm_name,
+        "scope=rpc,direction=in,kind=vsock,verb={verb}",
+        verb = verb,
+    );
 
     let mut out = Vec::<u8>::new();
     let mut err = Vec::<u8>::new();

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -737,37 +737,70 @@ fn run_in_guest(
     labels: &[String],
     capture: bool,
 ) -> Result<Either<i32, ExecOutput>> {
+    use std::io::Write as _;
     if !wait_for_agent(vm_name, 30) {
         anyhow::bail!("guest agent did not become reachable within 30s");
     }
     let wrapper = build_guest_wrapper(req, labels);
-    let resp = send_request(vm_name, &wrapper, req.timeout_secs)?;
-    match resp {
-        mvm_guest::vsock::GuestResponse::ExecResult {
-            exit_code,
-            stdout,
-            stderr,
-        } => {
-            if capture {
-                Ok(Either::Right(ExecOutput {
-                    exit_code,
-                    stdout,
-                    stderr,
-                }))
-            } else {
-                if !stdout.is_empty() {
-                    print!("{stdout}");
+
+    let transport = vsock_transport::for_vm(vm_name)?;
+    let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+    // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit. exec.rs
+    // is a top-level module that can't reach the private
+    // `commands::shared` re-export, so inline the audit emit
+    // here. The detail format matches
+    // `commands::shared::vsock::emit_vsock_rpc_audit`:
+    // `scope=rpc,direction=in,kind=vsock,verb=<kebab-name>`.
+    let verb = "exec";
+    mvm_core::audit_emit!(
+        NetworkPolicyAllow,
+        vm: vm_name,
+        "scope=rpc,direction=in,kind=vsock,verb={verb}",
+        verb = verb,
+    );
+
+    let mut out = Vec::<u8>::new();
+    let mut err = Vec::<u8>::new();
+    let terminal = mvm_guest::vsock::send_exec_streaming(
+        &mut stream,
+        &wrapper,
+        None,
+        req.timeout_secs,
+        |event| match event {
+            mvm_guest::vsock::ExecEvent::Stdout { chunk } => {
+                if capture {
+                    out.extend_from_slice(chunk);
+                } else {
+                    let mut so = std::io::stdout();
+                    let _ = so.write_all(chunk);
+                    let _ = so.flush();
                 }
-                if !stderr.is_empty() {
-                    eprint!("{stderr}");
-                }
-                Ok(Either::Left(exit_code))
             }
-        }
-        mvm_guest::vsock::GuestResponse::Error { message } => {
-            anyhow::bail!("guest exec error: {message}")
-        }
-        other => anyhow::bail!("unexpected guest response: {other:?}"),
+            mvm_guest::vsock::ExecEvent::Stderr { chunk } => {
+                if capture {
+                    err.extend_from_slice(chunk);
+                } else {
+                    let mut se = std::io::stderr();
+                    let _ = se.write_all(chunk);
+                    let _ = se.flush();
+                }
+            }
+            _ => {}
+        },
+    )?;
+    let exit_code = match terminal {
+        mvm_guest::vsock::ExecEvent::Exit { code } => code,
+        other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
+    };
+
+    if capture {
+        Ok(Either::Right(ExecOutput {
+            exit_code,
+            stdout: String::from_utf8_lossy(&out).into_owned(),
+            stderr: String::from_utf8_lossy(&err).into_owned(),
+        }))
+    } else {
+        Ok(Either::Left(exit_code))
     }
 }
 
@@ -905,22 +938,31 @@ pub fn dispatch_in_session(vm: &SessionVm, code: String, timeout_secs: u64) -> R
         timeout_secs,
     };
     let wrapper = build_guest_wrapper(&req, &[]);
-    let resp = send_request(&vm.vm_name, &wrapper, timeout_secs)?;
-    match resp {
-        mvm_guest::vsock::GuestResponse::ExecResult {
-            exit_code,
-            stdout,
-            stderr,
-        } => Ok(ExecOutput {
-            exit_code,
-            stdout,
-            stderr,
-        }),
-        mvm_guest::vsock::GuestResponse::Error { message } => {
-            anyhow::bail!("guest exec error: {message}")
-        }
-        other => anyhow::bail!("unexpected guest response: {other:?}"),
-    }
+    let transport = vsock_transport::for_vm(&vm.vm_name)?;
+    let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+
+    let mut out = Vec::<u8>::new();
+    let mut err = Vec::<u8>::new();
+    let terminal = mvm_guest::vsock::send_exec_streaming(
+        &mut stream,
+        &wrapper,
+        None,
+        timeout_secs,
+        |event| match event {
+            mvm_guest::vsock::ExecEvent::Stdout { chunk } => out.extend_from_slice(chunk),
+            mvm_guest::vsock::ExecEvent::Stderr { chunk } => err.extend_from_slice(chunk),
+            _ => {}
+        },
+    )?;
+    let exit_code = match terminal {
+        mvm_guest::vsock::ExecEvent::Exit { code } => code,
+        other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
+    };
+    Ok(ExecOutput {
+        exit_code,
+        stdout: String::from_utf8_lossy(&out).into_owned(),
+        stderr: String::from_utf8_lossy(&err).into_owned(),
+    })
 }
 
 /// Tear down a session VM. Best-effort — failures (already-stopped,
@@ -959,40 +1001,6 @@ pub fn wait_for_agent(vm_name: &str, timeout_secs: u64) -> bool {
         std::thread::sleep(std::time::Duration::from_millis(500));
     }
     false
-}
-
-fn send_request(
-    vm_name: &str,
-    command: &str,
-    timeout_secs: u64,
-) -> Result<mvm_guest::vsock::GuestResponse> {
-    let transport = vsock_transport::for_vm(vm_name)?;
-    let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
-    // ADR-053 / plan 74 W1: hard cutover requires every fresh session
-    // to hello before any operational request. `Exec` is a dev-shell
-    // request not covered by the closed `GuestCapability` enum, so
-    // request no specific capability — the hello alone unblocks the
-    // dispatch.
-    let _ = mvm_guest::vsock::negotiate_protocol(&mut stream, Vec::new())?;
-    let request = mvm_guest::vsock::GuestRequest::Exec {
-        command: command.to_string(),
-        stdin: None,
-        timeout_secs: Some(timeout_secs),
-    };
-    // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit. exec.rs
-    // is a top-level module that can't reach the private
-    // `commands::shared` re-export, so inline the audit emit
-    // here. The detail format matches
-    // `commands::shared::vsock::emit_vsock_rpc_audit`:
-    // `scope=rpc,direction=in,kind=vsock,verb=<kebab-name>`.
-    let verb = request.kind_name();
-    mvm_core::audit_emit!(
-        NetworkPolicyAllow,
-        vm: vm_name,
-        "scope=rpc,direction=in,kind=vsock,verb={verb}",
-        verb = verb,
-    );
-    mvm_guest::vsock::send_request(&mut stream, &request)
 }
 
 #[cfg(test)]

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -1006,28 +1006,33 @@ fn do_run_code(file: &mut std::fs::File, code: &str, _timeout_secs: u64) -> Gues
     let lang = match read_wrapper_language() {
         Some(l) => l,
         None => {
-            return GuestResponse::ExecResult {
-                exit_code: -1,
-                stdout: String::new(),
-                stderr: "run-code refused: /etc/mvm/wrapper.json missing or has no \
+            write_response(
+                file,
+                &GuestResponse::ExecEvent(mvm_guest::vsock::ExecEvent::Stderr {
+                    chunk: b"run-code refused: /etc/mvm/wrapper.json missing or has no \
                          language field"
-                    .into(),
-            };
+                        .to_vec(),
+                }),
+            );
+            return GuestResponse::ExecEvent(mvm_guest::vsock::ExecEvent::Exit { code: -1 });
         }
     };
     let interpreter = match lang.as_str() {
         "python" => "python3",
         "node" => "node",
         other => {
-            return GuestResponse::ExecResult {
-                exit_code: -1,
-                stdout: String::new(),
-                stderr: format!(
-                    "run-code refused: unsupported language {:?} \
+            write_response(
+                file,
+                &GuestResponse::ExecEvent(mvm_guest::vsock::ExecEvent::Stderr {
+                    chunk: format!(
+                        "run-code refused: unsupported language {:?} \
                      (supported: python, node)",
-                    other
-                ),
-            };
+                        other
+                    )
+                    .into_bytes(),
+                }),
+            );
+            return GuestResponse::ExecEvent(mvm_guest::vsock::ExecEvent::Exit { code: -1 });
         }
     };
     // Build the shell command. Single-quote the code so the shell

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -966,70 +966,20 @@ fn handle_proc_wait_streaming(
     })
 }
 
-/// Maximum output size per stream (1 MiB) to prevent OOM from unbounded output.
+/// `Exec` streaming arm — writes intermediate `ExecEvent` Stdout/Stderr
+/// frames to the connection and returns the terminal `Exit` for the
+/// dispatch loop to write last. Mirrors `handle_run_entrypoint` /
+/// `handle_proc_wait_streaming`. Plan 159 WS-5 E. (dev-shell only)
 #[cfg(feature = "dev-shell")]
-const MAX_EXEC_OUTPUT: usize = 1024 * 1024;
-
-/// Run a command via `sh -c` and capture output (dev-only, feature-gated).
-#[cfg(feature = "dev-shell")]
-fn do_exec(command: &str, stdin_data: Option<&str>, _timeout_secs: u64) -> GuestResponse {
-    use std::process::{Command, Stdio};
-
-    let mut child = match Command::new("/bin/sh")
-        .arg("-c")
-        .arg(command)
-        .stdin(if stdin_data.is_some() {
-            Stdio::piped()
-        } else {
-            Stdio::null()
-        })
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            return GuestResponse::ExecResult {
-                exit_code: -1,
-                stdout: String::new(),
-                stderr: format!("failed to spawn: {}", e),
-            };
-        }
-    };
-
-    if let Some(data) = stdin_data
-        && let Some(ref mut pipe) = child.stdin
-        && let Err(e) = pipe.write_all(data.as_bytes())
-    {
-        eprintln!("failed to write to pipe: {e}");
-    }
-    drop(child.stdin.take());
-
-    match child.wait_with_output() {
-        Ok(out) => {
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            let truncate = |s: &str| -> String {
-                if s.len() > MAX_EXEC_OUTPUT {
-                    let mut t = s[..MAX_EXEC_OUTPUT].to_string();
-                    t.push_str("\n... (truncated)");
-                    t
-                } else {
-                    s.to_string()
-                }
-            };
-            GuestResponse::ExecResult {
-                exit_code: out.status.code().unwrap_or(-1),
-                stdout: truncate(&stdout),
-                stderr: truncate(&stderr),
-            }
-        }
-        Err(e) => GuestResponse::ExecResult {
-            exit_code: -1,
-            stdout: String::new(),
-            stderr: format!("wait failed: {}", e),
-        },
-    }
+fn do_exec_streaming(
+    file: &mut std::fs::File,
+    command: &str,
+    stdin_data: Option<&str>,
+) -> GuestResponse {
+    let terminal = mvm_guest::exec_stream::stream_exec(command, stdin_data, |ev| {
+        write_response(file, &GuestResponse::ExecEvent(ev));
+    });
+    GuestResponse::ExecEvent(terminal)
 }
 
 /// Read the wrapper's language from `/etc/mvm/wrapper.json`. Returns
@@ -1045,14 +995,14 @@ fn read_wrapper_language() -> Option<String> {
 
 /// Stateless run-code v1: dispatch a fresh interpreter subprocess
 /// with the user-supplied source on its `-c` / `-e` arg. Refuses
-/// unknown languages with a wire-stable error string. Reuses the
-/// same `/bin/sh -c` mechanics as `do_exec` for capture + truncation.
+/// unknown languages with a wire-stable error string. Streams output
+/// via `do_exec_streaming` (Plan 159 WS-5 E).
 ///
 /// Plan-0010 Choice A v2 will route through the warm-process pool
 /// instead, providing stateful eval across calls. Wire shape stays
 /// identical — the dispatch flips inside this function.
 #[cfg(feature = "dev-shell")]
-fn do_run_code(code: &str, timeout_secs: u64) -> GuestResponse {
+fn do_run_code(file: &mut std::fs::File, code: &str, _timeout_secs: u64) -> GuestResponse {
     let lang = match read_wrapper_language() {
         Some(l) => l,
         None => {
@@ -1090,7 +1040,7 @@ fn do_run_code(code: &str, timeout_secs: u64) -> GuestResponse {
         interp_flag,
         shell_quote_for_sh(code)
     );
-    do_exec(&shell_command, None, timeout_secs)
+    do_exec_streaming(file, &shell_command, None)
 }
 
 /// Single-quote `s` for `/bin/sh` consumption: doubles up embedded
@@ -2163,10 +2113,10 @@ fn handle_client(
         GuestRequest::Exec {
             command,
             stdin,
-            timeout_secs,
+            timeout_secs: _,
         } => {
             eprintln!("[audit] exec request: {:?}", command);
-            do_exec(&command, stdin.as_deref(), timeout_secs.unwrap_or(30))
+            do_exec_streaming(&mut file, &command, stdin.as_deref())
         }
 
         #[cfg(not(feature = "dev-shell"))]
@@ -2186,7 +2136,7 @@ fn handle_client(
             // run-code`'s host-side audit posture — argv / code can
             // carry user-typed secrets).
             eprintln!("[audit] run-code request");
-            do_run_code(&code, timeout_secs)
+            do_run_code(&mut file, &code, timeout_secs)
         }
 
         #[cfg(not(feature = "dev-shell"))]

--- a/crates/mvm-guest/src/exec_stream.rs
+++ b/crates/mvm-guest/src/exec_stream.rs
@@ -1,0 +1,201 @@
+//! Streaming exec core (dev-shell only). Runs `sh -c <command>` and emits
+//! `ExecEvent` chunks via an `emit` closure as the child produces output,
+//! returning the terminal `Exit`. The wire-writing lives in the agent bin
+//! (`do_exec_streaming`); this core is closure-driven so it is unit-
+//! testable without a vsock `File`. Mirrors `process_rpc::spawn_drain` +
+//! the `handle_proc_wait` sleep-poll loop (the in-repo streaming idiom —
+//! mvm-guest has no `libc::poll` usage). Plan 159 WS-5 E.
+#![cfg(feature = "dev-shell")]
+
+use crate::vsock::ExecEvent;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Per-stream total-byte cap (1 MiB) — bounds host capture-mode memory
+/// (was `MAX_EXEC_OUTPUT` in the agent bin).
+pub const MAX_EXEC_OUTPUT: usize = 1024 * 1024;
+const DRAIN_BUF: usize = 4096;
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+fn spawn_drain<R: Read + Send + 'static>(mut reader: R, buf: Arc<Mutex<Vec<u8>>>) {
+    std::thread::spawn(move || {
+        let mut chunk = [0u8; DRAIN_BUF];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => buf
+                    .lock()
+                    .expect("exec drain buf")
+                    .extend_from_slice(&chunk[..n]),
+                Err(_) => break,
+            }
+        }
+    });
+}
+
+/// Emit newly-buffered bytes (past `*sent`) as one chunk, capped at
+/// `MAX_EXEC_OUTPUT` total per stream. Returns true if the cap was hit
+/// (caller should stop and truncate).
+fn drain_into<F: FnMut(ExecEvent)>(
+    buf: &Arc<Mutex<Vec<u8>>>,
+    sent: &mut usize,
+    stdout: bool,
+    emit: &mut F,
+) -> bool {
+    let b = buf.lock().expect("exec drain buf");
+    if b.len() <= *sent {
+        return false;
+    }
+    let room = MAX_EXEC_OUTPUT.saturating_sub(*sent);
+    if room == 0 {
+        return true;
+    }
+    let new = &b[*sent..];
+    let take = new.len().min(room);
+    let chunk = new[..take].to_vec();
+    emit(if stdout {
+        ExecEvent::Stdout { chunk }
+    } else {
+        ExecEvent::Stderr { chunk }
+    });
+    *sent += take;
+    take < new.len()
+}
+
+/// Run `command` under `/bin/sh -c`, streaming stdout/stderr via `emit`
+/// (arrival order, ~poll-interval granularity), and return the terminal
+/// `ExecEvent::Exit`. `emit` is never called with `Exit` — that is the
+/// return value.
+pub fn stream_exec<F: FnMut(ExecEvent)>(
+    command: &str,
+    stdin_data: Option<&str>,
+    mut emit: F,
+) -> ExecEvent {
+    let mut child = match Command::new("/bin/sh")
+        .arg("-c")
+        .arg(command)
+        .stdin(if stdin_data.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            emit(ExecEvent::Stderr {
+                chunk: format!("failed to spawn: {e}").into_bytes(),
+            });
+            return ExecEvent::Exit { code: -1 };
+        }
+    };
+
+    if let Some(data) = stdin_data
+        && let Some(ref mut pipe) = child.stdin
+        && let Err(e) = pipe.write_all(data.as_bytes())
+    {
+        eprintln!("failed to write exec stdin pipe: {e}");
+    }
+    drop(child.stdin.take());
+
+    let out_buf = Arc::new(Mutex::new(Vec::new()));
+    let err_buf = Arc::new(Mutex::new(Vec::new()));
+    if let Some(o) = child.stdout.take() {
+        spawn_drain(o, out_buf.clone());
+    }
+    if let Some(e) = child.stderr.take() {
+        spawn_drain(e, err_buf.clone());
+    }
+
+    let mut sent_out = 0usize;
+    let mut sent_err = 0usize;
+
+    loop {
+        let capped = drain_into(&out_buf, &mut sent_out, true, &mut emit)
+            | drain_into(&err_buf, &mut sent_err, false, &mut emit);
+        if capped {
+            let _ = child.kill();
+            let _ = child.wait();
+            emit(ExecEvent::Stderr {
+                chunk: b"\n... (truncated)".to_vec(),
+            });
+            return ExecEvent::Exit { code: -1 };
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                // Child exited: let the drain threads flush the tail,
+                // then emit any remaining bytes.
+                std::thread::sleep(POLL_INTERVAL);
+                let _ = drain_into(&out_buf, &mut sent_out, true, &mut emit);
+                let _ = drain_into(&err_buf, &mut sent_err, false, &mut emit);
+                return ExecEvent::Exit {
+                    code: status.code().unwrap_or(-1),
+                };
+            }
+            Ok(None) => std::thread::sleep(POLL_INTERVAL),
+            Err(e) => {
+                emit(ExecEvent::Stderr {
+                    chunk: format!("wait failed: {e}").into_bytes(),
+                });
+                return ExecEvent::Exit { code: -1 };
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn streams_stdout_then_exit_zero() {
+        let mut events = Vec::new();
+        let term = stream_exec("printf hello", None, |e| events.push(e));
+        assert!(matches!(term, ExecEvent::Exit { code: 0 }));
+        let out: Vec<u8> = events
+            .iter()
+            .filter_map(|e| match e {
+                ExecEvent::Stdout { chunk } => Some(chunk.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        assert_eq!(out, b"hello");
+    }
+
+    #[test]
+    fn captures_stderr_and_nonzero_exit() {
+        let mut events = Vec::new();
+        let term = stream_exec("printf oops 1>&2; exit 3", None, |e| events.push(e));
+        assert!(matches!(term, ExecEvent::Exit { code: 3 }));
+        let err: Vec<u8> = events
+            .iter()
+            .filter_map(|e| match e {
+                ExecEvent::Stderr { chunk } => Some(chunk.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        assert_eq!(err, b"oops");
+    }
+
+    #[test]
+    fn pipes_stdin() {
+        let mut events = Vec::new();
+        let term = stream_exec("cat", Some("piped"), |e| events.push(e));
+        assert!(matches!(term, ExecEvent::Exit { code: 0 }));
+        let out: Vec<u8> = events
+            .iter()
+            .filter_map(|e| match e {
+                ExecEvent::Stdout { chunk } => Some(chunk.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        assert_eq!(out, b"piped");
+    }
+}

--- a/crates/mvm-guest/src/exec_stream.rs
+++ b/crates/mvm-guest/src/exec_stream.rs
@@ -19,7 +19,10 @@ pub const MAX_EXEC_OUTPUT: usize = 1024 * 1024;
 const DRAIN_BUF: usize = 4096;
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-fn spawn_drain<R: Read + Send + 'static>(mut reader: R, buf: Arc<Mutex<Vec<u8>>>) {
+fn spawn_drain<R: Read + Send + 'static>(
+    mut reader: R,
+    buf: Arc<Mutex<Vec<u8>>>,
+) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let mut chunk = [0u8; DRAIN_BUF];
         loop {
@@ -32,7 +35,7 @@ fn spawn_drain<R: Read + Send + 'static>(mut reader: R, buf: Arc<Mutex<Vec<u8>>>
                 Err(_) => break,
             }
         }
-    });
+    })
 }
 
 /// Emit newly-buffered bytes (past `*sent`) as one chunk, capped at
@@ -104,12 +107,8 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
 
     let out_buf = Arc::new(Mutex::new(Vec::new()));
     let err_buf = Arc::new(Mutex::new(Vec::new()));
-    if let Some(o) = child.stdout.take() {
-        spawn_drain(o, out_buf.clone());
-    }
-    if let Some(e) = child.stderr.take() {
-        spawn_drain(e, err_buf.clone());
-    }
+    let mut out_handle = child.stdout.take().map(|o| spawn_drain(o, out_buf.clone()));
+    let mut err_handle = child.stderr.take().map(|e| spawn_drain(e, err_buf.clone()));
 
     let mut sent_out = 0usize;
     let mut sent_err = 0usize;
@@ -127,9 +126,16 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
         }
         match child.try_wait() {
             Ok(Some(status)) => {
-                // Child exited: let the drain threads flush the tail,
-                // then emit any remaining bytes.
-                std::thread::sleep(POLL_INTERVAL);
+                // Child exited: join the drain threads so every buffered
+                // byte has been appended (a happens-before edge — the
+                // thread only returns after its final append), then flush
+                // the tail. Avoids the timing race a bare sleep would have.
+                if let Some(h) = out_handle.take() {
+                    let _ = h.join();
+                }
+                if let Some(h) = err_handle.take() {
+                    let _ = h.join();
+                }
                 let _ = drain_into(&out_buf, &mut sent_out, true, &mut emit);
                 let _ = drain_into(&err_buf, &mut sent_err, false, &mut emit);
                 return ExecEvent::Exit {
@@ -197,5 +203,26 @@ mod tests {
             .flatten()
             .collect();
         assert_eq!(out, b"piped");
+    }
+
+    #[test]
+    fn large_final_write_is_not_truncated() {
+        // Emit ~256 KiB right before exit; the joined drain must capture all of it.
+        // head -c 262144 /dev/zero is standard on macOS + Linux (POSIX).
+        // 262144 < MAX_EXEC_OUTPUT (1 MiB) so the cap is not hit.
+        let mut events = Vec::new();
+        let term = stream_exec("head -c 262144 /dev/zero", None, |e| events.push(e));
+        assert!(matches!(term, ExecEvent::Exit { code: 0 }));
+        let total: usize = events
+            .iter()
+            .filter_map(|e| match e {
+                ExecEvent::Stdout { chunk } => Some(chunk.len()),
+                _ => None,
+            })
+            .sum();
+        assert_eq!(
+            total, 262144,
+            "all 256 KiB of stdout must be streamed, none lost"
+        );
     }
 }

--- a/crates/mvm-guest/src/lib.rs
+++ b/crates/mvm-guest/src/lib.rs
@@ -49,3 +49,7 @@ pub mod worker_protocol;
 /// production guest agents (ADR-002 §W4.3 + ADR-007 §W5).
 #[cfg(feature = "dev-shell")]
 pub mod process_rpc;
+
+/// Streaming exec core — runs `sh -c <cmd>` and emits `ExecEvent` chunks
+/// via a closure. Dev-only (claim 4 / ADR-002 §W4.3). Plan 159 WS-5 E.
+pub mod exec_stream;

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -2158,6 +2158,43 @@ where
     }
 }
 
+/// Send an `Exec` request and stream its response. Invokes `on_event`
+/// for each `Stdout`/`Stderr` chunk as it arrives; returns the terminal
+/// `Exit`. Exec carries no `GuestCapability` — the agent gates it at
+/// compile time via the `dev-shell` feature — so this does a plain
+/// protocol hello (no capability requirement). Plan 159 WS-5 E.
+pub fn send_exec_streaming<F>(
+    stream: &mut UnixStream,
+    command: &str,
+    stdin: Option<String>,
+    timeout_secs: u64,
+    mut on_event: F,
+) -> Result<ExecEvent>
+where
+    F: FnMut(&ExecEvent),
+{
+    let _ = negotiate_protocol(stream, Vec::new())?;
+    let req = GuestRequest::Exec {
+        command: command.to_string(),
+        stdin,
+        timeout_secs: Some(timeout_secs),
+    };
+    write_frame(stream, &req)?;
+
+    loop {
+        let resp: GuestResponse = read_frame(stream)?;
+        let event = match resp {
+            GuestResponse::ExecEvent(e) => e,
+            GuestResponse::Error { message } => bail!("guest exec error: {message}"),
+            other => bail!("expected ExecEvent during exec stream, got {other:?}"),
+        };
+        if event.is_terminal() {
+            return Ok(event);
+        }
+        on_event(&event);
+    }
+}
+
 // ============================================================================
 // High-level API
 // ============================================================================
@@ -5250,5 +5287,65 @@ mod tests {
         assert!(
             matches!(back, GuestResponse::ExecEvent(ExecEvent::Stdout { ref chunk }) if chunk == b"hi")
         );
+    }
+
+    // Plan 159 WS-5 E — send_exec_streaming host reader
+    // -------------------------------------------------------------------
+
+    fn answer_exec_protocol_hello(stream: &mut UnixStream) {
+        let req: GuestRequest = read_frame(stream).unwrap();
+        match req {
+            GuestRequest::ProtocolHello {
+                requested_capabilities,
+                ..
+            } => assert_eq!(requested_capabilities, vec![]),
+            other => panic!("expected ProtocolHello, got {other:?}"),
+        }
+        write_frame(
+            stream,
+            &GuestResponse::ProtocolHelloAck {
+                agent_protocol_version: PROTOCOL_VERSION,
+                min_supported_version: MIN_SUPPORTED_PROTOCOL_VERSION,
+                agent_version: "test-agent".to_string(),
+                capabilities: vec![],
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn send_exec_streaming_collects_chunks_until_exit() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        guest
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+
+        let guest_handle = std::thread::spawn(move || {
+            answer_exec_protocol_hello(&mut guest);
+            let req: GuestRequest = read_frame(&mut guest).unwrap();
+            assert!(matches!(req, GuestRequest::Exec { ref command, .. } if command == "echo hi"));
+            write_frame(
+                &mut guest,
+                &GuestResponse::ExecEvent(ExecEvent::Stdout {
+                    chunk: b"hi\n".to_vec(),
+                }),
+            )
+            .unwrap();
+            write_frame(
+                &mut guest,
+                &GuestResponse::ExecEvent(ExecEvent::Exit { code: 0 }),
+            )
+            .unwrap();
+        });
+
+        let mut got: Vec<ExecEvent> = Vec::new();
+        let terminal = send_exec_streaming(&mut host, "echo hi", None, 30, |e| got.push(e.clone()))
+            .expect("send_exec_streaming");
+        guest_handle.join().unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert!(matches!(got[0], ExecEvent::Stdout { ref chunk } if chunk == b"hi\n"));
+        assert!(matches!(terminal, ExecEvent::Exit { code: 0 }));
     }
 }

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -852,12 +852,6 @@ pub enum GuestResponse {
     ProbeStatusReport {
         probes: Vec<crate::probes::ProbeResult>,
     },
-    /// Result of an Exec request.
-    ExecResult {
-        exit_code: i32,
-        stdout: String,
-        stderr: String,
-    },
     /// One event in the response stream of a `RunEntrypoint` call.
     /// ADR-007 / plan 41 W1.
     ///
@@ -2374,24 +2368,6 @@ pub fn post_restore_at(vsock_uds_path: &str) -> Result<bool> {
     }
 }
 
-/// Execute a command inside the guest via vsock at a specific UDS path (dev-only).
-pub fn exec_at(
-    vsock_uds_path: &str,
-    command: &str,
-    stdin: Option<String>,
-    timeout_secs: u64,
-) -> Result<GuestResponse> {
-    let mut stream = connect_to(vsock_uds_path, timeout_secs)?;
-    send_request(
-        &mut stream,
-        &GuestRequest::Exec {
-            command: command.to_string(),
-            stdin,
-            timeout_secs: Some(timeout_secs),
-        },
-    )
-}
-
 /// Query filesystem diff from the guest agent at a specific UDS path.
 ///
 /// Returns the list of filesystem changes since boot (created, modified,
@@ -2835,11 +2811,6 @@ mod tests {
                     output: Some(serde_json::json!({"usage_pct": 42})),
                     checked_at: "2026-02-26T12:00:00Z".to_string(),
                 }],
-            },
-            GuestResponse::ExecResult {
-                exit_code: 0,
-                stdout: "Linux\n".to_string(),
-                stderr: String::new(),
             },
             GuestResponse::PostRestoreAck {
                 success: true,

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -2168,7 +2168,7 @@ pub fn send_exec_streaming<F>(
     command: &str,
     stdin: Option<String>,
     timeout_secs: u64,
-    mut on_event: F,
+    on_event: F,
 ) -> Result<ExecEvent>
 where
     F: FnMut(&ExecEvent),
@@ -2180,7 +2180,17 @@ where
         timeout_secs: Some(timeout_secs),
     };
     write_frame(stream, &req)?;
+    read_exec_stream(stream, on_event)
+}
 
+/// Read an `ExecEvent` response stream from `stream`: invoke `on_event`
+/// for each non-terminal chunk, return the terminal `Exit`. The caller
+/// must have already done the protocol hello and written the request
+/// frame (`Exec` or `RunCode` — both stream `ExecEvent`). Plan 159 WS-5 E.
+pub fn read_exec_stream<F>(stream: &mut UnixStream, mut on_event: F) -> Result<ExecEvent>
+where
+    F: FnMut(&ExecEvent),
+{
     loop {
         let resp: GuestResponse = read_frame(stream)?;
         let event = match resp {
@@ -5347,5 +5357,31 @@ mod tests {
         assert_eq!(got.len(), 1);
         assert!(matches!(got[0], ExecEvent::Stdout { ref chunk } if chunk == b"hi\n"));
         assert!(matches!(terminal, ExecEvent::Exit { code: 0 }));
+    }
+
+    #[test]
+    fn read_exec_stream_collects_until_exit() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        let guest_handle = std::thread::spawn(move || {
+            write_frame(
+                &mut guest,
+                &GuestResponse::ExecEvent(ExecEvent::Stderr {
+                    chunk: b"e".to_vec(),
+                }),
+            )
+            .unwrap();
+            write_frame(
+                &mut guest,
+                &GuestResponse::ExecEvent(ExecEvent::Exit { code: 2 }),
+            )
+            .unwrap();
+        });
+        let mut got = Vec::new();
+        let term = read_exec_stream(&mut host, |e| got.push(e.clone())).unwrap();
+        guest_handle.join().unwrap();
+        assert_eq!(got.len(), 1);
+        assert!(matches!(got[0], ExecEvent::Stderr { ref chunk } if chunk == b"e"));
+        assert!(matches!(term, ExecEvent::Exit { code: 2 }));
     }
 }

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -866,6 +866,9 @@ pub enum GuestResponse {
     /// whose `is_terminal` returns true (`Exit` or `Error`). The
     /// host reads frames in a loop until terminal.
     EntrypointEvent(EntrypointEvent),
+    /// One event in the streaming response of an `Exec` call (dev-shell
+    /// only). Terminated by `ExecEvent::Exit`. Plan 159 WS-5 E.
+    ExecEvent(ExecEvent),
     /// Post-restore acknowledgement.
     PostRestoreAck {
         success: bool,
@@ -1442,6 +1445,29 @@ impl EntrypointEvent {
             self,
             EntrypointEvent::Exit { .. } | EntrypointEvent::Error { .. }
         )
+    }
+}
+
+/// One event in the response stream of an `Exec` call (dev-shell only).
+/// The agent emits a sequence of these for a single `Exec` request,
+/// terminated by `Exit`. The host reads frames in a loop until terminal.
+/// Plan 159 WS-5 E.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ExecEvent {
+    /// Bytes from the command's stdout, as they arrive.
+    Stdout { chunk: Vec<u8> },
+    /// Bytes from the command's stderr, as they arrive.
+    Stderr { chunk: Vec<u8> },
+    /// Command exited with this code. Terminal.
+    Exit { code: i32 },
+}
+
+impl ExecEvent {
+    /// True if this event terminates the `Exec` response stream.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, ExecEvent::Exit { .. })
     }
 }
 
@@ -5195,5 +5221,34 @@ mod tests {
             assert!(!s.starts_with('-'), "verb must not start with hyphen: {s}");
             assert!(!s.ends_with('-'), "verb must not end with hyphen: {s}");
         }
+    }
+
+    #[test]
+    fn exec_event_exit_is_terminal_others_are_not() {
+        assert!(ExecEvent::Exit { code: 0 }.is_terminal());
+        assert!(
+            !ExecEvent::Stdout {
+                chunk: b"x".to_vec()
+            }
+            .is_terminal()
+        );
+        assert!(
+            !ExecEvent::Stderr {
+                chunk: b"y".to_vec()
+            }
+            .is_terminal()
+        );
+    }
+
+    #[test]
+    fn guest_response_exec_event_roundtrips() {
+        let r = GuestResponse::ExecEvent(ExecEvent::Stdout {
+            chunk: b"hi".to_vec(),
+        });
+        let j = serde_json::to_vec(&r).unwrap();
+        let back: GuestResponse = serde_json::from_slice(&j).unwrap();
+        assert!(
+            matches!(back, GuestResponse::ExecEvent(ExecEvent::Stdout { ref chunk }) if chunk == b"hi")
+        );
     }
 }

--- a/specs/docs/plan-159-wse-streamed-exec-design.md
+++ b/specs/docs/plan-159-wse-streamed-exec-design.md
@@ -1,0 +1,198 @@
+# Design — Plan 159 WS-5 E: truly streamed `exec`
+
+> **Status (2026-06-08):** Brainstormed, approved. Scoping/design artifact
+> for **Plan 159 WS-5 E** — the last substantive Plan-152-independent item
+> on the vz DX/UX parity checklist. The numbered implementation plan is
+> produced from this via writing-plans.
+>
+> **Naming:** the inspiration project's `StreamExecOutput` is referred to
+> obliquely ("the reference"); oblique key in auto-memory
+> `reference_objc2_vz_external_references`.
+
+## Goal
+
+Make `mvmctl exec` / `mvmctl run` stream the guest command's
+stdout/stderr **as they are produced, in arrival order**, plus the exit
+code — instead of the current capture-then-return (output lands all at
+once after the command exits). Matches the reference's live
+`StreamExecOutput`. `exec` is dev-only (`dev-shell`-gated, claim 4); this
+improves the dev inner loop for long-running commands.
+
+## Decisions (from brainstorm)
+
+- **D1 — Level B (truly progressive), not wire-shape only.** The guest
+  reads the child's stdout/stderr pipes incrementally and emits chunks as
+  they arrive. (Level A — multi-frame wire shape but still
+  `wait_with_output()` on the guest — was rejected: it changes the wire
+  but not what the user sees, so it wouldn't close the parity gap. Note:
+  the existing `RunEntrypoint` path is only Level A today; WS-5 E does
+  *not* change that — separate concern.)
+- **D2 — dedicated `ExecEvent`** (not reuse `EntrypointEvent`). `Exec`
+  (dev-only, arbitrary shell command) keeps its own event type, distinct
+  from `EntrypointEvent` whose variants (`Control` fd-3 records,
+  `RunEntrypointError` taxonomy) are prod-entrypoint-specific and
+  meaningless for a raw exec.
+- **D3 — capture accumulates the stream.** The guest always streams; the
+  host has two consumers — `run()` prints live, `run_captured()`
+  accumulates chunks into `ExecOutput`. The single-frame `GuestResponse::
+  ExecResult` is **removed** (dev-only surface, no back-compat per
+  `feedback_no_backcompat_first_version`). Capture keeps per-stream order
+  in its two-field shape; cross-stream interleaving is preserved only in
+  live mode (expected, not a regression).
+
+## Current state (exploration 2026-06-08)
+
+- Guest `do_exec` (`mvm-guest-agent.rs`) runs `/bin/sh -c <command>`,
+  `wait_with_output()` → captures full stdout/stderr (with a
+  `MAX_EXEC_OUTPUT` truncation) → returns one
+  `GuestResponse::ExecResult { exit_code, stdout, stderr }`. Gated
+  `#[cfg(feature = "dev-shell")]`; absent-feature arm returns an error.
+- Host `crates/mvm-cli/src/exec.rs`: `run_in_guest` → `send_request`
+  (single req/resp) → on `ExecResult`, prints stdout/stderr *after* the
+  whole response, returns exit code. `run()` = interactive; `run_captured()`
+  = capture for `--json`/`--receipt`/MCP.
+- The **proven streaming machinery already exists** for `RunEntrypoint`:
+  `EntrypointEvent` + `GuestResponse::EntrypointEvent`, guest
+  `write_response()` per frame, host `send_run_entrypoint(stream, …,
+  on_event)` reads frames in a loop until terminal
+  (`invoke.rs::dispatch_inner` is the live consumer). WS-5 E mirrors this
+  shape for exec.
+- Framing: length-prefixed JSON (`[4-byte BE len][JSON]`); multiple
+  response frames per request are already supported (entrypoint proves it).
+
+## Protocol (`crates/mvm-guest/src/vsock.rs`)
+
+```rust
+/// One event in the response stream of an `Exec` call (dev-shell only).
+/// The agent emits a sequence terminated by `Exit`. Plan 159 WS-5 E.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum ExecEvent {
+    /// Bytes from the command's stdout, as they arrive.
+    Stdout { chunk: Vec<u8> },
+    /// Bytes from the command's stderr, as they arrive.
+    Stderr { chunk: Vec<u8> },
+    /// Command exited. Terminal.
+    Exit { code: i32 },
+}
+```
+
+- `chunk: Vec<u8>` (raw bytes) so partial-UTF-8 / binary output streams
+  correctly (the host writes bytes through; capture lossily converts to
+  `String` at the boundary, as `ExecResult` did).
+- Add `GuestResponse::ExecEvent(ExecEvent)`; **remove**
+  `GuestResponse::ExecResult`.
+- `ExecEvent::is_terminal()` → `true` for `Exit`.
+- Host reader: `pub fn send_exec_streaming(stream, command, stdin,
+  timeout_secs, on_event) -> Result<ExecEvent>` — writes the `Exec`
+  request frame, then loops reading frames, invoking `on_event(&ExecEvent)`
+  for non-terminal chunks, returning the terminal `Exit`. Mirrors
+  `send_run_entrypoint`.
+
+## Guest side (`crates/mvm-guest/src/bin/mvm-guest-agent.rs`)
+
+Replace `do_exec` with `do_exec_streaming(file: &mut File, command,
+stdin, timeout_secs) -> GuestResponse` (returns the terminal frame; writes
+intermediate frames directly — same contract as `handle_run_entrypoint`):
+
+- Spawn `/bin/sh -c <command>` with `stdin` piped (write `stdin` as today),
+  stdout+stderr piped. Write stdin then drop it (EOF).
+- Set both pipe fds non-blocking; **`libc::poll` loop** over the two fds:
+  on each readable fd, read a chunk (bounded buffer, e.g. 32 KiB) and
+  immediately `write_response(file, &GuestResponse::ExecEvent(
+  ExecEvent::Stdout|Stderr { chunk }))` (flushes per frame). Single-thread
+  poll → chunks emitted in readiness/arrival order = true source-order
+  interleaving, no threads/mutex.
+- When both pipes hit EOF, reap the child and **return** the terminal
+  `GuestResponse::ExecEvent(ExecEvent::Exit { code })`
+  (`status.code().unwrap_or(-1)`).
+- **Spawn failure** → write one `Stderr` chunk (`"failed to spawn: {e}"`)
+  + return `Exit { code: -1 }` (preserves today's `-1`+message behavior).
+- **Total-byte safety cap** (today's `MAX_EXEC_OUTPUT`): a running counter
+  across both streams; once exceeded, write a final `Stderr` chunk
+  (`"... (truncated)"`) and return `Exit` early (kill the child). Protects
+  an unbounded `run_captured` accumulation.
+- Stays under `#[cfg(feature = "dev-shell")]`; the `not(dev-shell)` arm
+  still returns the "exec not available" error (a single `GuestResponse::
+  Error`, no stream).
+- Dispatch arm: `GuestRequest::Exec { .. } => do_exec_streaming(file, …)`
+  (the dispatcher already passes `file` for the streaming `RunEntrypoint`
+  path).
+
+## Host side
+
+- `crates/mvm-cli/src/exec.rs`:
+  - `run_in_guest` switches from `send_request` (single) to
+    `send_exec_streaming` (loop). The inbound-RPC audit emit
+    (`scope=rpc,direction=in,kind=vsock,verb=exec`) stays, emitted once
+    before the stream.
+  - `run()` (interactive): `on_event` writes `Stdout`→stdout,
+    `Stderr`→stderr, flushing per chunk. Returns the terminal `Exit.code`.
+  - `run_captured()` (capture): `on_event` appends `chunk` bytes into
+    `ExecOutput.stdout` / `.stderr` (convert to `String` at the end, as
+    `ExecResult` did). Returns `ExecOutput { exit_code, stdout, stderr }`.
+    Shape unchanged → `--json`/receipt/MCP consumers unaffected.
+- `crates/mvm-cli/src/commands/vm/console.rs`: the `console --command`
+  one-shot path currently sends `GuestRequest::Exec` and matches
+  `ExecResult`. Update it to consume the `ExecEvent` stream (it can use
+  `send_exec_streaming` and print chunks live, mirroring `run()`), since
+  `ExecResult` is gone.
+
+## Error / timeout / caps
+
+- Terminal is always `Exit { code }` (spawn-fail → `-1`).
+- **Timeout:** preserve current behavior — today `do_exec` ignores
+  `timeout_secs`. WS-5 E does not add enforcement (noted as a follow-up);
+  the host transport read still bounds a totally-silent stream.
+- The total-byte cap bounds capture-mode memory.
+
+## Testing
+
+- **Guest unit:** `do_exec_streaming` over a script that interleaves
+  stdout+stderr emits chunk frames then `Exit` (assert ordering +
+  terminal); cap truncation emits the note + `Exit`; spawn-fail →
+  `Stderr` + `Exit{-1}`. (Use a temp `File`/pipe seam mirroring existing
+  agent tests.)
+- **Host unit:** `send_exec_streaming` loop terminates on `Exit` and
+  invokes `on_event` per chunk over a mock socket (mirror the existing
+  `send_run_entrypoint` tests).
+- **CLI:** `exec`/`run` return the exit code; `--json`/receipt capture
+  shape unchanged (`run_captured` accumulation).
+- **Live E2E (libkrun host):** `mvmctl exec '<prints, sleeps 2s, prints
+  more>'` shows the first output **before** the sleep elapses (progressive,
+  not all-at-once); exit code propagates. Isolate with
+  `MVM_CACHE_DIR`/`MVM_DATA_DIR` (`project_dev_host_runs_builder_via_vz`).
+  Never run `core_demo_e2e` unbounded.
+- **Gates:** `rustup run nightly cargo fmt --all -- --check`,
+  `cargo clippy --workspace -- -D warnings`, `cargo nextest run`
+  (mvm-backend excluded locally per
+  `reference_mvm_backend_test_binary_macos_codesign_sigkill`),
+  `cargo test --doc`.
+
+## Scope / non-goals
+
+- **In:** progressive `ExecEvent` streaming for `Exec` (dev-only); host
+  live (`run`) + capture (`run_captured`) consumers; `console --command`
+  consumer; removal of `ExecResult`.
+- **Out:** progressive upgrade of `RunEntrypoint` (separate concern — its
+  v1 buffering is unchanged); enforcing exec `timeout_secs` (preserve
+  current behavior); any prod surface (`exec` stays `dev-shell`-gated —
+  claim 4 / claim 15 posture intact).
+
+## References
+
+- Parent: `specs/plans/159-vz-inspired-macos-dx.md` (WS-5 E).
+- `crates/mvm-guest/src/vsock.rs` — `GuestRequest`/`GuestResponse`,
+  `EntrypointEvent`, `send_run_entrypoint` (the pattern to mirror),
+  `read_frame`/`send_request` framing.
+- `crates/mvm-guest/src/bin/mvm-guest-agent.rs` — `do_exec`,
+  `handle_run_entrypoint`, `write_response`, the dispatch.
+- `crates/mvm-cli/src/exec.rs` — `run`/`run_captured`/`run_in_guest`/
+  `send_request`.
+- `crates/mvm-cli/src/commands/vm/exec.rs` — `exec`/`run` subcommands +
+  capture (`--json`/`--receipt`) path.
+- `crates/mvm-cli/src/commands/vm/invoke.rs` — `dispatch_inner` (live
+  stream consumer reference).
+- `crates/mvm-cli/src/commands/vm/console.rs` — `console --command`
+  one-shot Exec consumer (must update).
+</content>

--- a/specs/plans/172-plan-159-wse-streamed-exec.md
+++ b/specs/plans/172-plan-159-wse-streamed-exec.md
@@ -1,0 +1,825 @@
+# Plan 172 — Plan 159 WS-5 E: truly streamed `exec` (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Design source:** `specs/docs/plan-159-wse-streamed-exec-design.md`.
+> **Parent:** `specs/plans/159-vz-inspired-macos-dx.md` (WS-5 E).
+> **Numbering:** 172 was free (main tops at 171; no open PR claims it).
+> Re-confirm before merge — `check-spec-numbers` rejects duplicates.
+
+**Goal:** Make `mvmctl exec`/`run` stream the guest command's
+stdout/stderr as they're produced (arrival order) plus the exit code,
+instead of capture-then-return.
+
+**Architecture:** A new `ExecEvent` stream (`Stdout`/`Stderr`/`Exit`) on
+`GuestResponse` replaces the single-frame `ExecResult`. The guest runs the
+command and drains its pipes with the in-repo thread-drain + sleep-poll
+idiom (`process_rpc::spawn_drain` / `handle_proc_wait`), emitting chunks
+via an `emit` closure (testable lib core) — the bin wrapper writes each as
+a frame. The host reads frames in a loop (`send_exec_streaming`, mirroring
+`send_run_entrypoint`): `run()` prints live, `run_captured()` accumulates.
+Exec stays `dev-shell`-gated.
+
+**Tech Stack:** Rust, `std::process` + thread-drain (no `libc::poll` — not
+an in-repo idiom), serde, length-prefixed JSON vsock framing,
+`UnixStream::pair()` mock tests.
+
+> **Supersedes the design's sketch:** the design said `libc::poll`; the
+> scout found the established mvm-guest idiom is **thread-drain +
+> sleep-poll** (`process_rpc.rs`), with no `poll(2)` anywhere in the
+> crate. This plan uses that idiom. Interleaving is therefore
+> poll-interval-granular (~50 ms), matching `handle_proc_wait` — honest
+> "source order," not byte-exact.
+
+---
+
+## Guardrails (every task)
+
+- Never regress claims 1–15; `exec` stays `#[cfg(feature = "dev-shell")]`
+  (claim 4 — no exec in prod agent). The streaming core is gated too.
+- CI fmt is nightly: `rustup run nightly cargo fmt --all` before commits.
+- `mvm-backend` test bins can SIGKILL on macOS
+  (`reference_mvm_backend_test_binary_macos_codesign_sigkill`) — not
+  relevant here (we touch mvm-guest + mvm-cli), but scope nextest to the
+  crate under test.
+- Per task: `cargo clippy -p <crate> --all-targets -- -D warnings` clean.
+- Never run `core_demo_e2e` unbounded.
+
+## File Structure
+
+Created:
+- `crates/mvm-guest/src/exec_stream.rs` — testable streaming core
+  (`stream_exec`), `dev-shell`-gated (T3).
+
+Modified:
+- `crates/mvm-guest/src/vsock.rs` — `ExecEvent` enum + `is_terminal`;
+  `GuestResponse::ExecEvent`; `send_exec_streaming`; remove `ExecResult`
+  + `exec_at` (T1, T2, T7).
+- `crates/mvm-guest/src/lib.rs` — `pub mod exec_stream;` (T3).
+- `crates/mvm-guest/src/bin/mvm-guest-agent.rs` — `do_exec_streaming`
+  wrapper + dispatch arm; remove `do_exec` (T4).
+- `crates/mvm-cli/src/exec.rs` — `run_in_guest` streaming; `run`/
+  `run_captured` consumers; `dispatch_in_session` + warm path (T5).
+- `crates/mvm-cli/src/commands/vm/console.rs` — `console --command`
+  streaming consumer (T6).
+
+---
+
+# Phase 1 — Protocol (`mvm-guest`)
+
+### Task 1: `ExecEvent` + `GuestResponse::ExecEvent`
+
+**Files:**
+- Modify: `crates/mvm-guest/src/vsock.rs`
+
+- [ ] **Step 1: Failing test** (append to the `#[cfg(test)] mod tests` in `vsock.rs`)
+
+```rust
+#[test]
+fn exec_event_exit_is_terminal_others_are_not() {
+    assert!(ExecEvent::Exit { code: 0 }.is_terminal());
+    assert!(!ExecEvent::Stdout { chunk: b"x".to_vec() }.is_terminal());
+    assert!(!ExecEvent::Stderr { chunk: b"y".to_vec() }.is_terminal());
+}
+
+#[test]
+fn guest_response_exec_event_roundtrips() {
+    let r = GuestResponse::ExecEvent(ExecEvent::Stdout { chunk: b"hi".to_vec() });
+    let j = serde_json::to_vec(&r).unwrap();
+    let back: GuestResponse = serde_json::from_slice(&j).unwrap();
+    assert!(matches!(back, GuestResponse::ExecEvent(ExecEvent::Stdout { ref chunk }) if chunk == b"hi"));
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `cargo nextest run -p mvm-guest exec_event`
+Expected: FAIL — `ExecEvent` / `GuestResponse::ExecEvent` not found.
+
+- [ ] **Step 3: Add the enum** (near `EntrypointEvent`, ~`vsock.rs:1377`)
+
+```rust
+/// One event in the response stream of an `Exec` call (dev-shell only).
+/// The agent emits a sequence of these for a single `Exec` request,
+/// terminated by `Exit`. The host reads frames in a loop until terminal.
+/// Plan 159 WS-5 E.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ExecEvent {
+    /// Bytes from the command's stdout, as they arrive.
+    Stdout { chunk: Vec<u8> },
+    /// Bytes from the command's stderr, as they arrive.
+    Stderr { chunk: Vec<u8> },
+    /// Command exited with this code. Terminal.
+    Exit { code: i32 },
+}
+
+impl ExecEvent {
+    /// True if this event terminates the `Exec` response stream.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, ExecEvent::Exit { .. })
+    }
+}
+```
+
+- [ ] **Step 4: Add the `GuestResponse` variant** (next to `EntrypointEvent(...)`, ~`vsock.rs:837`). Do NOT remove `ExecResult` yet (consumers migrate first):
+
+```rust
+    /// One event in the streaming response of an `Exec` call (dev-shell
+    /// only). Terminated by `ExecEvent::Exit`. Plan 159 WS-5 E.
+    ExecEvent(ExecEvent),
+```
+
+- [ ] **Step 5: Run — expect PASS**
+
+Run: `cargo nextest run -p mvm-guest exec_event guest_response_exec_event`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-guest/src/vsock.rs
+git commit -m "feat(mvm-guest): ExecEvent stream variant (Plan 159 WS-5 E)"
+```
+
+### Task 2: `send_exec_streaming` host reader
+
+**Files:**
+- Modify: `crates/mvm-guest/src/vsock.rs`
+
+- [ ] **Step 1: Failing test** (append to `mod tests`, mirroring `test_send_run_entrypoint_collects_events_until_terminal`)
+
+```rust
+#[test]
+fn send_exec_streaming_collects_chunks_until_exit() {
+    let (mut host, mut guest) = UnixStream::pair().unwrap();
+    host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    guest.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+    let guest_handle = std::thread::spawn(move || {
+        // Exec uses a plain protocol hello (no capability), like exec.rs.
+        let req: GuestRequest = read_frame(&mut guest).unwrap();
+        assert!(matches!(req, GuestRequest::ProtocolHello { .. }));
+        write_frame(
+            &mut guest,
+            &GuestResponse::ProtocolHelloAck {
+                agent_protocol_version: PROTOCOL_VERSION,
+                min_supported_version: MIN_SUPPORTED_PROTOCOL_VERSION,
+                agent_version: "test-agent".to_string(),
+                capabilities: vec![],
+            },
+        )
+        .unwrap();
+        let req: GuestRequest = read_frame(&mut guest).unwrap();
+        assert!(matches!(req, GuestRequest::Exec { ref command, .. } if command == "echo hi"));
+        write_frame(&mut guest, &GuestResponse::ExecEvent(ExecEvent::Stdout { chunk: b"hi\n".to_vec() })).unwrap();
+        write_frame(&mut guest, &GuestResponse::ExecEvent(ExecEvent::Exit { code: 0 })).unwrap();
+    });
+
+    let mut got: Vec<ExecEvent> = Vec::new();
+    let terminal = send_exec_streaming(&mut host, "echo hi", None, 30, |e| got.push(e.clone()))
+        .expect("send_exec_streaming");
+    guest_handle.join().unwrap();
+
+    assert_eq!(got.len(), 1);
+    assert!(matches!(got[0], ExecEvent::Stdout { ref chunk } if chunk == b"hi\n"));
+    assert!(matches!(terminal, ExecEvent::Exit { code: 0 }));
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `cargo nextest run -p mvm-guest send_exec_streaming`
+Expected: FAIL — `send_exec_streaming` not found.
+
+- [ ] **Step 3: Implement** (near `send_run_entrypoint`, ~`vsock.rs:2105`). Exec is NOT capability-gated, so use a plain `negotiate_protocol` hello (mirroring `exec.rs::send_request` / `console.rs`):
+
+```rust
+/// Send an `Exec` request and stream its response. Invokes `on_event`
+/// for each `Stdout`/`Stderr` chunk as it arrives; returns the terminal
+/// `Exit`. Exec carries no `GuestCapability`, so this does a plain
+/// protocol hello (the agent gates exec at compile time via `dev-shell`).
+/// Plan 159 WS-5 E.
+pub fn send_exec_streaming<F>(
+    stream: &mut UnixStream,
+    command: &str,
+    stdin: Option<String>,
+    timeout_secs: u64,
+    mut on_event: F,
+) -> Result<ExecEvent>
+where
+    F: FnMut(&ExecEvent),
+{
+    let _ = negotiate_protocol(stream, Vec::new())?;
+    let req = GuestRequest::Exec {
+        command: command.to_string(),
+        stdin,
+        timeout_secs: Some(timeout_secs),
+    };
+    write_frame(stream, &req)?;
+
+    loop {
+        let resp: GuestResponse = read_frame(stream)?;
+        let event = match resp {
+            GuestResponse::ExecEvent(e) => e,
+            GuestResponse::Error { message } => bail!("guest exec error: {message}"),
+            other => bail!("expected ExecEvent during exec stream, got {other:?}"),
+        };
+        if event.is_terminal() {
+            return Ok(event);
+        }
+        on_event(&event);
+    }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `cargo nextest run -p mvm-guest send_exec_streaming`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-guest/src/vsock.rs
+git commit -m "feat(mvm-guest): send_exec_streaming host reader (Plan 159 WS-5 E)"
+```
+
+---
+
+# Phase 2 — Guest streaming core + agent
+
+### Task 3: `exec_stream` core (`stream_exec`)
+
+**Files:**
+- Create: `crates/mvm-guest/src/exec_stream.rs`
+- Modify: `crates/mvm-guest/src/lib.rs`
+
+- [ ] **Step 1: Create the module** `crates/mvm-guest/src/exec_stream.rs`
+
+```rust
+//! Streaming exec core (dev-shell only). Runs `sh -c <command>` and emits
+//! `ExecEvent` chunks via an `emit` closure as the child produces output,
+//! returning the terminal `Exit`. The wire-writing lives in the agent bin
+//! (`do_exec_streaming`); this core is closure-driven so it is unit-
+//! testable without a vsock `File`. Mirrors `process_rpc::spawn_drain` +
+//! the `handle_proc_wait` sleep-poll loop (the in-repo streaming idiom —
+//! mvm-guest has no `libc::poll` usage). Plan 159 WS-5 E.
+#![cfg(feature = "dev-shell")]
+
+use crate::vsock::ExecEvent;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Per-stream total-byte cap (1 MiB) — bounds host capture-mode memory
+/// (was `MAX_EXEC_OUTPUT` in the agent bin).
+pub const MAX_EXEC_OUTPUT: usize = 1024 * 1024;
+const DRAIN_BUF: usize = 4096;
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+fn spawn_drain<R: Read + Send + 'static>(mut reader: R, buf: Arc<Mutex<Vec<u8>>>) {
+    std::thread::spawn(move || {
+        let mut chunk = [0u8; DRAIN_BUF];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => buf.lock().expect("exec drain buf").extend_from_slice(&chunk[..n]),
+                Err(_) => break,
+            }
+        }
+    });
+}
+
+/// Emit newly-buffered bytes (past `*sent`) as one chunk, capped at
+/// `MAX_EXEC_OUTPUT` total per stream. Returns true if the cap was hit
+/// (caller should stop and truncate).
+fn drain_into<F: FnMut(ExecEvent)>(
+    buf: &Arc<Mutex<Vec<u8>>>,
+    sent: &mut usize,
+    stdout: bool,
+    emit: &mut F,
+) -> bool {
+    let b = buf.lock().expect("exec drain buf");
+    if b.len() <= *sent {
+        return false;
+    }
+    let room = MAX_EXEC_OUTPUT.saturating_sub(*sent);
+    if room == 0 {
+        return true;
+    }
+    let new = &b[*sent..];
+    let take = new.len().min(room);
+    let chunk = new[..take].to_vec();
+    emit(if stdout {
+        ExecEvent::Stdout { chunk }
+    } else {
+        ExecEvent::Stderr { chunk }
+    });
+    *sent += take;
+    take < new.len()
+}
+
+/// Run `command` under `/bin/sh -c`, streaming stdout/stderr via `emit`
+/// (arrival order, ~poll-interval granularity), and return the terminal
+/// `ExecEvent::Exit`. `emit` is never called with `Exit` — that is the
+/// return value.
+pub fn stream_exec<F: FnMut(ExecEvent)>(
+    command: &str,
+    stdin_data: Option<&str>,
+    mut emit: F,
+) -> ExecEvent {
+    let mut child = match Command::new("/bin/sh")
+        .arg("-c")
+        .arg(command)
+        .stdin(if stdin_data.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            emit(ExecEvent::Stderr {
+                chunk: format!("failed to spawn: {e}").into_bytes(),
+            });
+            return ExecEvent::Exit { code: -1 };
+        }
+    };
+
+    if let Some(data) = stdin_data
+        && let Some(ref mut pipe) = child.stdin
+        && let Err(e) = pipe.write_all(data.as_bytes())
+    {
+        eprintln!("failed to write exec stdin pipe: {e}");
+    }
+    drop(child.stdin.take());
+
+    let out_buf = Arc::new(Mutex::new(Vec::new()));
+    let err_buf = Arc::new(Mutex::new(Vec::new()));
+    if let Some(o) = child.stdout.take() {
+        spawn_drain(o, out_buf.clone());
+    }
+    if let Some(e) = child.stderr.take() {
+        spawn_drain(e, err_buf.clone());
+    }
+
+    let mut sent_out = 0usize;
+    let mut sent_err = 0usize;
+
+    loop {
+        let capped = drain_into(&out_buf, &mut sent_out, true, &mut emit)
+            | drain_into(&err_buf, &mut sent_err, false, &mut emit);
+        if capped {
+            let _ = child.kill();
+            let _ = child.wait();
+            emit(ExecEvent::Stderr {
+                chunk: b"\n... (truncated)".to_vec(),
+            });
+            return ExecEvent::Exit { code: -1 };
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                // Child exited: let the drain threads flush the tail,
+                // then emit any remaining bytes.
+                std::thread::sleep(POLL_INTERVAL);
+                let _ = drain_into(&out_buf, &mut sent_out, true, &mut emit);
+                let _ = drain_into(&err_buf, &mut sent_err, false, &mut emit);
+                return ExecEvent::Exit {
+                    code: status.code().unwrap_or(-1),
+                };
+            }
+            Ok(None) => std::thread::sleep(POLL_INTERVAL),
+            Err(e) => {
+                emit(ExecEvent::Stderr {
+                    chunk: format!("wait failed: {e}").into_bytes(),
+                });
+                return ExecEvent::Exit { code: -1 };
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn streams_stdout_then_exit_zero() {
+        let mut events = Vec::new();
+        let term = stream_exec("printf hello", None, |e| events.push(e));
+        assert!(matches!(term, ExecEvent::Exit { code: 0 }));
+        let out: Vec<u8> = events
+            .iter()
+            .filter_map(|e| match e {
+                ExecEvent::Stdout { chunk } => Some(chunk.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        assert_eq!(out, b"hello");
+    }
+
+    #[test]
+    fn captures_stderr_and_nonzero_exit() {
+        let mut events = Vec::new();
+        let term = stream_exec("printf oops 1>&2; exit 3", None, |e| events.push(e));
+        assert!(matches!(term, ExecEvent::Exit { code: 3 }));
+        let err: Vec<u8> = events
+            .iter()
+            .filter_map(|e| match e {
+                ExecEvent::Stderr { chunk } => Some(chunk.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        assert_eq!(err, b"oops");
+    }
+
+    #[test]
+    fn pipes_stdin() {
+        let mut events = Vec::new();
+        let term = stream_exec("cat", Some("piped"), |e| events.push(e));
+        assert!(matches!(term, ExecEvent::Exit { code: 0 }));
+        let out: Vec<u8> = events
+            .iter()
+            .filter_map(|e| match e {
+                ExecEvent::Stdout { chunk } => Some(chunk.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        assert_eq!(out, b"piped");
+    }
+}
+```
+
+- [ ] **Step 2: Declare the module** — add to `crates/mvm-guest/src/lib.rs` next to the other `pub mod` lines:
+
+```rust
+pub mod exec_stream;
+```
+
+(`exec_stream` is `#![cfg(feature = "dev-shell")]` at the file head, so it
+compiles out of the prod agent — claim 4. The `pub mod` line is
+unconditional; the file's inner attribute gates the contents.)
+
+- [ ] **Step 3: Run tests** (with the feature)
+
+Run: `cargo nextest run -p mvm-guest --features dev-shell exec_stream`
+Expected: PASS (3 tests). Also confirm prod build excludes it:
+`cargo build -p mvm-guest` (no dev-shell) — clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+cargo clippy -p mvm-guest --all-targets --features dev-shell -- -D warnings 2>&1 | tail -5
+git add crates/mvm-guest/src/exec_stream.rs crates/mvm-guest/src/lib.rs
+git commit -m "feat(mvm-guest): exec_stream core — progressive stream_exec (dev-shell)"
+```
+
+### Task 4: agent `do_exec_streaming` wrapper + dispatch
+
+**Files:**
+- Modify: `crates/mvm-guest/src/bin/mvm-guest-agent.rs`
+
+- [ ] **Step 1: Replace `do_exec`** (`mvm-guest-agent.rs:969-1033`, incl. the `MAX_EXEC_OUTPUT` const which moves to `exec_stream`). Add the streaming wrapper modeled on `handle_proc_wait_streaming` (`:953-967`):
+
+```rust
+/// `Exec` streaming arm — writes intermediate `ExecEvent` Stdout/Stderr
+/// frames to the connection and returns the terminal `Exit` for the
+/// dispatch loop to write last. Mirrors `handle_run_entrypoint` /
+/// `handle_proc_wait_streaming`. Plan 159 WS-5 E. (dev-shell only)
+#[cfg(feature = "dev-shell")]
+fn do_exec_streaming(
+    file: &mut std::fs::File,
+    command: &str,
+    stdin_data: Option<&str>,
+) -> GuestResponse {
+    let terminal = mvm_guest::exec_stream::stream_exec(command, stdin_data, |ev| {
+        write_response(file, &GuestResponse::ExecEvent(ev));
+    });
+    GuestResponse::ExecEvent(terminal)
+}
+```
+
+(Delete the old `do_exec` fn and the bin's `MAX_EXEC_OUTPUT` const — both
+superseded. `timeout_secs` is dropped from the wrapper signature because
+the old `do_exec` already ignored it; preserving current behavior, noted
+as a follow-up in the design.)
+
+- [ ] **Step 2: Update the dispatch arm** (`mvm-guest-agent.rs:2162-2175`) to call the streaming wrapper with `file`:
+
+```rust
+        #[cfg(feature = "dev-shell")]
+        GuestRequest::Exec {
+            command,
+            stdin,
+            timeout_secs: _,
+        } => {
+            eprintln!("[audit] exec request: {:?}", command);
+            do_exec_streaming(&mut file, &command, stdin.as_deref())
+        }
+
+        #[cfg(not(feature = "dev-shell"))]
+        GuestRequest::Exec { .. } => GuestResponse::Error {
+            message: "exec not available: guest agent built without dev-shell feature".to_string(),
+        },
+```
+
+(`file` is in scope in the dispatch — the `RunEntrypoint` arm already
+passes `&mut file` to `handle_run_entrypoint`; the dispatch tail writes
+the returned terminal via `write_response(&mut file, &resp)` exactly as
+for `RunEntrypoint`.)
+
+- [ ] **Step 3: Build both feature configs**
+
+Run: `cargo build -p mvm-guest --bin mvm-guest-agent --features dev-shell` and `cargo build -p mvm-guest --bin mvm-guest-agent`
+Expected: both clean. The prod build (no dev-shell) hits the `not` arm; the `do_exec`/`MAX_EXEC_OUTPUT` symbols are gone.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-guest/src/bin/mvm-guest-agent.rs
+git commit -m "feat(mvm-guest-agent): stream Exec via do_exec_streaming (Plan 159 WS-5 E)"
+```
+
+---
+
+# Phase 3 — Host consumers + remove `ExecResult`
+
+### Task 5: `exec.rs` — stream in `run_in_guest`; `run`/`run_captured`
+
+**Files:**
+- Modify: `crates/mvm-cli/src/exec.rs`
+
+- [ ] **Step 1: Refactor `run_in_guest`** (`exec.rs:734-772`) to stream. Replace the `send_request` call + `match ExecResult` with a streaming consumer that builds the stream and loops. Replace the whole body:
+
+```rust
+fn run_in_guest(
+    vm_name: &str,
+    req: &ExecRequest,
+    labels: &[String],
+    capture: bool,
+) -> Result<Either<i32, ExecOutput>> {
+    if !wait_for_agent(vm_name, 30) {
+        anyhow::bail!("guest agent did not become reachable within 30s");
+    }
+    let wrapper = build_guest_wrapper(req, labels);
+
+    let transport = vsock_transport::for_vm(vm_name)?;
+    let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+    // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit (verb=exec).
+    mvm_core::audit_emit!(
+        NetworkPolicyAllow,
+        vm: vm_name,
+        "scope=rpc,direction=in,kind=vsock,verb=exec",
+    );
+
+    let mut out = Vec::<u8>::new();
+    let mut err = Vec::<u8>::new();
+    let terminal = mvm_guest::vsock::send_exec_streaming(
+        &mut stream,
+        &wrapper,
+        None,
+        req.timeout_secs,
+        |event| match event {
+            mvm_guest::vsock::ExecEvent::Stdout { chunk } => {
+                if capture {
+                    out.extend_from_slice(chunk);
+                } else {
+                    let _ = std::io::Write::write_all(&mut std::io::stdout(), chunk);
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
+                }
+            }
+            mvm_guest::vsock::ExecEvent::Stderr { chunk } => {
+                if capture {
+                    err.extend_from_slice(chunk);
+                } else {
+                    let _ = std::io::Write::write_all(&mut std::io::stderr(), chunk);
+                    let _ = std::io::Write::flush(&mut std::io::stderr());
+                }
+            }
+            _ => {}
+        },
+    )?;
+    let exit_code = match terminal {
+        mvm_guest::vsock::ExecEvent::Exit { code } => code,
+        other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
+    };
+
+    if capture {
+        Ok(Either::Right(ExecOutput {
+            exit_code,
+            stdout: String::from_utf8_lossy(&out).into_owned(),
+            stderr: String::from_utf8_lossy(&err).into_owned(),
+        }))
+    } else {
+        Ok(Either::Left(exit_code))
+    }
+}
+```
+
+(Confirm `std::io::Write` is importable as shown, or add `use std::io::Write;` to the function/module if not already present.)
+
+- [ ] **Step 2: Remove the now-unused `send_request`** (`exec.rs:964-996`) — `run_in_guest` no longer calls it and it returns the deleted `ExecResult`. Delete the fn. (Grep first: `grep -n 'send_request' crates/mvm-cli/src/exec.rs` — if other callers exist, migrate them too.)
+
+- [ ] **Step 3: Migrate `dispatch_in_session`** (`exec.rs:888-924`, the warm-session path) which also matches `GuestResponse::ExecResult`. Read it and switch it to `send_exec_streaming` over its session stream the same way (capture/live per its existing shape). Quote-replace its `match ... ExecResult` block with the streaming loop returning the exit code / `ExecOutput`. (If `dispatch_in_session` is currently dead/unused, confirm with `grep` and remove it instead of migrating.)
+
+- [ ] **Step 4: Build + run exec tests**
+
+Run: `cargo build -p mvm-cli && cargo nextest run -p mvm-cli exec`
+Expected: builds; existing exec tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+cargo clippy -p mvm-cli --all-targets -- -D warnings 2>&1 | tail -5
+git add crates/mvm-cli/src/exec.rs
+git commit -m "feat(mvm-cli): stream exec output live (run) + accumulate (run_captured)"
+```
+
+### Task 6: `console --command` streaming consumer
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/vm/console.rs`
+
+- [ ] **Step 1: Replace the one-shot Exec block** (`console.rs:101-138`, the `if let Some(cmd) = command { ... match ExecResult ... }`) with a streaming consumer:
+
+```rust
+    if let Some(cmd) = command {
+        let transport = pick_console_transport(name)?;
+        let mut stream = transport.connect(mvm_guest::vsock::GUEST_AGENT_PORT)?;
+        // Plan 74 W2 / Plan 51 W6 — inbound vsock RPC audit (verb=exec).
+        super::shared::emit_vsock_rpc_audit(
+            name,
+            &mvm_guest::vsock::GuestRequest::Exec {
+                command: cmd.to_string(),
+                stdin: None,
+                timeout_secs: Some(30),
+            },
+        );
+        let terminal = mvm_guest::vsock::send_exec_streaming(
+            &mut stream,
+            cmd,
+            None,
+            30,
+            |event| match event {
+                mvm_guest::vsock::ExecEvent::Stdout { chunk } => {
+                    let _ = std::io::Write::write_all(&mut std::io::stdout(), chunk);
+                    let _ = std::io::Write::flush(&mut std::io::stdout());
+                }
+                mvm_guest::vsock::ExecEvent::Stderr { chunk } => {
+                    let _ = std::io::Write::write_all(&mut std::io::stderr(), chunk);
+                    let _ = std::io::Write::flush(&mut std::io::stderr());
+                }
+                _ => {}
+            },
+        )?;
+        match terminal {
+            mvm_guest::vsock::ExecEvent::Exit { code } => {
+                if code != 0 {
+                    std::process::exit(code);
+                }
+                Ok(())
+            }
+            other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
+        }
+    } else {
+        // Interactive PTY session
+        console_interactive(name)
+    }
+```
+
+(`send_exec_streaming` does its own protocol hello, so drop the prior
+explicit `negotiate_protocol` line. Keep the audit emit. Confirm
+`emit_vsock_rpc_audit` accepts a constructed `GuestRequest` ref as shown,
+matching the prior call.)
+
+- [ ] **Step 2: Build**
+
+Run: `cargo build -p mvm-cli && cargo nextest run -p mvm-cli console`
+Expected: clean; console tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+git add crates/mvm-cli/src/commands/vm/console.rs
+git commit -m "feat(mvm-cli): console --command streams exec output (Plan 159 WS-5 E)"
+```
+
+### Task 7: Remove `ExecResult` + `exec_at`
+
+**Files:**
+- Modify: `crates/mvm-guest/src/vsock.rs`
+
+- [ ] **Step 1: Find every remaining `ExecResult` reference**
+
+Run: `grep -rn 'ExecResult' crates/`
+Expected: only the `vsock.rs` variant definition + possibly `exec_at` (`vsock.rs:2305-2320`) + tests remain (all CLI consumers migrated in T5/T6).
+
+- [ ] **Step 2: Handle `exec_at`** (`vsock.rs:2305-2320`) — it builds `GuestRequest::Exec` and returns a single `GuestResponse` containing `ExecResult`. Grep its callers: `grep -rn 'exec_at' crates/`. If unused, delete it. If used, migrate the caller to `send_exec_streaming` and delete `exec_at`. (Per `feedback_no_backcompat_first_version`, prefer deletion over a shim.)
+
+- [ ] **Step 3: Remove the variant** — delete `GuestResponse::ExecResult { .. }` from the enum (`vsock.rs:826-831`) and any test referencing it.
+
+- [ ] **Step 4: Build the whole workspace** (catches any missed matcher; `GuestResponse` is matched in several places — a removed variant surfaces as a compile error)
+
+Run: `cargo build --workspace` and `cargo build -p mvm-guest --bin mvm-guest-agent --features dev-shell`
+Expected: clean. Fix any remaining `ExecResult` match arms (they should all be gone after T5/T6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+rustup run nightly cargo fmt --all
+cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tail -5
+git add crates/mvm-guest/src/vsock.rs
+git commit -m "refactor(mvm-guest): remove single-frame ExecResult (superseded by ExecEvent)"
+```
+
+---
+
+# Phase 4 — Live verification
+
+### Task 8: Progressive E2E on the libkrun host
+
+- [ ] **Step 1: Build a real `mvmctl`** (embedded host-vm bins) + the
+  libkrun supervisor (the workload runs on libkrun; exec is dev-shell, and
+  the dev image's agent is built with `dev-shell`):
+  `cargo build --bin mvmctl && cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys`.
+
+- [ ] **Step 2: Progressive output check** (isolate per
+  `project_dev_host_runs_builder_via_vz`):
+
+```bash
+MVM_WORKSPACE_PATH="$(pwd)" ./target/debug/mvmctl exec --hypervisor libkrun \
+  -- sh -c 'echo first; sleep 2; echo second' 2>&1 | ts '%.s' 2>/dev/null || \
+MVM_WORKSPACE_PATH="$(pwd)" ./target/debug/mvmctl exec --hypervisor libkrun \
+  -- sh -c 'echo first; sleep 2; echo second'
+```
+
+  Expected: `first` appears ~2s **before** `second` (progressive — not
+  both at once after the command finishes). Exit code propagates
+  (`sh -c 'exit 5'` → `mvmctl` exits 5). (Use the real `mvmctl exec`
+  invocation form for an inline command — confirm the arg shape from
+  `crates/mvm-cli/src/commands/vm/exec.rs`.)
+
+- [ ] **Step 3: Capture-mode unchanged** — `mvmctl run --json …` (or the
+  receipt path) still emits the same `RunJsonSummary` shape with full
+  stdout/stderr accumulated. Document both transcripts in the PR.
+
+---
+
+## Deferred (tracked, not in this plan)
+
+- [ ] Enforce exec `timeout_secs` (today ignored; preserved as-is).
+- [ ] Progressive upgrade of `RunEntrypoint` (its v1 buffering is a
+      separate concern; the wire shape already supports it).
+
+## Self-review notes
+
+- **Spec coverage:** D1 progressive → T3 (`stream_exec` thread-drain) +
+  T4 (frames as they arrive); D2 dedicated `ExecEvent` → T1; D3 capture
+  accumulates + remove `ExecResult` → T5 (`run_captured`) + T7. Host
+  reader → T2; console consumer → T6; live progressive proof → T8.
+- **Type consistency:** `ExecEvent {Stdout{chunk:Vec<u8>}, Stderr{chunk:
+  Vec<u8>}, Exit{code:i32}}` + `is_terminal()` used identically in T1/T2/
+  T3/T4/T5/T6; `send_exec_streaming(stream, command:&str, stdin:Option<
+  String>, timeout_secs:u64, on_event: FnMut(&ExecEvent)) -> Result<
+  ExecEvent>` consistent T2↔T5↔T6; `stream_exec(command:&str, stdin:
+  Option<&str>, emit: FnMut(ExecEvent)) -> ExecEvent` consistent T3↔T4.
+- **Mechanism note:** thread-drain + sleep-poll (not `libc::poll`) per
+  the in-repo idiom; interleaving is ~50ms-granular (honest, matches
+  `handle_proc_wait`).
+- **Gating:** `exec_stream` + `do_exec_streaming` are `dev-shell`-gated;
+  the prod agent excludes them (claim 4). T4/T7 build the prod (no-feature)
+  config to confirm.
+
+## References
+
+- Design: `specs/docs/plan-159-wse-streamed-exec-design.md`
+- `crates/mvm-guest/src/vsock.rs` — `EntrypointEvent`/`send_run_entrypoint`
+  (pattern), framing, `GuestResponse`, `GuestRequest::Exec`.
+- `crates/mvm-guest/src/process_rpc.rs` — `spawn_drain` +
+  `handle_proc_wait` (thread-drain + sleep-poll idiom T3 mirrors).
+- `crates/mvm-guest/src/bin/mvm-guest-agent.rs` — `do_exec`,
+  `handle_proc_wait_streaming`, `write_response`, dispatch (`file` scope).
+- `crates/mvm-cli/src/exec.rs` — `run`/`run_captured`/`run_in_guest`/
+  `send_request`/`dispatch_in_session`.
+- `crates/mvm-cli/src/commands/vm/console.rs` — `console --command`.
+- `crates/mvm-cli/src/commands/vm/invoke.rs` — `dispatch_inner` (live
+  stream-consumer reference).
+</content>

--- a/specs/plans/172-plan-159-wse-streamed-exec.md
+++ b/specs/plans/172-plan-159-wse-streamed-exec.md
@@ -754,32 +754,38 @@ git commit -m "refactor(mvm-guest): remove single-frame ExecResult (superseded b
 
 # Phase 4 — Live verification
 
-### Task 8: Progressive E2E on the libkrun host
+### Task 8: Progressive E2E on the libkrun host — PASSED
 
-- [ ] **Step 1: Build a real `mvmctl`** (embedded host-vm bins) + the
-  libkrun supervisor (the workload runs on libkrun; exec is dev-shell, and
-  the dev image's agent is built with `dev-shell`):
-  `cargo build --bin mvmctl && cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys`.
+- [x] **Live progressive proof (2026-06-08).**
+  `MVM_WORKSPACE_PATH="$(pwd)" mvmctl exec -- sh -c 'echo first; sleep 2;
+  echo second'`, with host output timestamped, produced:
+  `[01:11:44] first` … `[01:11:46] second` — a **2-second gap in the
+  host-side timestamps**, proving the output streamed progressively
+  (capture-then-return would print both at one timestamp after the command
+  exits). The agent was rebuilt from this branch's source (carries the
+  `ExecEvent` change); the host `send_exec_streaming` printed each chunk
+  live.
 
-- [ ] **Step 2: Progressive output check** (isolate per
-  `project_dev_host_runs_builder_via_vz`):
+- [x] **Protocol wiring confirmed earlier:** a first run against a *stale*
+  cached agent made the new host correctly reject the old frame
+  (`unknown variant ExecResult, expected ... ExecEvent`) — fail-closed,
+  proving the host deserializer is on the new protocol.
 
-```bash
-MVM_WORKSPACE_PATH="$(pwd)" ./target/debug/mvmctl exec --hypervisor libkrun \
-  -- sh -c 'echo first; sleep 2; echo second' 2>&1 | ts '%.s' 2>/dev/null || \
-MVM_WORKSPACE_PATH="$(pwd)" ./target/debug/mvmctl exec --hypervisor libkrun \
-  -- sh -c 'echo first; sleep 2; echo second'
-```
+- [~] **Environment notes (not WS-5 E code):** `--hypervisor` is not
+  honored by `exec` (it boots the macOS-26 default apple_container/Vz
+  backend — streaming is backend-agnostic over vsock, so this is fine).
+  The agent rebuild required a networked builder: the **libkrun builder
+  had no DNS** (`Could not resolve cache.nixos.org`) and the **Vz builder
+  needs the Swift `mvm-vz-supervisor`** (built here via
+  `crates/mvm-vz-supervisor/tools/build.sh` + `MVM_VZ_SUPERVISOR_PATH`).
+  Same dual-builder constraint Plan 171 (WS-A) hit — orthogonal to this
+  change.
 
-  Expected: `first` appears ~2s **before** `second` (progressive — not
-  both at once after the command finishes). Exit code propagates
-  (`sh -c 'exit 5'` → `mvmctl` exits 5). (Use the real `mvmctl exec`
-  invocation form for an inline command — confirm the arg shape from
-  `crates/mvm-cli/src/commands/vm/exec.rs`.)
-
-- [ ] **Step 3: Capture-mode unchanged** — `mvmctl run --json …` (or the
-  receipt path) still emits the same `RunJsonSummary` shape with full
-  stdout/stderr accumulated. Document both transcripts in the PR.
+- [x] **Capture-mode unchanged** is unit-covered: `run_captured`
+  accumulates the stream into the same `ExecOutput`/`RunJsonSummary`
+  shape; exit-code propagation is unit-covered (terminal `Exit` →
+  `run()` returns the code). (A second live boot to re-prove `exit 5`
+  was skipped — the streaming proof + units suffice.)
 
 ---
 


### PR DESCRIPTION
## Summary

Makes `mvmctl exec`/`run` (and `console --command`, `session run-code`) stream the guest command's stdout/stderr **as they're produced** (arrival order) instead of capture-then-return — the last Plan-152-independent item on the vz DX/UX parity checklist (the reference's `StreamExecOutput`).

Plan: `specs/plans/172-plan-159-wse-streamed-exec.md`. Design: `specs/docs/plan-159-wse-streamed-exec-design.md`.

### What changed
- **Protocol:** new `ExecEvent { Stdout, Stderr, Exit }` + `GuestResponse::ExecEvent`; the single-frame `ExecResult` is **removed**.
- **Guest core (`mvm-guest::exec_stream`, dev-shell):** `stream_exec` drains the child's stdout/stderr pipes with the in-repo thread-drain idiom (`spawn_drain` + sleep-poll), emitting chunks via an `emit` closure; **joins the drain threads on child exit** (happens-before edge → no tail-loss race, guarded by a 256 KiB final-write test); per-stream byte cap.
- **Agent:** `do_exec_streaming` + `do_run_code` stream `ExecEvent`; `do_exec`/`MAX_EXEC_OUTPUT` removed. Claim 4 preserved — all of it is `dev-shell`-gated and **absent from a prod agent build** (verified by symbol grep + the `prod-agent-no-exec` gate).
- **Host readers:** `send_exec_streaming` (Exec) + `read_exec_stream` (shared loop, reused by the RunCode consumer).
- **Consumers migrated** to the stream: `exec.rs` (`run` live / `run_captured` accumulate), `dispatch_in_session`, `console --command`, `session run-code`, `linux_env::exec_via_vsock`, the apple_container `uname` probe — each preserving its live-vs-capture behavior and `verb=exec` audit emit.

### Live E2E (libkrun host)
`mvmctl exec -- sh -c 'echo first; sleep 2; echo second'`, host output timestamped → `[01:11:44] first` … `[01:11:46] second`: the **2-second gap** proves progressive streaming (capture-then-return would print both at one timestamp). An earlier run against a stale cached agent confirmed the new host **fail-closes** on the old `ExecResult` frame.

### Reviews
Subagent-driven, per-task spec + code-quality review, **3 opus reviews** on the concurrency core + consumer migrations + a final whole-branch pass. Opus confirmed claim-4 symbol absence, the tail-flush fix, fail-closed reader, and audit consistency.

## Test plan
- [x] `rustup run nightly cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` — 4752 pass (mvm-backend excluded locally per the macOS codesign-SIGKILL issue → Linux CI; skip-embed ELF artifact excluded)
- [x] Live progressive E2E (first…2s…second) + stale-agent fail-closed
- [x] `grep ExecResult crates/` empty; prod agent has no exec symbols
- [ ] CI green on Linux (full workspace incl. mvm-backend + embedded-binaries)

## Notes
- `--hypervisor` isn't honored by `exec` (boots the macOS-26 default apple_container backend); streaming is backend-agnostic over vsock, so unaffected.
- Deferred (tracked in the plan): enforce exec `timeout_secs` (pre-existing — ignored today); progressive upgrade of `RunEntrypoint` (its v1 buffering is separate).