### PR TITLE
test(plan-152): harden vz parity gate — validate Rust, fix save/restore probe

### DIFF
--- a/crates/mvm-build/tests/vz_supervisor_parity.rs
+++ b/crates/mvm-build/tests/vz_supervisor_parity.rs
@@ -68,6 +68,20 @@ const VSOCK_REQUEST: &str = "MVM_VZ_PARITY_VSOCK_REQUEST";
 /// real launch path does.
 const DEFAULT_CMDLINE: &str = "console=hvc0 root=/dev/vda rw init=/init";
 
+/// Override for [`DEFAULT_CMDLINE`]. The committed default boots the dev `/init`,
+/// whose shell self-exits on console EOF — fine for boot parity, but too
+/// short-lived for the control-verb / save-restore gates (the guest can power
+/// off mid-test). Export this to a long-lived PID 1 (e.g.
+/// `console=hvc0 root=/dev/vda rw init=/bin/busybox sleep 1000000`) so the guest
+/// stays up while the verbs run.
+const CMDLINE_OVERRIDE: &str = "MVM_VZ_PARITY_CMDLINE";
+
+/// Resolve the boot cmdline: [`CMDLINE_OVERRIDE`] if exported, else
+/// [`DEFAULT_CMDLINE`].
+fn cmdline() -> String {
+    std::env::var(CMDLINE_OVERRIDE).unwrap_or_else(|_| DEFAULT_CMDLINE.to_string())
+}
+
 /// Build the minimal bootable [`SupervisorConfig`] both supervisors must accept
 /// identically: one rootfs disk, a vsock device, capture-only console, a control
 /// socket, no network (the smallest config that still exercises the full boot
@@ -80,7 +94,7 @@ fn build_boot_config(name: &str, kernel: &str, rootfs: &str, state_dir: &Path) -
         pid_file_name: Some("vz.pid".to_string()),
         kernel: KernelConfig {
             path: kernel.to_string(),
-            cmdline: DEFAULT_CMDLINE.to_string(),
+            cmdline: cmdline(),
             initrd_path: None,
         },
         resources: ResourceConfig {
@@ -425,6 +439,9 @@ fn probe_save_restore(
     let mut child = spawn_with_config(bin, &boot_cfg)?;
     let control_ready = wait_for_running(&control_sock, Instant::now() + Duration::from_secs(30));
     let save_reply = if control_ready {
+        // VZ rejects saveMachineStateToURL unless the VM is paused first
+        // (VZErrorDomain:3 "state 'running' is invalid for saving").
+        let _ = send_command(&control_sock, "PAUSE");
         send_command(&control_sock, &format!("SAVE {}", snapshot.display())).ok()
     } else {
         None
@@ -436,6 +453,9 @@ fn probe_save_restore(
     // Phase 2 — restore in a fresh supervisor against the same disk copy.
     let restore_reached_running = if snapshot_written {
         let restore_dir = root.join("restore");
+        // The supervisor opens its console log under vm_state_dir on boot; create
+        // the dir first or restore fails with ENOENT before it ever reaches VZ.
+        std::fs::create_dir_all(&restore_dir).expect("create restore state dir");
         let mut restore_cfg = build_boot_config(label, kernel, &rootfs_copy, &restore_dir);
         restore_cfg.startup_mode = StartupMode::Restore {
             snapshot_path: snapshot.to_string_lossy().into_owned(),
@@ -487,7 +507,7 @@ fn boot_config_matches_the_decoded_contract() {
     // use, so a drift in the shared schema fails here, not at boot.
     let back: SupervisorConfig = serde_json::from_str(&json).expect("decode");
     assert_eq!(back.kernel.path, "/k/vmlinux");
-    assert_eq!(back.kernel.cmdline, DEFAULT_CMDLINE);
+    assert_eq!(back.kernel.cmdline, cmdline());
     assert_eq!(back.disks.len(), 1);
     assert_eq!(back.disks[0].path, "/r/rootfs.ext4");
     assert_eq!(back.vsock.ports, vec![5252]);
@@ -654,55 +674,71 @@ fn vsock_roundtrip_parity_swift_vs_rust() {
     );
 }
 
+/// Rust control-verb correctness (Plan 152 WS-B). Swift is probed for information
+/// only: it self-deadlocks on the first async VZ control op — `synchronousVZCall`
+/// does `sema.wait()` on the VM's own serial dispatch queue while the completion
+/// handler is dispatched back to that same queue, so the queue wedges after the
+/// first verb. The Rust supervisor's serial-queue→tokio bridge avoids this (the
+/// reason WS-B exists). We assert Rust is correct; Swift divergence is logged, not
+/// failed, because Swift is being retired. Set `MVM_VZ_PARITY_CMDLINE` to a
+/// long-lived guest so the VM stays up across the sequence.
 #[test]
-fn control_verb_parity_swift_vs_rust() {
+fn control_verbs_rust_correct() {
     let Some((swift, rust, kernel, rootfs)) = live_env() else {
         eprintln!(
-            "SKIP control_verb_parity_swift_vs_rust: set {SWIFT_BIN}, {RUST_BIN}, {KERNEL}, \
-             {ROOTFS} to run the live control-verb parity gate."
+            "SKIP control_verbs_rust_correct: set {SWIFT_BIN}, {RUST_BIN}, {KERNEL}, {ROOTFS} \
+             (+ {CMDLINE_OVERRIDE} for a long-lived guest) to run the live control-verb gate."
         );
         return;
     };
-    // Stateful but symmetric: both supervisors get the same sequence, so the
-    // replies must match step-for-step. BALLOON/SAVE/RESTORE join once the boot
-    // config carries a balloon device and the save/restore slice lands.
     let verbs = ["STATUS", "PAUSE", "RESUME", "STATUS"];
-    let swift_replies =
-        probe_control_verbs(&swift, &kernel, &rootfs, &verbs, "swift").expect("swift probe");
+    let expected: Vec<Option<String>> = vec![
+        Some("OK running".to_string()),
+        Some("OK".to_string()),
+        Some("OK".to_string()),
+        Some("OK running".to_string()),
+    ];
     let rust_replies =
         probe_control_verbs(&rust, &kernel, &rootfs, &verbs, "rust").expect("rust probe");
-
-    assert!(
-        swift_replies.iter().any(Option::is_some),
-        "Swift supervisor answered no control verbs — fix the fixture before judging parity"
-    );
     assert_eq!(
-        rust_replies, swift_replies,
-        "Rust supervisor diverged from Swift on control verbs: rust={rust_replies:?} \
-         swift={swift_replies:?}"
+        rust_replies, expected,
+        "Rust supervisor control verbs incorrect: got {rust_replies:?}, want {expected:?}"
     );
+    // Informational only — Swift's known serial-queue deadlock is expected.
+    if let Ok(swift_replies) = probe_control_verbs(&swift, &kernel, &rootfs, &verbs, "swift")
+        && swift_replies != rust_replies
+    {
+        eprintln!("note: Swift diverges (known deadlock, being retired): swift={swift_replies:?}");
+    }
 }
 
+/// Rust save/restore correctness (Plan 152 WS-B slice 6). Swift is informational:
+/// it deadlocks on SAVE (same serial-queue bug as the control verbs). We assert
+/// the Rust supervisor writes a snapshot + machine-id sidecar and that a fresh
+/// supervisor restores it to a running guest. Needs `MVM_VZ_PARITY_CMDLINE` set to
+/// a long-lived guest (macOS 14+).
 #[test]
-fn save_restore_parity_swift_vs_rust() {
+fn save_restore_rust_correct() {
     let Some((swift, rust, kernel, rootfs)) = live_env() else {
         eprintln!(
-            "SKIP save_restore_parity_swift_vs_rust: set {SWIFT_BIN}, {RUST_BIN}, {KERNEL}, \
-             {ROOTFS} to run the live save/restore parity gate (macOS 14+)."
+            "SKIP save_restore_rust_correct: set {SWIFT_BIN}, {RUST_BIN}, {KERNEL}, {ROOTFS} \
+             (+ {CMDLINE_OVERRIDE} for a long-lived guest) to run the live save/restore gate (macOS 14+)."
         );
         return;
     };
-    let swift_outcome = probe_save_restore(&swift, &kernel, &rootfs, "swift").expect("swift probe");
     let rust_outcome = probe_save_restore(&rust, &kernel, &rootfs, "rust").expect("rust probe");
-
     assert!(
-        swift_outcome.snapshot_written && swift_outcome.restore_reached_running,
-        "Swift supervisor could not save+restore — fix the fixture (macOS 14+?) before judging \
-         parity: {swift_outcome:?}"
+        rust_outcome.snapshot_written
+            && rust_outcome.sidecar_written
+            && rust_outcome.restore_reached_running,
+        "Rust supervisor save/restore failed: {rust_outcome:?}"
     );
-    assert_eq!(
-        rust_outcome, swift_outcome,
-        "Rust supervisor diverged from Swift on save/restore: rust={rust_outcome:?} \
-         swift={swift_outcome:?}"
-    );
+    // Informational only — Swift's known serial-queue deadlock is expected.
+    if let Ok(swift_outcome) = probe_save_restore(&swift, &kernel, &rootfs, "swift")
+        && swift_outcome != rust_outcome
+    {
+        eprintln!(
+            "note: Swift diverges on save/restore (known deadlock, being retired): {swift_outcome:?}"
+        );
+    }
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -40,13 +40,18 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 core done & box-validated
   [ ] full guest-VM boot e2e (depends on the above) — runbook in plan 129
   [ ] forward-path signing integration (SigV4)        — DEFERRED (user)
 
-PLAN 152 — Rust-native VZ supervisor            🟡 design locked
+PLAN 152 — Rust-native VZ supervisor            🟡 Rust supervisor landed; finalize next
   [x] WS-A exit channel (vsock + PID-1 helper) — PR #698 (merged)
-  [x] WS-B threading decision (serial queue) — PR #697
-  [ ] WS-B the actual Swift→Rust rewrite (~1,450 LOC)
-  [ ] WS-C snapshot/restore + fork
+  [x] WS-B threading decision (serial queue) — PR #697 (merged)
+  [x] WS-B Swift→Rust rewrite (boot/vsock/control/snapshot/flow-audit) — PR #700 (merged)
+  [x] WS-B parity gate (Swift↔Rust subprocess harness) — PR #703 (merged)
+  [x] WS-B gate hardening + Rust live-validated boot/control/save/restore — this PR
+  [x] WS-E VZ-config hardening (validateSaveRestore gate, NAT MAC pin) — folded into #700
+  [ ] WS-B finalize: flip resolve_supervisor_path to the Rust bin + delete Swift crate
+  [ ] WS-C fork primitive (snapshot/restore already in #700)
   [ ] WS-D nested KVM (/dev/kvm in guest)
-  [ ] WS-E VZ-config hardening
+  NOTE: Swift control socket has a serial-queue deadlock (PAUSE/RESUME/SAVE);
+  Rust fixes it — gate now asserts Rust correctness, Swift is informational.
 
 PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice shipped
   [x] WS-3 mvmctl sign + doctor signing — PR #667 (plan-168)
@@ -54,8 +59,9 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
   [x] WS-5 B session --continue/--resume/--ephemeral — PR #667
   [x] WS-4 resumable + honest-cost dev-image download — PR #667
   [x] WS-5 E streamed exec (ExecEvent) — PR #712 (plan-172)
-  [x] WS-5 E follow-up: enforce exec timeout_secs — plan-173
-  [ ] WS-1 warm pool / WS-2 checkpoint+fork  (gated on 152 WS-B)
+  [x] WS-5 E follow-up: enforce exec timeout_secs — plan-173 / PR #726 (merged)
+  [~] WS-3 follow-up: doctor probes ALL sign targets — PR #728 (open)
+  [ ] WS-1 warm pool / WS-2 checkpoint+fork  (UNBLOCKED — 152 WS-B landed #700)
   [ ] WS-5 D verb renames; curl|sh installer; --json remainder
   [ ] signed delta-image distribution (unowned — needs a home)
 


### PR DESCRIPTION
## Summary

Hardens the Plan 152 WS-B parity gate (`crates/mvm-build/tests/vz_supervisor_parity.rs`, merged in #703) after running it **live on macOS 26 / Apple Silicon** against both supervisors. The live run found that the gate's `rust == swift` byte-equality contract is unachievable — **the Swift control socket self-deadlocks** — and surfaced two harness bugs.

### Why byte-equality can't hold
The Swift control socket runs on the VM's *own serial `DispatchQueue`* and `synchronousVZCall` does `sema.wait()` on that queue while `vm.pause/resume/save`'s completion handler is dispatched back to the same queue → **self-deadlock**. `STATUS` works (pure read); the first async verb wedges the queue, so every later connection times out. The Rust supervisor's serial-queue→tokio bridge avoids this — that's the bug WS-B exists to fix. Asserting equality with a broken baseline would block the *correct* implementation, so the live control-verb and save/restore tests now **assert Rust correctness**, with Swift probed informationally (logged, not failed) since it's being retired.

### Harness bugs fixed (both surfaced by the live run)
- `probe_save_restore` now sends `PAUSE` before `SAVE` — VZ rejects `saveMachineStateToURL` on a running VM (`VZErrorDomain:3`).
- `probe_save_restore` now `create_dir_all`s the restore state dir — otherwise the supervisor's console-log open fails with `ENOENT` before it reaches VZ (this was the sole cause of the earlier "restore didn't reach running").

### Also
- New `MVM_VZ_PARITY_CMDLINE` env to supply a long-lived guest cmdline (the dev `/init` self-exits on console EOF, too short for the control/save sequence).
- Renamed the two pivoted tests: `control_verbs_rust_correct`, `save_restore_rust_correct`.
- Refresh `specs/REFACTOR-STATUS.md`: Plan 152 WS-B (rewrite #700, gate #703, this hardening) + WS-E folded into #700; Plan 159 WS-1 now unblocked; doctor follow-up #728.

## Test Plan
- [x] Live on macOS 26 / Apple Silicon (both supervisors built + signed): **9/9 pass** — `boot_parity`, `control_verbs_rust_correct`, `save_restore_rust_correct` (snapshot+sidecar+restore-running), config/contract/proxy tests. Rust validated on boot/control/save/restore.
- [x] `cargo clippy -p mvm-build --tests -- -D warnings` clean; nightly `cargo fmt` clean.
- [x] Live tests skip cleanly without the env vars (CI Linux / plain Mac), as before.

## Follow-ups (tracked, not in this PR)
- Flip `resolve_supervisor_path` to the Rust bin + delete the Swift crate (then the Swift-informational probes here are removed and the gate is Rust-only).
- Security-review items from #700: stale SAVE doc, `tenant_id`-without-`plan` fail-open (mirrors libkrun), exit-listener leak, a Vz-bridge deny-path CI test.