### PR TITLE
fix(netinit+init): make the guest's own loopback functional

### DIFF
--- a/crates/mvm-backend/src/netinit_audit.rs
+++ b/crates/mvm-backend/src/netinit_audit.rs
@@ -149,6 +149,7 @@ mod tests {
             }],
             failed: vec![],
             skipped_ipv6: vec![],
+            skipped_loopback: vec![],
         }
     }
 
@@ -164,6 +165,7 @@ mod tests {
                 reason: "operation not permitted".to_string(),
             }],
             skipped_ipv6: vec![],
+            skipped_loopback: vec![],
         }
     }
 

--- a/crates/mvm-guest/src/netinit.rs
+++ b/crates/mvm-guest/src/netinit.rs
@@ -148,6 +148,18 @@ pub struct Report {
     /// v6 entries were deliberately not attempted, not silently
     /// missing.
     pub skipped_ipv6: Vec<IpNet>,
+    /// Loopback ranges (`127.0.0.0/8`) are intentionally **not**
+    /// blackholed inside the guest: a blackhole route is
+    /// interface-agnostic, so it would also kill the guest's own `lo`
+    /// — breaking the Plan 129 forward proxy on `127.0.0.1` and any
+    /// local service. The host-loopback-via-bridge threat
+    /// `MANDATORY_DENY_RANGES` guards against is enforced host-side
+    /// (the L4 / nft egress enforcers on the bridge), which still
+    /// carry the full range list. Reported so the skip is observable,
+    /// not silent. `#[serde(default)]` keeps older report JSON
+    /// (without this field) parseable.
+    #[serde(default)]
+    pub skipped_loopback: Vec<IpNet>,
 }
 
 impl Report {
@@ -156,6 +168,7 @@ impl Report {
             installed: Vec::new(),
             failed: Vec::new(),
             skipped_ipv6: Vec::new(),
+            skipped_loopback: Vec::new(),
         }
     }
 
@@ -230,6 +243,17 @@ pub fn install_mandatory_deny<I: RouteInstaller>(installer: &I) -> Report {
     for cidr in mvm_core::network_policy::mandatory_deny_ranges() {
         if !cidr.network().is_ipv4() {
             report.skipped_ipv6.push(cidr);
+            continue;
+        }
+        // Never blackhole the guest's own loopback. A blackhole route matches
+        // by destination regardless of interface, so blackholing 127.0.0.0/8
+        // kills guest-internal loopback (the Plan 129 forward proxy on
+        // 127.0.0.1:18080, and any local service) — not just host loopback
+        // reached via a misconfigured bridge. That host-side threat is the
+        // host bridge / L4 enforcer's job; they still carry the full
+        // `MANDATORY_DENY_RANGES`. Skip-and-report, never silently.
+        if categorize(&cidr) == "loopback" {
+            report.skipped_loopback.push(cidr);
             continue;
         }
         let category = categorize_v4(&cidr).to_string();
@@ -551,19 +575,19 @@ mod tests {
     }
 
     #[test]
-    fn install_calls_installer_for_every_ipv4_entry() {
+    fn install_calls_installer_for_every_ipv4_entry_except_loopback() {
         let mock = MockInstaller::new();
         let report = install_mandatory_deny(&mock);
-        // Every IPv4 entry in `MANDATORY_DENY_RANGES` should have
-        // exactly one call. Mirror the const's IPv4 entry count
-        // exactly so a future const edit that adds a v4 entry
-        // also has to update this test.
-        let v4_count = mvm_core::network_policy::mandatory_deny_ranges()
+        // Every IPv4 entry in `MANDATORY_DENY_RANGES` is blackholed except
+        // loopback (skipped so the guest's own `lo` survives — see
+        // `install_skips_loopback_*`). Mirror the const's count so a future
+        // edit that adds a v4 entry also has to update this test.
+        let v4_installable = mvm_core::network_policy::mandatory_deny_ranges()
             .iter()
-            .filter(|n| n.network().is_ipv4())
+            .filter(|n| n.network().is_ipv4() && categorize(n) != "loopback")
             .count();
-        assert_eq!(mock.recorded().len(), v4_count);
-        assert_eq!(report.installed.len(), v4_count);
+        assert_eq!(mock.recorded().len(), v4_installable);
+        assert_eq!(report.installed.len(), v4_installable);
         assert!(report.failed.is_empty());
     }
 
@@ -583,6 +607,29 @@ mod tests {
                 "installer was called with non-v4 CIDR {recorded}"
             );
         }
+    }
+
+    #[test]
+    fn install_skips_loopback_so_guest_internal_loopback_survives() {
+        // A guest must not blackhole its own loopback: a blackhole route for
+        // 127.0.0.0/8 is interface-agnostic and kills guest-internal loopback,
+        // including the Plan 129 forward proxy on 127.0.0.1. The host-loopback
+        // threat stays handled host-side with the full range list.
+        let mock = MockInstaller::new();
+        let report = install_mandatory_deny(&mock);
+        let loopback: IpNet = "127.0.0.0/8".parse().unwrap();
+        assert!(
+            !mock.recorded().contains(&loopback),
+            "guest installed a blackhole for its own loopback (breaks the forward proxy)"
+        );
+        assert!(
+            !report.installed.iter().any(|r| r.cidr == loopback),
+            "loopback must not appear in installed routes"
+        );
+        assert!(
+            report.skipped_loopback.contains(&loopback),
+            "the loopback skip must be reported"
+        );
     }
 
     #[test]

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -310,6 +310,20 @@ let
       /bin/busybox modprobe vmw_vsock_virtio_transport 2>/dev/null || true
     fi
 
+    # Stage 2.27 — bring up the loopback interface. The kernel creates `lo`
+    # administratively DOWN; nothing else in this init ups it, so `127.0.0.1`
+    # has no route and ANY guest-internal loopback service is unreachable
+    # (`connect()` → ENETUNREACH) — the Plan 129 egress forward proxy on
+    # 127.0.0.1:18080, the in-guest addon-dns resolver, and any local service a
+    # workload binds. Must run before the agent (which binds the forward proxy)
+    # and before netinit. `ip` first (canonical), `ifconfig` fallback — both are
+    # busybox applets in the defconfig this image already relies on for
+    # `modprobe`. Non-fatal: a failure logs and leaves loopback down (the prior
+    # behaviour), never wedges PID 1.
+    /bin/busybox ip link set lo up 2>/dev/null \
+      || /bin/busybox ifconfig lo up 2>/dev/null \
+      || echo "mvm-init: WARNING could not bring up loopback (no ip/ifconfig applet); guest-internal loopback (egress forward proxy, addon-dns) will be unreachable"
+
     # Stage 2.3 — user-supplied volumes (`--volume` / MVM_VOLUMES).
     # The host (mvm_core::vm_backend::encode_user_volumes_cmdline) wrote
     # `mvm.uvols=<tag>:<hex(guest_path)>:<ro|rw>:<fs|blk>;...` onto the


### PR DESCRIPTION
## Summary

The guest's loopback (`lo`) was non-functional, so any guest-internal loopback service was unreachable — including the Plan 129 egress forward proxy on `127.0.0.1:18080`. Two independent causes, both fixed here:

1. **netinit blackholed it.** `MANDATORY_DENY_RANGES` (claim 10) includes `127.0.0.0/8`, and the guest's `install_mandatory_deny` installed a kernel **blackhole route** for every entry. A blackhole route matches by destination regardless of interface, so it killed the guest's own `lo`. Now skipped in the guest install (`Report.skipped_loopback`); the host-side L4/nft enforcers on the bridge keep the full `MANDATORY_DENY_RANGES`, so claim-10's on-the-wire posture is unchanged.
2. **`/init` never brought `lo` up.** The kernel creates `lo` administratively DOWN; nothing in PID-1 init ups it, so `127.0.0.1` had no route at all (`connect` → `ENETUNREACH`). `/init` now brings it up early (before netinit and the agent).

Either alone is insufficient — a blackhole-free but down `lo` still has no route, and an up `lo` that's blackholed still drops the traffic. Together they make guest loopback work.

## How it was found

The first end-to-end secret-egress run on a live QEMU guest (`mvmctl invoke <secret-workload> --attach`): the function body ran but its request to its own forward proxy failed — `EINVAL` (blackhole route hit, proving no `local 127/8 dev lo` route ⇒ `lo` down), then `ENETUNREACH` after the blackhole skip (still no route ⇒ `lo` down). On-box the netinit report now shows `"skipped_loopback":["127.0.0.0/8"]`.

## Tests
- `install_skips_loopback_so_guest_internal_loopback_survives`; updated `install_calls_installer_for_every_ipv4_entry_except_loopback` + host-side `Report` literals; `Report.skipped_loopback` is `#[serde(default)]`.
- The `/init` bringup is a busybox `ip`/`ifconfig` one-liner (non-fatal fallback), validated on-box.

Surfaced by the Plan 129 local secret-workload launch work (#745, which depends on this).