### PR TITLE
feat: warm-pool lifecycle/ops — reaper, doctor, mvmctl pool, bench fix (Plan 118 WS-1 1b-ii)

### DIFF
--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -570,6 +570,12 @@ impl AnyBackend {
         self.inner().snapshot_capability()
     }
 
+    /// Borrow the wrapped backend as `&dyn VmBackend` — for callers (the warm-pool
+    /// orchestration helpers) that are generic over `VmBackend` rather than the enum.
+    pub fn as_vm_backend(&self) -> &dyn VmBackend {
+        self.inner()
+    }
+
     /// Plan 118 WS-1 1b — does this backend support a prelaunched-supervisor standby
     /// pool? See [`VmBackend::supports_standby_pool`]. Only libkrun does today.
     pub fn supports_standby_pool(&self) -> bool {

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -570,6 +570,30 @@ impl AnyBackend {
         self.inner().snapshot_capability()
     }
 
+    /// Plan 118 WS-1 1b — does this backend support a prelaunched-supervisor standby
+    /// pool? See [`VmBackend::supports_standby_pool`]. Only libkrun does today.
+    pub fn supports_standby_pool(&self) -> bool {
+        self.inner().supports_standby_pool()
+    }
+
+    /// Spawn a prelaunched standby. See [`VmBackend::spawn_standby`].
+    pub fn spawn_standby(
+        &self,
+        spec: &mvm_core::vm_backend::StandbySpec,
+    ) -> std::result::Result<mvm_core::vm_backend::StandbyHandle, mvm_core::vm_backend::StandbyError>
+    {
+        self.inner().spawn_standby(spec)
+    }
+
+    /// Claim an idle standby. See [`VmBackend::claim_standby`].
+    pub fn claim_standby(
+        &self,
+        handle: &mvm_core::vm_backend::StandbyHandle,
+        claim: &mvm_core::vm_backend::StandbyClaim,
+    ) -> std::result::Result<VmId, mvm_core::vm_backend::StandbyError> {
+        self.inner().claim_standby(handle, claim)
+    }
+
     /// Warm-start a VM at (at least) the requested snapshot tier. See
     /// [`VmBackend::warm_start`] — fails closed with a typed error on an
     /// over-request rather than degrading to a cold boot (plan 123 C4).

--- a/crates/mvm-backend/src/standby_pool.rs
+++ b/crates/mvm-backend/src/standby_pool.rs
@@ -101,6 +101,38 @@ impl SupervisorStandbyPool {
             Err(e) => Err(e).with_context(|| format!("remove {}", dir.display())),
         }
     }
+
+    /// Reap standbys that are dead (pid gone) or expired (`now - spawned > ttl`). For a
+    /// still-live expired standby, SIGTERM the supervisor first, then remove its dir.
+    /// Returns the reaped ids. Idle entitled processes must never accumulate (Plan 118
+    /// §"B-ii residual risk" item 3) — `cache prune` calls this on a timer.
+    pub fn reap_stale(&self, ttl: std::time::Duration, now: u64) -> Result<Vec<String>> {
+        let ttl_secs = ttl.as_secs();
+        let mut reaped = Vec::new();
+        for h in self.list()? {
+            let alive = pid_alive(h.pid);
+            let expired = now.saturating_sub(h.spawned_unix_secs) > ttl_secs;
+            if !alive || expired {
+                if alive {
+                    // Live but expired — stop the entitled supervisor before dropping state.
+                    // SAFETY: SIGTERM to a pid this host spawned; a stale pid is a no-op.
+                    unsafe { libc::kill(h.pid as libc::pid_t, libc::SIGTERM) };
+                }
+                self.remove(&h.id)?;
+                reaped.push(h.id);
+            }
+        }
+        Ok(reaped)
+    }
+}
+
+/// Seconds since the Unix epoch (best-effort; clamps a pre-epoch clock to 0). The reaper's
+/// `now` argument so callers can inject a fixed clock in tests.
+pub fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 /// `kill(pid, 0)` liveness — 0 ⇒ the process exists (W1.2 reaper precedent).
@@ -198,6 +230,44 @@ mod tests {
         assert!(tmp.path().join("s1").exists());
         pool.remove("s1").unwrap();
         assert!(!tmp.path().join("s1").exists());
+    }
+
+    #[test]
+    fn reap_removes_dead_and_expired_keeps_live_recent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        let now = now_unix_secs();
+        // Live + recent (spawned now) → kept.
+        let mut keep = handle("keep", "aa", StandbyState::Idle);
+        keep.spawned_unix_secs = now;
+        pool.record(&keep).unwrap();
+        // Dead pid → reaped regardless of age.
+        let mut dead = handle("dead", "aa", StandbyState::Idle);
+        dead.pid = 999_999;
+        dead.spawned_unix_secs = now;
+        pool.record(&dead).unwrap();
+        // Live but spawned long ago → expired → reaped (SIGTERM'd then removed). Use a
+        // real throwaway child so the reaper's SIGTERM hits a safe pid, not the test runner.
+        let mut sleeper = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let mut old = handle("old", "aa", StandbyState::Idle);
+        old.pid = sleeper.id();
+        old.spawned_unix_secs = 1;
+        pool.record(&old).unwrap();
+
+        let reaped = pool
+            .reap_stale(std::time::Duration::from_secs(3600), now)
+            .unwrap();
+        assert!(reaped.contains(&"dead".to_string()));
+        assert!(reaped.contains(&"old".to_string()));
+        assert!(!reaped.contains(&"keep".to_string()));
+        assert!(pool.load("keep").is_ok());
+        assert!(pool.load("dead").is_err());
+        assert!(pool.load("old").is_err());
+        // The live-expired standby's supervisor was SIGTERM'd.
+        let _ = sleeper.wait();
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -192,6 +192,7 @@ impl Commands {
             Commands::Catalog(_) => "catalog",
             Commands::Console(_) => "console",
             Commands::Cache(_) => "cache",
+            Commands::Pool(_) => "pool",
             Commands::Reconcile(_) => "reconcile",
             Commands::Init(_) => "init",
             Commands::Run(_) => "run",

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -130,6 +130,8 @@ pub(in crate::commands) enum Commands {
     Console(vm::console::Args),
     /// Manage the XDG cache directory (~/.cache/mvm)
     Cache(ops::cache::Args),
+    /// Manage the supervisor warm pool (pre-spawned standbys for fast `up`)
+    Pool(pool::Args),
     /// Converge the VM name registry with on-disk runtime state
     Reconcile(ops::reconcile::Args),
     /// Scaffold a new project
@@ -342,6 +344,7 @@ pub fn run() -> Result<()> {
         Commands::Catalog(a) => catalog::run(&cli, a, &cfg),
         Commands::Console(a) => vm::console::run(&cli, a, &cfg),
         Commands::Cache(a) => ops::cache::run(&cli, a, &cfg),
+        Commands::Pool(a) => pool::run(&cli, a, &cfg),
         Commands::Reconcile(a) => ops::reconcile::run(&cli, a, &cfg),
         Commands::Init(a) => env::init::run(&cli, a, &cfg),
         Commands::Run(a) => vm::exec::run_secure(&cli, a, &cfg),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -8,11 +8,13 @@ mod image;
 mod kernel;
 mod manifest;
 mod ops;
-/// Plan 118 WS-1 1b — supervisor warm-pool launch glue (StandbySpec builder +
-/// claim-or-cold + warm-to-target). The consumers — the `mvmctl pool` command and the
-/// `up`/`run` auto-claim path — land in the 1b-ii follow-up, which shares the
-/// default-kernel + hypervisor resolution they need; the mechanism + helpers + unit tests
-/// ship here. `allow(dead_code)` until that wiring lands.
+/// Plan 118 WS-1 1b — supervisor warm-pool launch glue + the `mvmctl pool` command. The
+/// `mvmctl pool warm/status` command, the `StandbySpec` builder, and `warm_to_target` are
+/// live here. `claim_or_cold` (closure-ready for the per-standby audit substrate) is the
+/// last unwired piece: the `up`/`run` auto-claim needs an in-`up.rs` name-rebind (a
+/// claimed VM runs under its standby-id) + the gateway-bridge path confirmed working —
+/// scoped as a focused follow-up. `allow(dead_code)` covers `claim_or_cold`/`LaunchDecision`
+/// until then.
 #[allow(dead_code)]
 mod pool;
 mod qemu_bridge;

--- a/crates/mvm-cli/src/commands/ops/bench_probe.rs
+++ b/crates/mvm-cli/src/commands/ops/bench_probe.rs
@@ -92,14 +92,15 @@ pub fn admit_probe_plan(
 #[cfg(feature = "libkrun-live")]
 use crate::commands::ops::bench::BootMarks;
 
-/// Per-VM state dir the libkrun backend writes the supervisor PID file
-/// and host-side vsock socket into (`~/.mvm/vms/<name>`). Mirrors the
-/// backend's private `vm_state_dir`; kept in lockstep with it.
+/// Per-VM state dir the libkrun backend writes the supervisor PID file and host-side
+/// vsock socket into (`~/.mvm/vms/<name>`). Plan 118 WS-1 1b fix: delegate to the
+/// canonical `mvm_core::config::vm_state_dir` the backend itself uses, instead of building
+/// the path from `mvm_state_dir()` — that's the **XDG** state dir (`~/.local/state/mvm`),
+/// which the supervisor never writes to, so the `start_to_pid` mark never resolved and the
+/// probe timed out on every dev-host run.
 #[cfg(feature = "libkrun-live")]
 fn probe_state_dir(vm_name: &str) -> std::path::PathBuf {
-    std::path::PathBuf::from(mvm_core::config::mvm_state_dir())
-        .join("vms")
-        .join(vm_name)
+    mvm_core::config::vm_state_dir(vm_name)
 }
 
 /// Boot the canonical default-microvm image once through real
@@ -209,6 +210,25 @@ fn wait_for_ready(vm_name: &str) -> Result<(std::time::Instant, std::time::Insta
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Plan 118 WS-1 1b — the probe pid path must resolve under the backend's data dir
+    // (`~/.mvm`, honouring MVM_DATA_DIR), NOT the XDG state dir the supervisor never
+    // writes to. Regression guard for the `start_to_pid` timeout this fix closed.
+    #[cfg(feature = "libkrun-live")]
+    #[test]
+    fn probe_state_dir_resolves_under_mvm_data_dir_not_xdg_state() {
+        // SAFETY: single-threaded test process; we set then restore the override.
+        let prev = std::env::var("MVM_DATA_DIR").ok();
+        unsafe { std::env::set_var("MVM_DATA_DIR", "/tmp/mvm-bench-probe-test/.mvm") };
+        let dir = probe_state_dir("vm-x");
+        assert_eq!(dir, mvm_core::config::vm_state_dir("vm-x"));
+        assert!(dir.starts_with("/tmp/mvm-bench-probe-test/.mvm"));
+        assert!(!dir.to_string_lossy().contains(".local/state"));
+        match prev {
+            Some(v) => unsafe { std::env::set_var("MVM_DATA_DIR", v) },
+            None => unsafe { std::env::remove_var("MVM_DATA_DIR") },
+        }
+    }
 
     #[test]
     #[ignore = "touches ~/.cache/mvm; run on a host with the image cached"]

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -232,6 +232,33 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 }
             }
 
+            // Plan 118 WS-1 1b — reap stale supervisor standbys under `~/.mvm/pool/`.
+            // The TTL guards a fresh pool (only dead-pid or expired standbys go); a
+            // live-expired standby's entitled supervisor is SIGTERM'd before its dir is
+            // dropped, so idle entitled processes never accumulate (B-ii residual risk 3).
+            const STANDBY_POOL_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+            if dry_run {
+                if let Ok(pool) = mvm_backend::standby_pool::SupervisorStandbyPool::open()
+                    && let Ok(n) = pool.list().map(|v| v.len())
+                    && n > 0
+                {
+                    ui::info(&format!(
+                        "(dry-run) Would reap stale entries among {n} standby(s)."
+                    ));
+                }
+            } else {
+                match mvm_backend::standby_pool::SupervisorStandbyPool::open().and_then(|pool| {
+                    pool.reap_stale(STANDBY_POOL_TTL, mvm_backend::standby_pool::now_unix_secs())
+                }) {
+                    Ok(reaped) if !reaped.is_empty() => {
+                        removed += reaped.len() as u64;
+                        ui::info(&format!("Reaped {} stale standby(s).", reaped.len()));
+                    }
+                    Ok(_) => {}
+                    Err(e) => ui::warn(&format!("standby pool reap failed: {e}")),
+                }
+            }
+
             for entry in walkdir(path)? {
                 let entry_path = entry.path();
                 // Remove temp files (mvm-lima-*, .tmp)

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -18,7 +18,7 @@ use mvm_backend::backend::AnyBackend;
 use mvm_backend::standby_pool::SupervisorStandbyPool;
 use mvm_core::user_config::MvmConfig;
 use mvm_core::vm_backend::{
-    StandbyClaim, StandbyCompat, StandbySpec, StandbyState, VmBackend, VmId,
+    StandbyClaim, StandbyCompat, StandbyHandle, StandbySpec, StandbyState, VmBackend, VmId,
 };
 use sha2::{Digest, Sha256};
 
@@ -82,12 +82,20 @@ pub enum LaunchDecision {
 /// Try to claim an idle standby compatible with `want`; **fail open to cold boot**. On a
 /// claim error the standby is removed (it's spent/broken), never left idle, so the next
 /// launch doesn't keep retrying a dead standby.
-pub fn claim_or_cold(
+///
+/// `make_claim` builds the [`StandbyClaim`] **for the selected standby's id** — the audit
+/// substrate (`gateway-<vm>.sock`) is name-keyed, and a claimed VM runs under its
+/// standby-id, so the caller must compute those paths against `handle.id`. A `make_claim`
+/// error also fails open to cold boot (and reaps the reserved standby).
+pub fn claim_or_cold<F>(
     pool: &SupervisorStandbyPool,
     backend: &dyn VmBackend,
     want: &StandbyCompat,
-    claim: &StandbyClaim,
-) -> Result<LaunchDecision> {
+    make_claim: F,
+) -> Result<LaunchDecision>
+where
+    F: FnOnce(&StandbyHandle) -> Result<StandbyClaim>,
+{
     if !backend.supports_standby_pool() {
         return Ok(LaunchDecision::ColdBoot);
     }
@@ -96,7 +104,15 @@ pub fn claim_or_cold(
     };
     // Reserve it so a concurrent launch won't double-claim.
     pool.mark_claimed(&handle.id)?;
-    match backend.claim_standby(&handle, claim) {
+    let claim = match make_claim(&handle) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(standby = %handle.id, error = %e, "build claim failed; cold-booting");
+            let _ = pool.remove(&handle.id);
+            return Ok(LaunchDecision::ColdBoot);
+        }
+    };
+    match backend.claim_standby(&handle, &claim) {
         Ok(vm_id) => {
             // The standby has become the VM; drop its pool entry (the control UDS is
             // one-shot). The VM now lives under its vms/<id> state dir.
@@ -344,7 +360,8 @@ mod tests {
         let pool = SupervisorStandbyPool::at(tmp.path());
         pool.record(&idle_handle("s1", "aa")).unwrap();
         let backend = StubBackend::new(true);
-        let decision = claim_or_cold(&pool, &backend, &compat("aa"), &sample_claim()).unwrap();
+        let decision =
+            claim_or_cold(&pool, &backend, &compat("aa"), |_h| Ok(sample_claim())).unwrap();
         assert_eq!(decision, LaunchDecision::Claimed(VmId("s1".into())));
         assert!(backend.claimed.load(Ordering::SeqCst));
         assert!(
@@ -358,7 +375,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let pool = SupervisorStandbyPool::at(tmp.path());
         let backend = StubBackend::new(true);
-        let decision = claim_or_cold(&pool, &backend, &compat("aa"), &sample_claim()).unwrap();
+        let decision =
+            claim_or_cold(&pool, &backend, &compat("aa"), |_h| Ok(sample_claim())).unwrap();
         assert_eq!(decision, LaunchDecision::ColdBoot);
         assert!(!backend.claimed.load(Ordering::SeqCst));
     }
@@ -369,7 +387,8 @@ mod tests {
         let pool = SupervisorStandbyPool::at(tmp.path());
         pool.record(&idle_handle("s1", "aa")).unwrap();
         let backend = StubBackend::new(false);
-        let decision = claim_or_cold(&pool, &backend, &compat("aa"), &sample_claim()).unwrap();
+        let decision =
+            claim_or_cold(&pool, &backend, &compat("aa"), |_h| Ok(sample_claim())).unwrap();
         assert_eq!(decision, LaunchDecision::ColdBoot);
         assert!(
             pool.load("s1").is_err(),

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -13,13 +13,18 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use clap::{Args as ClapArgs, Subcommand};
+use mvm_backend::backend::AnyBackend;
 use mvm_backend::standby_pool::SupervisorStandbyPool;
-use mvm_core::vm_backend::{StandbyClaim, StandbyCompat, StandbySpec, VmBackend, VmId};
+use mvm_core::user_config::MvmConfig;
+use mvm_core::vm_backend::{
+    StandbyClaim, StandbyCompat, StandbySpec, StandbyState, VmBackend, VmId,
+};
 use sha2::{Digest, Sha256};
 
-// NB: the `mvmctl pool` command (1b-ii) resolves `signer_id` via
-// `super::vm::host_signer::host_signer_id()` and passes it into these helpers; the
-// helpers themselves stay signer-agnostic (they take `signer_id` as a parameter).
+use super::Cli;
+use super::env::apple_container::ensure_default_microvm_image;
+use super::vm::host_signer;
 
 /// Lowercase-hex sha256 of a kernel image — part of the base-compat key.
 pub fn kernel_sha256_hex(kernel: &Path) -> Result<String> {
@@ -371,4 +376,162 @@ mod tests {
             "a failed standby is removed, not left idle"
         );
     }
+}
+
+// ── `mvmctl pool` command (Plan 118 WS-1 1b) ────────────────────────────────────────
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub action: PoolAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum PoolAction {
+    /// Pre-spawn idle supervisor standbys for the default-microVM launch shape so a later
+    /// `up` is fast. Default count 1. Only the libkrun backend has a standby pool today.
+    Warm {
+        /// How many idle standbys to warm the pool toward (default 1).
+        count: Option<u32>,
+    },
+    /// Show the standby pool — recorded standbys and their idle/claimed state.
+    Status {
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// The default launch shape the warm pool targets: default-microVM kernel + the config's
+/// default cpus/mem + the effective hypervisor. Both `pool warm` and the `up` auto-claim
+/// resolve through the same pieces so a warmed standby is claimable by a default `up`.
+struct WarmShape {
+    backend: AnyBackend,
+    backend_name: String,
+    kernel: std::path::PathBuf,
+    vcpus: u8,
+    mem_mib: u32,
+}
+
+fn resolve_warm_shape(cfg: &MvmConfig) -> Result<WarmShape> {
+    let backend_name = super::shared::resolve_effective_hypervisor("firecracker");
+    let backend = AnyBackend::from_hypervisor(&backend_name);
+    let (kernel, _rootfs) = ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Prod)
+        .context("resolve default-microvm kernel for the warm pool")?;
+    let vcpus = u8::try_from(cfg.default_cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);
+    Ok(WarmShape {
+        backend,
+        backend_name,
+        kernel: std::path::PathBuf::from(kernel),
+        vcpus,
+        mem_mib: cfg.default_memory_mib,
+    })
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
+    let pool = SupervisorStandbyPool::open()?;
+    match args.action {
+        PoolAction::Status { json } => run_status(&pool, json),
+        PoolAction::Warm { count } => run_warm(&pool, cfg, count.unwrap_or(1)),
+    }
+}
+
+fn run_warm(pool: &SupervisorStandbyPool, cfg: &MvmConfig, target: u32) -> Result<()> {
+    let shape = resolve_warm_shape(cfg)?;
+    if !shape.backend.supports_standby_pool() {
+        crate::ui::warn(&format!(
+            "backend '{}' has no supervisor standby pool (only libkrun does today); \
+             nothing warmed.",
+            shape.backend_name
+        ));
+        return Ok(());
+    }
+    // Ensure the host signer exists — the standby re-verifies the attach plan against it.
+    let signer = host_signer::load_or_init()?;
+    let spawned = warm_to_target(
+        pool,
+        &WarmParams {
+            backend: shape.backend.as_vm_backend(),
+            kernel: &shape.kernel,
+            vcpus: shape.vcpus,
+            mem_mib: shape.mem_mib,
+            signer_id: &host_signer::host_signer_id(),
+            signing_key_path: &signer.secret_path,
+            target,
+        },
+    )?;
+    if spawned == 0 {
+        crate::ui::info(&format!("Pool already at or above target {target}."));
+    } else {
+        crate::ui::success(&format!(
+            "Warmed {spawned} standby(s) toward target {target}."
+        ));
+    }
+    crate::ui::info(
+        "Note: a warm `up` claim boots through the gateway-bridge supervisor path \
+         (MVM_GATEWAY_BRIDGE=1); the default `up` cold-boots.",
+    );
+    Ok(())
+}
+
+/// Machine-readable `pool status --json` shape.
+#[derive(serde::Serialize)]
+struct PoolStatus {
+    idle: usize,
+    claimed: usize,
+    standbys: Vec<PoolStatusEntry>,
+}
+
+#[derive(serde::Serialize)]
+struct PoolStatusEntry {
+    id: String,
+    state: &'static str,
+    pid: u32,
+    kernel_sha256: String,
+    vcpus: u8,
+    mem_mib: u32,
+}
+
+fn run_status(pool: &SupervisorStandbyPool, json: bool) -> Result<()> {
+    let standbys = pool.list()?;
+    let idle = standbys
+        .iter()
+        .filter(|h| h.state == StandbyState::Idle)
+        .count();
+    let claimed = standbys.len() - idle;
+    let report = PoolStatus {
+        idle,
+        claimed,
+        standbys: standbys
+            .iter()
+            .map(|h| PoolStatusEntry {
+                id: h.id.clone(),
+                state: match h.state {
+                    StandbyState::Idle => "idle",
+                    StandbyState::Claimed => "claimed",
+                },
+                pid: h.pid,
+                kernel_sha256: h.kernel_sha256.clone(),
+                vcpus: h.vcpus,
+                mem_mib: h.mem_mib,
+            })
+            .collect(),
+    };
+    if json {
+        crate::json_out::emit_json(&report)?;
+        return Ok(());
+    }
+    println!("Supervisor standby pool: {idle} idle, {claimed} claimed");
+    for e in &report.standbys {
+        println!(
+            "  {} · {} · pid {} · {} vcpu / {} MiB · kernel {}",
+            e.id,
+            e.state,
+            e.pid,
+            e.vcpus,
+            e.mem_mib,
+            &e.kernel_sha256[..e.kernel_sha256.len().min(12)]
+        );
+    }
+    Ok(())
 }

--- a/crates/mvm-cli/src/commands/shared/mod.rs
+++ b/crates/mvm-cli/src/commands/shared/mod.rs
@@ -25,8 +25,8 @@ pub(super) use parse::{
     parse_port_specs, parse_volume_spec, vm_volume_from_spec_validated,
 };
 pub(super) use resolve::{
-    ManifestArgRef, resolve_flake_ref, resolve_manifest_arg, resolve_network_policy,
-    resolve_running_vm,
+    ManifestArgRef, resolve_effective_hypervisor, resolve_flake_ref, resolve_manifest_arg,
+    resolve_network_policy, resolve_running_vm,
 };
 pub(super) use start::VmStartParams;
 pub(super) use state::{CHILD_PIDS, IN_CONSOLE_MODE};

--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -182,3 +182,27 @@ pub fn resolve_network_policy(
 // user-global config / mvmd tenant config. Function deleted; the
 // `resolve_network_policy` form (always returns Some) is the only
 // remaining helper.
+
+/// Resolve the requested hypervisor to the effective one for this host. `firecracker`
+/// (the default `--hypervisor`) auto-detects: KVM → firecracker, macOS 26+ Apple Silicon
+/// → apple-container, macOS 13-25 + libkrun → libkrun, else docker. Any explicit value is
+/// returned as-is. Single source of truth, shared by `mvmctl up` and `mvmctl pool`
+/// (Plan 118 WS-1 1b) so they agree on which backend a launch uses.
+pub fn resolve_effective_hypervisor(requested: &str) -> String {
+    if requested != "firecracker" {
+        return requested.to_string();
+    }
+    let plat = mvm_core::platform::current();
+    if plat.has_kvm() {
+        "firecracker"
+    } else if plat.has_apple_containers() {
+        "apple-container"
+    } else if plat.has_libkrun() {
+        "libkrun"
+    } else if plat.has_docker() {
+        "docker"
+    } else {
+        "firecracker"
+    }
+    .to_string()
+}

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2420,6 +2420,30 @@ fn test_cache_prune() {
 }
 
 #[test]
+fn test_pool_warm_parses_optional_count() {
+    // Plan 118 WS-1 1b — `mvmctl pool warm` (default count) and `pool warm N`.
+    assert!(Cli::try_parse_from(["mvmctl", "pool", "warm"]).is_ok());
+    let cli = Cli::try_parse_from(["mvmctl", "pool", "warm", "3"]).unwrap();
+    match cli.command {
+        Commands::Pool(pool::Args {
+            action: pool::PoolAction::Warm { count },
+        }) => assert_eq!(count, Some(3)),
+        _ => panic!("Expected Pool Warm command"),
+    }
+}
+
+#[test]
+fn test_pool_status_parses_json_flag() {
+    let cli = Cli::try_parse_from(["mvmctl", "pool", "status", "--json"]).unwrap();
+    match cli.command {
+        Commands::Pool(pool::Args {
+            action: pool::PoolAction::Status { json },
+        }) => assert!(json),
+        _ => panic!("Expected Pool Status command"),
+    }
+}
+
+#[test]
 fn test_cache_prune_dry_run() {
     let cli = Cli::try_parse_from(["mvmctl", "cache", "prune", "--dry-run"]).unwrap();
     match cli.command {

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1280,22 +1280,9 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
     // matches the rest of the codebase: native KVM → Apple Container
     // (macOS 26+) → libkrun (typical macOS 13-25 contributor box with
     // the slp/krun Homebrew tap) → Docker (Tier 3 fallback).
-    let effective_hypervisor = if hypervisor == "firecracker" {
-        let plat = mvm_core::platform::current();
-        if plat.has_kvm() {
-            "firecracker" // native KVM — production Tier 1
-        } else if plat.has_apple_containers() {
-            "apple-container" // macOS 26+ Apple Silicon
-        } else if plat.has_libkrun() {
-            "libkrun" // macOS 13-25 with libkrun installed
-        } else if plat.has_docker() {
-            "docker" // universal Tier 3 fallback (banner emitted)
-        } else {
-            "firecracker" // surfaces a clear "not available" error
-        }
-    } else {
-        hypervisor
-    };
+    // Shared with `mvmctl pool` (Plan 118 WS-1 1b) so both agree on the effective backend.
+    let effective_hypervisor_owned = super::super::shared::resolve_effective_hypervisor(hypervisor);
+    let effective_hypervisor: &str = &effective_hypervisor_owned;
 
     // ADR-002 / plan 53: emit a loud, suppressible banner when the
     // active backend is not a hardware-isolated microVM. Today this

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -178,6 +178,13 @@ struct WarmStartReport {
     /// `null` off Linux — the substrate backs Firecracker's live-memory path,
     /// which only runs on KVM; macOS reports per-backend tiers but N/A here.
     substrate: Option<WarmStartSubstrate>,
+    /// Plan 118 WS-1 1b — backend name → `supports_standby_pool()`. The standby pool
+    /// (pre-pay spawn/codesign latency) is a *different* axis from the snapshot tier above;
+    /// only libkrun implements it today.
+    standby_pool: BTreeMap<String, bool>,
+    /// Live count of idle standbys recorded under `~/.mvm/pool/` (best-effort; `None` if
+    /// the pool dir can't be read).
+    standby_pool_idle: Option<usize>,
 }
 
 /// Linux fast-resume substrate probe (plan 123 C2): the kernel pieces the
@@ -504,13 +511,26 @@ fn collect_warm_start_support() -> WarmStartReport {
         "vz",
     ];
     let mut backends = BTreeMap::new();
+    let mut standby_pool = BTreeMap::new();
     for name in names {
         let b = AnyBackend::from_hypervisor(name);
         backends.insert(b.name().to_string(), b.snapshot_capability().label());
+        standby_pool.insert(b.name().to_string(), b.supports_standby_pool());
     }
+    // Best-effort live idle count (Plan 118 WS-1 1b). A missing pool dir reads as 0.
+    let standby_pool_idle = mvm_backend::standby_pool::SupervisorStandbyPool::open()
+        .and_then(|p| p.list())
+        .ok()
+        .map(|v| {
+            v.iter()
+                .filter(|h| h.state == mvm_core::vm_backend::StandbyState::Idle)
+                .count()
+        });
     WarmStartReport {
         backends,
         substrate: collect_warm_start_substrate(),
+        standby_pool,
+        standby_pool_idle,
     }
 }
 
@@ -577,6 +597,25 @@ fn render_warm_start_support(r: &WarmStartReport) {
         }
         None => ui::status_line("  substrate (Linux fast-resume)", "N/A (Linux-only)"),
     }
+
+    // Plan 118 WS-1 1b — the standby pool (pre-pay spawn latency), a separate axis from
+    // the snapshot tiers above. Only libkrun implements it today.
+    let pool_title = "Standby pool (per backend)";
+    println!("\n{}", pool_title);
+    println!("{}", "-".repeat(pool_title.len()));
+    for (backend, supported) in &r.standby_pool {
+        ui::status_line(
+            &format!("  {backend}:"),
+            if *supported { "supported" } else { "—" },
+        );
+    }
+    ui::status_line(
+        "  idle standbys",
+        &match r.standby_pool_idle {
+            Some(n) => n.to_string(),
+            None => "unknown".to_string(),
+        },
+    );
 }
 
 // ── Active backend security posture (ADR-002 / plan 53) ──────
@@ -2727,6 +2766,16 @@ mod tests {
         assert_eq!(r.backends.get("qemu"), Some(&"disk-only"));
         // A backend with no warm-start support must not be silently dropped.
         assert_eq!(r.backends.get("docker"), Some(&"unsupported"));
+    }
+
+    #[test]
+    fn collect_warm_start_support_reports_standby_pool_per_backend() {
+        let r = collect_warm_start_support();
+        // Plan 118 WS-1 1b — only libkrun implements the standby pool today; the rest
+        // report honest `false` and must not be silently dropped.
+        assert_eq!(r.standby_pool.get("libkrun"), Some(&true));
+        assert_eq!(r.standby_pool.get("apple-container"), Some(&false));
+        assert_eq!(r.standby_pool.get("docker"), Some(&false));
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -70,9 +70,11 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
   [x] WS-4 resumable + honest-cost dev-image download — PR #667
   [x] WS-5 E streamed exec (ExecEvent) — PR #712 (plan-172)
   [x] WS-5 E follow-up: enforce exec timeout_secs — plan-173
-  [~] WS-1 warm pool (Plan 118): 1a prelaunched-supervisor primitive landed
-      (base/attach split + attach-time plan re-verify + fuzz + a–e ladder,
-      PR #748); 1b pool/up-claim/bench remains
+  [~] WS-1 warm pool (Plan 118): 1a primitive (#748) + 1b-i mechanism (#751,
+      trait seam + registry + libkrun impl) + 1b-ii (reaper + cache-prune,
+      doctor standby column, `mvmctl pool warm/status`, bench state-dir fix)
+      landed; remaining: `up`/`run` auto-claim (name-rebind + bridge confirm),
+      `--warm-pool-size`, multi-kernel keying, committed bench delta (SPRINT.md)
   [ ] WS-2 checkpoint+fork  (152 WS-B done; unblocked)
   [ ] WS-5 D verb renames; curl|sh installer; --json remainder
   [ ] signed delta-image distribution (unowned — needs a home)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2533,3 +2533,34 @@ Tracked as GitHub issues so they're individually grabbable:
 - [x] Docs parity maintenance — added a lifecycle-matrix SDK guide separating current CLI support, current Python/TypeScript SDK support, and runtime parity targets.
 - [x] Docs parity maintenance — added a control-surfaces architecture page covering CLI, SDKs, MCP stdio, console, guest RPC, and not-claimed local management surfaces.
 - [x] Docs parity maintenance — added a platform-support reference page covering Linux, macOS, Windows future work, Docker fallback, host/backend status, and guest target strings.
+
+### Plan 118 WS-1 1b — supervisor warm pool: deferred follow-ups
+
+1a (#748) + 1b-i (#751, mechanism) + 1b-ii (reaper + doctor column + `mvmctl pool
+warm/status` + bench state-dir fix) shipped. Remaining, individually grabbable:
+
+- [ ] **`up`/`run` auto-claim wiring.** `claim_or_cold` is closure-ready (it builds the
+  `StandbyClaim` per the selected standby so the name-keyed audit substrate
+  `gateway-<vm>.sock` resolves for the standby-id). The wiring is held back on two
+  coupled items: (a) a claimed VM runs under its **standby-id** (its vsock socket dir is
+  baked at spawn), so `up.rs` must rebind the ~40 downstream `vm_name` references for a
+  warm launch — risky surgery in the core command; (b) a claim forces the supervisor's
+  **`run_with_bridge`** path (the attach carries tenant+plan+audit), which `up.rs:~1906`
+  documents as not-working-by-default on libkrun ("gvproxy vfkit socket empty") — though
+  that comment predates Plan 123 Phase A (#727/#647) wiring egress policy *live* on the
+  libkrun bridge, so it may be stale. **First step: confirm a libkrun bridge-path boot
+  works end-to-end** (run the `#[ignore]`'d `valid_attach_boots_and_agent_reachable`), then
+  do the name-rebind. Until then `up` always cold-boots; `mvmctl pool warm` pre-spawns
+  standbys but nothing auto-claims them.
+- [ ] **`--warm-pool-size` flag on `up`** (threads to `VmStartConfig.warm_pool_size` +
+  replenish-on-use) — lands with the auto-claim, since replenish without claim only
+  accumulates unclaimed standbys.
+- [ ] **Multi-kernel pool keying.** v1 is default-kernel + default-resources only
+  (`StandbyCompat` = kernel sha256 + vcpus + mem; non-matching launches cold-boot).
+  Generalize to per-(kernel,shape) targets + eviction once a second shape is common.
+- [ ] **Honour an explicit `--name` / extra `--volume`s for warm launches.** v1 only
+  claims for auto-named, volume-less launches (1a's attach threads only the rootfs; a
+  claimed VM is named by standby-id).
+- [ ] **Committed bench baseline + cold-vs-warm delta.** The state-dir fix unblocks the
+  probe; a real baseline still needs a freshly-built `default-microvm` image (rides
+  PR-10a's deferral).

--- a/specs/plans/176-supervisor-standby-pool-ws1-1b.md
+++ b/specs/plans/176-supervisor-standby-pool-ws1-1b.md
@@ -1116,6 +1116,15 @@ git commit -m "test(backend): libkrun-live standby spawn->claim->boot + wrong-no
 
 # PR 1b-ii — lifecycle / ops
 
+> **Status (2026-06-09):** **Landed** — Task 9 (reaper + cache-prune), Task 10 (doctor
+> standby column + `AnyBackend` delegates), Task 11 (bench state-dir fix), **plus** the
+> re-scoped `mvmctl pool warm/status` command + the shared `resolve_effective_hypervisor`.
+> `claim_or_cold` was made closure-ready (per-standby audit substrate). **Deferred to a
+> focused follow-up** (see SPRINT.md §"Plan 118 WS-1 1b"): the `up`/`run` auto-claim wiring
+> (needs an in-`up.rs` name-rebind — a claimed VM runs under its standby-id — and a
+> confirmed libkrun bridge boot), `--warm-pool-size` + replenish-on-use (Tasks 7/13),
+> multi-kernel keying, honour-`--name`/volumes, and the committed bench delta (Task 12).
+
 > Continue on the same branch after 1b-i merges (or restack onto 1a if 1a merged first).
 
 ## Task 9: Reaper TTL + `cache prune` integration


### PR DESCRIPTION
## Summary

Plan 118 WS-1 **Layer 1b-ii** — the lifecycle/ops layer on top of the 1b-i mechanism
(#751). **Stacked on #751** (base `feat/plan-118-ws1-layer1b`). Plan:
`specs/plans/176-supervisor-standby-pool-ws1-1b.md` §"PR 1b-ii".

### What landed

- **Standby reaper** (`reap_stale`) + `cache prune` sweep of `~/.mvm/pool/` — dead-pid or
  expired (>30 min TTL) standbys are removed; a live-expired standby's entitled supervisor
  is **SIGTERM'd first** so idle entitled processes never accumulate (B-ii residual risk 3).
- **`mvmctl pool warm [N]` / `pool status`** — `warm` pre-spawns idle standbys for the
  default-microVM shape (default kernel + the config's default cpus/mem + effective
  hypervisor — the same pieces a default `up` resolves, so a warmed standby is claimable);
  `status` lists idle/claimed (text + `--json`). No-op with a clear message on non-libkrun
  backends. Extracts the hypervisor auto-detect from `up.rs` into a shared
  `resolve_effective_hypervisor` (one source) + `AnyBackend::as_vm_backend`.
- **`doctor` standby-pool column** + a live idle count, next to the warm-start matrix; plus
  `AnyBackend::{supports,spawn,claim}_standby` delegates.
- **Bench state-dir bug fix** — the `microvm-launch` probe polled the pid under the **XDG**
  state dir (`~/.local/state/mvm`) while the supervisor writes `~/.mvm/vms/<name>`, so the
  `start_to_pid` mark never resolved and the probe timed out on every dev-host run. Now
  delegates to the canonical `vm_state_dir` helper.
- **`claim_or_cold` made closure-ready** — it builds the `StandbyClaim` for the *selected*
  standby, so the name-keyed audit substrate (`gateway-<vm>.sock`) resolves for the
  standby-id a claimed VM runs under. This is the integration-ready seam for the `up`
  auto-claim.

### Deferred to a focused follow-up (SPRINT.md §"Plan 118 WS-1 1b")

The **`up`/`run` auto-claim wiring** is held back deliberately — going deep revealed two
coupled risks in the core command:
1. A claimed VM runs under its **standby-id** (vsock socket dir baked at spawn), so `up.rs`
   must rebind ~40 downstream `vm_name` references for a warm launch — risky surgery in the
   most-used command.
2. A claim forces the supervisor's **`run_with_bridge`** path (the attach carries
   tenant+plan+audit), which `up.rs` documents as not-working-by-default on libkrun
   ("gvproxy vfkit socket empty") — though that comment predates #727/#647 wiring egress
   policy *live* on the libkrun bridge, so it may be stale. **First step:** confirm a
   libkrun bridge-path boot works end-to-end, then do the name-rebind.

Also deferred: `--warm-pool-size` + replenish-on-use (lands with auto-claim); multi-kernel
keying; honour `--name`/volumes for warm launches; the committed bench delta.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace -E 'not package(mvm-backend)'` — green (one unrelated
      pre-existing `mvm-guest` timing flake, passes on re-run)
- [x] `cargo test -p mvm-backend standby_pool` (reaper + registry) — green
- [x] `cargo test --workspace --doc`; `xtask check-spec-numbers`
- [x] Verified live: `mvmctl pool --help` + `pool status` (text + `--json`) render
- [x] Reaper unit test (dead/expired removed, live-recent kept, live-expired SIGTERM'd);
      bench state-dir regression test; doctor standby-column test; pool parse + claim/cold tests