### PR TITLE
feat: warm-pool up auto-claim wiring + bridge-boot validation (Plan 118 WS-1 1b-iii)

### DIFF
--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -8,14 +8,9 @@ mod image;
 mod kernel;
 mod manifest;
 mod ops;
-/// Plan 118 WS-1 1b — supervisor warm-pool launch glue + the `mvmctl pool` command. The
-/// `mvmctl pool warm/status` command, the `StandbySpec` builder, and `warm_to_target` are
-/// live here. `claim_or_cold` (closure-ready for the per-standby audit substrate) is the
-/// last unwired piece: the `up`/`run` auto-claim needs an in-`up.rs` name-rebind (a
-/// claimed VM runs under its standby-id) + the gateway-bridge path confirmed working —
-/// scoped as a focused follow-up. `allow(dead_code)` covers `claim_or_cold`/`LaunchDecision`
-/// until then.
-#[allow(dead_code)]
+/// Plan 118 WS-1 1b — supervisor warm-pool: the `mvmctl pool warm/status` command + the
+/// launch glue (`try_warm_claim`/`replenish_after_launch`) the `up` path calls to claim a
+/// warm standby (auto-named, bridge-admitted launches) and top the pool back up.
 mod pool;
 mod qemu_bridge;
 mod shared;

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -178,6 +178,15 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
 
 /// The base-compat key a launch needs from its `VmStartConfig` (kernel sha256 + the fixed
 /// vcpus/mem). `None` if the config carries no kernel path.
+///
+/// **Known limitation (libkrun mkGuest):** a mkGuest workload image ships no kernel — its
+/// `kernel_path` `vmlinux` is materialized by libkrun (`extract_bundled_kernel`) only at
+/// `start_enter`, so it's **absent on disk here** and `kernel_sha256_hex` errors →
+/// `try_warm_claim` fails open to cold boot. A libkrun standby is in fact
+/// workload-*independent* (it pre-loads the bundled kernel; the rootfs arrives at attach),
+/// so the right key is the **bundled** kernel sha the standby actually loads, not the
+/// workload's kernel path. Wiring that (the bundled-kernel identity lives in `libkrun-sys`)
+/// is the follow-up that makes the libkrun warm claim fire end-to-end (SPRINT.md).
 fn compat_for_launch(cfg: &VmStartConfig) -> Result<Option<StandbyCompat>> {
     let Some(kernel) = cfg.kernel_path.as_ref() else {
         return Ok(None);

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -19,6 +19,7 @@ use mvm_backend::standby_pool::SupervisorStandbyPool;
 use mvm_core::user_config::MvmConfig;
 use mvm_core::vm_backend::{
     StandbyClaim, StandbyCompat, StandbyHandle, StandbySpec, StandbyState, VmBackend, VmId,
+    VmStartConfig,
 };
 use sha2::{Digest, Sha256};
 
@@ -173,6 +174,97 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
         }
     }
     Ok(spawned)
+}
+
+/// The base-compat key a launch needs from its `VmStartConfig` (kernel sha256 + the fixed
+/// vcpus/mem). `None` if the config carries no kernel path.
+fn compat_for_launch(cfg: &VmStartConfig) -> Result<Option<StandbyCompat>> {
+    let Some(kernel) = cfg.kernel_path.as_ref() else {
+        return Ok(None);
+    };
+    Ok(Some(StandbyCompat {
+        kernel_sha256: kernel_sha256_hex(Path::new(kernel))?,
+        vcpus: u8::try_from(cfg.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
+        mem_mib: cfg.memory_mib,
+    }))
+}
+
+/// Attempt a warm-pool claim for this launch. Returns the claimed `VmId` (the standby-id
+/// the VM now runs under) or `None` to cold-boot. **Fail-open**: anything not default-
+/// shaped, not bridge-admitted, or any error → `None` (the caller cold-boots as normal).
+///
+/// Eligibility (all required): `warm_pool_size > 0`, the launch is auto-named (no explicit
+/// `--name` — a claimed VM is named by its standby-id), no extra volumes (1a's attach
+/// threads only the rootfs), the backend supports the pool, and the **admitted plan +
+/// tenant** are threaded into the config — which only the gateway-bridge path
+/// (`MVM_GATEWAY_BRIDGE=1`) does, and which a claimed standby's `run_with_bridge` requires.
+pub fn try_warm_claim(
+    backend: &AnyBackend,
+    cfg: &VmStartConfig,
+    user_named: bool,
+) -> Result<Option<VmId>> {
+    if cfg.warm_pool_size == 0
+        || user_named
+        || !cfg.volumes.is_empty()
+        || !backend.supports_standby_pool()
+    {
+        return Ok(None);
+    }
+    let (Some(plan_json), Some(tenant)) = (cfg.plan_json.clone(), cfg.tenant_id.clone()) else {
+        // No admitted plan threaded in → not the bridge path → cold-boot.
+        return Ok(None);
+    };
+    let Some(want) = compat_for_launch(cfg)? else {
+        return Ok(None);
+    };
+    let rootfs = cfg.rootfs_path.clone();
+    let bundle_json = cfg.bundle_json.clone();
+    let pool = SupervisorStandbyPool::open()?;
+    let decision = claim_or_cold(&pool, backend.as_vm_backend(), &want, |handle| {
+        // The audit substrate (`gateway-<vm>.sock`) is name-keyed; the claimed VM runs
+        // under the standby-id, so compute it for `handle.id`.
+        let sub = mvm_backend::audit_substrate::compute_audit_substrate(&handle.id, Some(&tenant))?;
+        Ok(StandbyClaim {
+            rootfs_path: rootfs.clone(),
+            tenant_id: tenant.clone(),
+            audit_dir: sub.audit_dir.context("audit substrate missing audit_dir")?,
+            gateway_audit_socket: sub
+                .gateway_audit_socket
+                .context("audit substrate missing gateway_audit_socket")?,
+            gateway_events_socket: sub.gateway_events_socket,
+            plan_json: plan_json.clone(),
+            bundle_json: bundle_json.clone(),
+        })
+    })?;
+    Ok(match decision {
+        LaunchDecision::Claimed(id) => Some(id),
+        LaunchDecision::ColdBoot => None,
+    })
+}
+
+/// Top the pool back up toward `cfg.warm_pool_size` after a launch (the no-daemon
+/// replenish-on-use maintainer). Best-effort — failures are logged, never propagated.
+pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Result<u32> {
+    if cfg.warm_pool_size == 0 || !backend.supports_standby_pool() {
+        return Ok(0);
+    }
+    let Some(kernel) = cfg.kernel_path.as_ref() else {
+        return Ok(0);
+    };
+    let signer = host_signer::load_or_init()?;
+    let pool = SupervisorStandbyPool::open()?;
+    warm_to_target(
+        &pool,
+        &WarmParams {
+            backend: backend.as_vm_backend(),
+            kernel: Path::new(kernel),
+            vcpus: u8::try_from(cfg.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
+            mem_mib: cfg.memory_mib,
+            signer_id: &host_signer::host_signer_id(),
+            signing_key_path: &signer.secret_path,
+            target: cfg.warm_pool_size,
+        },
+    )
 }
 
 fn hex_lower(bytes: &[u8]) -> String {
@@ -394,6 +486,60 @@ mod tests {
             pool.load("s1").is_err(),
             "a failed standby is removed, not left idle"
         );
+    }
+
+    // try_warm_claim eligibility gates — each must cold-boot (return None) before touching
+    // the pool. A real libkrun AnyBackend (supports the pool, no I/O at construction) so the
+    // tested gate is the deciding one.
+    fn eligible_cfg() -> VmStartConfig {
+        VmStartConfig {
+            warm_pool_size: 2,
+            kernel_path: Some("/k/vmlinux".into()),
+            rootfs_path: "/vol/rootfs.ext4".into(),
+            cpus: 2,
+            memory_mib: 1024,
+            tenant_id: Some("tenant-a".into()),
+            plan_json: Some("{}".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn try_warm_claim_cold_when_pool_size_zero() {
+        let b = AnyBackend::from_hypervisor("libkrun");
+        let mut c = eligible_cfg();
+        c.warm_pool_size = 0;
+        assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);
+    }
+
+    #[test]
+    fn try_warm_claim_cold_when_user_named() {
+        let b = AnyBackend::from_hypervisor("libkrun");
+        assert_eq!(try_warm_claim(&b, &eligible_cfg(), true).unwrap(), None);
+    }
+
+    #[test]
+    fn try_warm_claim_cold_with_extra_volumes() {
+        use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+        let b = AnyBackend::from_hypervisor("libkrun");
+        let mut c = eligible_cfg();
+        c.volumes = vec![VmVolume {
+            host: "/h".into(),
+            guest: "/g".into(),
+            size: String::new(),
+            read_only: false,
+            kind: VmVolumeKind::DirShare,
+            encrypted: false,
+        }];
+        assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);
+    }
+
+    #[test]
+    fn try_warm_claim_cold_without_admitted_plan() {
+        let b = AnyBackend::from_hypervisor("libkrun");
+        let mut c = eligible_cfg();
+        c.plan_json = None; // not the gateway-bridge/admitted path → cold-boot
+        assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);
     }
 }
 

--- a/crates/mvm-cli/src/commands/shared/start.rs
+++ b/crates/mvm-cli/src/commands/shared/start.rs
@@ -30,6 +30,8 @@ pub struct VmStartParams<'a> {
     pub config_files: &'a [microvm::DriveFile],
     pub secret_files: &'a [microvm::DriveFile],
     pub port_mappings: &'a [config::PortMapping],
+    /// Plan 118 WS-1 1b — warm-pool target (`--warm-pool-size`); 0 = off.
+    pub warm_pool_size: u32,
 }
 
 impl VmStartParams<'_> {
@@ -47,6 +49,7 @@ impl VmStartParams<'_> {
             cpus: self.cpus,
             memory_mib: self.memory_mib,
             mem_initial_mib: self.mem_initial_mib,
+            warm_pool_size: self.warm_pool_size,
             ports: self
                 .port_mappings
                 .iter()

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -791,6 +791,11 @@ pub(in crate::commands) struct Args {
     /// Bind a Prometheus metrics endpoint on this port (0 = disabled)
     #[arg(long, default_value = "0")]
     pub metrics_port: u16,
+    /// Plan 118 WS-1 1b — keep this many prelaunched supervisor standbys warm so the next
+    /// auto-named `up` claims one instead of cold-booting. 0 (default) = feature off. Only
+    /// the libkrun backend has a standby pool today; a claim uses the gateway-bridge path.
+    #[arg(long, default_value = "0")]
+    pub warm_pool_size: u32,
     /// Reload ~/.mvm/config.toml automatically when it changes
     #[arg(long)]
     pub watch_config: bool,
@@ -1088,6 +1093,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         env_vars: &args.env,
         forward: args.forward,
         metrics_port: args.metrics_port,
+        warm_pool_size: args.warm_pool_size,
         watch_config: args.watch_config,
         watch: args.watch,
         detach: args.detach || args.up_json,
@@ -1173,6 +1179,8 @@ pub(in crate::commands) struct RunParams<'a> {
     pub(super) env_vars: &'a [String],
     pub(super) forward: bool,
     pub(super) metrics_port: u16,
+    /// Plan 118 WS-1 1b — `--warm-pool-size`; 0 = off.
+    pub(super) warm_pool_size: u32,
     pub(super) watch_config: bool,
     pub(super) watch: bool,
     pub(super) detach: bool,
@@ -1239,6 +1247,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         env_vars,
         forward,
         metrics_port,
+        warm_pool_size,
         watch_config,
         watch,
         detach,
@@ -1768,7 +1777,8 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         });
     }
 
-    let vm_name_owned = vm_name.clone();
+    // `mut` so a warm-pool claim can rebind it to the claimed standby-id (Plan 118 WS-1 1b).
+    let mut vm_name_owned = vm_name.clone();
     let has_ports = !port_mappings.is_empty();
 
     // Stash the generated VM name so that if the Apple Container backend
@@ -1882,6 +1892,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             config_files: &config_files,
             secret_files: &secret_files,
             port_mappings: &port_mappings,
+            warm_pool_size,
         }
         .into_start_config();
         // Plan 124 C1 — attach the verity-sealed runtime overlay (Firecracker only, non-fatal).
@@ -1947,12 +1958,40 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         }
 
         enforce_shares_if(&admission_main, &start_config.volumes)?;
-        if let Err(e) = backend.start(&start_config) {
-            emit_failed_if(&admission_main, "backend-start", &e);
-            return Err(e);
+        // Plan 118 WS-1 1b — try a warm-pool claim first (auto-named + bridge-admitted
+        // launches only; fail-open to cold boot). A claimed VM runs under its standby-id,
+        // so rebind `vm_name_owned` for all downstream (agent wait, audit, readiness, stop).
+        let claimed: Option<String> =
+            match super::super::pool::try_warm_claim(&backend, &start_config, name.is_some()) {
+                Ok(Some(id)) => {
+                    ui::info(&format!(
+                        "Claimed a warm standby ({}) — skipping cold boot.",
+                        id.0
+                    ));
+                    Some(id.0)
+                }
+                Ok(None) => None,
+                Err(e) => {
+                    // try_warm_claim itself erroring (pool I/O, etc.) must not fail the launch.
+                    tracing::warn!(error = %e, "warm-claim attempt errored; cold-booting");
+                    None
+                }
+            };
+        match claimed {
+            Some(name) => vm_name_owned = name,
+            None => {
+                if let Err(e) = backend.start(&start_config) {
+                    emit_failed_if(&admission_main, "backend-start", &e);
+                    return Err(e);
+                }
+            }
         }
         emit_launched_if(&admission_main, effective_hypervisor);
         record_vm_readiness(&vm_name_owned, InstanceReadiness::LaunchAccepted);
+        // Replenish the pool toward target after launch — best-effort, no daemon.
+        if let Err(e) = super::super::pool::replenish_after_launch(&backend, &start_config) {
+            tracing::debug!(error = %e, "pool replenish skipped (best-effort)");
+        }
     }
 
     mvm_core::audit_emit!(VmStart, vm: &vm_name_owned);
@@ -2301,6 +2340,8 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 config_files: &w_config_files,
                 secret_files: &w_secret_files,
                 port_mappings: &w_port_mappings,
+                // `--wait` is a one-shot workload; no warm-pool claim on this path.
+                warm_pool_size: 0,
             }
             .into_start_config();
             // Plan 124 C1 — attach the verity-sealed runtime overlay (Firecracker only, non-fatal).

--- a/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
@@ -65,7 +65,13 @@ use mvm_hostd::supervisor::gateway_bridge::{
 
 /// Per-connection attach timeout. An abandoned connect must not wedge the
 /// standby (1a; pool size bounds the blast radius in 1b).
-const ATTACH_TIMEOUT: Duration = Duration::from_secs(30);
+// A prelaunched **pool** standby legitimately blocks a long time waiting to be claimed —
+// it's the warm pool's whole point. Its lifetime is bounded by the pool reaper TTL
+// (`mvmctl cache prune`, ~30 min), NOT a short self-timeout; a 30s value (Plan 118 WS-1 1a)
+// made standbys self-exit before a later `up` could claim them. The per-conn read timeout
+// (set on the accepted stream) still caps a connected-but-silent peer, so DoS protection is
+// unaffected. Keep this aligned with the reaper TTL.
+const ATTACH_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 /// Cap on the attach frame — workload config is small; reject hostile prefixes.
 const MAX_ATTACH_BYTES: usize = 1 << 20; // 1 MiB
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2564,3 +2564,29 @@ warm/status` + bench state-dir fix) shipped. Remaining, individually grabbable:
 - [ ] **Committed bench baseline + cold-vs-warm delta.** The state-dir fix unblocks the
   probe; a real baseline still needs a freshly-built `default-microvm` image (rides
   PR-10a's deferral).
+
+#### Plan 118 WS-1 1b auto-claim — live validation findings (2026-06-10)
+
+The `up` auto-claim wiring shipped (try_warm_claim/replenish/--warm-pool-size, fail-open).
+A live libkrun bridge boot was confirmed: `MVM_GATEWAY_BRIDGE=1 mvmctl up --flake
+examples/exit_code --hypervisor libkrun --wait` → **exit 7** (the `up.rs` "bridge gvproxy
+broken" comment is STALE — `run_with_bridge` boots end-to-end today). Two real fixes/finds:
+
+- [x] **Standby attach timeout 30s → 30 min.** A pool standby legitimately waits to be
+  claimed; the 1a `ATTACH_TIMEOUT=30s` made standbys self-exit before a later `up` could
+  claim them. Bounded now by the pool reaper TTL, not a short self-timeout.
+- [ ] **Compat key can't be the workload kernel sha for libkrun mkGuest.** A mkGuest image
+  ships no kernel; libkrun materializes the *bundled* kernel at `start_enter`, so
+  `cfg.kernel_path` is **absent** when `try_warm_claim` runs → it always fails open to cold
+  boot. A libkrun standby is workload-independent (bundled kernel + resources; rootfs at
+  attach), so the compat key must be the **bundled kernel** sha (or just (vcpus, mem) for
+  libkrun), not the workload path. This is the last blocker to the libkrun warm claim
+  firing end-to-end; the bundled-kernel identity lives in `libkrun-sys`, so it needs a
+  small cross-layer helper. Everything else (eligibility, claim, name-rebind, replenish,
+  reaper) is wired + fail-open + validated.
+- [ ] **`pool status` lists dead-but-unreaped standbys as "idle"** (it shows recorded
+  state, not liveness). Cosmetic — `select_idle_compatible` correctly skips dead pids;
+  filter the display by `pid_alive` for accuracy.
+- [ ] Independent bug: `libkrun_sys::home_mvm_keys_dir()` hardcodes `$HOME/.mvm/keys` and
+  ignores `MVM_DATA_DIR`, so `validate_audit_substrate` rejects an isolated data dir. Route
+  it through `mvm_core::config`.


### PR DESCRIPTION
## Summary

Plan 118 WS-1 **Layer 1b-iii** — wires the warm-pool **auto-claim into `up`**, plus the
live validation that drove two fixes/findings. **Stacked on #754** (base
`feat/plan-118-ws1-layer1b-ii`).

### Bridge-boot verification (the unlock)

`MVM_GATEWAY_BRIDGE=1 mvmctl up --flake examples/exit_code --hypervisor libkrun --wait` →
**exit 7**. The guest booted through `run_supervisor_with_bridge`, ran the sealed workload,
reported its exit code over the control vsock. So **the `up.rs` "bridge gvproxy broken"
comment is stale** — the bridge path a warm claim uses boots end-to-end today.

### The auto-claim wiring

On the main `up` path, `try_warm_claim` claims a compatible idle standby and rebinds
`vm_name_owned` to the standby-id the VM runs under (so agent-wait/audit/readiness/stop are
consistent); `replenish_after_launch` tops the pool back up (no daemon); `--warm-pool-size`
threads through `RunParams`/`VmStartParams` (default 0 = off; the `--wait` one-shot path
stays 0). Eligibility (all required, else **fail-open to cold boot**): `warm_pool_size > 0`,
auto-named, no extra volumes, backend supports the pool, and an admitted plan is threaded
in (the gateway-bridge path). Unit-tested eligibility gates + the claim/cold ladder.

### Fixes + findings from live validation

- **Fixed: standby attach timeout 30s → 30 min.** A pool standby legitimately waits to be
  claimed; the 1a 30s timeout made standbys self-exit before a later `up` could claim them.
  Now bounded by the pool reaper TTL; the per-conn read timeout still caps a silent peer.
- **Documented blocker (the last mile for libkrun mkGuest):** the kernel-sha compat key
  **can't be computed pre-boot** for mkGuest workloads — the image ships no kernel; libkrun
  materializes the *bundled* kernel at `start_enter`, so `cfg.kernel_path` is absent when
  `try_warm_claim` runs → it **fails open to cold boot**. A libkrun standby is
  workload-*independent* (bundled kernel + resources; rootfs at attach), so the compat key
  must key on the **bundled kernel** the standby actually loads (its identity lives in
  `libkrun-sys`) — a small cross-layer follow-up. Everything else is wired + validated.
  (SPRINT.md §"auto-claim — live validation findings".)
- Independent bug noted: `libkrun_sys::home_mvm_keys_dir()` ignores `MVM_DATA_DIR`.

**Safety:** with `warm_pool_size = 0` (default) the `up` path is byte-for-byte unchanged;
even with a warmed pool, the claim fail-opens to cold for mkGuest until the compat-key
follow-up — so this never regresses a launch.

## Test Plan

- [x] `cargo clippy -p mvm-cli -p mvm-vm-host -p mvm-backend --lib -- -D warnings`
- [x] `cargo nextest run -p mvm-cli pool::` (10 tests incl. eligibility gates + claim ladder)
- [x] Live: libkrun bridge boot returns workload exit code 7; replenish spawns standbys;
      fail-open cold-boots on the mkGuest kernel-read; the 30-min timeout keeps standbys
      alive across runs
- [ ] End-to-end warm claim for libkrun mkGuest — blocked on the bundled-kernel compat key
      (documented follow-up)