### PR TITLE
feat(secrets): egress redact-to-XXX detector for undeclared secrets/PII (plan 129 Phase E)

### DIFF
--- a/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
@@ -70,7 +70,7 @@ use crate::supervisor::network::pipeline::{PacketDecision, run_packet_pipeline};
 // ObserverWiring (default no-op) so plan 129 sets them without touching the
 // call sites.
 use crate::supervisor::network::stages::{
-    NoopSubstitution, ScanStage, SubstitutionStage, build_egress_scan,
+    RedactingSubstitution, ScanStage, SubstitutionStage, build_egress_scan,
 };
 use crate::supervisor::proxy::l4::LiveL4Gate;
 use std::collections::HashSet;
@@ -593,7 +593,12 @@ fn run_bridge_inner(endpoints: BridgeEndpoints, cfg: BridgeConfig) {
             )),
             killed_flows: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
             mtu: BRIDGE_MTU,
-            substitution: Arc::new(NoopSubstitution),
+            // Plan 129 Phase E — always-on egress redactor: mask any UNDECLARED
+            // secret-shaped / PII run in the guest's outbound bytes to `XXX`
+            // (mask-and-continue). Declared secrets never reach the guest (they
+            // substitute host-side via the endpoint); this is the backstop for
+            // anything that got onto the guest by another path.
+            substitution: Arc::new(RedactingSubstitution::with_default_rules()),
             // Host-side mandatory-deny (link-local + cloud metadata), always on
             // and unbypassable from inside a compromised guest; the per-tenant
             // L4 + DNS filters compose under it when a bundle is present.
@@ -1776,7 +1781,7 @@ mod tests {
     use super::*;
     // The live default scan is MandatoryDenyEgressScan; the bridge tests want a
     // pass-through default, so wiring_with keeps NoopScan (test-scoped import).
-    use crate::supervisor::network::stages::NoopScan;
+    use crate::supervisor::network::stages::{NoopScan, NoopSubstitution};
     use crate::supervisor::proxy::l4::{L4Policy, LiveL4Gate};
     use mvm_core::policy::L4RuleSpec;
 

--- a/crates/mvm-hostd/src/supervisor/network/stages.rs
+++ b/crates/mvm-hostd/src/supervisor/network/stages.rs
@@ -16,7 +16,9 @@ use mvm_core::network_policy::{NetworkPolicy, is_mandatory_deny};
 use crate::keyholder::substitution::PLACEHOLDER_PREFIX;
 use crate::supervisor::network::packet::{L4Proto, ParsedPacket};
 use crate::supervisor::network::{FlowDirection, PacketCtx};
+use crate::supervisor::pii_redactor::{PiiRedactor, REDACTION_MASK};
 use crate::supervisor::proxy::l4::{L4Decision, L4Policy, Protocol};
+use crate::supervisor::secrets_scanner::SecretsScanner;
 
 /// Outcome of the scan stage. `Pass` forwards the packet; `Drop` kills the
 /// flow — the same fail-closed path as `Verdict::Drop`. `by` names the scan that
@@ -60,6 +62,57 @@ pub struct NoopSubstitution;
 impl SubstitutionStage for NoopSubstitution {
     fn name(&self) -> &'static str {
         "noop-substitution"
+    }
+}
+
+/// Plan 129 Phase E — the egress secret/PII redactor. A `SubstitutionStage`
+/// (the `Verdict::Modify` rebuild path), **not** a scan/drop: an *undeclared*
+/// secret-shaped or PII run on outbound bytes is masked in place (replaced with
+/// [`REDACTION_MASK`]) and the request continues, rather than dropping the whole
+/// flow. This is the backstop for the no-secret-on-the-guest invariant when a
+/// secret reaches the guest by some path *other* than a declared
+/// `mvm.secret(...)` (baked in, hardcoded, fetched) — declared secrets are
+/// substituted host-side via the endpoint and never on the guest in the first
+/// place. (A leaked *placeholder* is still dropped by [`PlaceholderLeakScan`] —
+/// that's a host/transport bug, fail-closed; a raw secret-shaped blob is a
+/// workload mistake, mask-and-continue.)
+pub struct RedactingSubstitution {
+    secrets: SecretsScanner,
+    pii: PiiRedactor,
+}
+
+impl RedactingSubstitution {
+    /// The curated secret-pattern + PII rulesets (`DEFAULT_RULES`).
+    pub fn with_default_rules() -> Self {
+        Self {
+            secrets: SecretsScanner::with_default_rules(),
+            pii: PiiRedactor::with_default_rules(),
+        }
+    }
+}
+
+impl SubstitutionStage for RedactingSubstitution {
+    fn name(&self) -> &'static str {
+        "redact-secrets-pii"
+    }
+
+    fn substitute(&self, _ctx: &PacketCtx<'_>, pkt: &ParsedPacket<'_>) -> Option<Vec<u8>> {
+        // Secret-shaped first, then PII; both mask to REDACTION_MASK.
+        let (after_secrets, secret_hits) = self.secrets.redact(pkt.l4_payload, REDACTION_MASK);
+        let (after_pii, pii_hits) = self.pii.redact(&after_secrets);
+        if secret_hits.is_empty() && pii_hits.is_empty() {
+            return None; // clean payload — pass through unchanged.
+        }
+        // Observability only: the categories that fired + the destination,
+        // never the matched bytes (claim-13 discipline).
+        tracing::warn!(
+            dst = %pkt.five_tuple.dst_ip,
+            dst_port = pkt.five_tuple.dst_port,
+            secrets = ?secret_hits,
+            pii = ?pii_hits,
+            "egress redactor masked undeclared secret/PII content"
+        );
+        Some(after_pii)
     }
 }
 
@@ -441,6 +494,23 @@ mod tests {
             l4_payload: payload,
             raw_frame: payload,
         }
+    }
+
+    #[test]
+    fn redacting_substitution_masks_secret_and_passes_clean() {
+        let r = RedactingSubstitution::with_default_rules();
+        // A clean payload passes through (None — no rewrite).
+        assert_eq!(r.substitute(&egress_ctx(), &tcp_egress(b"GET / nothing here")), None);
+        // A payload carrying an undeclared secret-shaped token is rewritten with
+        // the mask, and the original token is gone.
+        let key = "sk-".to_owned() + &"z".repeat(48);
+        let body = format!("POST {{\"k\":\"{key}\"}}").into_bytes();
+        let out = r
+            .substitute(&egress_ctx(), &tcp_egress(&body))
+            .expect("secret-bearing payload must be rewritten");
+        let masked = String::from_utf8_lossy(&out);
+        assert!(!masked.contains(&key), "secret survived redaction: {masked}");
+        assert!(masked.contains("XXX"), "no mask present: {masked}");
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/network/stages.rs
+++ b/crates/mvm-hostd/src/supervisor/network/stages.rs
@@ -500,7 +500,10 @@ mod tests {
     fn redacting_substitution_masks_secret_and_passes_clean() {
         let r = RedactingSubstitution::with_default_rules();
         // A clean payload passes through (None — no rewrite).
-        assert_eq!(r.substitute(&egress_ctx(), &tcp_egress(b"GET / nothing here")), None);
+        assert_eq!(
+            r.substitute(&egress_ctx(), &tcp_egress(b"GET / nothing here")),
+            None
+        );
         // A payload carrying an undeclared secret-shaped token is rewritten with
         // the mask, and the original token is gone.
         let key = "sk-".to_owned() + &"z".repeat(48);
@@ -509,7 +512,10 @@ mod tests {
             .substitute(&egress_ctx(), &tcp_egress(&body))
             .expect("secret-bearing payload must be rewritten");
         let masked = String::from_utf8_lossy(&out);
-        assert!(!masked.contains(&key), "secret survived redaction: {masked}");
+        assert!(
+            !masked.contains(&key),
+            "secret survived redaction: {masked}"
+        );
         assert!(masked.contains("XXX"), "no mask present: {masked}");
     }
 

--- a/crates/mvm-hostd/src/supervisor/pii_redactor.rs
+++ b/crates/mvm-hostd/src/supervisor/pii_redactor.rs
@@ -296,7 +296,46 @@ impl PiiRedactor {
         }
         hits
     }
+
+    /// Replace every *validated* rule match in `body` with
+    /// [`REDACTION_MASK`], returning the redacted bytes + the rule names
+    /// that fired (stable order, no dups). The Plan 129 Phase E
+    /// mask-and-continue path: an undeclared PII run on egress is scrubbed
+    /// in place rather than dropping the request. A match that fails its
+    /// validator (e.g. a 16-digit run that isn't Luhn-valid) is left
+    /// intact — the same precision `scan` uses, so we never mangle
+    /// non-PII. Returns `(body.to_vec(), [])` unchanged when nothing fires.
+    pub fn redact(&self, body: &[u8]) -> (Vec<u8>, Vec<&'static str>) {
+        let candidate_indices: Vec<usize> = self.set.matches(body).into_iter().collect();
+        if candidate_indices.is_empty() {
+            return (body.to_vec(), Vec::new());
+        }
+        let mut out = body.to_vec();
+        let mut fired: Vec<&'static str> = Vec::new();
+        for idx in candidate_indices {
+            let rule = &self.rules[idx];
+            let mut hit = false;
+            let replaced = self.regexes[idx].replace_all(&out, |caps: &regex::bytes::Captures| {
+                let m = caps.get(0).expect("capture group 0 always present");
+                if match_passes_validator(rule, m.as_bytes()) {
+                    hit = true;
+                    REDACTION_MASK.to_vec()
+                } else {
+                    m.as_bytes().to_vec()
+                }
+            });
+            out = replaced.into_owned();
+            if hit {
+                fired.push(rule.name);
+            }
+        }
+        (out, fired)
+    }
 }
+
+/// The token an undeclared secret/PII match is replaced with on egress
+/// (Plan 129 Phase E). Fixed + short; the matched bytes never leave the host.
+pub const REDACTION_MASK: &[u8] = b"XXX";
 
 /// True iff at least one regex match in `body` survives the rule's
 /// post-validator (or the rule has no validator). Stops at the first
@@ -304,7 +343,19 @@ impl PiiRedactor {
 fn rule_passes_validator(rule: &PiiRule, re: &Regex, body: &[u8]) -> bool {
     match rule.validator {
         None => true,
-        Some(PiiValidator::Luhn) => re.find_iter(body).any(|m| luhn_valid(m.as_bytes())),
+        Some(PiiValidator::Luhn) => re
+            .find_iter(body)
+            .any(|m| match_passes_validator(rule, m.as_bytes())),
+    }
+}
+
+/// True iff a single regex match's bytes survive the rule's post-validator
+/// (or the rule has no validator). The per-match form `redact` needs to
+/// decide whether *this* match should be masked.
+fn match_passes_validator(rule: &PiiRule, m: &[u8]) -> bool {
+    match rule.validator {
+        None => true,
+        Some(PiiValidator::Luhn) => luhn_valid(m),
     }
 }
 
@@ -373,6 +424,38 @@ mod tests {
 
     fn ctx_with_body(body: &[u8]) -> RequestCtx {
         RequestCtx::new("api.openai.com", 443, "/v1/chat").with_body(body.to_vec())
+    }
+
+    #[test]
+    fn redact_masks_validated_matches_and_leaves_non_validated() {
+        let r = PiiRedactor::with_default_rules();
+        // email (no validator), a Luhn-valid card, and a Luhn-INVALID 16-digit
+        // run (4111…1112 — last digit broken) that must be left untouched.
+        let body = b"mail a@b.com good 4111111111111111 bad 4111111111111112 end";
+        let (out, fired) = r.redact(body);
+        let s = String::from_utf8_lossy(&out);
+        assert!(!s.contains("a@b.com"), "email not masked: {s}");
+        assert!(
+            !s.contains("4111111111111111"),
+            "valid card not masked: {s}"
+        );
+        assert!(
+            s.contains("4111111111111112"),
+            "non-Luhn run wrongly masked: {s}"
+        );
+        assert!(s.contains("XXX"), "no redaction mask present: {s}");
+        assert!(
+            fired.contains(&"email") && fired.contains(&"credit_card"),
+            "fired={fired:?}"
+        );
+    }
+
+    #[test]
+    fn redact_passes_clean_body_through_unchanged() {
+        let r = PiiRedactor::with_default_rules();
+        let (out, fired) = r.redact(b"nothing sensitive here");
+        assert_eq!(out, b"nothing sensitive here");
+        assert!(fired.is_empty());
     }
 
     // ---- Luhn helper unit tests ----

--- a/crates/mvm-hostd/src/supervisor/secrets_scanner.rs
+++ b/crates/mvm-hostd/src/supervisor/secrets_scanner.rs
@@ -38,7 +38,7 @@
 //!   This inspector trusts the proxy to hand it bounded bytes.
 
 use async_trait::async_trait;
-use regex::bytes::RegexSet;
+use regex::bytes::{Regex, RegexSet};
 
 use crate::supervisor::inspector::{Inspector, InspectorVerdict, RequestCtx};
 
@@ -122,6 +122,9 @@ pub const DEFAULT_RULES: &[SecretRule] = &[
 pub struct SecretsScanner {
     set: RegexSet,
     rule_names: Vec<&'static str>,
+    /// Per-rule compiled `Regex` (same source pattern as `set`) — used by
+    /// [`Self::redact`] to extract match spans for in-place masking.
+    regexes: Vec<Regex>,
 }
 
 impl SecretsScanner {
@@ -133,7 +136,15 @@ impl SecretsScanner {
         let patterns: Vec<&str> = rules.iter().map(|r| r.pattern).collect();
         let set = RegexSet::new(&patterns)?;
         let rule_names = rules.iter().map(|r| r.name).collect();
-        Ok(Self { set, rule_names })
+        let regexes = patterns
+            .iter()
+            .map(|p| Regex::new(p))
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
+            set,
+            rule_names,
+            regexes,
+        })
     }
 
     /// Convenience constructor with the curated [`DEFAULT_RULES`]
@@ -151,6 +162,27 @@ impl SecretsScanner {
             .into_iter()
             .map(|idx| self.rule_names[idx])
             .collect()
+    }
+
+    /// Replace every secret-pattern match in `body` with
+    /// `mask`, returning the redacted bytes + the rule names that fired
+    /// (stable order). Plan 129 Phase E mask-and-continue: an undeclared
+    /// secret-shaped blob on egress is scrubbed in place rather than
+    /// dropping the request. `(body.to_vec(), [])` unchanged when nothing
+    /// matches.
+    pub fn redact(&self, body: &[u8], mask: &[u8]) -> (Vec<u8>, Vec<&'static str>) {
+        let candidate_indices: Vec<usize> = self.set.matches(body).into_iter().collect();
+        if candidate_indices.is_empty() {
+            return (body.to_vec(), Vec::new());
+        }
+        let mut out = body.to_vec();
+        let mut fired: Vec<&'static str> = Vec::with_capacity(candidate_indices.len());
+        for idx in candidate_indices {
+            // Every match of a secret rule is masked (no validators here).
+            out = self.regexes[idx].replace_all(&out, mask).into_owned();
+            fired.push(self.rule_names[idx]);
+        }
+        (out, fired)
     }
 }
 
@@ -193,6 +225,25 @@ mod tests {
         let scanner = SecretsScanner::with_default_rules();
         let mut c = RequestCtx::new("example.com", 443, "/");
         assert!(scanner.inspect(&mut c).await.is_allow());
+    }
+
+    #[test]
+    fn redact_masks_secret_match_and_passes_clean_body() {
+        let s = SecretsScanner::with_default_rules();
+        let key = "sk-".to_owned() + &"a".repeat(48); // openai_api_key shape
+        let body = format!("auth Bearer {key} trailing").into_bytes();
+        let (out, fired) = s.redact(&body, b"XXX");
+        let masked = String::from_utf8_lossy(&out);
+        assert!(!masked.contains(&key), "secret not masked: {masked}");
+        assert!(
+            masked.contains("XXX") && masked.contains("trailing"),
+            "got {masked}"
+        );
+        assert!(fired.contains(&"openai_api_key"), "fired={fired:?}");
+
+        let (clean, none) = s.redact(b"no secrets here", b"XXX");
+        assert_eq!(clean, b"no secrets here");
+        assert!(none.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
The backstop that makes **"no raw secret on the microVM, with or without the SDK"** hold for **undeclared** secrets — those that reach the guest by a path *other* than a declared `mvm.secret(...)` (baked into the image, hardcoded, fetched at runtime). Declared secrets never enter the guest (host-side substitution via the endpoint); this masks anything else on the guest's **direct** egress.

## What

- **`PiiRedactor::redact` + `SecretsScanner::redact`** — replace validated matches in a byte body with a mask (`REDACTION_MASK = b"XXX"`), returning the masked bytes + the fired rule names. `PiiRedactor` respects per-rule validators (a 16-digit run that fails Luhn is left intact), finally implementing the long-stubbed `Mode::Redact` mutation; `SecretsScanner` gains per-rule regexes for span masking.
- **`RedactingSubstitution`** — a `SubstitutionStage` (the `Verdict::Modify` / **mask-and-continue** path, **not** a drop) composing both redactors over the L4 payload. Returns `Some(masked)` when anything fires, `None` for clean traffic; logs the fired categories + destination only (never the value — claim-13 discipline).
- **Wired always-on** into the live gateway-bridge `ObserverWiring.substitution` (was `NoopSubstitution`).

## Behavior (the decision you set)

An undeclared-but-detected secret is **masked in place to `XXX` and the request continues** — distinct from `PlaceholderLeakScan`, which **drops** a leaked *placeholder* (a host/transport bug → fail-closed). A raw secret-shaped blob is a workload mistake → scrub-and-continue (it'll likely 401 downstream, the correct nudge to *declare* the secret so it gets substituted).

## Tests

`redact` unit tests (mask validated matches; leave non-validated; pass clean bodies unchanged) + a `RedactingSubstitution` stage test (masks a secret-bearing payload, passes a clean one). clippy clean.

## Follow-up

Chain-signed audit of redactions (currently a `tracing::warn` with categories + destination) and box-validation of live masking through the gateway bridge.