### PR TITLE
fix(secrets): substitution endpoint forwards http to the destination's real port

### DIFF
--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -34,7 +34,9 @@ use crate::keyholder::{
 };
 use crate::supervisor::audit_recorder::Recorder;
 use crate::supervisor::secret_audit::emit_secret_substituted;
-use crate::supervisor::tools::http_hardening::hardened_client_builder;
+use crate::supervisor::tools::http_hardening::{
+    hardened_client_builder_no_dns, resolve_ssrf_safe_ips,
+};
 
 /// 16 MiB cap on a single routed request/response frame.
 const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
@@ -183,18 +185,20 @@ fn err_chain(e: &dyn std::error::Error) -> String {
     out
 }
 
-/// Production forwarder: a hardened reqwest client (TLS 1.3 min, SSRF-filtered
-/// resolver, no redirects — `hardened_client_builder`) makes the real request.
+/// Production forwarder: a hardened reqwest client (TLS 1.3 min, no redirects)
+/// makes the real request. Unlike the HTTPS-only tool clients, the egress
+/// forward target can be plain `http` (the guest's request scheme), so the
+/// client is built **per request**: we resolve the host, SSRF-filter the IPs,
+/// and pin them on the URL's *real* port via `resolve_to_addrs` — the shared
+/// `SsrfFilteringResolver` hardcodes 443 and would send an `http` forward to the
+/// HTTPS port. Plan 129 / ADR-067.
 pub struct ReqwestForwarder {
-    client: reqwest::Client,
+    timeout_secs: u64,
 }
 
 impl ReqwestForwarder {
     pub fn new(timeout_secs: u64) -> Result<Self, ForwardError> {
-        let client = hardened_client_builder(timeout_secs)
-            .build()
-            .map_err(|e| ForwardError::Failed(e.to_string()))?;
-        Ok(Self { client })
+        Ok(Self { timeout_secs })
     }
 }
 
@@ -203,7 +207,29 @@ impl Forwarder for ReqwestForwarder {
     async fn forward(&self, req: PreparedRequest) -> Result<ForwardResponse, ForwardError> {
         let method = reqwest::Method::from_bytes(req.method.as_bytes())
             .map_err(|e| ForwardError::Failed(format!("bad method: {e}")))?;
-        let mut rb = self.client.request(method, &req.url);
+        // Resolve + SSRF-filter the host ourselves, then pin reqwest to the safe
+        // IPs on the URL's real port (default 80 for http, 443 for https, or an
+        // explicit port). Keeps SSRF filtering without the resolver's 443 bug.
+        let url = Url::parse(&req.url)
+            .map_err(|e| ForwardError::Failed(format!("bad url {}: {e}", req.url)))?;
+        let host = url
+            .host_str()
+            .ok_or_else(|| ForwardError::Failed(format!("url {} has no host", req.url)))?
+            .to_string();
+        let port = url
+            .port_or_known_default()
+            .ok_or_else(|| ForwardError::Failed(format!("url {} has no port", req.url)))?;
+        let addrs: Vec<std::net::SocketAddr> = resolve_ssrf_safe_ips(&host)
+            .await
+            .map_err(ForwardError::Failed)?
+            .into_iter()
+            .map(|ip| std::net::SocketAddr::new(ip, port))
+            .collect();
+        let client = hardened_client_builder_no_dns(self.timeout_secs)
+            .resolve_to_addrs(&host, &addrs)
+            .build()
+            .map_err(|e| ForwardError::Failed(e.to_string()))?;
+        let mut rb = client.request(method, &req.url);
         for (k, v) in &req.headers {
             rb = rb.header(k, v);
         }

--- a/crates/mvm-hostd/src/supervisor/tools/http_hardening.rs
+++ b/crates/mvm-hostd/src/supervisor/tools/http_hardening.rs
@@ -86,10 +86,14 @@ impl Resolve for SsrfFilteringResolver {
     fn resolve(&self, name: Name) -> Resolving {
         let host = name.as_str().to_string();
         Box::pin(async move {
-            // The port we pass to `lookup_host` is a placeholder —
-            // reqwest reads the IP out of each `SocketAddr` and
-            // uses the URL's port for the actual connect. 443 is
-            // a reasonable default since most callers are HTTPS.
+            // ⚠️ reqwest connects on the **resolver's** SocketAddr port, NOT
+            // the URL's — so this 443 forces every request through HTTPS:443.
+            // Fine for the HTTPS-only callers (web_fetch, MCP tools), but it
+            // breaks plain `http` (the request hits :443 → "plain HTTP request
+            // was sent to HTTPS port"). HTTP/arbitrary-port callers must use
+            // `resolve_ssrf_safe_ips` + `hardened_client_builder_no_dns` +
+            // `resolve_to_addrs` instead (the `Resolve` trait never sees the
+            // port, so a custom resolver cannot be port-correct).
             let resolved: Vec<SocketAddr> = tokio::net::lookup_host((host.as_str(), 443u16))
                 .await
                 .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?
@@ -169,6 +173,42 @@ pub fn filter_ssrf_addrs(
         ));
     }
     Ok(safe)
+}
+
+/// Resolve `host` to its SSRF-safe IP addresses (the IPs only — no port). The
+/// caller pins these to the request's **actual** port (see
+/// [`hardened_client_builder_no_dns`] + `resolve_to_addrs`).
+///
+/// This exists because the [`SsrfFilteringResolver`] above hardcodes port 443
+/// (the `Resolve` trait only hands the resolver the host, never the port), and
+/// reqwest connects on the *resolver's* port — so a plain-`http` forward would
+/// hit the destination's HTTPS port (`400 "plain HTTP request was sent to HTTPS
+/// port"`). Callers that forward to arbitrary URL ports resolve here, then pin
+/// the safe IPs on the URL's real port, keeping SSRF filtering without the port
+/// bug. Errors when the host doesn't resolve or every address is SSRF-blocked.
+pub async fn resolve_ssrf_safe_ips(host: &str) -> Result<Vec<std::net::IpAddr>, String> {
+    // The port handed to `lookup_host` is irrelevant — we keep only the IPs.
+    let resolved: Vec<SocketAddr> = tokio::net::lookup_host((host, 0u16))
+        .await
+        .map_err(|e| format!("resolving {host}: {e}"))?
+        .collect();
+    Ok(filter_ssrf_addrs(resolved)?
+        .into_iter()
+        .map(|sa| sa.ip())
+        .collect())
+}
+
+/// A hardened reqwest builder (W1 no-redirect + W7 TLS-1.3 floor + timeout)
+/// **without** the port-hardcoding [`SsrfFilteringResolver`]. Pair it with
+/// `.resolve_to_addrs(host, &[ip:url_port, …])` built from
+/// [`resolve_ssrf_safe_ips`] so SSRF filtering survives while the connection
+/// uses the URL's real port. Use this (not [`hardened_client_builder`]) when the
+/// forward target may be plain `http`.
+pub fn hardened_client_builder_no_dns(timeout_secs: u64) -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .redirect(reqwest::redirect::Policy::none())
+        .min_tls_version(MIN_TLS_VERSION)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

The substitution endpoint's forward leg (`ReqwestForwarder`) used `hardened_client_builder`, whose `SsrfFilteringResolver` **hardcodes port 443** in its DNS lookup. reqwest connects on the **resolver's** `SocketAddr` port — not the URL's — so a plain-`http` forward connected to the destination's HTTPS port and sent plaintext → `400 "plain HTTP request was sent to HTTPS port"`.

The egress-substitution forward target is the guest's request scheme, which is **`http`** today (https CONNECT-tunnels through the in-guest forward proxy and can't be read), so **every real forward failed**. The HTTPS tool callers (`web_fetch`, MCP) are unaffected — 443 is correct for them.

## Fix

`ReqwestForwarder` now resolves the host and SSRF-filters the IPs itself (`resolve_ssrf_safe_ips`), then pins reqwest to those IPs on the URL's **real** port (`url.port_or_known_default()`) via `resolve_to_addrs`, built from a hardened builder **without** the port-hardcoding resolver (`hardened_client_builder_no_dns`). SSRF filtering is preserved — the IPs are still run through `SsrfGuard::classify`, and DNS-rebinding to a private IP is still rejected. The `Resolve` trait only ever receives the host (never the port), so a custom resolver fundamentally cannot be port-correct; pinning the resolved+filtered addresses is the correct pattern.

The misleading comment in `SsrfFilteringResolver` (which claimed reqwest uses the URL's port) is corrected, and the resolver is documented as HTTPS-only-correct.

## How it was found

The on-box Plan 129 secret-egress e2e: substitution succeeded (placeholder substituted, never on the wire) but the forward to an `http` target returned `400 "plain HTTP request was sent to HTTPS port"` consistently across destinations, while a host `curl` to the same `http://` URL returned 200 — isolating the client (reqwest + the 443-hardcoding resolver).

## Tests
- `cargo test -p mvm-hostd` (http_hardening + substitution_proxy) green; fmt + clippy clean.
- The end-to-end forward is validated on the dev-kvm QEMU box (the substitution endpoint forwarding a live guest's `http` request).

Surfaced by the local secret-workload launch work (#745); the forward-leg fix is independent and lands on its own.