### PR TITLE
docs(plan-129): terminator+FC wiring delivered; defer live FC e2e to a bringup session

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,7 +17,7 @@ PLAN 169 — Backend-agnostic agent RPC           ✅ DONE
 PLAN 166 — QEMU Linux dev/test backend          ✅ DONE (Phase 2)
 PLAN 165 — Sealed-prod interactivity (claim 15) ✅ DONE
 
-PLAN 129 — Secrets / SigV4 substitution         🟢 declared substitution + undeclared egress redaction landed (box-validated); SDK-free transparent-terminator core landed (#735), FC wiring + e2e next
+PLAN 129 — Secrets / SigV4 substitution         🟢 declared substitution + undeclared redaction (box-validated); SDK-free terminator core (#735) + FC wiring (#744) landed; live FC e2e deferred to a bringup/debug session
   [x] keyholder, resolver, binding store, `secret set`
   [x] host substitution endpoint (UDS + AF_VSOCK)
   [x] SigV4 canonical-request builder
@@ -35,10 +35,15 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared substitution + u
   — SDK-free egress (transparent terminator) · direction 2026-06-08 · branch feat/plan-129-egress-terminator · draft PR #735 · plan: specs/notes/plan-129-stage1b-2-transparent-terminator-plan.md ("Resume state")
   [x] SDK secret() type/hosts + ADR-049 retire             — PR #722/#723
   [x] passt-redirect feasibility PoC (nft OUTPUT + SO_ORIGINAL_DST) — GREEN on box
-  [x] terminator core (orig_dst, request parse, handler, reader) — 4 commits, reviewed
-  [ ] terminator listener + EndpointConfig wiring          — Task 4 (Linux)
-  [ ] passt --runas + scoped nft redirect at launch        — Task 5 (Linux)
-  [ ] box e2e: generic curl http, SDK-free, audited        — Task 0/6
+  [x] terminator core (orig_dst, request parse, handler, reader) — reviewed — PR #735 (merged)
+  [x] terminator listener + raw-http forward + EndpointConfig wiring — Task 4 — PR #735 (merged)
+  [x] redirect mechanism box-validated: nft prerouting iifname<tap> REDIRECT + SO_ORIGINAL_DST (Task 0')
+  [x] FC wiring: EgressRedirect (nft TAP redirect) + wire_egress_substitution + stop_vm reap — Task 5 — PR #744 (merged)
+      (mechanism corrected: FC=TAP+nft NAT, not passt/skuid; passt path deferred to libkrun)
+  [ ] live SDK-free FC box e2e — Task 6 — DEFERRED to a bringup/debug session
+      (prompt: specs/prompts/129-fc-bringup-debug.md). Gated on: published default
+      x86_64 kernel is bzImage not ELF vmlinux (#746); FC guest-agent reachability;
+      the local secret-launch glue below
   [ ] Stage 2: name-constrained CA + https termination     — ADR-006
   [x] Python `mvm.secret(type=,hosts=)` egress surface + retire `_runtime.py` — PR #722
   [x] TS `secret()` egress + retire `runtime.ts` + docs .mdx  — PR #723

--- a/specs/notes/plan-129-stage1b-2-transparent-terminator-plan.md
+++ b/specs/notes/plan-129-stage1b-2-transparent-terminator-plan.md
@@ -29,7 +29,7 @@
 
 **Design refinement that changes Task 4 (already applied in code):** the plan's original `handle(stream, …)` (which called the Linux-only `original_dst` inline, making it un-testable off-Linux) was split. The testable core is now `handler::handle_request(raw: &[u8], orig_dst: SocketAddr, endpoint, forward)`. **Task 4's Linux-gated listener** is the glue that does, per accepted connection: `original_dst(&stream)` → `read::read_http_request(&mut stream)` → `handle_request(&raw, orig_dst, &endpoint, forward)` → write the returned bytes back. Use that shape, not the original `handle`.
 
-**Remaining:** Task 5 (passt `--runas` + scoped `nft` redirect at launch), Task 6 (box e2e), then Stage 2 (CA/`https`). Task 0 ✅ PASS (skuid scoping confirmed — see RESULT under Task 0). Task 4 ✅ DONE + reviewed (commits `3201006c`/`53f5b2b1`).
+**Status (2026-06-09):** Task 0 ✅, Task 4 ✅ (PR #735, **merged**), Task 5 ✅ (PR #744, **merged** — FC TAP `nft prerouting iifname` redirect + endpoint/terminator wiring). **Task 6 (live box e2e) DEFERRED** to a dedicated bringup/debug session — kickoff prompt at `specs/prompts/129-fc-bringup-debug.md`. The FC microVM now boots on the box, but the live SDK-free e2e is gated on: the published default x86_64 kernel being a bzImage not an ELF vmlinux (issue **#746**), FC guest-agent reachability, and the local secret-launch glue (`specs/prompts/129-local-admission-launch.md`). Then Stage 2 (CA/`https`, ADR-006).
 
 **✅ RESOLVED (2026-06-09) — Option 2 (Firecracker), with a mechanism correction.** The premise gap (substitution endpoint wired only on QEMU/slirp; `skuid` needs a passt-uid) was resolved by targeting **Firecracker** — but FC's egress is **TAP + nft NAT**, NOT passt, so the redirect mechanism changed from `meta skuid` (OUTPUT) to **`nat prerouting iifname "<tap>"`** (naturally guest-scoped; no passt, no uid). Re-validated on the box (PASS — see Task 5). No `passt.rs`/`--runas` change. Box is nft-only. See Task 5 for the corrected design; `[[project_plan_129_terminator_backend_gap]]`.
 
@@ -335,13 +335,13 @@ where
 
 **Files:** Create `crates/mvm-hostd/src/supervisor/egress_redirect.rs` (`EgressRedirect::install(vm, tap_iface, term_port)` / `Drop` teardown + a pure `nft_rule_argv(table, iface, port)` for unit tests). Wire into the **Firecracker parent context** (`crates/mvm-backend/src/microvm.rs` `run_from_build` + `stop_vm` — the bridge child is Landlock-confined and can't run `nft`, so install in the unconfined parent), gated on `mvm_core::plan::secrets_from_signed_json(plan_json)` being non-empty (`plan_json` is already read at `spawn_fc_bridge`/available; the tap name comes from the slot/network provision). Replicate `qemu.rs::spawn_substitution_endpoint` for FC but set `terminator_listen: Some(0.0.0.0:<per-VM port>)` (per-VM port = a base + `slot.index` to avoid host-wide collisions) and record the endpoint PID + write `substitution-env.json` (consumed by `mvmctl invoke`'s `substitution_env`, the existing guest env-injection path).
 
-- [ ] **Step 1: Write the failing test** — `EgressRedirect::nft_rule_argv("mvm_egress_x", "tap-x", 18080)` produces the exact tokens for `add rule ip mvm_egress_x prerouting iifname "tap-x" tcp dport 80 redirect to :18080`. Pure-function test; the live `nft` call + the FC wiring are covered by Task 6.
+- [x] **Step 1: Write the failing test** — `EgressRedirect::nft_rule_argv("mvm_egress_x", "tap-x", 18080)` produces the exact tokens for `add rule ip mvm_egress_x prerouting iifname "tap-x" tcp dport 80 redirect to :18080`. Pure-function test; the live `nft` call + the FC wiring are covered by Task 6.
 
 - [ ] **Step 2: Run it (fails)**
 
 - [ ] **Step 3: Implement** `egress_redirect.rs`: per-VM table `mvm_egress_<sanitized-vm>`, a `nat prerouting` chain (priority -100), and the iifname-scoped REDIRECT rule built from `nft_rule_argv`; `install` runs the `nft` calls, `Drop`/explicit `teardown` runs `nft delete table ip <table>`. Then wire FC `run_from_build`/`stop_vm`: when the plan carries secrets, spawn the substitution endpoint (vsock transport + `terminator_listen: Some(0.0.0.0:<port>)`), then `EgressRedirect::install(vm, tap, port)`; on stop, reap the endpoint PID, drop the redirect table, remove `substitution-env.json`. Gate everything on secrets; fail closed (roll back the FC boot if the endpoint/redirect can't come up, mirroring qemu.rs).
 
-- [ ] **Step 4: Run it (passes)**; **Step 5: Commit** — `"feat(terminator): per-VM TAP nft REDIRECT + FC endpoint/terminator wiring (plan 129 stage 1b)"`
+- [x] **Step 4: Run it (passes)**; **Step 5: Commit** — landed as PR #744 (5A `EgressRedirect` + 5B FC wiring + review fix), merged squash `8c3a327b`.
 
 (Original passt/skuid `egress_redirect` sketch removed — it targeted the libkrun passt path; Firecracker uses TAP. A future libkrun-on-Linux terminator could add the skuid variant Task 0 validated, but that is out of scope for the FC slice.)
 

--- a/specs/prompts/129-fc-bringup-debug.md
+++ b/specs/prompts/129-fc-bringup-debug.md
@@ -1,0 +1,82 @@
+# Plan 129 — live SDK-free egress e2e: Firecracker bringup + debug (session kickoff)
+
+> Paste as the opening message of the next session. This is a **research + live-debug** session on a real box, not a code-authoring one — though small fixes (and one or two PRs) will fall out.
+
+## Goal (the acceptance test)
+
+Prove, live on the dev-KVM box, the Plan 129 **SDK-free egress substitution** end-to-end on **Firecracker**:
+
+A secret-declaring workload boots on FC; a generic client in the guest (`curl http://<bound-host>` — no `import mvm`, no `HTTP_PROXY`) has its placeholder swapped for the **real** credential by the host-side transparent terminator, and:
+
+- the destination receives the **real** `Authorization` value (substitution worked);
+- the guest only ever held `mvm-secret-<hex>` (never the value);
+- a `secret.substituted` entry is in the chain-signed audit log (no secret bytes);
+- a request to an **unbound** host is refused (claim 12);
+- the **host's own** egress is NOT intercepted (the `iifname` redirect is guest-scoped).
+
+## What's already DONE (do not rebuild — verify, then build on it)
+
+- **Terminator core** — PR #735 (merged, squash `111ae55e`): `mvm_hostd::supervisor::terminator` (`orig_dst`/`request`/`read`/`handler`/`listener`), `SubstitutionService::serve_terminator`, `EndpointConfig.terminator_listen`, bin runs the terminator concurrently. Reviewed, 805 tests.
+- **FC wiring** — PR #744 (merged, squash `8c3a327b`): `mvm_backend::egress_redirect::EgressRedirect` (per-VM nft `nat prerouting iifname "<tap>" tcp dport 80 redirect to :<port>`), `mvm_backend::microvm::wire_egress_substitution` (spawns the per-VM `mvm-substitution-endpoint` with `terminator_listen: 0.0.0.0:<18080+slot.index>` + installs the redirect, gated on the admitted plan carrying secrets, fail-closed), shared `substitution_spawn` helper, `stop_vm` reaps the moat **before** its not-running early return, `mvm_core::plan::tenant_from_signed_json`.
+- **Mechanism box-validated (Task 0'):** `nft … prerouting iifname "<iface>" tcp dport 80 redirect to :<port>` (chain `type nat hook prerouting priority -100`) + `SO_ORIGINAL_DST` recovers the dest; guest egress captured, host's own untouched. (Note: FC egress is **TAP + nft NAT**, NOT passt — passt/`skuid` is the libkrun path, deferred.)
+- Background: declared substitution + undeclared-secret/PII redaction tiers are landed and box-validated over loopback (see `specs/prompts/129-local-admission-launch.md` and memory `project_plan_129_secrets_subsystem`).
+
+## The box and its provisioning state (already set up — reuse)
+
+`root@88.99.197.234` (Debian 12, x86_64, `/dev/kvm`). Already provisioned by the prior session:
+
+- `iptables` installed (v1.8.9 **nf_tables shim**; mvm's FC MASQUERADE NAT uses iptables — the box was nft-only).
+- **Firecracker v1.14.1** installed at `/usr/local/bin/firecracker` (the prior binary was the wrong arch; mvm uses PATH `firecracker`, expects v1.14.x).
+- `~/.mvm-129/passt-hashes.toml` populated with the sha256 of `/usr/bin/passt` (the FC bridge hash-verifies passt).
+- Default image cached at `/root/.cache/mvm-129/default-microvm/prod/` — **its `vmlinux` was swapped** from the published bzImage to an extracted ELF (`.bzimage.bak` is the original; see #746). **If the cache is wiped/re-downloaded, re-apply the swap** (the published x86_64 kernel is a bzImage; `scripts/extract-vmlinux <bzimage> > vmlinux`).
+- `/root/mvm-129` checked out + built (`mvmctl`, `mvm-firecracker-bridge`, `mvm-substitution-endpoint`). Build with rustup cargo (`/root/.cargo/bin`); `mvmctl` is the **root** package bin (`cargo build --bin mvmctl`, not `-p mvm-cli`).
+- Always run with `MVM_CACHE_DIR=/root/.cache/mvm-129 MVM_DATA_DIR=/root/.mvm-129` to isolate from parallel sessions (`/root/mvm`, `/root/mvm-p129`).
+
+With those, `MVM_CACHE_DIR=… MVM_DATA_DIR=… mvmctl up --hypervisor firecracker --builder qemu --kernel-source download --name fctest` **boots an FC microVM** (Guest IP 172.16.0.2). Confirm this still works first.
+
+## Blockers to research/debug, in order
+
+1. **FC guest-agent not reachable within 30s** (the immediate wall). The default image boots but `mvmctl up` reports "Guest agent not reachable" and auto-stops the VM; `console.log` is empty (no `hvc0` on the plain-Image kernel — see memory `reference_libkrun_workload_boot_verify_and_empty_console`). Investigate:
+   - Is the agent actually failing, or just slow / is 30s too short? Can the wait be extended / the VM kept alive to inspect?
+   - Does the **extracted** vmlinux differ behaviorally from a proper FC kernel (missing vsock/virtio config)? Compare against a known-good FC x86_64 vmlinux. Confirm `vhost-vsock` + the host UDS `v.sock` bridge come up (FC vsock guest-CID + `~/.mvm-129/vms/<vm>/v.sock`).
+   - Instrument: add a serial console the kernel will write to (FC `--boot-source` cmdline `console=ttyS0`?), or boot a vmlinux that logs, to see how far init/the agent gets.
+   - Cross-check the agent's vsock port/CID expectations vs what the FC backend configures.
+
+2. **The real fix for #746** (kernel artifact). The extract-vmlinux swap is a workaround. Decide + implement the real fix (issue #746): release pipeline emits an ELF `vmlinux` for x86_64 FC, OR the FC boot path extracts `vmlinux` from a bzImage before `--boot-source`, OR a publish-time x86_64 FC smoke-boot gate. (This may also be the root of (1) if the extracted kernel is subtly wrong.)
+
+3. **Local secret-workload launch glue** (so a *secret-declaring* workload can boot locally — see `specs/prompts/129-local-admission-launch.md`). `mvmctl compile` refuses managed secret refs (`crates/mvm-sdk/src/compile/orchestrator.rs:98`); `mvmctl up` lowers secrets via `lower_workload_secrets` + `admit_plan_for_boot` (`up.rs:1010/1400`) and accepts **`--from-workload-ir <ir.json>`** (Plan 73 B.3). Settle the scope question (local secret launch in mvm vs mvmd — ADRs put deploy/tenant in mvmd) then wire/drive the path. `mvmctl invoke <manifest>` runs a workload **entrypoint**, not an arbitrary command — so the e2e needs the **`examples/python/secret-egress`** workload (its `app.py` does the curl-with-secret), which must be **built** (cold builder VM → #576 Stage-0 panic risk; warm the cache / `--kernel-source download`).
+
+## The e2e recipe (once 1–3 are unblocked)
+
+```
+export MVM_CACHE_DIR=/root/.cache/mvm-129 MVM_DATA_DIR=/root/.mvm-129
+# 1. store + bind a secret to an HTTP (:80, Stage-1b has no TLS) echo host you control
+printf '%s' "$REAL" | mvmctl secret set echo-key --host <bound-host> --type bearer --value -
+# 2. launch the secret-declaring workload on FC (via the decided glue: up --from-workload-ir <ir>, or up --manifest)
+mvmctl up --hypervisor firecracker --builder qemu --from-workload-ir <ir.json> --name segress
+# 3. observe the wiring fired (the whole point):
+#    - ~/.mvm-129/vms/segress/substitution.pid is live during the run, gone after stop
+#    - a terminator listener on 0.0.0.0:<18080+slot.index>
+#    - nft table `mvm_egress_segress` with the prerouting iifname "<tap>" redirect
+#    - invoke/run the entrypoint; assert the echo dest saw the REAL Authorization, guest held only mvm-secret-…
+#    - mvmctl audit verify exits 0 with a secret.substituted entry (no secret bytes)
+#    - a request to an UNBOUND host is refused (claim 12)
+#    - a host-side curl to the bound host is NOT intercepted
+```
+
+Run a small HTTP echo on a box-reachable address as the bound host (the terminator forwards to the original dst over plain http; Stage 1b is http-only).
+
+## Code/file anchors
+
+- FC wiring: `crates/mvm-backend/src/microvm.rs` (`wire_egress_substitution`, `stop_vm`, `start_vm_firecracker`, `configure_flake_microvm`), `crates/mvm-backend/src/egress_redirect.rs`, `crates/mvm-backend/src/substitution_spawn.rs`.
+- Endpoint+terminator: `crates/mvm-hostd/src/supervisor/{substitution_endpoint.rs, substitution_proxy.rs, terminator/*}`, bin `crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs`.
+- FC bridge + passt-hash: `crates/mvm-vm-host/src/bin/mvm-firecracker-bridge.rs`, `crates/mvm-vm-host/src/firecracker_bridge/parse.rs`.
+- Launch glue: `crates/mvm-cli/src/commands/vm/{up.rs, run_plan.rs, managed_secrets.rs}`, `crates/mvm-sdk/src/compile/orchestrator.rs`.
+- Plan + design: `specs/notes/plan-129-stage1b-2-transparent-terminator-plan.md`, `specs/prompts/129-local-admission-launch.md`.
+
+## Norms / gotchas
+
+- Worktree only; **no `Co-Authored-By`/Claude trailer**; repo merges are **squash**; main needs a review/`enforce_admins` toggle for self-merge.
+- Box: `pkill -f mvm-substitution-endpoint` **self-kills the launching shell** (path in its own argv) — use `pkill -x mvm-substitutio`. Isolate every run with `MVM_CACHE_DIR`/`MVM_DATA_DIR`. The box locale is broken — pipe ssh output through `grep -v 'setlocale\|LC_ALL'`.
+- Stage 2 (name-constrained CA + `https`, ADR-006) is out of scope; Stage 1b is http-only.
+- Memory: `project_plan_129_terminator_backend_gap` (the full bringup chain + decisions), `project_plan_129_secrets_subsystem`, `reference_passt_outbound_nft_redirectable`.


### PR DESCRIPTION
Follow-up bookkeeping for #735 (terminator core) + #744 (FC wiring), both merged.

- Tick Task 4/5 in the plan doc + REFACTOR-STATUS rollup.
- Mark Task 6 (live SDK-free FC e2e) deferred to a dedicated bringup/debug session, gated on: published default x86_64 kernel is a bzImage not ELF vmlinux (#746), FC guest-agent reachability, and the local secret-launch glue.
- Add `specs/prompts/129-fc-bringup-debug.md` — the kickoff prompt for that session (box provisioning state, blockers, e2e recipe, anchors).