### PR TITLE
feat(secrets): inject HTTP_PROXY + placeholders at invoke; guest starts forward proxy (plan 129, stage 2b+2c)

### DIFF
--- a/crates/mvm-backend/src/qemu.rs
+++ b/crates/mvm-backend/src/qemu.rs
@@ -71,7 +71,6 @@ const BRIDGE_PID_FILE: &str = "qemu-vsock-bridge.pid";
 /// invoke path reads this to inject `HTTP_PROXY` + placeholder vars). Spawned
 /// only when the admitted plan carries secret bindings.
 const SUBST_PID_FILE: &str = "substitution.pid";
-const SUBST_ENV_FILE: &str = "substitution-env.json";
 /// How long the endpoint gets to bind its listener + write the ready
 /// handshake line before `start` declares the spawn failed.
 const SUBST_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -253,7 +252,9 @@ impl VmBackend for QemuBackend {
         {
             match mvm_core::plan::secrets_from_signed_json(plan_json) {
                 Ok(secrets) if !secrets.is_empty() => {
-                    if let Err(e) = spawn_substitution_endpoint(&state_dir, tenant, &secrets) {
+                    if let Err(e) =
+                        spawn_substitution_endpoint(&config.name, &state_dir, tenant, &secrets)
+                    {
                         rollback_qemu(&state_dir, &pid_file);
                         return Err(e);
                     }
@@ -295,7 +296,7 @@ impl VmBackend for QemuBackend {
             send_signal(spid, libc::SIGTERM);
         }
         let _ = std::fs::remove_file(state_dir.join(SUBST_PID_FILE));
-        let _ = std::fs::remove_file(state_dir.join(SUBST_ENV_FILE));
+        let _ = std::fs::remove_file(mvm_core::config::vm_substitution_env_path(&id.0));
 
         let pid_path = state_dir.join(QEMU_PID_FILE);
         let Some(pid) = read_pid(&pid_path) else {
@@ -729,6 +730,7 @@ fn resolve_substitution_endpoint_path() -> Result<PathBuf> {
 /// it via `SUBST_PID_FILE`. The real secret values never leave the endpoint's
 /// address space — only the opaque placeholders are persisted/handed out.
 fn spawn_substitution_endpoint(
+    vm_name: &str,
     state_dir: &Path,
     tenant: &str,
     secrets: &[SecretBinding],
@@ -776,8 +778,9 @@ fn spawn_substitution_endpoint(
     let pid_file = state_dir.join(SUBST_PID_FILE);
     std::fs::write(&pid_file, child.id().to_string())
         .map_err(|e| anyhow!("write {}: {e}", pid_file.display()))?;
-    std::fs::write(state_dir.join(SUBST_ENV_FILE), handshake.trim().as_bytes())
-        .map_err(|e| anyhow!("write substitution env file: {e}"))?;
+    let env_path = mvm_core::config::vm_substitution_env_path(vm_name);
+    std::fs::write(&env_path, handshake.trim().as_bytes())
+        .map_err(|e| anyhow!("write {}: {e}", env_path.display()))?;
     // Detach: drop the child handle without killing. The endpoint runs
     // daemonized (setsid) and is reaped by `stop` via SUBST_PID_FILE.
     Ok(())

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -6,8 +6,10 @@
 //! is the production-safe call surface — it dispatches the
 //! `RunEntrypoint` vsock verb, which the guest agent serves only by
 //! spawning the program named in `/etc/mvm/entrypoint`. There is no
-//! shell, no argv override, and no env injection beyond what the
-//! wrapper template defined at image build time.
+//! shell and no argv override. The only env injected is the Plan 129
+//! substitution env — `HTTP_PROXY` + the opaque secret placeholders —
+//! and only when the VM's admitted plan carried secrets; never a raw
+//! secret value (those stay in the host substitution endpoint).
 //!
 //! v1 behaviour:
 //!   - boots a transient microVM from a registered template,
@@ -400,9 +402,11 @@ fn dispatch_inner(vm_name: &str, stdin: Vec<u8>, timeout_secs: u64) -> Result<i3
         &mut stream,
         stdin,
         timeout_secs,
-        // No injected env on the plain invoke path yet; Plan 129 will supply
-        // HTTP_PROXY + secret placeholder vars here from the admitted plan.
-        Vec::new(),
+        // Plan 129: when the VM has a substitution endpoint (the admitted plan
+        // carried secrets), inject HTTP_PROXY + the opaque placeholder vars so
+        // the workload routes secret-bearing egress through the in-guest
+        // forward proxy → host endpoint. Empty when there are no secrets.
+        substitution_env(vm_name),
         |event| match event {
             mvm_guest::vsock::EntrypointEvent::Stdout { chunk } => {
                 let _ = std::io::stdout().write_all(chunk);
@@ -444,6 +448,42 @@ fn dispatch_inner(vm_name: &str, stdin: Vec<u8>, timeout_secs: u64) -> Result<i3
     let _ = std::io::stderr().flush();
 
     Ok(exit_code_for(&terminal))
+}
+
+/// Plan 129 — the workload launch env that routes secret-bearing egress
+/// through the substitution endpoint. Reads the `(guest var, placeholder)`
+/// pairs the endpoint minted at boot (`vm_substitution_env_path`); when
+/// present, prepends `HTTP(S)_PROXY` pointing at the in-guest forward proxy so
+/// outbound requests carrying a placeholder are routed to the host for
+/// substitution. Empty (no proxy, no vars) when the VM has no secrets — so a
+/// plain workload is unaffected.
+fn substitution_env(vm_name: &str) -> Vec<(String, String)> {
+    let path = mvm_core::config::vm_substitution_env_path(vm_name);
+    let Ok(bytes) = std::fs::read(&path) else {
+        return Vec::new();
+    };
+    let placeholders: Vec<(String, String)> = serde_json::from_slice(&bytes).unwrap_or_default();
+    build_substitution_env(placeholders)
+}
+
+/// Pure half of [`substitution_env`]: given the endpoint's minted placeholder
+/// vars, prepend `HTTP(S)_PROXY` (the in-guest forward proxy) so the workload
+/// routes secret-bearing egress for substitution. Empty placeholders ⇒ empty
+/// env (a plain workload is left untouched).
+fn build_substitution_env(placeholders: Vec<(String, String)>) -> Vec<(String, String)> {
+    if placeholders.is_empty() {
+        return Vec::new();
+    }
+    let proxy = mvm_guest::forward_proxy::proxy_env_url();
+    // Both upper- and lower-case forms — toolchains differ on which they read.
+    let mut env = vec![
+        ("HTTP_PROXY".to_string(), proxy.clone()),
+        ("HTTPS_PROXY".to_string(), proxy.clone()),
+        ("http_proxy".to_string(), proxy.clone()),
+        ("https_proxy".to_string(), proxy),
+    ];
+    env.extend(placeholders);
+    env
 }
 
 fn exit_code_for(event: &mvm_guest::vsock::EntrypointEvent) -> i32 {
@@ -564,5 +604,32 @@ mod tests {
     fn test_read_stdin_missing_file_errors() {
         let err = read_stdin_payload(Some("/this/does/not/exist")).unwrap_err();
         assert!(err.to_string().contains("Reading stdin from"));
+    }
+
+    #[test]
+    fn build_substitution_env_empty_when_no_placeholders() {
+        assert!(super::build_substitution_env(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn build_substitution_env_prepends_proxy_and_keeps_placeholders() {
+        let env = super::build_substitution_env(vec![(
+            "OPENAI_API_KEY".to_string(),
+            "mvm-secret-abc123".to_string(),
+        )]);
+        let proxy = mvm_guest::forward_proxy::proxy_env_url();
+        // HTTP(S)_PROXY (upper + lower) point at the in-guest forward proxy.
+        assert_eq!(
+            env.iter()
+                .find(|(k, _)| k == "HTTP_PROXY")
+                .map(|(_, v)| v.as_str()),
+            Some(proxy.as_str())
+        );
+        assert!(env.iter().any(|(k, v)| k == "https_proxy" && *v == proxy));
+        // The opaque placeholder var survives (never the value).
+        assert!(
+            env.iter()
+                .any(|(k, v)| k == "OPENAI_API_KEY" && v == "mvm-secret-abc123")
+        );
     }
 }

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -392,6 +392,14 @@ pub fn vm_console_log(name: &str) -> std::path::PathBuf {
     vm_state_dir(name).join("console.log")
 }
 
+/// Plan 129 — per-VM JSON file of `(guest var, placeholder)` pairs the
+/// substitution endpoint minted at boot. The backend writes it; the invoke
+/// path reads it to inject `HTTP_PROXY` + the placeholder env vars into the
+/// workload. Holds opaque placeholders only — never secret values.
+pub fn vm_substitution_env_path(name: &str) -> std::path::PathBuf {
+    vm_state_dir(name).join("substitution-env.json")
+}
+
 // ============================================================================
 // Sensitive ~/.mvm subdirectories
 // ============================================================================

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -2808,6 +2808,19 @@ fn main() {
         std::thread::spawn(move || init_probes(&bs, &s));
     }
 
+    // Plan 129 — start the egress forward proxy (loopback FORWARD_PROXY_PORT).
+    // The workload's HTTP_PROXY (set by the host invoke path only when the VM
+    // has a substitution endpoint) routes secret-bearing requests here; this
+    // relays them over vsock to the host endpoint, which substitutes the real
+    // credential. Always started (cheap, loopback-only): with no HTTP_PROXY in
+    // the workload env it simply sees no connections. Not dev-shell-gated —
+    // egress substitution is a production feature.
+    std::thread::spawn(|| {
+        if let Err(e) = mvm_guest::forward_proxy::start_forward_proxy(30) {
+            eprintln!("mvm-guest-agent: forward proxy failed to start: {e}");
+        }
+    });
+
     // Port forwarders are started on-demand via StartPortForward requests
     // from the host (works with all backends, no config drive needed).
 


### PR DESCRIPTION
## What

Closes the **in-guest half** of the egress-substitution loop (builds on the Stage 2a endpoint spawn, #717).

**2b — invoke env injection.** `dispatch_inner` reads `<vm_state>/substitution-env.json` (written by the QEMU endpoint spawn at boot) and, when the VM has a substitution endpoint, injects `HTTP_PROXY`/`HTTPS_PROXY` (= the in-guest forward proxy) plus the opaque placeholder env vars as `RunEntrypoint.env` (#711). A workload with no secrets gets an empty env and is unaffected.

**2c — guest forward proxy.** The guest agent starts `start_forward_proxy` on a startup thread (loopback `FORWARD_PROXY_PORT`), relaying placeholder-bearing egress over vsock to the host endpoint for substitution. Always started (cheap, loopback-only; idle without `HTTP_PROXY`) and **not** dev-shell-gated — egress substitution is a production feature.

## Now the loop is wired end to end

`mvmctl up` (secret-bearing plan) → QEMU spawns the endpoint moat (2a) → handshake placeholders persisted → invoke injects `HTTP_PROXY` + placeholders (2b) → workload's egress hits the in-guest forward proxy (2c) → relayed over vsock → host endpoint substitutes the real credential → real TLS. **The guest only ever holds opaque placeholders; the real secret never leaves the host endpoint.**

## Details

- Path centralized in `mvm_core::config::vm_substitution_env_path` so the qemu writer and invoke reader can't drift (qemu.rs refactored onto it).
- `build_substitution_env` split out as a pure fn + unit-tested (empty → empty; non-empty → `HTTP(S)_PROXY` prepended, placeholder preserved, never a value).
- `invoke.rs` module doc updated (it previously claimed "no env injection").

## Tests / validation

- `build_substitution_env` unit tests (2).
- Builds clean on Linux: mvm-backend, mvm-cli, and the `mvm-guest-agent` bin; clippy clean.

## Next — the final gate

On-box `mvmctl up` of a workload that makes a bound-host request through `HTTP_PROXY` with a placeholder → assert the destination saw the real credential (substitution) and an unbound host is refused. Needs a small workload + local secret + admitted plan harness.