### PR TITLE
feat(secrets): Plan 129 #1b — egress-substitution inject leg (handoff + QEMU serve_vsock + guest proxy)

### DIFF
--- a/crates/mvm-backend/src/qemu.rs
+++ b/crates/mvm-backend/src/qemu.rs
@@ -590,6 +590,8 @@ fn spawn_vsock_bridge(name: &str, cid: u32, state_dir: &Path) -> Result<()> {
         .arg(cid.to_string())
         .arg("--port")
         .arg(mvm_guest::vsock::GUEST_AGENT_PORT.to_string())
+        .arg("--name")
+        .arg(name)
         .arg("--watch-pid-file")
         .arg(state_dir.join(QEMU_PID_FILE))
         .stdin(std::process::Stdio::null())

--- a/crates/mvm-cli/src/commands/qemu_bridge.rs
+++ b/crates/mvm-cli/src/commands/qemu_bridge.rs
@@ -25,11 +25,103 @@ pub(in crate::commands) struct Args {
     /// Guest vsock port to dial.
     #[arg(long)]
     port: u32,
+    /// VM name — used to locate the stashed admitted plan and write the
+    /// per-VM substitution handoff sidecar (Plan 129).
+    #[arg(long)]
+    name: String,
     /// Exit when this PID file's process is no longer alive (the VM is gone).
     #[arg(long)]
     watch_pid_file: PathBuf,
 }
 
 pub(in crate::commands) fn run(args: &Args) -> Result<()> {
+    // Plan 129 #1b: if this VM's admitted plan binds secrets, serve the egress
+    // substitution endpoint over AF_VSOCK alongside the agent bridge. The guest
+    // reaches it via `connect_host_vsock(SUBSTITUTION_PORT)` -> host CID 2.
+    // Best-effort + self-gating (no plan / no secrets -> no-op); the agent
+    // bridge below is the blocking call that owns process lifetime.
+    #[cfg(target_os = "linux")]
+    serve_substitution(&args.name);
     mvm_backend::qemu::run_vsock_bridge(&args.uds, args.cid, args.port, &args.watch_pid_file)
+}
+
+/// Spawn the egress-substitution `serve_vsock` for `name` on a background
+/// thread if its admitted plan (stashed at `<vm_state_dir>/plan.json` by
+/// `stash_plan_for_bridge`) binds secrets. Process exit reaps the thread.
+#[cfg(target_os = "linux")]
+fn serve_substitution(name: &str) {
+    use mvm_core::plan::{ExecutionPlan, SignedExecutionPlan};
+    use mvm_hostd::supervisor::substitution_proxy::prepare_substitution;
+
+    /// Real-TLS forward timeout for the host substitution leg.
+    const FORWARD_TIMEOUT_SECS: u64 = 30;
+
+    let plan_path = mvm_core::config::vm_state_dir(name).join("plan.json");
+    let body = match std::fs::read(&plan_path) {
+        Ok(b) => b,
+        // No admission (legacy / dev-test boot) -> nothing to substitute.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => {
+            tracing::warn!(error = %e, vm = %name, "read stashed plan for substitution");
+            return;
+        }
+    };
+    // The stash is host-written 0600; decode without re-verify, mirroring the
+    // libkrun supervisor (defense-in-depth `verify_plan` is the same follow-up
+    // flagged there — the host is in the TCB per ADR-002).
+    let plan: ExecutionPlan = match serde_json::from_slice::<SignedExecutionPlan>(&body)
+        .and_then(|signed| serde_json::from_slice::<ExecutionPlan>(&signed.0.payload))
+    {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, vm = %name, "decode stashed plan for substitution");
+            return;
+        }
+    };
+    if plan.secrets.is_empty() {
+        return;
+    }
+
+    let tenant = plan.tenant.0.clone();
+    let proxy_url = mvm_guest::forward_proxy::proxy_env_url();
+    let prepared = match prepare_substitution(
+        &plan.secrets,
+        &tenant,
+        name,
+        &proxy_url,
+        FORWARD_TIMEOUT_SECS,
+    ) {
+        Ok(Some(p)) => p,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!(error = %e, vm = %name, "prepare substitution");
+            return;
+        }
+    };
+
+    let name_owned = name.to_string();
+    let spawned = std::thread::Builder::new()
+        .name("mvm-subst-serve".into())
+        .spawn(move || {
+            let rt = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    tracing::error!(error = %e, "build substitution serve runtime");
+                    return;
+                }
+            };
+            if let Err(e) = rt.block_on(
+                prepared
+                    .service
+                    .serve_vsock_port(mvm_guest::vsock::SUBSTITUTION_PORT),
+            ) {
+                tracing::error!(error = %e, vm = %name_owned, "bind/serve substitution vsock");
+            }
+        });
+    if let Err(e) = spawned {
+        tracing::error!(error = %e, vm = %name, "spawn substitution serve thread");
+    }
 }

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -389,6 +389,29 @@ pub(in crate::commands) fn dispatch(
     }
 }
 
+/// Workload env to inject into `vm_name`'s `RunEntrypoint` call: the
+/// egress-substitution handoff the supervisor wrote at boot (Plan 129 #1b —
+/// `HTTP_PROXY` + the opaque placeholder vars), or empty when there's no
+/// sidecar (a plan with no secret bindings → today's no-injected-env
+/// behavior). A malformed sidecar degrades to empty with a warning rather
+/// than failing the call: the workload then can't reach its secrets (a
+/// visible functional failure), but nothing leaks and default-deny egress
+/// (claim 10) still holds.
+fn injected_env(vm_name: &str) -> Vec<(String, String)> {
+    match mvm_core::substitution_handoff::read(vm_name) {
+        Ok(Some(handoff)) => handoff.env,
+        Ok(None) => Vec::new(),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                vm = %vm_name,
+                "reading substitution handoff; proceeding with no injected env"
+            );
+            Vec::new()
+        }
+    }
+}
+
 fn dispatch_inner(vm_name: &str, stdin: Vec<u8>, timeout_secs: u64) -> Result<i32> {
     let transport = mvm::vsock_transport::for_vm(vm_name)
         .with_context(|| format!("Picking transport for guest agent on '{vm_name}'"))?;
@@ -400,9 +423,10 @@ fn dispatch_inner(vm_name: &str, stdin: Vec<u8>, timeout_secs: u64) -> Result<i3
         &mut stream,
         stdin,
         timeout_secs,
-        // No injected env on the plain invoke path yet; Plan 129 will supply
-        // HTTP_PROXY + secret placeholder vars here from the admitted plan.
-        Vec::new(),
+        // Plan 129 #1b: the supervisor wrote the egress-substitution env
+        // (HTTP_PROXY + opaque placeholder vars) to a per-VM sidecar at boot;
+        // inject it here. Empty when the plan bound no secrets.
+        injected_env(vm_name),
         |event| match event {
             mvm_guest::vsock::EntrypointEvent::Stdout { chunk } => {
                 let _ = std::io::stdout().write_all(chunk);
@@ -485,6 +509,56 @@ fn exit_code_for(event: &mvm_guest::vsock::EntrypointEvent) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Run `f` with `MVM_DATA_DIR` pointed at a fresh tempdir so
+    /// `injected_env` resolves the per-VM sidecar in isolation. `MVM_DATA_DIR`
+    /// is process-global, so the lock serializes the env-mutating tests —
+    /// keeping them correct under shared-process `cargo test`, not just
+    /// process-per-test nextest.
+    fn with_data_dir(f: impl FnOnce(&str)) {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var_os("MVM_DATA_DIR");
+        unsafe { std::env::set_var("MVM_DATA_DIR", tmp.path()) };
+        f("vm-under-test");
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MVM_DATA_DIR", v),
+                None => std::env::remove_var("MVM_DATA_DIR"),
+            }
+        }
+    }
+
+    #[test]
+    fn injected_env_empty_without_sidecar() {
+        with_data_dir(|vm| assert!(injected_env(vm).is_empty()));
+    }
+
+    #[test]
+    fn injected_env_reads_supervisor_sidecar() {
+        with_data_dir(|vm| {
+            let handoff = mvm_core::substitution_handoff::SubstitutionHandoff {
+                env: vec![
+                    ("HTTP_PROXY".into(), "http://127.0.0.1:5254".into()),
+                    ("OPENAI_API_KEY".into(), "mvm-secret-abc123".into()),
+                ],
+            };
+            mvm_core::substitution_handoff::write(vm, &handoff).expect("write sidecar");
+            assert_eq!(injected_env(vm), handoff.env);
+        });
+    }
+
+    #[test]
+    fn injected_env_degrades_to_empty_on_malformed_sidecar() {
+        with_data_dir(|vm| {
+            let path = mvm_core::substitution_handoff::handoff_path(vm);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, b"{ not json").unwrap();
+            assert!(injected_env(vm).is_empty());
+        });
+    }
 
     #[test]
     fn test_exit_code_normal_exit_zero() {

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -31,6 +31,9 @@ pub mod plan;
 pub mod platform;
 pub mod policy;
 pub mod protocol;
+/// Plan 129 #1b — per-VM sidecar handing the admission-minted placeholders +
+/// egress-proxy env from the supervisor to `mvmctl` invoke and the guest init.
+pub mod substitution_handoff;
 /// Plan 129 / ADR-067 §1 — the guest↔host substitution-endpoint wire contract,
 /// shared so the in-guest client and the host server serialize identical bytes.
 pub mod substitution_wire;

--- a/crates/mvm-core/src/substitution_handoff.rs
+++ b/crates/mvm-core/src/substitution_handoff.rs
@@ -1,0 +1,138 @@
+//! Per-VM handoff of the admission-minted secret placeholders + egress-proxy
+//! env. Written by the per-VM supervisor at boot (Plan 129 #1b), consumed by
+//! `mvmctl` invoke (the `RunEntrypoint` workload env) and the guest `/init`.
+//!
+//! A sidecar in the VM state dir, parallel to the runtime `mode.json` that
+//! `mvm_backend::base::runtime_meta` writes. It lives in `mvm-core` because
+//! it is the lowest crate both the producer (`mvm-vm-host` supervisor bin)
+//! and the consumer (`mvm-cli`) already depend on.
+//!
+//! The file carries only **opaque placeholders** (`mvm-secret-<hex>` tokens)
+//! plus the loopback `HTTP_PROXY` env — never a real secret value
+//! (ADR-067 §4 / claim 13). It is mode 0600 as defense-in-depth, not because
+//! the tokens are themselves sensitive.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::vm_state_dir;
+
+/// Ready-to-inject workload env for a running VM's egress substitution.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubstitutionHandoff {
+    /// `(name, value)` env pairs injected into the workload after
+    /// `env_clear()`: `HTTP_PROXY`/`HTTPS_PROXY` pointing at the guest-local
+    /// forward proxy, plus the opaque placeholder vars (e.g. `OPENAI_API_KEY`
+    /// -> `mvm-secret-<hex>`). No real secret bytes ever land here.
+    pub env: Vec<(String, String)>,
+}
+
+impl SubstitutionHandoff {
+    /// Nothing to inject — the supervisor skips writing the sidecar for a
+    /// plan with no secret bindings, so consumers treat absent and empty
+    /// identically.
+    pub fn is_empty(&self) -> bool {
+        self.env.is_empty()
+    }
+}
+
+/// Sidecar path for `name`: `<vm_state_dir>/substitution.json`.
+pub fn handoff_path(name: &str) -> PathBuf {
+    vm_state_dir(name).join("substitution.json")
+}
+
+/// Write the handoff sidecar for `name` (mode 0600), creating the VM state
+/// dir if absent. Errors propagate: a producer that can't persist the
+/// placeholders must decide how to fail — it must not silently boot a
+/// workload that believes its secrets are wired when they aren't.
+pub fn write(name: &str, handoff: &SubstitutionHandoff) -> io::Result<()> {
+    write_at(&handoff_path(name), handoff)
+}
+
+/// Read the handoff sidecar for `name`. `Ok(None)` when absent (no secrets,
+/// or not yet written) — the backward-compatible default the invoke path
+/// relies on to preserve its no-injected-env behavior.
+pub fn read(name: &str) -> io::Result<Option<SubstitutionHandoff>> {
+    read_at(&handoff_path(name))
+}
+
+fn write_at(path: &Path, handoff: &SubstitutionHandoff) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let body = serde_json::to_string(handoff).map_err(io::Error::from)?;
+    std::fs::write(path, format!("{body}\n"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+fn read_at(path: &Path) -> io::Result<Option<SubstitutionHandoff>> {
+    let body = match std::fs::read_to_string(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    let handoff = serde_json::from_str(&body).map_err(io::Error::from)?;
+    Ok(Some(handoff))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> SubstitutionHandoff {
+        SubstitutionHandoff {
+            env: vec![
+                ("HTTP_PROXY".into(), "http://127.0.0.1:5254".into()),
+                ("HTTPS_PROXY".into(), "http://127.0.0.1:5254".into()),
+                ("OPENAI_API_KEY".into(), "mvm-secret-deadbeef".into()),
+            ],
+        }
+    }
+
+    #[test]
+    fn roundtrip_preserves_env_pairs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("substitution.json");
+        let handoff = sample();
+        write_at(&path, &handoff).unwrap();
+        assert_eq!(read_at(&path).unwrap(), Some(handoff));
+    }
+
+    #[test]
+    fn read_absent_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(read_at(&dir.path().join("nope.json")).unwrap(), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn written_file_is_private_0600() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("substitution.json");
+        write_at(&path, &sample()).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        // A tampered or future-shaped sidecar fails closed rather than
+        // silently dropping fields.
+        assert!(serde_json::from_str::<SubstitutionHandoff>(r#"{"env":[],"x":1}"#).is_err());
+    }
+
+    #[test]
+    fn empty_when_no_pairs() {
+        assert!(SubstitutionHandoff::default().is_empty());
+        assert!(!sample().is_empty());
+    }
+}

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -2786,6 +2786,23 @@ fn main() {
     HOT_SAMPLE_INTERVAL_SECS.store(cfg.sample_interval_secs, Ordering::Release);
     std::thread::spawn(move || monitoring_loop(monitor_state));
 
+    // Plan 129 #1b: the guest-local egress forward proxy. Binds loopback
+    // FORWARD_PROXY_PORT and relays each proxied request to the host
+    // substitution endpoint over AF_VSOCK. Started unconditionally — it only
+    // dials the host when a request arrives, and is only *used* when the
+    // workload's HTTP_PROXY points at it (secret-bearing VMs, set from the
+    // admission handoff). Best-effort: a bind failure logs and the agent keeps
+    // serving; non-secret VMs simply never route through it.
+    std::thread::spawn(|| {
+        // Real-TLS forward happens host-side; this is the guest→host relay hop.
+        const FORWARD_PROXY_RELAY_TIMEOUT_SECS: u64 = 30;
+        if let Err(e) =
+            mvm_guest::forward_proxy::start_forward_proxy(FORWARD_PROXY_RELAY_TIMEOUT_SECS)
+        {
+            eprintln!("mvm-guest-agent: forward proxy exited: {e}");
+        }
+    });
+
     // Plan 76 Phase 3: defer integration drop-in scanning + health
     // loop startup to a dedicated background thread. The scan
     // itself is fast (single directory read), but moving it off the

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -411,6 +411,17 @@ impl SubstitutionService {
         }
     }
 
+    /// Bind AF_VSOCK on `(VMADDR_CID_ANY, port)` and serve until the listener
+    /// errors — the convenience the per-VM host bridge calls so it never
+    /// handles the raw listener. Returns only if the bind fails; serving
+    /// otherwise loops for the VM's lifetime.
+    #[cfg(target_os = "linux")]
+    pub async fn serve_vsock_port(self: Arc<Self>, port: u32) -> std::io::Result<()> {
+        let listener = vsock::VsockListener::bind(port)?;
+        self.serve_vsock(listener).await;
+        Ok(())
+    }
+
     async fn handle_connection(&self, mut stream: UnixStream) -> Result<(), FrameError> {
         let wire: WireRequest = read_json_frame(&mut stream, MAX_FRAME_BYTES).await?;
         let resp = self.process(wire).await;

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -21,16 +21,16 @@ use base64::engine::general_purpose::STANDARD as B64;
 use tokio::net::{UnixListener, UnixStream};
 use url::Url;
 
-use mvm_core::crypto::secret_store::SecretStore;
+use mvm_core::crypto::secret_store::{SecretStore, default_secret_store};
 use mvm_core::plan::SecretBinding;
 use mvm_core::substitution_wire::{WireRequest, WireResponse};
 use mvm_sdk::ir::AuthType;
 
 use crate::framing::{FrameError, read_json_frame, write_json_frame};
 use crate::keyholder::{
-    AssembleError, BindingStore, HandedPlaceholders, LocalResolver, SecretResolver,
-    SubstituteError, SubstitutionEndpoint, SubstitutionRegistry, assemble_registry,
-    find_placeholder,
+    AssembleError, BindingStore, FileBindingStore, HandedPlaceholders, LocalResolver,
+    SecretResolver, SubstituteError, SubstitutionEndpoint, SubstitutionRegistry, assemble_registry,
+    find_placeholder, secret_placeholder_env,
 };
 use crate::supervisor::audit_recorder::Recorder;
 use crate::supervisor::secret_audit::emit_secret_substituted;
@@ -141,6 +141,110 @@ pub enum FromPlanError {
     Assemble(#[from] AssembleError),
     #[error(transparent)]
     Forward(#[from] ForwardError),
+}
+
+/// Egress substitution wired for a VM that's about to boot: the running
+/// service to serve on the host (vsock for QEMU/Firecracker, per-port UDS for
+/// libkrun), plus the workload env that was persisted to the per-VM handoff
+/// sidecar.
+pub struct PreparedSubstitution {
+    /// The host endpoint to `serve`/`serve_vsock` for the VM's lifetime.
+    pub service: Arc<SubstitutionService>,
+    /// The env written to the handoff sidecar: the opaque placeholder vars +
+    /// `HTTP_PROXY`/`HTTPS_PROXY`. Exposed for callers that also set the guest
+    /// launch env directly; the sidecar is the source `mvmctl invoke` reads.
+    pub env: Vec<(String, String)>,
+}
+
+/// Errors preparing egress substitution at boot.
+#[derive(Debug, thiserror::Error)]
+pub enum PrepareError {
+    #[error(transparent)]
+    FromPlan(#[from] FromPlanError),
+    /// Opening the host default binding/secret stores failed.
+    #[error(transparent)]
+    Store(#[from] anyhow::Error),
+    /// Persisting the per-VM handoff sidecar failed. Propagated (not swallowed)
+    /// because a workload booted believing its secrets are wired, when the
+    /// invoke path can't read them, would silently lose egress credentials.
+    #[error("write substitution handoff for {vm}: {source}")]
+    Handoff { vm: String, source: std::io::Error },
+}
+
+/// Prepare egress substitution for `vm_name` from its admitted plan's secret
+/// bindings, using the host's default binding + secret stores (the same ones
+/// `mvmctl secret set` writes). `Ok(None)` when the plan binds no secrets —
+/// nothing to wire, and `mvmctl invoke` finds no sidecar (its no-injected-env
+/// default). See [`prepare_substitution_with_stores`] for the injectable form.
+pub fn prepare_substitution(
+    plan_secrets: &[SecretBinding],
+    tenant: &str,
+    vm_name: &str,
+    proxy_url: &str,
+    forward_timeout_secs: u64,
+) -> Result<Option<PreparedSubstitution>, PrepareError> {
+    if plan_secrets.is_empty() {
+        return Ok(None);
+    }
+    let bindings = FileBindingStore::default_location()?;
+    let secret_store: Arc<dyn SecretStore> = default_secret_store().into();
+    prepare_substitution_with_stores(
+        plan_secrets,
+        tenant,
+        vm_name,
+        proxy_url,
+        forward_timeout_secs,
+        &bindings,
+        secret_store,
+    )
+}
+
+/// [`prepare_substitution`] over caller-supplied stores (tests inject
+/// tempdir-backed `FileBindingStore`/`FileSecretStore`).
+///
+/// Mints the registry + service via [`SubstitutionService::from_plan`], builds
+/// the workload env (each secret's opaque placeholder + `HTTP_PROXY`/
+/// `HTTPS_PROXY` → `proxy_url`), and writes it to the per-VM handoff sidecar
+/// (`mvm_core::substitution_handoff`) so `mvmctl invoke` injects it into the
+/// `RunEntrypoint` call. No real secret value reaches the sidecar (claim 13);
+/// the placeholders resolve only host-side at serve time.
+pub fn prepare_substitution_with_stores(
+    plan_secrets: &[SecretBinding],
+    tenant: &str,
+    vm_name: &str,
+    proxy_url: &str,
+    forward_timeout_secs: u64,
+    bindings: &dyn BindingStore,
+    secret_store: Arc<dyn SecretStore>,
+) -> Result<Option<PreparedSubstitution>, PrepareError> {
+    if plan_secrets.is_empty() {
+        return Ok(None);
+    }
+    let (service, handed) = SubstitutionService::from_plan(
+        plan_secrets,
+        tenant,
+        bindings,
+        secret_store,
+        forward_timeout_secs,
+    )?;
+
+    let mut env = secret_placeholder_env(&handed);
+    // Route the workload's egress through the guest-local forward proxy. curl/
+    // libcurl honor only the lowercase names, most other runtimes the
+    // uppercase — set both so every workload's HTTP client picks it up.
+    for key in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] {
+        env.push((key.to_string(), proxy_url.to_string()));
+    }
+
+    let handoff = mvm_core::substitution_handoff::SubstitutionHandoff { env: env.clone() };
+    mvm_core::substitution_handoff::write(vm_name, &handoff).map_err(|source| {
+        PrepareError::Handoff {
+            vm: vm_name.to_string(),
+            source,
+        }
+    })?;
+
+    Ok(Some(PreparedSubstitution { service, env }))
 }
 
 /// Forwards a prepared (credential-substituted) request to the real
@@ -905,6 +1009,102 @@ mod server_tests {
         assert_eq!(handed.len(), 1);
         assert_eq!(handed[0].0, "OPENAI_API_KEY");
         assert!(handed[0].1.as_str().starts_with("mvm-secret-"));
+    }
+
+    #[test]
+    fn prepare_substitution_none_when_no_secrets() {
+        // Returns before touching any store or the sidecar.
+        let dir = tempdir().unwrap();
+        let bindings = FileBindingStore::with_dir(dir.path().join("bindings"));
+        let secret_store: Arc<dyn SecretStore> =
+            Arc::new(FileSecretStore::with_dir(dir.path().join("secrets")));
+        let out = prepare_substitution_with_stores(
+            &[],
+            "local",
+            "vm1",
+            "http://127.0.0.1:18080",
+            30,
+            &bindings,
+            secret_store,
+        )
+        .unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn prepare_substitution_writes_sidecar_with_placeholder_and_proxy() {
+        use crate::keyholder::SecretBindingMeta;
+        use mvm_core::plan::{SecretBinding, SecretSource};
+
+        // The sidecar write targets `vm_state_dir`, which reads MVM_DATA_DIR;
+        // serialize the env mutation so shared-process `cargo test` is honest.
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        let dir = tempdir().unwrap();
+        let prev = std::env::var_os("MVM_DATA_DIR");
+        unsafe { std::env::set_var("MVM_DATA_DIR", dir.path()) };
+
+        let bindings = FileBindingStore::with_dir(dir.path().join("bindings"));
+        bindings
+            .put(
+                "local",
+                "openai",
+                &SecretBindingMeta {
+                    auth_type: AuthType::Bearer,
+                    allowed_hosts: vec!["api.openai.com".into()],
+                },
+            )
+            .unwrap();
+        // No value set: prepare mints placeholders from the binding only — the
+        // value is resolved host-side at serve time, never here.
+        let secret_store: Arc<dyn SecretStore> =
+            Arc::new(FileSecretStore::with_dir(dir.path().join("secrets")));
+
+        let plan = [SecretBinding {
+            name: "OPENAI_API_KEY".into(),
+            source: SecretSource::Keystore {
+                address: "openai".into(),
+            },
+        }];
+        let prepared = prepare_substitution_with_stores(
+            &plan,
+            "local",
+            "vm1",
+            "http://127.0.0.1:18080",
+            30,
+            &bindings,
+            secret_store,
+        )
+        .unwrap()
+        .expect("plan binds a secret");
+
+        let get = |k: &str| {
+            prepared
+                .env
+                .iter()
+                .find(|(n, _)| n == k)
+                .map(|(_, v)| v.clone())
+        };
+        assert_eq!(get("HTTP_PROXY").as_deref(), Some("http://127.0.0.1:18080"));
+        assert_eq!(
+            get("https_proxy").as_deref(),
+            Some("http://127.0.0.1:18080")
+        );
+        assert!(get("OPENAI_API_KEY").unwrap().starts_with("mvm-secret-"));
+
+        // The persisted sidecar matches and carries no secret value.
+        let sidecar = mvm_core::substitution_handoff::read("vm1")
+            .unwrap()
+            .expect("sidecar written");
+        assert_eq!(sidecar.env, prepared.env);
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MVM_DATA_DIR", v),
+                None => std::env::remove_var("MVM_DATA_DIR"),
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Wires the **inject/bearer leg** of Plan 129 egress secret substitution (ADR-067) end-to-end on the QEMU backend: a secret-bearing workload's egress is routed through a guest-local forward proxy to a host substitution endpoint that swaps an opaque placeholder for the real credential — the guest only ever holds `mvm-secret-<hex>`.

### What's wired (4 commits)
- **`mvm-core::substitution_handoff`** — per-VM sidecar (`<vm_state_dir>/substitution.json`, mode 0600) carrying the ready-to-inject workload env (placeholders + `HTTP_PROXY`), parallel to `runtime_meta`'s `mode.json`. **`invoke`** injects it into the `RunEntrypoint` env (was `Vec::new()`); absent sidecar → today's no-env behavior.
- **`prepare_substitution` (mvm-hostd)** — boot-time producer: from a plan's `SecretBinding`s → `from_plan` (mints the service) → builds the env → writes the sidecar. `Ok(None)` when the plan binds no secrets.
- **QEMU bridge** (`__qemu-vsock-bridge`) — reads the admitted plan stashed at `<vm_state_dir>/plan.json`; if it binds secrets, `prepare_substitution` + `serve_vsock` on `SUBSTITUTION_PORT` on a background runtime thread alongside the agent bridge. Self-gating; `--name` added so the bridge can locate the plan + sidecar. Plus `SubstitutionService::serve_vsock_port`.
- **Guest agent** — starts `start_forward_proxy` at boot (unconditional bind, dial-on-demand; only used when `HTTP_PROXY` is set).

### Validation
- Unit tests for every new unit (handoff roundtrip/0600/gating, `prepare_substitution`, invoke consumer) — green on macOS **and** the Linux x86_64 box.
- `cargo fmt --all` + `clippy -D warnings` clean (incl. the cfg(linux) paths, on the box).
- **Live QEMU boot on a KVM box:** a real `--hypervisor qemu --builder qemu` boot confirms the full chain — plan admitted (`backend=qemu`) → `plan.json` stashed (0600) → bridge spawned with `--name` → secret-gating verified (`substitution.json` correctly absent for a no-secret workload).

### Deferred follow-up (separate workstream)
The **live positive substitution demo** is gated on the **Python/TS SDK toolchain** item, not this leg: (1) `mvm.secret()` doesn't yet expose `auth_type`/`allowed_hosts`, so a compiled secret app emits an unbound `SecretRef` that validation rejects; (2) the forward proxy parses absolute-form HTTP, so the workload needs the SDK egress client. Tracked for the next slice. The other backends' bin glue (libkrun/vz/firecracker) follow the same shape as the QEMU bridge here.