### PR TITLE
feat(plan-173): enforce exec timeout_secs (pgroup kill + ExecEvent::TimedOut)

### DIFF
--- a/crates/mvm-backend/src/base/linux_env.rs
+++ b/crates/mvm-backend/src/base/linux_env.rs
@@ -193,7 +193,7 @@ impl AppleContainerEnv {
             &mut stream,
             &wrapped,
             None,
-            timeout_secs,
+            Some(timeout_secs),
             |event| match event {
                 mvm_guest::vsock::ExecEvent::Stdout { chunk } => out_buf.extend_from_slice(chunk),
                 mvm_guest::vsock::ExecEvent::Stderr { chunk } => err_buf.extend_from_slice(chunk),
@@ -211,6 +211,10 @@ impl AppleContainerEnv {
                     stderr: err_buf,
                 })
             }
+            mvm_guest::vsock::ExecEvent::TimedOut => anyhow::bail!(
+                "command timed out after {timeout_secs}s in dev VM '{}'",
+                self.vm_id
+            ),
             other => anyhow::bail!("unexpected terminal exec event from dev VM: {other:?}"),
         }
     }

--- a/crates/mvm-cli/src/commands/env/apple_container.rs
+++ b/crates/mvm-cli/src/commands/env/apple_container.rs
@@ -472,7 +472,7 @@ pub(super) fn cmd_dev_apple_container_status() -> Result<()> {
         );
         // Best-effort kernel probe via streaming exec (Plan 159 WS-5 E).
         let mut out_buf: Vec<u8> = Vec::new();
-        if mvm_guest::vsock::send_exec_streaming(&mut stream, "uname -r", None, 5, |event| {
+        if mvm_guest::vsock::send_exec_streaming(&mut stream, "uname -r", None, Some(5), |event| {
             if let mvm_guest::vsock::ExecEvent::Stdout { chunk } = event {
                 out_buf.extend_from_slice(chunk);
             }

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -406,7 +406,7 @@ impl ExecDispatcher {
             add_dirs: Vec::new(),
             env: Vec::new(),
             target: crate::exec::ExecTarget::Inline { argv },
-            timeout_secs: timeout,
+            timeout_secs: Some(timeout),
         };
         crate::exec::run_captured(req)
     }
@@ -427,7 +427,7 @@ impl ExecDispatcher {
         let vm = handle
             .lock()
             .map_err(|_| anyhow::anyhow!("warm-VM lock poisoned for session '{session_id}'"))?;
-        crate::exec::dispatch_in_session(&vm, code.to_string(), timeout)
+        crate::exec::dispatch_in_session(&vm, code.to_string(), Some(timeout))
     }
 
     /// Look up an existing warm VM for the session, or boot a new one

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1841,7 +1841,10 @@ fn exec_default_manifest_argv_only() {
             assert_eq!(memory, "512M");
             assert!(add_dir.is_empty());
             assert!(env.is_empty());
-            assert_eq!(timeout, None, "unset --timeout ⇒ None (no per-command kill)");
+            assert_eq!(
+                timeout, None,
+                "unset --timeout ⇒ None (no per-command kill)"
+            );
             assert!(launch_plan.is_none(), "launch_plan should default to None");
             assert_eq!(argv, vec!["uname".to_string(), "-a".to_string()]);
         }
@@ -1878,7 +1881,10 @@ fn run_default_profile_argv_only() {
             assert_eq!(profile, exec::RunProfile::Standard);
             assert!(add_dir.is_empty());
             assert!(env.is_empty());
-            assert_eq!(timeout, None, "unset --timeout ⇒ None (no per-command kill)");
+            assert_eq!(
+                timeout, None,
+                "unset --timeout ⇒ None (no per-command kill)"
+            );
             assert!(receipt.is_none(), "receipt should default to None");
             assert!(!json, "json should default to false");
             assert!(!dry_run, "dry_run should default to false");

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1841,7 +1841,7 @@ fn exec_default_manifest_argv_only() {
             assert_eq!(memory, "512M");
             assert!(add_dir.is_empty());
             assert!(env.is_empty());
-            assert_eq!(timeout, 60);
+            assert_eq!(timeout, None, "unset --timeout ⇒ None (no per-command kill)");
             assert!(launch_plan.is_none(), "launch_plan should default to None");
             assert_eq!(argv, vec!["uname".to_string(), "-a".to_string()]);
         }
@@ -1878,7 +1878,7 @@ fn run_default_profile_argv_only() {
             assert_eq!(profile, exec::RunProfile::Standard);
             assert!(add_dir.is_empty());
             assert!(env.is_empty());
-            assert_eq!(timeout, 60);
+            assert_eq!(timeout, None, "unset --timeout ⇒ None (no per-command kill)");
             assert!(receipt.is_none(), "receipt should default to None");
             assert!(!json, "json should default to false");
             assert!(!dry_run, "dry_run should default to false");

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1853,6 +1853,18 @@ fn exec_default_manifest_argv_only() {
 }
 
 #[test]
+fn exec_timeout_parses_to_some() {
+    let cli = Cli::try_parse_from(["mvmctl", "exec", "--timeout", "5", "--", "sleep", "10"])
+        .expect("parse");
+    match cli.command {
+        Commands::Exec(exec::Args { timeout, .. }) => {
+            assert_eq!(timeout, Some(5), "--timeout 5 ⇒ Some(5)");
+        }
+        _ => panic!("Expected Exec command"),
+    }
+}
+
+#[test]
 fn run_default_profile_argv_only() {
     let cli = Cli::try_parse_from(["mvmctl", "run", "--", "uname", "-a"]).expect("parse");
     match cli.command {
@@ -1893,6 +1905,18 @@ fn run_default_profile_argv_only() {
             assert!(!dev, "dev should default to false");
             assert!(!prod, "prod should default to false");
             assert_eq!(argv, vec!["uname".to_string(), "-a".to_string()]);
+        }
+        _ => panic!("Expected Run command"),
+    }
+}
+
+#[test]
+fn run_timeout_parses_to_some() {
+    let cli = Cli::try_parse_from(["mvmctl", "run", "--timeout", "5", "--", "sleep", "10"])
+        .expect("parse");
+    match cli.command {
+        Commands::Run(exec::RunArgs { timeout, .. }) => {
+            assert_eq!(timeout, Some(5), "--timeout 5 ⇒ Some(5)");
         }
         _ => panic!("Expected Run command"),
     }

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -107,7 +107,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             &mvm_guest::vsock::GuestRequest::Exec {
                 command: cmd.to_string(),
                 stdin: None,
-                timeout_secs: Some(30),
+                timeout_secs: None,
             },
         );
         // send_exec_streaming does the protocol hello internally (Plan 159 WS-5 E).
@@ -116,7 +116,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             &mut stream,
             cmd,
             None,
-            30,
+            None,
             |event| match event {
                 mvm_guest::vsock::ExecEvent::Stdout { chunk } => {
                     let mut so = std::io::stdout();
@@ -137,6 +137,10 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                     std::process::exit(code);
                 }
                 Ok(())
+            }
+            mvm_guest::vsock::ExecEvent::TimedOut => {
+                eprintln!("error: command timed out");
+                std::process::exit(crate::exec::EXEC_TIMEOUT_EXIT_CODE);
             }
             other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
         }

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -139,7 +139,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 Ok(())
             }
             mvm_guest::vsock::ExecEvent::TimedOut => {
-                eprintln!("error: command timed out");
+                eprintln!("{}", crate::exec::timeout_exit_message(None));
                 std::process::exit(crate::exec::EXEC_TIMEOUT_EXIT_CODE);
             }
             other => anyhow::bail!("unexpected terminal exec event: {other:?}"),

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -43,9 +43,9 @@ pub(in crate::commands) struct Args {
     /// carried by `--launch-plan`.
     #[arg(short, long)]
     pub env: Vec<String>,
-    /// Per-command timeout in seconds (default: 60)
-    #[arg(long, default_value = "60")]
-    pub timeout: u64,
+    /// Per-command timeout in seconds. Unset ⇒ no per-command kill.
+    #[arg(long)]
+    pub timeout: Option<u64>,
     /// Path to an mvmforge document — either the `launch.json` artifact
     /// from `mvmforge compile` (top-level `entrypoint`) or the Workload IR
     /// manifest from `mvmforge emit` (top-level `apps[]`). The resolved
@@ -104,9 +104,9 @@ pub(in crate::commands) struct RunArgs {
     /// Disabled by `--profile restrictive`.
     #[arg(short, long)]
     pub env: Vec<String>,
-    /// Per-command timeout in seconds (default: 60)
-    #[arg(long, default_value = "60")]
-    pub timeout: u64,
+    /// Per-command timeout in seconds. Unset ⇒ no per-command kill.
+    #[arg(long)]
+    pub timeout: Option<u64>,
     /// Write a signed execution receipt to this path. The receipt records
     /// command/env/mount hashes, output hashes, and exit status; it never
     /// stores raw argv, env values, stdout, or stderr.
@@ -454,8 +454,13 @@ fn build_exec_request(
                 "Using OCI image {} ({})",
                 cached.reference, cached.resolved_digest
             ));
-            emit_oci_run_admission(&cached, args.cpus, u64::from(memory_mib), args.timeout)
-                .context("admitting OCI image provenance for mvmctl run --image")?;
+            emit_oci_run_admission(
+                &cached,
+                args.cpus,
+                u64::from(memory_mib),
+                args.timeout.unwrap_or(60),
+            )
+            .context("admitting OCI image provenance for mvmctl run --image")?;
             if cached.pulled {
                 let auth_source = cached.auth_source.as_deref().unwrap_or("unknown");
                 mvm_core::audit_emit!(
@@ -745,7 +750,7 @@ impl RunPreflightSummary {
                 cpus: args.cpus,
                 memory: args.memory.clone(),
                 memory_mib,
-                timeout_secs: args.timeout,
+                timeout_secs: args.timeout.unwrap_or(60),
             },
             image,
             receipt: RunPreflightReceipt {
@@ -857,7 +862,7 @@ impl ReceiptInput {
             command,
             env_keys,
             add_dirs,
-            timeout_secs: args.timeout,
+            timeout_secs: args.timeout.unwrap_or(60),
         })
     }
 }
@@ -1013,7 +1018,7 @@ mod tests {
             profile,
             add_dir: Vec::new(),
             env: Vec::new(),
-            timeout: 60,
+            timeout: Some(60),
             receipt: None,
             json: false,
             dry_run: false,

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -344,7 +344,7 @@ mod tests {
             profile: RunProfile::Standard,
             add_dir: Vec::new(),
             env: Vec::new(),
-            timeout: 60,
+            timeout: Some(60),
             receipt: None,
             json: false,
             launch_plan: None,

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -143,9 +143,9 @@ pub(in crate::commands) struct AttachArgs {
     /// no stdin (the wrapper sees an empty pipe).
     #[arg(long, value_name = "PATH")]
     pub stdin: Option<String>,
-    /// Wall-clock timeout for the call, in seconds. Default 30.
-    #[arg(long, default_value = "30")]
-    pub timeout: u64,
+    /// Wall-clock timeout for the call, in seconds. Unset ⇒ no kill.
+    #[arg(long)]
+    pub timeout: Option<u64>,
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -157,9 +157,9 @@ pub(in crate::commands) struct ExecArgs {
     /// `mvmctl` flags (e.g. `mvmctl session exec <id> -- ls -la`).
     #[arg(required = true, last = true)]
     pub argv: Vec<String>,
-    /// Wall-clock timeout for the call, in seconds. Default 30.
-    #[arg(long, default_value = "30")]
-    pub timeout: u64,
+    /// Wall-clock timeout for the call, in seconds. Unset ⇒ no kill.
+    #[arg(long)]
+    pub timeout: Option<u64>,
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -170,9 +170,9 @@ pub(in crate::commands) struct RunCodeArgs {
     /// runtime (Python, Node, etc. — language is determined by the
     /// session's wrapper, not by the CLI).
     pub code: String,
-    /// Wall-clock timeout for the call, in seconds. Default 30.
-    #[arg(long, default_value = "30")]
-    pub timeout: u64,
+    /// Wall-clock timeout for the call, in seconds. Unset ⇒ no kill.
+    #[arg(long)]
+    pub timeout: Option<u64>,
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -646,8 +646,16 @@ fn cmd_attach(args: AttachArgs) -> Result<()> {
         Some(&record.vm_name),
         Some(&format!("session={id}")),
     );
-    let exit_code = super::invoke::dispatch(&record.vm_name, stdin_bytes, args.timeout, Some(&id))
-        .with_context(|| format!("dispatching into session {id}"))?;
+    // attach forwards to the entrypoint-runner leg (invoke::dispatch), which
+    // requires a concrete u64 and has its own Timeout→124 mapping. Preserve
+    // the prior default-30 kill window when --timeout is unset.
+    let exit_code = super::invoke::dispatch(
+        &record.vm_name,
+        stdin_bytes,
+        args.timeout.unwrap_or(30),
+        Some(&id),
+    )
+    .with_context(|| format!("dispatching into session {id}"))?;
 
     // Bump the session's invoke counter / last-used timestamp so
     // observers (`mvmctl session info`) see the activity.
@@ -743,7 +751,7 @@ fn dispatch_run_code(
     id: &SessionId,
     record: &mvm_core::session::SessionRecord,
     code: String,
-    timeout_secs: u64,
+    timeout_secs: Option<u64>,
 ) -> Result<()> {
     use std::io::Write;
 
@@ -784,6 +792,13 @@ fn dispatch_run_code(
     })?;
     let exit_code = match terminal {
         mvm_guest::vsock::ExecEvent::Exit { code } => code,
+        mvm_guest::vsock::ExecEvent::TimedOut => {
+            let suffix = timeout_secs
+                .map(|s| format!(" after {s}s"))
+                .unwrap_or_default();
+            eprintln!("error: command timed out{suffix}");
+            crate::exec::EXEC_TIMEOUT_EXIT_CODE
+        }
         other => bail!("unexpected terminal exec event: {other:?}"),
     };
 
@@ -830,7 +845,7 @@ fn run_in_session(
     id: &SessionId,
     record: &mvm_core::session::SessionRecord,
     command: String,
-    timeout_secs: u64,
+    timeout_secs: Option<u64>,
 ) -> Result<()> {
     use std::io::Write;
 
@@ -1271,7 +1286,7 @@ mod tests {
         let err = cmd_exec(ExecArgs {
             session_id: id,
             argv: vec![],
-            timeout: 30,
+            timeout: None,
         })
         .unwrap_err();
         assert!(
@@ -1307,7 +1322,7 @@ mod tests {
             continue_latest: false,
             resume: None,
             stdin: None,
-            timeout: 1,
+            timeout: None,
         })
         .unwrap_err();
         assert!(
@@ -1326,7 +1341,7 @@ mod tests {
             continue_latest: true,
             resume: None,
             stdin: None,
-            timeout: 30,
+            timeout: None,
         })
         .unwrap_err();
         assert!(
@@ -1344,7 +1359,7 @@ mod tests {
         let err = cmd_run_code(RunCodeArgs {
             session_id: id,
             code: "print(1)".into(),
-            timeout: 1,
+            timeout: None,
         })
         .unwrap_err();
         assert!(

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -793,10 +793,7 @@ fn dispatch_run_code(
     let exit_code = match terminal {
         mvm_guest::vsock::ExecEvent::Exit { code } => code,
         mvm_guest::vsock::ExecEvent::TimedOut => {
-            let suffix = timeout_secs
-                .map(|s| format!(" after {s}s"))
-                .unwrap_or_default();
-            eprintln!("error: command timed out{suffix}");
+            eprintln!("{}", crate::exec::timeout_exit_message(timeout_secs));
             crate::exec::EXEC_TIMEOUT_EXIT_CODE
         }
         other => bail!("unexpected terminal exec event: {other:?}"),

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -994,9 +994,7 @@ pub fn dispatch_in_session(
     let exit_code = match terminal {
         mvm_guest::vsock::ExecEvent::Exit { code } => code,
         mvm_guest::vsock::ExecEvent::TimedOut => {
-            err.extend_from_slice(
-                format!("{}\n", timeout_exit_message(timeout_secs)).as_bytes(),
-            );
+            err.extend_from_slice(format!("{}\n", timeout_exit_message(timeout_secs)).as_bytes());
             EXEC_TIMEOUT_EXIT_CODE
         }
         other => anyhow::bail!("unexpected terminal exec event: {other:?}"),

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -25,6 +25,15 @@ use crate::ui;
 /// Matches GNU `timeout(1)` so scripts can branch on it.
 pub const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
 
+/// Human-facing message for a command killed by its `--timeout`. `None`
+/// timeout ⇒ no duration suffix (e.g. the interactive console path).
+pub(crate) fn timeout_exit_message(timeout_secs: Option<u64>) -> String {
+    let suffix = timeout_secs
+        .map(|s| format!(" after {s}s"))
+        .unwrap_or_default();
+    format!("error: command timed out{suffix}")
+}
+
 /// Where to source the command that runs inside the transient microVM.
 ///
 /// Marked `non_exhaustive` so future variants (e.g. baked-in template
@@ -796,11 +805,12 @@ fn run_in_guest(
     let exit_code = match terminal {
         mvm_guest::vsock::ExecEvent::Exit { code } => code,
         mvm_guest::vsock::ExecEvent::TimedOut => {
-            let suffix = req
-                .timeout_secs
-                .map(|s| format!(" after {s}s"))
-                .unwrap_or_default();
-            eprintln!("error: command timed out{suffix}");
+            let msg = timeout_exit_message(req.timeout_secs);
+            if capture {
+                err.extend_from_slice(format!("{msg}\n").as_bytes());
+            } else {
+                eprintln!("{msg}");
+            }
             EXEC_TIMEOUT_EXIT_CODE
         }
         other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
@@ -984,10 +994,9 @@ pub fn dispatch_in_session(
     let exit_code = match terminal {
         mvm_guest::vsock::ExecEvent::Exit { code } => code,
         mvm_guest::vsock::ExecEvent::TimedOut => {
-            let suffix = timeout_secs
-                .map(|s| format!(" after {s}s"))
-                .unwrap_or_default();
-            err.extend_from_slice(format!("error: command timed out{suffix}\n").as_bytes());
+            err.extend_from_slice(
+                format!("{}\n", timeout_exit_message(timeout_secs)).as_bytes(),
+            );
             EXEC_TIMEOUT_EXIT_CODE
         }
         other => anyhow::bail!("unexpected terminal exec event: {other:?}"),

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -21,6 +21,10 @@ use std::path::Path;
 
 use crate::ui;
 
+/// Exit code the CLI returns when a guest command exceeds its `--timeout`.
+/// Matches GNU `timeout(1)` so scripts can branch on it.
+pub const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
+
 /// Where to source the command that runs inside the transient microVM.
 ///
 /// Marked `non_exhaustive` so future variants (e.g. baked-in template
@@ -157,8 +161,9 @@ pub struct ExecRequest {
     pub add_dirs: Vec<AddDir>,
     pub env: Vec<(String, String)>,
     pub target: ExecTarget,
-    /// Timeout for the in-guest command in seconds.
-    pub timeout_secs: u64,
+    /// Timeout for the in-guest command in seconds. `None` ⇒ no per-command
+    /// kill (the default for interactive/ad-hoc exec).
+    pub timeout_secs: Option<u64>,
 }
 
 impl ExecRequest {
@@ -790,6 +795,14 @@ fn run_in_guest(
     )?;
     let exit_code = match terminal {
         mvm_guest::vsock::ExecEvent::Exit { code } => code,
+        mvm_guest::vsock::ExecEvent::TimedOut => {
+            let suffix = req
+                .timeout_secs
+                .map(|s| format!(" after {s}s"))
+                .unwrap_or_default();
+            eprintln!("error: command timed out{suffix}");
+            EXEC_TIMEOUT_EXIT_CODE
+        }
         other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
     };
 
@@ -918,7 +931,11 @@ pub fn boot_session_vm(
 /// Dispatch a single command into an already-booted session VM,
 /// capturing stdout/stderr. Equivalent to the dispatch step of
 /// [`run_captured`] without any boot/teardown.
-pub fn dispatch_in_session(vm: &SessionVm, code: String, timeout_secs: u64) -> Result<ExecOutput> {
+pub fn dispatch_in_session(
+    vm: &SessionVm,
+    code: String,
+    timeout_secs: Option<u64>,
+) -> Result<ExecOutput> {
     if !wait_for_agent(&vm.vm_name, 30) {
         anyhow::bail!("guest agent did not become reachable within 30s");
     }
@@ -966,6 +983,13 @@ pub fn dispatch_in_session(vm: &SessionVm, code: String, timeout_secs: u64) -> R
     )?;
     let exit_code = match terminal {
         mvm_guest::vsock::ExecEvent::Exit { code } => code,
+        mvm_guest::vsock::ExecEvent::TimedOut => {
+            let suffix = timeout_secs
+                .map(|s| format!(" after {s}s"))
+                .unwrap_or_default();
+            err.extend_from_slice(format!("error: command timed out{suffix}\n").as_bytes());
+            EXEC_TIMEOUT_EXIT_CODE
+        }
         other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
     };
     Ok(ExecOutput {
@@ -1123,7 +1147,7 @@ mod tests {
             target: ExecTarget::Inline {
                 argv: vec!["uname".into(), "-a".into()],
             },
-            timeout_secs: 30,
+            timeout_secs: Some(30),
         };
         assert_eq!(req.target_command(), "exec 'uname' '-a'");
     }
@@ -1140,7 +1164,7 @@ mod tests {
             target: ExecTarget::Inline {
                 argv: vec!["true".into()],
             },
-            timeout_secs: 30,
+            timeout_secs: Some(30),
         };
         let script = build_guest_wrapper(&req, &[]);
         assert!(script.starts_with("set -e\n"));
@@ -1165,7 +1189,7 @@ mod tests {
             target: ExecTarget::Inline {
                 argv: vec!["echo".into(), "$FOO".into()],
             },
-            timeout_secs: 30,
+            timeout_secs: Some(30),
         };
         let script = build_guest_wrapper(&req, &["mvm-extra-0".to_string()]);
         assert!(script.contains("mkdir -p '/g'"));
@@ -1190,7 +1214,7 @@ mod tests {
             target: ExecTarget::Inline {
                 argv: vec!["true".into()],
             },
-            timeout_secs: 30,
+            timeout_secs: Some(30),
         };
         let script = build_guest_wrapper(&req, &["mvm-extra-0".to_string()]);
         // RW mount is unqualified — no `-o ro`.
@@ -1419,7 +1443,7 @@ mod tests {
                     env: BTreeMap::new(),
                 },
             },
-            timeout_secs: 30,
+            timeout_secs: Some(30),
         };
         assert_eq!(req.target_command(), "exec 'python' '-m' 'x'");
     }
@@ -1443,7 +1467,7 @@ mod tests {
                     env,
                 },
             },
-            timeout_secs: 30,
+            timeout_secs: Some(30),
         };
         let script = build_guest_wrapper(&req, &[]);
         // Env from entrypoint exported.
@@ -1478,7 +1502,7 @@ mod tests {
             target: ExecTarget::Inline {
                 argv: vec!["true".into()],
             },
-            timeout_secs: 30,
+            timeout_secs: Some(30),
         };
         let script = build_guest_wrapper(&req, &[]);
         assert!(!script.contains("cd "));

--- a/crates/mvm-guest/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-guest/src/bin/mvm-guest-agent.rs
@@ -967,16 +967,17 @@ fn handle_proc_wait_streaming(
 }
 
 /// `Exec` streaming arm — writes intermediate `ExecEvent` Stdout/Stderr
-/// frames to the connection and returns the terminal `Exit` for the
-/// dispatch loop to write last. Mirrors `handle_run_entrypoint` /
+/// frames to the connection and returns the terminal `Exit` or `TimedOut`
+/// for the dispatch loop to write last. Mirrors `handle_run_entrypoint` /
 /// `handle_proc_wait_streaming`. Plan 159 WS-5 E. (dev-shell only)
 #[cfg(feature = "dev-shell")]
 fn do_exec_streaming(
     file: &mut std::fs::File,
     command: &str,
     stdin_data: Option<&str>,
+    timeout_secs: Option<u64>,
 ) -> GuestResponse {
-    let terminal = mvm_guest::exec_stream::stream_exec(command, stdin_data, |ev| {
+    let terminal = mvm_guest::exec_stream::stream_exec(command, stdin_data, timeout_secs, |ev| {
         write_response(file, &GuestResponse::ExecEvent(ev));
     });
     GuestResponse::ExecEvent(terminal)
@@ -1002,7 +1003,7 @@ fn read_wrapper_language() -> Option<String> {
 /// instead, providing stateful eval across calls. Wire shape stays
 /// identical — the dispatch flips inside this function.
 #[cfg(feature = "dev-shell")]
-fn do_run_code(file: &mut std::fs::File, code: &str, _timeout_secs: u64) -> GuestResponse {
+fn do_run_code(file: &mut std::fs::File, code: &str, timeout_secs: Option<u64>) -> GuestResponse {
     let lang = match read_wrapper_language() {
         Some(l) => l,
         None => {
@@ -1045,7 +1046,7 @@ fn do_run_code(file: &mut std::fs::File, code: &str, _timeout_secs: u64) -> Gues
         interp_flag,
         shell_quote_for_sh(code)
     );
-    do_exec_streaming(file, &shell_command, None)
+    do_exec_streaming(file, &shell_command, None, timeout_secs)
 }
 
 /// Single-quote `s` for `/bin/sh` consumption: doubles up embedded
@@ -2121,10 +2122,10 @@ fn handle_client(
         GuestRequest::Exec {
             command,
             stdin,
-            timeout_secs: _,
+            timeout_secs,
         } => {
             eprintln!("[audit] exec request: {:?}", command);
-            do_exec_streaming(&mut file, &command, stdin.as_deref())
+            do_exec_streaming(&mut file, &command, stdin.as_deref(), timeout_secs)
         }
 
         #[cfg(not(feature = "dev-shell"))]

--- a/crates/mvm-guest/src/exec_stream.rs
+++ b/crates/mvm-guest/src/exec_stream.rs
@@ -9,11 +9,11 @@
 
 use crate::vsock::ExecEvent;
 use std::io::{Read, Write};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-#[cfg(unix)]
-use std::os::unix::process::CommandExt;
 
 /// Per-stream total-byte cap (1 MiB) — bounds host capture-mode memory
 /// (was `MAX_EXEC_OUTPUT` in the agent bin).

--- a/crates/mvm-guest/src/exec_stream.rs
+++ b/crates/mvm-guest/src/exec_stream.rs
@@ -279,6 +279,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn timeout_kills_the_whole_process_group() {
         // The command backgrounds a long sleep in the SAME process group,

--- a/crates/mvm-guest/src/exec_stream.rs
+++ b/crates/mvm-guest/src/exec_stream.rs
@@ -9,9 +9,11 @@
 
 use crate::vsock::ExecEvent;
 use std::io::{Read, Write};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 /// Per-stream total-byte cap (1 MiB) — bounds host capture-mode memory
 /// (was `MAX_EXEC_OUTPUT` in the agent bin).
@@ -67,16 +69,35 @@ fn drain_into<F: FnMut(ExecEvent)>(
     take < new.len()
 }
 
+/// SIGKILL the child's entire process group. The child is spawned with
+/// `process_group(0)`, so it is the group leader and `pgid == child.id()`.
+/// Negative pid targets the group (POSIX `kill(2)`). Best-effort.
+#[cfg(unix)]
+fn kill_pgroup(child: &Child) {
+    let pgid = child.id() as libc::pid_t;
+    unsafe {
+        let _ = libc::kill(-pgid, libc::SIGKILL);
+    }
+}
+#[cfg(not(unix))]
+fn kill_pgroup(child: &Child) {
+    // No pgroups off-unix; mvm guests are always Linux. Exists only so
+    // host-side unit tests build on non-unix CI (there are none today).
+    let _ = child;
+}
+
 /// Run `command` under `/bin/sh -c`, streaming stdout/stderr via `emit`
 /// (arrival order, ~poll-interval granularity), and return the terminal
-/// `ExecEvent::Exit`. `emit` is never called with `Exit` — that is the
-/// return value.
+/// `ExecEvent::Exit` or `ExecEvent::TimedOut`. `emit` is never called
+/// with a terminal event — that is the return value.
 pub fn stream_exec<F: FnMut(ExecEvent)>(
     command: &str,
     stdin_data: Option<&str>,
+    timeout_secs: Option<u64>,
     mut emit: F,
 ) -> ExecEvent {
-    let mut child = match Command::new("/bin/sh")
+    let mut builder = Command::new("/bin/sh");
+    builder
         .arg("-c")
         .arg(command)
         .stdin(if stdin_data.is_some() {
@@ -85,9 +106,10 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
             Stdio::null()
         })
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    builder.process_group(0);
+    let mut child = match builder.spawn() {
         Ok(c) => c,
         Err(e) => {
             emit(ExecEvent::Stderr {
@@ -112,17 +134,33 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
 
     let mut sent_out = 0usize;
     let mut sent_err = 0usize;
+    let deadline = timeout_secs.map(|s| Instant::now() + Duration::from_secs(s));
 
     loop {
         let capped = drain_into(&out_buf, &mut sent_out, true, &mut emit)
             | drain_into(&err_buf, &mut sent_err, false, &mut emit);
         if capped {
-            let _ = child.kill();
+            kill_pgroup(&child);
             let _ = child.wait();
             emit(ExecEvent::Stderr {
                 chunk: b"\n... (truncated)".to_vec(),
             });
             return ExecEvent::Exit { code: -1 };
+        }
+        if deadline.is_some_and(|d| Instant::now() >= d) {
+            kill_pgroup(&child);
+            let _ = child.wait();
+            // Same no-tail-loss discipline as the normal exit path: join the
+            // drain threads so all buffered bytes are appended, then flush.
+            if let Some(h) = out_handle.take() {
+                let _ = h.join();
+            }
+            if let Some(h) = err_handle.take() {
+                let _ = h.join();
+            }
+            let _ = drain_into(&out_buf, &mut sent_out, true, &mut emit);
+            let _ = drain_into(&err_buf, &mut sent_err, false, &mut emit);
+            return ExecEvent::TimedOut;
         }
         match child.try_wait() {
             Ok(Some(status)) => {
@@ -156,11 +194,13 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use libc;
 
     #[test]
     fn streams_stdout_then_exit_zero() {
         let mut events = Vec::new();
-        let term = stream_exec("printf hello", None, |e| events.push(e));
+        let term = stream_exec("printf hello", None, None, |e| events.push(e));
         assert!(matches!(term, ExecEvent::Exit { code: 0 }));
         let out: Vec<u8> = events
             .iter()
@@ -176,7 +216,7 @@ mod tests {
     #[test]
     fn captures_stderr_and_nonzero_exit() {
         let mut events = Vec::new();
-        let term = stream_exec("printf oops 1>&2; exit 3", None, |e| events.push(e));
+        let term = stream_exec("printf oops 1>&2; exit 3", None, None, |e| events.push(e));
         assert!(matches!(term, ExecEvent::Exit { code: 3 }));
         let err: Vec<u8> = events
             .iter()
@@ -192,7 +232,7 @@ mod tests {
     #[test]
     fn pipes_stdin() {
         let mut events = Vec::new();
-        let term = stream_exec("cat", Some("piped"), |e| events.push(e));
+        let term = stream_exec("cat", Some("piped"), None, |e| events.push(e));
         assert!(matches!(term, ExecEvent::Exit { code: 0 }));
         let out: Vec<u8> = events
             .iter()
@@ -211,7 +251,7 @@ mod tests {
         // head -c 262144 /dev/zero is standard on macOS + Linux (POSIX).
         // 262144 < MAX_EXEC_OUTPUT (1 MiB) so the cap is not hit.
         let mut events = Vec::new();
-        let term = stream_exec("head -c 262144 /dev/zero", None, |e| events.push(e));
+        let term = stream_exec("head -c 262144 /dev/zero", None, None, |e| events.push(e));
         assert!(matches!(term, ExecEvent::Exit { code: 0 }));
         let total: usize = events
             .iter()
@@ -224,5 +264,48 @@ mod tests {
             total, 262144,
             "all 256 KiB of stdout must be streamed, none lost"
         );
+    }
+
+    #[test]
+    fn times_out_and_returns_timedout() {
+        // `sleep 5` with a 1s deadline must return TimedOut well under 5s.
+        let start = std::time::Instant::now();
+        let term = stream_exec("sleep 5", None, Some(1), |_| {});
+        assert!(matches!(term, ExecEvent::TimedOut), "got {term:?}");
+        assert!(
+            start.elapsed() < Duration::from_secs(4),
+            "should have been killed near the 1s deadline, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn timeout_kills_the_whole_process_group() {
+        // The command backgrounds a long sleep in the SAME process group,
+        // writes the grandchild PID, then blocks. On timeout we SIGKILL the
+        // pgroup, so the grandchild must also be gone afterward.
+        let pidfile = std::env::temp_dir().join(format!("mvm-pgkill-{}", std::process::id()));
+        let pidfile_s = pidfile.to_string_lossy().into_owned();
+        let cmd = format!("sleep 30 & echo $! > {pidfile_s}; wait");
+        let term = stream_exec(&cmd, None, Some(1), |_| {});
+        assert!(matches!(term, ExecEvent::TimedOut), "got {term:?}");
+        // Give the kernel a beat to reap the SIGKILL'd group.
+        std::thread::sleep(Duration::from_millis(200));
+        let pid: i32 = std::fs::read_to_string(&pidfile)
+            .expect("grandchild pidfile")
+            .trim()
+            .parse()
+            .expect("pid");
+        let _ = std::fs::remove_file(&pidfile);
+        // kill(pid, 0) returns -1/ESRCH when the process is gone.
+        let alive = unsafe { libc::kill(pid, 0) } == 0;
+        assert!(!alive, "grandchild {pid} survived the pgroup kill");
+    }
+
+    #[test]
+    fn no_timeout_runs_to_completion() {
+        let mut events = Vec::new();
+        let term = stream_exec("printf done", None, None, |e| events.push(e));
+        assert!(matches!(term, ExecEvent::Exit { code: 0 }), "got {term:?}");
     }
 }

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -457,7 +457,10 @@ pub enum GuestRequest {
     /// through the warm-process pool's wrapper for stateful eval
     /// across calls; the wire shape stays identical, the dispatch
     /// flips inside the agent.
-    RunCode { code: String, timeout_secs: Option<u64> },
+    RunCode {
+        code: String,
+        timeout_secs: Option<u64>,
+    },
 }
 
 impl GuestRequest {
@@ -5425,8 +5428,10 @@ mod tests {
         });
 
         let mut got: Vec<ExecEvent> = Vec::new();
-        let terminal = send_exec_streaming(&mut host, "echo hi", None, Some(30), |e| got.push(e.clone()))
-            .expect("send_exec_streaming");
+        let terminal = send_exec_streaming(&mut host, "echo hi", None, Some(30), |e| {
+            got.push(e.clone())
+        })
+        .expect("send_exec_streaming");
         guest_handle.join().unwrap();
 
         assert_eq!(got.len(), 1);

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -5345,8 +5345,9 @@ mod tests {
     }
 
     #[test]
-    fn exec_event_exit_is_terminal_others_are_not() {
+    fn exec_event_exit_and_timedout_are_terminal() {
         assert!(ExecEvent::Exit { code: 0 }.is_terminal());
+        assert!(ExecEvent::TimedOut.is_terminal());
         assert!(
             !ExecEvent::Stdout {
                 chunk: b"x".to_vec()

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -457,7 +457,7 @@ pub enum GuestRequest {
     /// through the warm-process pool's wrapper for stateful eval
     /// across calls; the wire shape stays identical, the dispatch
     /// flips inside the agent.
-    RunCode { code: String, timeout_secs: u64 },
+    RunCode { code: String, timeout_secs: Option<u64> },
 }
 
 impl GuestRequest {
@@ -1461,12 +1461,17 @@ pub enum ExecEvent {
     Stderr { chunk: Vec<u8> },
     /// Command exited with this code. Terminal.
     Exit { code: i32 },
+    /// `timeout_secs` elapsed; the agent killed the command's process
+    /// group. Terminal. Mirrors `ProcWaitEvent::TimedOut`. The host maps
+    /// this to exit code 124 (GNU `timeout(1)` convention) for user
+    /// commands. Plan 173.
+    TimedOut,
 }
 
 impl ExecEvent {
     /// True if this event terminates the `Exec` response stream.
     pub fn is_terminal(&self) -> bool {
-        matches!(self, ExecEvent::Exit { .. })
+        matches!(self, ExecEvent::Exit { .. } | ExecEvent::TimedOut)
     }
 }
 
@@ -2228,14 +2233,14 @@ where
 
 /// Send an `Exec` request and stream its response. Invokes `on_event`
 /// for each `Stdout`/`Stderr` chunk as it arrives; returns the terminal
-/// `Exit`. Exec carries no `GuestCapability` — the agent gates it at
-/// compile time via the `dev-shell` feature — so this does a plain
-/// protocol hello (no capability requirement). Plan 159 WS-5 E.
+/// `Exit` or `TimedOut`. Exec carries no `GuestCapability` — the agent
+/// gates it at compile time via the `dev-shell` feature — so this does
+/// a plain protocol hello (no capability requirement). Plan 159 WS-5 E.
 pub fn send_exec_streaming<F>(
     stream: &mut UnixStream,
     command: &str,
     stdin: Option<String>,
-    timeout_secs: u64,
+    timeout_secs: Option<u64>,
     on_event: F,
 ) -> Result<ExecEvent>
 where
@@ -2245,7 +2250,7 @@ where
     let req = GuestRequest::Exec {
         command: command.to_string(),
         stdin,
-        timeout_secs: Some(timeout_secs),
+        timeout_secs,
     };
     write_frame(stream, &req)?;
     read_exec_stream(stream, on_event)
@@ -2797,7 +2802,7 @@ mod tests {
             GuestRequest::UpdateIdleTimeout { secs: 0 },
             GuestRequest::RunCode {
                 code: "print('hello')".into(),
-                timeout_secs: 30,
+                timeout_secs: Some(30),
             },
             GuestRequest::ReadinessStatus,
         ];
@@ -4865,7 +4870,7 @@ mod tests {
             GuestRequest::UpdateIdleTimeout { secs: 0 },
             GuestRequest::RunCode {
                 code: "x".into(),
-                timeout_secs: 1,
+                timeout_secs: Some(1),
             },
         ];
 
@@ -4919,7 +4924,7 @@ mod tests {
             },
             GuestRequest::RunCode {
                 code: "print(1)".into(),
-                timeout_secs: 1,
+                timeout_secs: Some(1),
             },
             GuestRequest::FsWrite {
                 path: "/x".into(),
@@ -5419,7 +5424,7 @@ mod tests {
         });
 
         let mut got: Vec<ExecEvent> = Vec::new();
-        let terminal = send_exec_streaming(&mut host, "echo hi", None, 30, |e| got.push(e.clone()))
+        let terminal = send_exec_streaming(&mut host, "echo hi", None, Some(30), |e| got.push(e.clone()))
             .expect("send_exec_streaming");
         guest_handle.join().unwrap();
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -54,6 +54,7 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
   [x] WS-5 B session --continue/--resume/--ephemeral — PR #667
   [x] WS-4 resumable + honest-cost dev-image download — PR #667
   [x] WS-5 E streamed exec (ExecEvent) — PR #712 (plan-172)
+  [x] WS-5 E follow-up: enforce exec timeout_secs — plan-173
   [ ] WS-1 warm pool / WS-2 checkpoint+fork  (gated on 152 WS-B)
   [ ] WS-5 D verb renames; curl|sh installer; --json remainder
   [ ] signed delta-image distribution (unowned — needs a home)

--- a/specs/notes/plan-172-exec-timeout-enforcement-design.md
+++ b/specs/notes/plan-172-exec-timeout-enforcement-design.md
@@ -1,0 +1,174 @@
+# Design — enforce `exec` `timeout_secs` (streamed-exec path)
+
+> **Status (2026-06-08):** Brainstormed, approved for spec review. Follow-on
+> to Plan 159 WS-5 E (streamed `exec`, PR #712 / `specs/plans/172-plan-159-wse-streamed-exec.md`).
+> The numbered implementation plan is produced from this via writing-plans.
+
+## Goal
+
+Make `mvmctl exec` / `run` / `console --command` / `session run-code` honor a
+per-command timeout. Today the value is plumbed all the way to the guest as
+`GuestRequest::Exec { timeout_secs: Option<u64> }` but the agent **discards it**
+(`timeout_secs: _`) and `stream_exec` has no deadline — a non-terminating guest
+command runs until the 1 MiB output cap trips, or forever if it's quiet.
+
+## Why this path specifically
+
+The repo has **three** streaming-response families; two already enforce timeouts,
+which is exactly why this one is the genuine gap (and gives us the pattern to copy):
+
+- `ProcWaitEvent` (Plan 169 proc/wait) — `process_rpc::handle_proc_wait` sets
+  `deadline = Instant::now() + timeout`, kills the **pgroup** on overrun, returns
+  the dedicated terminal `ProcWaitEvent::TimedOut`. Spawns children with
+  `cmd.process_group(0)`. **This is the template.**
+- `RunEntrypointError::Timeout` (warm-pool / entrypoint dispatch) — the wrapper
+  enforces and emits `EntrypointEvent::Error { Timeout }`.
+- `ExecEvent` (Plan 159 WS-5 E) — `{ Stdout, Stderr, Exit }` only. **No
+  enforcement.** ← this design.
+
+## Non-goals / invariants (do not regress)
+
+- **Claim 4 stays intact.** `stream_exec` and `ExecEvent` are `dev-shell`-gated;
+  the prod agent links neither. No new symbol reaches a sealed agent.
+- The transient `run`/entrypoint leg's existing host-side timeout (the
+  `exec_timeout_secs` config consumed by the wrapper, enforced via
+  `RunEntrypointError::Timeout`) is **untouched** — this slice only closes the
+  ad-hoc `send_exec_streaming` leg.
+- No change to the buffered→streamed tail-loss discipline from WS-5 E
+  (drain threads are joined on child exit before emitting the terminal).
+- Semantics decision **(b)**: an *unset* `--timeout` means **no per-command kill**
+  for user-facing interactive/ad-hoc exec. The killer arms only when the user
+  passes `--timeout`, or when an internal caller passes an explicit bound (the
+  health probe). This avoids silently killing long-running dev commands that
+  "worked" before purely because the value was ignored.
+
+## Design
+
+### 1. Protocol — `ExecEvent::TimedOut`
+
+Add a dedicated terminal variant mirroring `ProcWaitEvent::TimedOut`:
+
+```rust
+pub enum ExecEvent {
+    Stdout { chunk: Vec<u8> },
+    Stderr { chunk: Vec<u8> },
+    /// Command exited with this code. Terminal.
+    Exit { code: i32 },
+    /// `timeout_secs` elapsed; agent killed the process group. Terminal.
+    TimedOut,
+}
+```
+
+`is_terminal()` returns true for `Exit` **and** `TimedOut`. Not `Exit { code: 124 }`
+on the wire — the repo idiom is a distinct terminal event, and it keeps "timed out"
+unambiguous and serde-checked. The host maps `TimedOut` → exit code **124** (GNU
+`timeout(1)` convention) at the CLI boundary, not in the protocol.
+
+### 2. Guest enforcement — `crates/mvm-guest/src/exec_stream.rs`
+
+`stream_exec` gains a `timeout_secs: Option<u64>` parameter.
+
+- Spawn the child with `cmd.process_group(0)` (it currently does not), so the
+  whole tree is reapable as one pgroup. Child is the group leader ⇒ `pgid == child.id()`.
+- `let deadline = timeout_secs.map(|s| Instant::now() + Duration::from_secs(s));`
+- In the existing sleep-poll loop, after the drain step: if
+  `deadline.is_some_and(|d| Instant::now() >= d)` and the child hasn't exited →
+  `libc::killpg(child.id() as i32, libc::SIGKILL)` (same primitive
+  `process_rpc::handle_proc_signal(_, 9)` uses), then fall through to the existing
+  drain-remaining + join-drain-threads path and return `ExecEvent::TimedOut`.
+- `None` ⇒ today's unbounded behavior.
+- The existing 1 MiB cap-kill branch switches from `child.kill()` to the same
+  pgroup kill, so a chatty command's children are reaped too (consistency).
+
+### 3. Dispatch — stop discarding (`crates/mvm-guest/src/bin/mvm-guest-agent.rs`)
+
+Both arms funnel through `do_exec_streaming → stream_exec` and currently drop the
+timeout:
+
+- `GuestRequest::Exec { command, stdin, timeout_secs }` — pass `timeout_secs` to
+  `do_exec_streaming`.
+- `GuestRequest::RunCode { code, timeout_secs }` — `do_run_code` currently takes
+  `_timeout_secs`; thread it through (`RunCode.timeout_secs` is `u64`; wrap as
+  `Some` since RunCode always carries an explicit value).
+- `do_exec_streaming(file, command, stdin, timeout_secs)` forwards to `stream_exec`.
+
+### 4. Host — `Option` pass-through + (b) (`crates/mvm-guest/src/vsock.rs`)
+
+`send_exec_streaming` signature changes `timeout_secs: u64` → `timeout_secs: Option<u64>`
+and passes it straight into `GuestRequest::Exec` (today it force-wraps `Some`).
+
+Per-caller policy:
+
+| Caller | Today | New |
+|---|---|---|
+| `mvm-cli/exec.rs:764` (`exec`/ad-hoc) | `req.timeout_secs` | `None` unless `--timeout` explicit |
+| `mvm-cli/exec.rs:956` (run ad-hoc leg) | `timeout_secs` | `None` unless `--timeout` explicit |
+| `mvm-cli/commands/vm/console.rs:115` (`console --command`) | `30` | `None` unless `--timeout` explicit |
+| `mvm-backend/base/linux_env.rs:192` (setup scripts) | `timeout_secs` | pass-through (caller decides; default `None`) |
+| `mvm-cli/commands/env/apple_container.rs:475` (`uname -r` probe) | `5` | `Some(5)` — a hung probe *should* die |
+
+"Explicit `--timeout`" is detected via clap `ValueSource::CommandLine` on the
+existing shared `--timeout` arg, so the other legs that read `args.timeout`
+(default 60: boot/admission/entrypoint) are **left untouched** — no field-type
+ripple.
+
+### 5. Host — terminal mapping
+
+Every caller's `match terminal { Exit { code } => …, other => bail!(…) }` gains a
+real `TimedOut` arm:
+
+- **User-facing (`exec`, `run`, `console`):** print `command timed out after {N}s`
+  to stderr, exit code **124**. Define `const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;`
+  (mvm-cli).
+- **`linux_env` (infrastructure):** return `Err(anyhow!("command timed out after {N}s"))`
+  — **not** a fabricated `Output { status: 124 }`. A timed-out provisioning script
+  is a hard failure that must propagate via `?` (the call site already
+  `.with_context(...)`s); synthesizing a 124 `Output` would let a hung step
+  masquerade as "ran, exited 124" to condition-checking callers (silent-failure smell).
+- **`apple_container` probe:** already a boolean context — `TimedOut` reads as
+  probe-failed, no special arm needed beyond not matching `Exit { code: 0 }`.
+
+## Testing
+
+- `exec_stream.rs` unit tests (dev-shell):
+  - `sleep 5` with `Some(1)` → returns `TimedOut`.
+  - the killed command's **backgrounded grandchild** is also dead (proves pgroup
+    kill, not just child kill).
+  - `Some(N)` large / `None` → command completes normally with `Exit`.
+  - output emitted before the deadline still arrives in the stream (no tail loss).
+- `vsock.rs`: `read_exec_stream` returns `TimedOut` as terminal; `is_terminal()`
+  covers it.
+- `tests/cli.rs`: `--timeout` explicit-vs-unset parsing; the `ValueSource` branch.
+- Claim 4: prod-agent symbol grep already asserts `stream_exec`/console absence —
+  no new prod symbol introduced (the variant is on a `dev-shell`-gated enum path
+  that prod never constructs; the enum itself is shared but unconstructed in prod).
+- Gates: `cargo nextest run --workspace`, `cargo test --workspace --doc`,
+  `rustup run nightly cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`.
+  mvm-backend test bins can codesign-SIGKILL on this macOS host
+  (`reference_mvm_backend_test_binary_macos_codesign_sigkill`) — lean on Linux CI
+  for those; run `-E 'not package(mvm-backend)'` locally.
+
+## Live verification (this Vz/libkrun host)
+
+Reuse the WS-5 E recipe: a long-lived dev guest, then
+`mvmctl console <vm> --command "sleep 30" --timeout 2` → exits 124 with the
+timeout message in ~2s; `--timeout` omitted → `sleep 2` completes normally.
+Isolate with `MVM_CACHE_DIR`/`MVM_DATA_DIR` (`project_dev_host_runs_builder_via_vz`).
+
+## Files
+
+- `crates/mvm-guest/src/vsock.rs` — `ExecEvent::TimedOut` + `is_terminal()`;
+  `send_exec_streaming` → `Option<u64>`.
+- `crates/mvm-guest/src/exec_stream.rs` — timeout param + pgroup kill + deadline.
+- `crates/mvm-guest/src/bin/mvm-guest-agent.rs` — thread timeout through both
+  dispatch arms + `do_exec_streaming`/`do_run_code`.
+- `crates/mvm-cli/src/exec.rs` — `None`-default + `TimedOut`→124 arm + constant.
+- `crates/mvm-cli/src/commands/vm/console.rs` — `None`-default + `TimedOut`→124.
+- `crates/mvm-cli/src/commands/env/apple_container.rs` — `Some(5)` probe.
+- `crates/mvm-backend/src/base/linux_env.rs` — pass-through + `TimedOut`→`Err`.
+
+## References
+
+- `specs/plans/172-plan-159-wse-streamed-exec.md` — parent (streamed exec).
+- `crates/mvm-guest/src/process_rpc.rs:240-640` — the timeout+pgroup-kill template.
+- `specs/notes/plan-159-dx-152-independent-slice-design.md` — WS-5 lineage.

--- a/specs/notes/plan-172-exec-timeout-enforcement-design.md
+++ b/specs/notes/plan-172-exec-timeout-enforcement-design.md
@@ -94,23 +94,36 @@ timeout:
 
 ### 4. Host — `Option` pass-through + (b) (`crates/mvm-guest/src/vsock.rs`)
 
-`send_exec_streaming` signature changes `timeout_secs: u64` → `timeout_secs: Option<u64>`
-and passes it straight into `GuestRequest::Exec` (today it force-wraps `Some`).
+`send_exec_streaming` and `GuestRequest::{Exec,RunCode}` carry `timeout_secs: Option<u64>`
+(`Exec` already does; `RunCode` is widened to match). `send_exec_streaming` passes the
+`Option` straight through (today it force-wraps `Some`).
+
+**Mechanism for "unset ⇒ unbounded": the `Option<u64>` type, not clap `ValueSource`.**
+The user-facing per-command `--timeout` flags drop their `default_value` and become
+`Option<u64>` (clap derive: absent ⇒ `None`). This is the idiomatic, robust way to
+distinguish unset-from-default across the **three** commands that share the verb
+(`exec`/`run`, `session exec`/`run-code`, plus `console`), and it avoids threading
+`ArgMatches` into the engine. `--timeout` on `exec`/`run` is overloaded — it *also*
+feeds the **signed `ExecutionPlan.exec_timeout_secs`** (claim-8 admission) and the
+receipt/preflight display. Those legs call `args.timeout.unwrap_or(60)`, so an unset
+flag keeps their existing default-60 byte-for-byte; an explicit `--timeout N` flows to
+*both* the admitted plan and the ad-hoc stream (consistent intent). The engine's
+`ExecRequest.timeout_secs` and `dispatch_in_session(timeout_secs)` widen to `Option<u64>`
+and carry only the ad-hoc value.
 
 Per-caller policy:
 
 | Caller | Today | New |
 |---|---|---|
-| `mvm-cli/exec.rs:764` (`exec`/ad-hoc) | `req.timeout_secs` | `None` unless `--timeout` explicit |
-| `mvm-cli/exec.rs:956` (run ad-hoc leg) | `timeout_secs` | `None` unless `--timeout` explicit |
-| `mvm-cli/commands/vm/console.rs:115` (`console --command`) | `30` | `None` unless `--timeout` explicit |
-| `mvm-backend/base/linux_env.rs:192` (setup scripts) | `timeout_secs` | pass-through (caller decides; default `None`) |
-| `mvm-cli/commands/env/apple_container.rs:475` (`uname -r` probe) | `5` | `Some(5)` — a hung probe *should* die |
+| `exec.rs::run_in_guest` (`exec`/`run` ad-hoc) | `req.timeout_secs: u64` | `Option` — `None` unless `--timeout` set |
+| `exec.rs::dispatch_in_session` (`session run-code`/`exec`, MCP) | `timeout_secs: u64` | `Option` — `None` unless set; MCP passes `Some(clamped)` |
+| `commands/vm/console.rs` (`console --command`) | hard-coded `30` | `None` (interactive; unbounded) |
+| `base/linux_env.rs::exec_via_vsock` (setup scripts, bounds 60/300) | ignored `u64` | `Some(timeout_secs)` — enforce the *existing* deliberate bounds; `TimedOut ⇒ Err` |
+| `commands/env/apple_container.rs:475` (`uname -r` probe) | `5` | `Some(5)` — a hung probe *should* die |
 
-"Explicit `--timeout`" is detected via clap `ValueSource::CommandLine` on the
-existing shared `--timeout` arg, so the other legs that read `args.timeout`
-(default 60: boot/admission/entrypoint) are **left untouched** — no field-type
-ripple.
+The signed-plan / admission / receipt / display legs are **not** widened — they read
+`args.timeout.unwrap_or(60)` and are otherwise untouched (no claim-8 behavior change
+when unset).
 
 ### 5. Host — terminal mapping
 

--- a/specs/plans/172-plan-159-wse-streamed-exec.md
+++ b/specs/plans/172-plan-159-wse-streamed-exec.md
@@ -791,7 +791,7 @@ git commit -m "refactor(mvm-guest): remove single-frame ExecResult (superseded b
 
 ## Deferred (tracked, not in this plan)
 
-- [ ] Enforce exec `timeout_secs` (today ignored; preserved as-is).
+- [x] Enforce exec `timeout_secs` (today ignored; preserved as-is). (shipped — see specs/plans/173-exec-timeout-enforcement.md)
 - [ ] Progressive upgrade of `RunEntrypoint` (its v1 buffering is a
       separate concern; the wire shape already supports it).
 

--- a/specs/plans/173-exec-timeout-enforcement.md
+++ b/specs/plans/173-exec-timeout-enforcement.md
@@ -1,0 +1,712 @@
+# Exec `timeout_secs` Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `mvmctl exec` / `run` / `console --command` / `session run-code` / `session exec` actually honor a per-command timeout — today the value reaches the guest but the agent discards it and `stream_exec` has no deadline.
+
+**Architecture:** Mirror the already-shipped `process_rpc` timeout idiom: spawn the child in its own process group (`process_group(0)`), compute a deadline, kill the **pgroup** with `SIGKILL` on overrun, and return a dedicated terminal `ExecEvent::TimedOut` (sibling to `ProcWaitEvent::TimedOut`). Semantics **(b)**: an *unset* `--timeout` means *no* per-command kill — the user-facing flags become `Option<u64>` (absent ⇒ `None` ⇒ unbounded), so long-running dev commands that "worked" before (because the value was ignored) are not silently killed. The overloaded `--timeout` on `exec`/`run` still feeds the signed `ExecutionPlan.exec_timeout_secs` via `args.timeout.unwrap_or(60)`, so the claim-8 admission path is byte-for-byte unchanged when the flag is unset. The host maps `TimedOut` to exit code **124** (GNU `timeout(1)` convention) for user commands, and to `Err` for the `linux_env` infrastructure leg.
+
+**Tech Stack:** Rust, `libc` (already a `mvm-guest` dep) for `kill(-pgid, SIGKILL)`, clap derive (`Option<u64>` flags), the `dev-shell`-gated `mvm-guest` exec path.
+
+**Spec:** `specs/notes/plan-172-exec-timeout-enforcement-design.md` (approved 2026-06-08).
+
+**Worktree:** `/Users/auser/work/tinylabs/mvmco/mvm-exec-timeout`, branch `feat/plan-172-exec-timeout` off `main`.
+
+**Cross-crate note:** `send_exec_streaming`, `ExecEvent`, and `RunCode` are in `mvm-guest`; widening their signatures breaks downstream callers in `mvm-backend` and `mvm-cli` until those crates are updated. Tasks are scoped one crate each (mvm-guest → mvm-backend → mvm-cli → integration) so each task ends with its own crate green; the **full** `cargo nextest run --workspace` gate runs in the final task.
+
+**Claim 4 invariant:** `stream_exec` and the `Exec`/`RunCode` agent arms are `#[cfg(feature = "dev-shell")]`. The prod agent (`--no-default-features`) constructs no `ExecEvent` and links no `stream_exec`. Adding the `TimedOut` variant does not introduce a prod-constructed symbol. The `prod-agent-no-console` / `prod-agent-no-exec` CI greps stay green — do **not** remove the cfg gates.
+
+---
+
+### Task 1: mvm-guest — `ExecEvent::TimedOut` + `stream_exec` enforcement + agent dispatch
+
+**Files:**
+- Modify: `crates/mvm-guest/src/vsock.rs` (ExecEvent + is_terminal; `RunCode.timeout_secs` → `Option<u64>`; `send_exec_streaming` → `Option<u64>`; test call sites)
+- Modify: `crates/mvm-guest/src/exec_stream.rs` (timeout param, pgroup, deadline, tests)
+- Modify: `crates/mvm-guest/src/bin/mvm-guest-agent.rs` (`do_exec_streaming`, `do_run_code`, `Exec`/`RunCode` arms)
+
+- [ ] **Step 1: Add the `TimedOut` variant + update `is_terminal()`**
+
+In `crates/mvm-guest/src/vsock.rs`, the `ExecEvent` enum (currently `Stdout`/`Stderr`/`Exit`) and its `is_terminal()` — replace with:
+
+```rust
+pub enum ExecEvent {
+    /// Bytes from the command's stdout, as they arrive.
+    Stdout { chunk: Vec<u8> },
+    /// Bytes from the command's stderr, as they arrive.
+    Stderr { chunk: Vec<u8> },
+    /// Command exited with this code. Terminal.
+    Exit { code: i32 },
+    /// `timeout_secs` elapsed; the agent killed the command's process
+    /// group. Terminal. Mirrors `ProcWaitEvent::TimedOut`. The host maps
+    /// this to exit code 124 (GNU `timeout(1)` convention) for user
+    /// commands. Plan 173.
+    TimedOut,
+}
+
+impl ExecEvent {
+    /// True if this event terminates the `Exec` response stream.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, ExecEvent::Exit { .. } | ExecEvent::TimedOut)
+    }
+}
+```
+
+- [ ] **Step 2: Widen `RunCode.timeout_secs` to `Option<u64>`**
+
+In `crates/mvm-guest/src/vsock.rs`, the `GuestRequest::RunCode` variant (currently `RunCode { code: String, timeout_secs: u64 }`):
+
+```rust
+    RunCode { code: String, timeout_secs: Option<u64> },
+```
+
+`#[serde(deny_unknown_fields)]` is already on `GuestRequest`; `Option<u64>` serializes as `null`/number and round-trips. Leave the `"run-code"` verb string and `RequestClass::DevOnly` mapping unchanged.
+
+- [ ] **Step 3: Widen `send_exec_streaming` to `Option<u64>` (host helper)**
+
+In `crates/mvm-guest/src/vsock.rs`, `send_exec_streaming` — change the parameter and drop the forced `Some`:
+
+```rust
+pub fn send_exec_streaming<F>(
+    stream: &mut UnixStream,
+    command: &str,
+    stdin: Option<String>,
+    timeout_secs: Option<u64>,
+    on_event: F,
+) -> Result<ExecEvent>
+where
+    F: FnMut(&ExecEvent),
+{
+    let _ = negotiate_protocol(stream, Vec::new())?;
+    let req = GuestRequest::Exec {
+        command: command.to_string(),
+        stdin,
+        timeout_secs,
+    };
+    write_frame(stream, &req)?;
+    read_exec_stream(stream, on_event)
+}
+```
+
+`read_exec_stream` needs **no** change — it already returns on `event.is_terminal()`, which now covers `TimedOut`.
+
+- [ ] **Step 4: Update in-crate test call sites in `vsock.rs`**
+
+Find every test constructing `RunCode { ... timeout_secs: <u64> }` (around lines 2798, 4866, 4920) and the `send_exec_streaming(..., 30, ...)` call (around line 5422). Wrap the literals in `Some(...)`:
+- `timeout_secs: 30` → `timeout_secs: Some(30)` (in `RunCode { .. }` literals).
+- `send_exec_streaming(&mut host, "echo hi", None, 30, ...)` → `... None, Some(30), ...`.
+
+- [ ] **Step 5: Run mvm-guest lib tests to confirm the protocol change compiles**
+
+Run: `cargo test -p mvm-guest --features dev-shell --lib exec -- --list`
+Expected: lists `exec_stream::tests::*` and the vsock exec tests without a compile error. (Full run happens after Step 9.)
+
+- [ ] **Step 6: Write the failing timeout tests in `exec_stream.rs`**
+
+Append to the `mod tests` block in `crates/mvm-guest/src/exec_stream.rs`:
+
+```rust
+    #[test]
+    fn times_out_and_returns_timedout() {
+        // `sleep 5` with a 1s deadline must return TimedOut well under 5s.
+        let start = std::time::Instant::now();
+        let term = stream_exec("sleep 5", None, Some(1), |_| {});
+        assert!(matches!(term, ExecEvent::TimedOut), "got {term:?}");
+        assert!(
+            start.elapsed() < Duration::from_secs(4),
+            "should have been killed near the 1s deadline, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn timeout_kills_the_whole_process_group() {
+        // The command backgrounds a long sleep in the SAME process group,
+        // writes the grandchild PID, then blocks. On timeout we SIGKILL the
+        // pgroup, so the grandchild must also be gone afterward.
+        let pidfile = std::env::temp_dir().join(format!("mvm-pgkill-{}", std::process::id()));
+        let pidfile_s = pidfile.to_string_lossy().into_owned();
+        let cmd = format!("sleep 30 & echo $! > {pidfile_s}; wait");
+        let term = stream_exec(&cmd, None, Some(1), |_| {});
+        assert!(matches!(term, ExecEvent::TimedOut), "got {term:?}");
+        // Give the kernel a beat to reap the SIGKILL'd group.
+        std::thread::sleep(Duration::from_millis(200));
+        let pid: i32 = std::fs::read_to_string(&pidfile)
+            .expect("grandchild pidfile")
+            .trim()
+            .parse()
+            .expect("pid");
+        let _ = std::fs::remove_file(&pidfile);
+        // kill(pid, 0) returns -1/ESRCH when the process is gone.
+        let alive = unsafe { libc::kill(pid, 0) } == 0;
+        assert!(!alive, "grandchild {pid} survived the pgroup kill");
+    }
+
+    #[test]
+    fn no_timeout_runs_to_completion() {
+        let mut events = Vec::new();
+        let term = stream_exec("printf done", None, None, |e| events.push(e));
+        assert!(matches!(term, ExecEvent::Exit { code: 0 }), "got {term:?}");
+    }
+```
+
+- [ ] **Step 7: Run the new tests to verify they fail to compile (signature mismatch)**
+
+Run: `cargo test -p mvm-guest --features dev-shell --lib exec_stream::tests::times_out_and_returns_timedout`
+Expected: FAIL — `stream_exec` takes 3 args, called with 4 (`Some(1)`).
+
+- [ ] **Step 8: Implement the timeout in `stream_exec`**
+
+In `crates/mvm-guest/src/exec_stream.rs`:
+
+Add to the imports at the top (`use std::time::Duration;` already present):
+
+```rust
+use std::time::{Duration, Instant};
+use std::process::Child;
+```
+
+Add a pgroup-kill helper above `stream_exec` (mirrors `process_rpc::handle_proc_signal`'s `kill(-pgid, …)`; the child is its own group leader so `pgid == child.id()`):
+
+```rust
+/// SIGKILL the child's entire process group. The child is spawned with
+/// `process_group(0)`, so it is the group leader and `pgid == child.id()`.
+/// Negative pid targets the group (POSIX `kill(2)`). Best-effort.
+#[cfg(unix)]
+fn kill_pgroup(child: &Child) {
+    let pgid = child.id() as libc::pid_t;
+    unsafe {
+        let _ = libc::kill(-pgid, libc::SIGKILL);
+    }
+}
+#[cfg(not(unix))]
+fn kill_pgroup(child: &Child) {
+    // No pgroups off-unix; fall back to killing the child only. mvm guests
+    // are always Linux, so this arm exists purely to keep host-side unit
+    // tests building on non-unix CI (there are none today).
+    let _ = child;
+}
+```
+
+Change the `stream_exec` signature to take `timeout_secs: Option<u64>`:
+
+```rust
+pub fn stream_exec<F: FnMut(ExecEvent)>(
+    command: &str,
+    stdin_data: Option<&str>,
+    timeout_secs: Option<u64>,
+    mut emit: F,
+) -> ExecEvent {
+```
+
+After the `Command::new("/bin/sh")` builder line and BEFORE `.spawn()`, add the process-group setup so the whole tree is reapable as one group:
+
+```rust
+    let mut builder = Command::new("/bin/sh");
+    builder
+        .arg("-c")
+        .arg(command)
+        .stdin(if stdin_data.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    builder.process_group(0);
+    let mut child = match builder.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            emit(ExecEvent::Stderr {
+                chunk: format!("failed to spawn: {e}").into_bytes(),
+            });
+            return ExecEvent::Exit { code: -1 };
+        }
+    };
+```
+
+(This replaces the existing `let mut child = match Command::new("/bin/sh") … .spawn() { … };` block. `process_group` is `std::os::unix::process::CommandExt::process_group`; add `use std::os::unix::process::CommandExt;` under the unix cfg or unconditionally — it is unix-only, so gate the `use` with `#[cfg(unix)]`.)
+
+Compute the deadline just before the poll loop (after `let mut sent_err = 0usize;`):
+
+```rust
+    let deadline = timeout_secs.map(|s| Instant::now() + Duration::from_secs(s));
+```
+
+Change the existing cap-kill branch from `child.kill()` to the pgroup kill:
+
+```rust
+        if capped {
+            kill_pgroup(&child);
+            let _ = child.wait();
+            emit(ExecEvent::Stderr {
+                chunk: b"\n... (truncated)".to_vec(),
+            });
+            return ExecEvent::Exit { code: -1 };
+        }
+```
+
+Add the deadline check immediately after the cap branch and before `match child.try_wait()`:
+
+```rust
+        if deadline.is_some_and(|d| Instant::now() >= d) {
+            kill_pgroup(&child);
+            let _ = child.wait();
+            // Same no-tail-loss discipline as the normal exit path: join the
+            // drain threads so all buffered bytes are appended, then flush.
+            if let Some(h) = out_handle.take() {
+                let _ = h.join();
+            }
+            if let Some(h) = err_handle.take() {
+                let _ = h.join();
+            }
+            let _ = drain_into(&out_buf, &mut sent_out, true, &mut emit);
+            let _ = drain_into(&err_buf, &mut sent_err, false, &mut emit);
+            return ExecEvent::TimedOut;
+        }
+```
+
+Update the three existing tests (`streams_stdout_then_exit_zero`, `captures_stderr_and_nonzero_exit`, `pipes_stdin`, `large_final_write_is_not_truncated`) to pass `None` as the new third argument, e.g.:
+
+```rust
+        let term = stream_exec("printf hello", None, None, |e| events.push(e));
+```
+
+- [ ] **Step 9: Run the exec_stream tests to verify they pass**
+
+Run: `cargo test -p mvm-guest --features dev-shell --lib exec_stream`
+Expected: PASS — all of `streams_stdout_then_exit_zero`, `captures_stderr_and_nonzero_exit`, `pipes_stdin`, `large_final_write_is_not_truncated`, `times_out_and_returns_timedout`, `timeout_kills_the_whole_process_group`, `no_timeout_runs_to_completion`.
+
+- [ ] **Step 10: Thread the timeout through the agent dispatch**
+
+In `crates/mvm-guest/src/bin/mvm-guest-agent.rs`:
+
+`do_exec_streaming` — add the param and forward it:
+
+```rust
+#[cfg(feature = "dev-shell")]
+fn do_exec_streaming(
+    file: &mut std::fs::File,
+    command: &str,
+    stdin_data: Option<&str>,
+    timeout_secs: Option<u64>,
+) -> GuestResponse {
+    let terminal = mvm_guest::exec_stream::stream_exec(command, stdin_data, timeout_secs, |ev| {
+        write_response(file, &GuestResponse::ExecEvent(ev));
+    });
+    GuestResponse::ExecEvent(terminal)
+}
+```
+
+`do_run_code` — change `_timeout_secs: u64` to `timeout_secs: Option<u64>` and pass it to the final `do_exec_streaming` call:
+
+```rust
+#[cfg(feature = "dev-shell")]
+fn do_run_code(file: &mut std::fs::File, code: &str, timeout_secs: Option<u64>) -> GuestResponse {
+```
+
+and at the end of that function:
+
+```rust
+    do_exec_streaming(file, &shell_command, None, timeout_secs)
+```
+
+The `Exec` dispatch arm — stop discarding `timeout_secs`:
+
+```rust
+        #[cfg(feature = "dev-shell")]
+        GuestRequest::Exec {
+            command,
+            stdin,
+            timeout_secs,
+        } => {
+            eprintln!("[audit] exec request: {:?}", command);
+            do_exec_streaming(&mut file, &command, stdin.as_deref(), timeout_secs)
+        }
+```
+
+The `RunCode` dispatch arm — `timeout_secs` is now `Option<u64>`, pass it straight through (the body comment block stays):
+
+```rust
+            eprintln!("[audit] run-code request");
+            do_run_code(&mut file, &code, timeout_secs)
+```
+
+- [ ] **Step 11: Build the agent + run mvm-guest tests + clippy**
+
+Run: `cargo build -p mvm-guest --features dev-shell --bin mvm-guest-agent`
+Expected: builds clean.
+Run: `cargo test -p mvm-guest --features dev-shell`
+Expected: PASS (lib + exec tests).
+Run: `cargo clippy -p mvm-guest --features dev-shell -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add crates/mvm-guest/src/vsock.rs crates/mvm-guest/src/exec_stream.rs crates/mvm-guest/src/bin/mvm-guest-agent.rs
+git commit -m "feat(guest): enforce exec timeout_secs via pgroup kill + ExecEvent::TimedOut"
+```
+
+---
+
+### Task 2: mvm-backend — enforce `linux_env` setup-script timeouts, map `TimedOut` to `Err`
+
+**Files:**
+- Modify: `crates/mvm-backend/src/base/linux_env.rs:185-216` (`exec_via_vsock`)
+
+The callers (`exec_via_vsock(script, 60)` / `(script, 300)` at lines 224/239/266) pass deliberate per-operation bounds that were silently dead. Enforcing them is the intent; a hung provisioning step is a hard failure (`Err`), not a fabricated `Output`.
+
+- [ ] **Step 1: Pass the bound through and add the `TimedOut` arm**
+
+In `exec_via_vsock`, change the `send_exec_streaming` call's timeout argument from `timeout_secs` to `Some(timeout_secs)`:
+
+```rust
+        let terminal = mvm_guest::vsock::send_exec_streaming(
+            &mut stream,
+            &wrapped,
+            None,
+            Some(timeout_secs),
+            |event| match event {
+                mvm_guest::vsock::ExecEvent::Stdout { chunk } => out_buf.extend_from_slice(chunk),
+                mvm_guest::vsock::ExecEvent::Stderr { chunk } => err_buf.extend_from_slice(chunk),
+                _ => {}
+            },
+        )
+        .with_context(|| format!("Failed to execute command in dev VM '{}'", self.vm_id))?;
+```
+
+Replace the terminal `match` with one that handles `TimedOut` as a hard error:
+
+```rust
+        match terminal {
+            mvm_guest::vsock::ExecEvent::Exit { code } => {
+                use std::os::unix::process::ExitStatusExt;
+                Ok(Output {
+                    status: std::process::ExitStatus::from_raw(code << 8),
+                    stdout: out_buf,
+                    stderr: err_buf,
+                })
+            }
+            mvm_guest::vsock::ExecEvent::TimedOut => anyhow::bail!(
+                "command timed out after {timeout_secs}s in dev VM '{}'",
+                self.vm_id
+            ),
+            other => anyhow::bail!("unexpected terminal exec event from dev VM: {other:?}"),
+        }
+```
+
+- [ ] **Step 2: Build mvm-backend + clippy**
+
+Run: `cargo build -p mvm-backend`
+Expected: builds clean (mvm-guest signature change from Task 1 now satisfied).
+Run: `cargo clippy -p mvm-backend -- -D warnings`
+Expected: no warnings. (Note: `cargo nextest -p mvm-backend` may SIGKILL on this macOS host via codesign — see `reference_mvm_backend_test_binary_macos_codesign_sigkill`; lean on Linux CI. A plain `cargo build`/`clippy` is sufficient here.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/mvm-backend/src/base/linux_env.rs
+git commit -m "feat(backend): enforce linux_env setup-script timeouts (TimedOut -> Err)"
+```
+
+---
+
+### Task 3: mvm-cli — `Option<u64>` flags, `unwrap_or(60)` at signed-plan legs, `TimedOut` → 124
+
+**Files:**
+- Modify: `crates/mvm-cli/src/exec.rs` (const; `ExecRequest.timeout_secs` → `Option`; `run_in_guest` + `dispatch_in_session` terminal arms)
+- Modify: `crates/mvm-cli/src/commands/vm/exec.rs` (`--timeout` → `Option<u64>` on both Args; `unwrap_or(60)` at admission/receipt/display legs)
+- Modify: `crates/mvm-cli/src/commands/vm/session.rs` (`--timeout` → `Option<u64>` on the 3 Args; `dispatch_run_code` / `dispatch` `timeout_secs` → `Option`; `TimedOut` arm; test args)
+- Modify: `crates/mvm-cli/src/commands/ops/mcp.rs` (`dispatch_in_session(..., Some(timeout))`)
+- Modify: `crates/mvm-cli/src/commands/vm/console.rs` (`None`; `TimedOut` → 124)
+
+This whole task is one crate; it compiles green only at the end (Step 12). Work top-down (engine first), committing in logical chunks.
+
+- [ ] **Step 1: Add the 124 constant in the engine**
+
+In `crates/mvm-cli/src/exec.rs`, near the top (after imports / before `ExecRequest`):
+
+```rust
+/// Exit code the CLI returns when a guest command exceeds its `--timeout`.
+/// Matches GNU `timeout(1)` so scripts can branch on it.
+pub const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
+```
+
+- [ ] **Step 2: Widen `ExecRequest.timeout_secs` to `Option<u64>`**
+
+In `crates/mvm-cli/src/exec.rs`, the `ExecRequest` struct field:
+
+```rust
+    /// Timeout for the in-guest command in seconds. `None` ⇒ no per-command
+    /// kill (the default for interactive/ad-hoc exec).
+    pub timeout_secs: Option<u64>,
+```
+
+- [ ] **Step 3: `run_in_guest` — pass the `Option` + add the `TimedOut` arm**
+
+In `crates/mvm-cli/src/exec.rs`, `run_in_guest` already passes `req.timeout_secs` to `send_exec_streaming` (now type-compatible). Replace its terminal `match` (the `let exit_code = match terminal { … }` near line 791):
+
+```rust
+    let exit_code = match terminal {
+        mvm_guest::vsock::ExecEvent::Exit { code } => code,
+        mvm_guest::vsock::ExecEvent::TimedOut => {
+            let suffix = req
+                .timeout_secs
+                .map(|s| format!(" after {s}s"))
+                .unwrap_or_default();
+            eprintln!("error: command timed out{suffix}");
+            EXEC_TIMEOUT_EXIT_CODE
+        }
+        other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
+    };
+```
+
+- [ ] **Step 4: `dispatch_in_session` — `Option` param + `TimedOut` → 124 in `ExecOutput`**
+
+In `crates/mvm-cli/src/exec.rs`, change the signature:
+
+```rust
+pub fn dispatch_in_session(
+    vm: &SessionVm,
+    code: String,
+    timeout_secs: Option<u64>,
+) -> Result<ExecOutput> {
+```
+
+The `ExecRequest { … timeout_secs }` literal inside it now type-checks (field is `Option`). Replace its terminal `match` (the `let exit_code = match terminal { … }`):
+
+```rust
+    let exit_code = match terminal {
+        mvm_guest::vsock::ExecEvent::Exit { code } => code,
+        mvm_guest::vsock::ExecEvent::TimedOut => {
+            let suffix = timeout_secs
+                .map(|s| format!(" after {s}s"))
+                .unwrap_or_default();
+            err.extend_from_slice(format!("error: command timed out{suffix}\n").as_bytes());
+            EXEC_TIMEOUT_EXIT_CODE
+        }
+        other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
+    };
+```
+
+- [ ] **Step 5: Commit the engine changes**
+
+```bash
+git add crates/mvm-cli/src/exec.rs
+git commit -m "feat(cli): exec engine carries Option timeout, maps TimedOut to 124"
+```
+
+- [ ] **Step 6: `commands/vm/exec.rs` — make both `--timeout` flags `Option<u64>`**
+
+In `crates/mvm-cli/src/commands/vm/exec.rs`, both Args structs (around lines 47-48 and 108-109) — change:
+
+```rust
+    /// Per-command timeout in seconds. Unset ⇒ no per-command kill.
+    #[arg(long)]
+    pub timeout: Option<u64>,
+```
+
+Update the passthrough at line ~214 — `timeout: self.timeout` stays as-is (both fields are now `Option<u64>`).
+
+- [ ] **Step 7: `commands/vm/exec.rs` — `unwrap_or(60)` at the non-ad-hoc legs**
+
+The ad-hoc `ExecRequest` build (around line 507) carries the raw `Option`:
+
+```rust
+        timeout_secs: args.timeout,
+```
+
+(no change needed — `ExecRequest.timeout_secs` is now `Option<u64>`.)
+
+The signed-plan / admission / receipt / display legs keep the existing default-60 behavior — apply `.unwrap_or(60)`:
+- Line ~457: `emit_oci_run_admission(&cached, args.cpus, u64::from(memory_mib), args.timeout.unwrap_or(60))`
+- Line ~748 (preflight resources display): `timeout_secs: args.timeout.unwrap_or(60),`
+- Line ~860 (receipt input build): `timeout_secs: args.timeout.unwrap_or(60),`
+
+The function at line ~515 already takes `timeout_secs: u64` and feeds `exec_timeout_secs` / `SynthesisInput` — its callers pass `args.timeout`; change those call sites to `args.timeout.unwrap_or(60)`. (Search the file for the function's invocation; it is the one building the `SynthesisInput` with `exec_timeout_secs`.) Do **not** change that function's `u64` param.
+
+The test literal at line ~1016 (`timeout: 60`) → `timeout: Some(60)`.
+
+- [ ] **Step 8: Commit the exec command changes**
+
+```bash
+git add crates/mvm-cli/src/commands/vm/exec.rs
+git commit -m "feat(cli): exec/run --timeout is Option; signed-plan legs default 60"
+```
+
+- [ ] **Step 9: `commands/vm/session.rs` — `Option` flags, dispatch params, `TimedOut` arm**
+
+In `crates/mvm-cli/src/commands/vm/session.rs`:
+
+The three Args structs with `#[arg(long, default_value = "30")] pub timeout: u64` (lines ~147, ~161, ~174) — change each to:
+
+```rust
+    /// Wall-clock timeout for the call, in seconds. Unset ⇒ no kill.
+    #[arg(long)]
+    pub timeout: Option<u64>,
+```
+
+`dispatch_run_code` (line ~742) — change `timeout_secs: u64` to `timeout_secs: Option<u64>`. The `GuestRequest::RunCode { code, timeout_secs }` literal at line ~765 now type-checks (`RunCode.timeout_secs` is `Option`). Replace its terminal `match` (the `let exit_code = match terminal { … }` near line ~787):
+
+```rust
+    let exit_code = match terminal {
+        mvm_guest::vsock::ExecEvent::Exit { code } => code,
+        mvm_guest::vsock::ExecEvent::TimedOut => {
+            let suffix = timeout_secs
+                .map(|s| format!(" after {s}s"))
+                .unwrap_or_default();
+            eprintln!("error: command timed out{suffix}");
+            crate::exec::EXEC_TIMEOUT_EXIT_CODE
+        }
+        other => bail!("unexpected terminal exec event: {other:?}"),
+    };
+```
+
+The `session exec` dispatch helper (the `cmd` around line 830 that takes `timeout_secs: u64` and calls `crate::exec::dispatch_in_session`) — change its `timeout_secs` param to `Option<u64>` (it forwards directly).
+
+Trace `cmd_exec` (line 683) and `cmd_run_code` (line 712): they pass `args.timeout` into the dispatch helpers — now `Option<u64>`, so they forward unchanged.
+
+The two test arg literals (line ~1271 `ExecArgs { … }` and ~1344 `RunCodeArgs { … }`) — set `timeout: None` (or `Some(30)` if a test asserts a specific value; default `None`).
+
+- [ ] **Step 10: `commands/ops/mcp.rs` — pass `Some(clamped)`**
+
+In `crates/mvm-cli/src/commands/ops/mcp.rs`, the `dispatch_in_session(&vm, code.to_string(), timeout)` call (line ~430) — MCP always has a clamped, meaningful timeout, so enforce it:
+
+```rust
+        crate::exec::dispatch_in_session(&vm, code.to_string(), Some(timeout))
+```
+
+The `run_cold` ad-hoc `ExecRequest` build (around line 409, `timeout_secs: timeout`) — wrap as `Some(timeout)`:
+
+```rust
+            timeout_secs: Some(timeout),
+```
+
+(Leave `clamp_timeout` and the `timeout: u64` params unchanged — MCP's contract is a bounded value, not optional.)
+
+- [ ] **Step 11: `commands/vm/console.rs` — `None` + `TimedOut` → 124**
+
+In `crates/mvm-cli/src/commands/vm/console.rs`:
+
+The audit-emit `GuestRequest::Exec { … timeout_secs: Some(30) }` (line ~110) → `timeout_secs: None`.
+
+The `send_exec_streaming(&mut stream, cmd, None, 30, …)` call (line ~115) → `… None, None, …`.
+
+The terminal `match` (line ~138) — add the `TimedOut` arm:
+
+```rust
+        match terminal {
+            mvm_guest::vsock::ExecEvent::Exit { code } => {
+                if code != 0 {
+                    std::process::exit(code);
+                }
+                Ok(())
+            }
+            mvm_guest::vsock::ExecEvent::TimedOut => {
+                eprintln!("error: command timed out");
+                std::process::exit(crate::exec::EXEC_TIMEOUT_EXIT_CODE);
+            }
+            other => anyhow::bail!("unexpected terminal exec event: {other:?}"),
+        }
+```
+
+- [ ] **Step 12: Build the whole crate, clippy, fmt**
+
+Run: `cargo build -p mvm-cli`
+Expected: builds clean (all `send_exec_streaming` / `ExecEvent` / `RunCode` / `dispatch_in_session` call sites now consistent).
+Run: `cargo clippy -p mvm-cli -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 13: Commit the remaining CLI changes**
+
+```bash
+git add crates/mvm-cli/src/commands/vm/session.rs crates/mvm-cli/src/commands/ops/mcp.rs crates/mvm-cli/src/commands/vm/console.rs
+git commit -m "feat(cli): session/mcp/console honor Option timeout, map TimedOut to 124"
+```
+
+---
+
+### Task 4: Integration — CLI parse test, full gate, docs, live verification
+
+**Files:**
+- Modify: `crates/mvm-cli/tests/cli.rs` (parse test for `--timeout` present vs absent)
+- Modify: `specs/REFACTOR-STATUS.md` (tick the deferred item)
+- Modify: `specs/plans/172-plan-159-wse-streamed-exec.md` (strike the deferred "enforce exec timeout_secs" follow-up)
+
+- [ ] **Step 1: Write a CLI parse test asserting `--timeout` is optional and parses**
+
+Add to `crates/mvm-cli/tests/cli.rs` (follow the existing `Cli::try_parse_from` style in that file — match the exact command path for `exec`):
+
+```rust
+#[test]
+fn exec_timeout_defaults_to_none_and_parses_when_set() {
+    use clap::Parser;
+    // Unset → None (no per-command kill).
+    let cli = Cli::try_parse_from(["mvmctl", "exec", "myvm", "--", "echo", "hi"])
+        .expect("parse without --timeout");
+    // Set → Some(N).
+    let cli2 = Cli::try_parse_from(["mvmctl", "exec", "myvm", "--timeout", "5", "--", "echo", "hi"])
+        .expect("parse with --timeout");
+    // Reach the timeout field via the parsed command; assert None vs Some(5).
+    // (Adjust the match arms to this repo's Commands enum shape — see the
+    // sibling exec parse tests already in this file.)
+    let _ = (cli, cli2);
+}
+```
+
+Note for the implementer: this file already has exec-parsing tests — copy their exact enum-destructuring pattern to read `args.timeout` and assert `None` then `Some(5)`. Do not invent a new harness.
+
+- [ ] **Step 2: Run the parse test**
+
+Run: `cargo test -p mvm-cli --test cli exec_timeout_defaults_to_none_and_parses_when_set`
+Expected: PASS.
+
+- [ ] **Step 3: Full workspace gate**
+
+Run: `cargo fmt --all -- --check` (CI uses nightly rustfmt: `rustup run nightly cargo fmt --all -- --check`)
+Expected: clean.
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: no warnings.
+Run: `cargo nextest run --workspace -E 'not package(mvm-backend)'` (mvm-backend test bins SIGKILL on this macOS host — Linux CI covers them)
+Expected: PASS.
+Run: `cargo test --workspace --doc`
+Expected: PASS.
+
+- [ ] **Step 4: Commit the test**
+
+```bash
+git add crates/mvm-cli/tests/cli.rs
+git commit -m "test(cli): exec --timeout is optional and parses"
+```
+
+- [ ] **Step 5: Live verification on the local VZ/libkrun host**
+
+Boot a long-lived dev guest, then (isolate with `MVM_CACHE_DIR`/`MVM_DATA_DIR` per `project_dev_host_runs_builder_via_vz`):
+- `mvmctl console <vm> --command "sleep 30"` (no `--timeout`) → runs to completion (unbounded). NOTE: console has no `--timeout` flag; the unbounded path is the assertion. For an armed test use `session run-code`/`exec` with `--timeout`.
+- `mvmctl session exec <id> --timeout 2 -- sleep 30` → exits **124** within ~2s with `command timed out after 2s` on stderr.
+- `mvmctl session exec <id> -- sleep 2` (no `--timeout`) → completes normally, exit 0.
+
+Record the observed exit codes + timing. If a microVM backend isn't readily bootable, the `exec_stream` unit tests (Task 1, Step 9) are the authoritative functional proof; note that in the PR.
+
+- [ ] **Step 6: Update REFACTOR-STATUS + the parent plan's deferred list**
+
+In `specs/REFACTOR-STATUS.md`, under the Plan 159 row, strike "enforce exec `timeout_secs`" from the open/deferred list (it's now shipped via Plan 173) and bump the "Last updated" date to 2026-06-08.
+
+In `specs/plans/172-plan-159-wse-streamed-exec.md`, find the deferred follow-up bullet for enforcing exec `timeout_secs` and mark it `- [x]` with a pointer to `specs/plans/173-exec-timeout-enforcement.md`.
+
+- [ ] **Step 7: Commit the docs**
+
+```bash
+git add specs/REFACTOR-STATUS.md specs/plans/172-plan-159-wse-streamed-exec.md
+git commit -m "docs(plan-173): tick exec-timeout deferred item in rollup + plan 172"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** §1 ExecEvent::TimedOut → T1.S1; §2 guest enforcement (pgroup/deadline) → T1.S6-9; §3 dispatch threading (Exec + RunCode) → T1.S10; §4 Option pass-through + per-caller table → T1.S3 (send_exec_streaming), T2 (linux_env Some + Err), T3 (exec/run/session Option, mcp Some, console None); §5 terminal mapping (124 / Err) → T3.S3/S4/S9/S11 + T2.S1; testing → T1.S6-9, T4.S1-3; live verify → T4.S5; claim-4 invariant → header note + cfg gates preserved.
+- **Type consistency:** `timeout_secs: Option<u64>` is consistent across `ExecEvent`-adjacent `GuestRequest::{Exec,RunCode}`, `send_exec_streaming`, `stream_exec`, `do_exec_streaming`, `do_run_code`, `ExecRequest`, `dispatch_in_session`, `dispatch_run_code`. `EXEC_TIMEOUT_EXIT_CODE` is defined once in `crate::exec` and referenced (not redefined) from session/console. The signed-plan/admission/receipt legs keep `u64` and read `.unwrap_or(60)`.
+- **Placeholder scan:** every code step shows real code; the one "match this file's existing pattern" note (T4.S1) points at concrete sibling tests rather than leaving a body blank, because the `Commands` enum destructuring is repo-specific and copying the wrong shape would be worse than directing the implementer to the established pattern.


### PR DESCRIPTION
## Summary

`mvmctl exec` / `run` / `console --command` / `session run-code` / `session exec` now **honor a per-command timeout**. Previously `timeout_secs` reached the guest but the agent discarded it and `stream_exec` had no deadline — a non-terminating guest command ran until the 1 MiB output cap, or forever.

This is the WS-5 E follow-on flagged in plan 172. Plan: `specs/plans/173-exec-timeout-enforcement.md`; design: `specs/notes/plan-172-exec-timeout-enforcement-design.md`.

### What changed
- **Guest enforcement** (`mvm-guest`, dev-shell-gated): `stream_exec` spawns the child in its own process group (`process_group(0)`), computes a deadline from `timeout_secs: Option<u64>`, and on overrun SIGKILLs the **whole process group** (`kill(-pgid, …)`) then returns a new terminal `ExecEvent::TimedOut`. Mirrors the existing `process_rpc` timeout idiom; the drain-join/no-tail-loss discipline is preserved on the timeout path.
- **Wire**: `ExecEvent::TimedOut` (terminal, `is_terminal()` covers it); `GuestRequest::RunCode.timeout_secs` and `send_exec_streaming(timeout_secs)` widened to `Option<u64>`. Agent dispatch threads it through (`Exec` + `RunCode`).
- **Semantics (b)**: the user-facing `--timeout` flags are now `Option<u64>` (unset ⇒ **no** per-command kill — long-running dev commands aren't silently killed). The killer arms only when `--timeout` is passed, or for internal callers that pass an explicit bound.
- **Host mapping**: `TimedOut` → exit code **124** (GNU `timeout(1)` convention) + `command timed out [after Ns]` on stderr, at all user-facing sites (capture-aware so MCP cold-path output lands in the returned stderr). `linux_env` provisioning timeouts map to `Err` (hard failure, not a fabricated `Output`). The `apple_container` probe and MCP keep their explicit bounds.

### Invariants preserved
- **Claim 4/15**: `stream_exec` + the `Exec`/`RunCode` arms stay `#[cfg(feature = "dev-shell")]`; the prod agent constructs no `ExecEvent`. No gate weakened.
- **Claim 8**: the overloaded `exec`/`run` `--timeout` still feeds the signed `ExecutionPlan.exec_timeout_secs` / receipt / preflight via `args.timeout.unwrap_or(60)` — byte-for-byte unchanged when unset.

## Test Plan
- [x] `cargo nextest run --workspace -E 'not package(mvm-backend)'` — 4763 passed (1 pre-existing leaky `mvm-build` test, unrelated)
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `rustup run nightly cargo fmt --all -- --check` — clean
- [x] Guest unit tests: `TimedOut` returned on overrun; backgrounded **grandchild** killed (proves pgroup kill, not just child); `None` runs to completion; no tail-loss
- [x] CLI parse tests: unset `--timeout` ⇒ `None`; `--timeout N` ⇒ `Some(N)`
- [ ] Live microVM boot deferred (dev-VM boot is flaky on the dev host; the `exec_stream` unit tests are the authoritative functional proof per the plan)