### PR TITLE
feat: Plan 118 WS-1 supervisor warm pool (1a–1b-iii) — prelaunched standbys + backend-agnostic trait seam + up auto-claim

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -270,7 +270,7 @@ jobs:
         run: cargo fuzz run fuzz_authed_path -- -max_total_time="$DURATION"
 
       - name: Fuzz SupervisorConfig (host-side)
-        working-directory: crates/libkrun-sys
+        working-directory: crates/deps/libkrun-sys
         env:
           DURATION: ${{ steps.duration.outputs.secs }}
           RUSTUP_TOOLCHAIN: nightly
@@ -281,6 +281,18 @@ jobs:
         # contract as `fuzz_guest_request` for the guest-side
         # `GuestRequest` parser.
         run: cargo fuzz run fuzz_supervisor_config -- -max_total_time="$DURATION"
+
+      - name: Fuzz SupervisorAttachConfig (prelaunch attach)
+        working-directory: crates/deps/libkrun-sys
+        env:
+          DURATION: ${{ steps.duration.outputs.secs }}
+          RUSTUP_TOOLCHAIN: nightly
+        # Plan 118 WS-1 1a — the prelaunched supervisor reads a
+        # `SupervisorAttachConfig` off a same-uid control UDS. It is the
+        # only attacker-reachable surface after spawn; any panic is a
+        # hard process death before the plan re-verify can fail closed.
+        # Same "never panic on any input" contract as fuzz_supervisor_config.
+        run: cargo fuzz run fuzz_attach_message -- -max_total_time="$DURATION"
 
       - name: Fuzz Vz SupervisorConfig (host-side)
         working-directory: crates/mvm-build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,6 +3389,7 @@ version = "0.16.1"
 dependencies = [
  "anyhow",
  "block2",
+ "chrono",
  "dispatch2",
  "ed25519-dalek",
  "libc",
@@ -3405,6 +3406,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "toml",
  "tracing",

--- a/crates/deps/libkrun-sys/fuzz/Cargo.toml
+++ b/crates/deps/libkrun-sys/fuzz/Cargo.toml
@@ -42,3 +42,13 @@ path = "fuzz_targets/fuzz_supervisor_config.rs"
 test = false
 doc = false
 bench = false
+
+# Plan 118 WS-1 1a — fuzz the `SupervisorAttachConfig` decoder, the only
+# attacker-reachable-post-spawn surface (the prelaunched supervisor reads it
+# off a same-uid control UDS). Goal: never panic on any input.
+[[bin]]
+name = "fuzz_attach_message"
+path = "fuzz_targets/fuzz_attach_message.rs"
+test = false
+doc = false
+bench = false

--- a/crates/deps/libkrun-sys/fuzz/fuzz_targets/fuzz_attach_message.rs
+++ b/crates/deps/libkrun-sys/fuzz/fuzz_targets/fuzz_attach_message.rs
@@ -1,0 +1,17 @@
+// Plan 118 WS-1 1a / ADR-055 §"New untrusted-input surfaces" — fuzz the
+// host-side `SupervisorAttachConfig` JSON parser.
+//
+// The prelaunched `mvm-libkrun-supervisor` reads this struct off a same-uid
+// control UDS — the only attacker-reachable surface after spawn. Any panic
+// here is a hard process death before `start_enter`. Sibling of
+// `fuzz_supervisor_config`; the harness goal is "never panic on any input"
+// (`serde_json::Error` is the expected outcome for malformed bytes).
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use libkrun_sys::SupervisorAttachConfig;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = serde_json::from_slice::<SupervisorAttachConfig>(data);
+});

--- a/crates/deps/libkrun-sys/src/framing.rs
+++ b/crates/deps/libkrun-sys/src/framing.rs
@@ -1,0 +1,143 @@
+//! Sync length-prefixed JSON framing for the same-uid supervisor control channels.
+//!
+//! Wire format: a 4-byte big-endian length prefix followed by the JSON body. The cap is
+//! enforced on read **before** allocating the body buffer (a hostile `length_prefix =
+//! u32::MAX` must not OOM the reader).
+//!
+//! Lives here — next to the `SupervisorBaseConfig`/`SupervisorAttachConfig` wire types it
+//! frames — because both ends need it without a dependency cycle: the **writer** is
+//! `mvm-backend`'s libkrun `claim_standby` (Plan 118 WS-1 1b) and the **reader** is the
+//! `mvm-libkrun-supervisor` bin's prelaunch attach path (Plan 118 WS-1 1a). `mvm-backend`
+//! cannot depend on `mvm-hostd` (that crate depends on `mvm-backend`), so this can't live
+//! in `mvm_hostd::framing` (which keeps the *async* tokio variants for its own channels).
+//!
+//! This is the no-auth transport — correct for the same-uid control UDS. The trust
+//! boundary is the supervisor's independent plan re-verify on the attach (1a), not this
+//! frame.
+
+use std::io::{Read, Write};
+
+/// Width of the big-endian length prefix.
+pub const FRAME_LEN_BYTES: usize = 4;
+
+/// Errors from the sync framing layer. Hand-rolled (no `thiserror`) to keep this leaf
+/// crate's dependency surface minimal.
+#[derive(Debug)]
+pub enum FrameError {
+    /// Underlying stream read/write failed.
+    Io(std::io::Error),
+    /// Body failed to (de)serialize.
+    Json(serde_json::Error),
+    /// The length prefix exceeded the caller's cap — rejected before allocating.
+    TooLarge { size: usize, cap: usize },
+    /// Body length did not fit the u32 length prefix.
+    LengthOverflow,
+}
+
+impl std::fmt::Display for FrameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FrameError::Io(e) => write!(f, "frame I/O failed: {e}"),
+            FrameError::Json(e) => write!(f, "frame body JSON failed: {e}"),
+            FrameError::TooLarge { size, cap } => {
+                write!(f, "frame body {size} bytes exceeds cap {cap}")
+            }
+            FrameError::LengthOverflow => {
+                write!(f, "frame body too large for the u32 length prefix")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FrameError {}
+
+impl From<std::io::Error> for FrameError {
+    fn from(e: std::io::Error) -> Self {
+        FrameError::Io(e)
+    }
+}
+
+/// Write a length-prefixed JSON frame: 4-byte BE length + JSON body.
+pub fn write_json_frame_sync<W, T>(stream: &mut W, value: &T) -> Result<(), FrameError>
+where
+    W: Write + ?Sized,
+    T: serde::Serialize,
+{
+    let body = serde_json::to_vec(value).map_err(FrameError::Json)?;
+    let len: u32 = body
+        .len()
+        .try_into()
+        .map_err(|_| FrameError::LengthOverflow)?;
+    stream.write_all(&len.to_be_bytes())?;
+    stream.write_all(&body)?;
+    Ok(())
+}
+
+/// Read a length-prefixed JSON frame, enforcing `max_frame_bytes` on the length prefix
+/// **before** allocating the body buffer.
+pub fn read_json_frame_sync<R, T>(stream: &mut R, max_frame_bytes: usize) -> Result<T, FrameError>
+where
+    R: Read + ?Sized,
+    T: serde::de::DeserializeOwned,
+{
+    let mut len_buf = [0u8; FRAME_LEN_BYTES];
+    stream.read_exact(&mut len_buf)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > max_frame_bytes {
+        return Err(FrameError::TooLarge {
+            size: len,
+            cap: max_frame_bytes,
+        });
+    }
+    let mut body = vec![0u8; len];
+    stream.read_exact(&mut body)?;
+    serde_json::from_slice(&body).map_err(FrameError::Json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Msg {
+        kind: String,
+        n: u32,
+    }
+
+    #[test]
+    fn round_trips_a_json_frame() {
+        let msg = Msg {
+            kind: "ping".into(),
+            n: 7,
+        };
+        let mut buf = Vec::new();
+        write_json_frame_sync(&mut buf, &msg).unwrap();
+        let body_len = u32::from_be_bytes(buf[..4].try_into().unwrap()) as usize;
+        assert_eq!(body_len, buf.len() - FRAME_LEN_BYTES);
+        let mut cursor = std::io::Cursor::new(buf);
+        let got: Msg = read_json_frame_sync(&mut cursor, 65_536).unwrap();
+        assert_eq!(got, msg);
+    }
+
+    #[test]
+    fn rejects_oversize_length_prefix_before_alloc() {
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&u32::MAX.to_be_bytes());
+        let mut cursor = std::io::Cursor::new(framed);
+        let err = read_json_frame_sync::<_, Msg>(&mut cursor, 65_536).unwrap_err();
+        assert!(
+            matches!(err, FrameError::TooLarge { size, cap: 65_536 } if size == u32::MAX as usize)
+        );
+    }
+
+    #[test]
+    fn truncated_body_is_an_io_error() {
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&16u32.to_be_bytes());
+        framed.extend_from_slice(b"abcd");
+        let mut cursor = std::io::Cursor::new(framed);
+        let err = read_json_frame_sync::<_, Msg>(&mut cursor, 65_536).unwrap_err();
+        assert!(matches!(err, FrameError::Io(_)));
+    }
+}

--- a/crates/deps/libkrun-sys/src/lib.rs
+++ b/crates/deps/libkrun-sys/src/lib.rs
@@ -54,6 +54,12 @@ pub mod passt;
 #[cfg(target_family = "unix")]
 pub mod gvproxy;
 
+// Plan 118 WS-1 1b — sync length-prefixed JSON framing for the supervisor control
+// channels. Colocated with the `Supervisor*Config` wire types it frames so both the
+// `mvm-backend` writer (`claim_standby`) and the supervisor-bin reader reach it without
+// a dependency cycle (`mvm-backend` can't depend on `mvm-hostd`).
+pub mod framing;
+
 /// Cross-module env mutation serializer. Both `passt::tests` and
 /// `gvproxy::tests` mutate `$PATH` to verify their `NotInstalled`
 /// error paths; `cargo test`'s default parallelism would race them

--- a/crates/deps/libkrun-sys/src/lib.rs
+++ b/crates/deps/libkrun-sys/src/lib.rs
@@ -1456,6 +1456,215 @@ impl SupervisorConfig {
     }
 }
 
+/// Workload-**independent** supervisor config — everything a prelaunched
+/// standby (Plan 118 WS-1 1a) sets up before it knows which workload it will
+/// run. Carries no rootfs and no plan; those arrive in the
+/// [`SupervisorAttachConfig`] over the control UDS. `krun.rootfs_path` MUST be
+/// `None` — [`SupervisorConfig::from_base_and_attach`] rejects a base that
+/// already carries one (it would shadow the workload rootfs).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupervisorBaseConfig {
+    /// Workload-independent guest config: kernel, vcpus/ram, vsock wiring,
+    /// console, `host_listen_ports`. `rootfs_path` must be `None`.
+    pub krun: KrunContext,
+    /// Per-VM state dir (`~/.mvm/vms/<name>/`) — see [`SupervisorConfig::vm_state_dir`].
+    pub vm_state_dir: String,
+    /// PID file name inside `vm_state_dir`; defaults to `libkrun.pid`.
+    #[serde(default)]
+    pub pid_file_name: Option<String>,
+    /// `~/.mvm/keys/host-signer.ed25519` — host signing key. Source of the
+    /// **public** key the attach-time plan re-verify checks against (claim 8;
+    /// no new key). Carried in base because it is host identity, not workload.
+    pub signing_key_path: std::path::PathBuf,
+    /// Expected envelope `signer_id` (`host:{hostname}`). The attach plan must
+    /// be signed by this id, else `verify_plan` reports `UnknownSigner`.
+    pub signer_id: String,
+    /// Per-spawn binding nonce (hex of 32 random bytes). The attach must echo
+    /// it; a standby with a different nonce rejects (cross-standby replay).
+    pub binding_nonce: String,
+    /// Control UDS the standby binds and blocks on. Mode `0700`, in a `0700`
+    /// dir, with the binding nonce embedded in the path.
+    pub control_socket_path: std::path::PathBuf,
+    /// Bridge crash policy — see [`BridgeRestartPolicy`].
+    #[serde(default)]
+    pub bridge_restart_policy: BridgeRestartPolicy,
+}
+
+/// Workload-**specific** supervisor config — the bytes that arrive over the
+/// control UDS at attach. The only attacker-reachable-post-spawn surface
+/// (fuzzed by `fuzz_attach_message`). The plan re-verify in
+/// `mvm_vm_host::prelaunch` is what makes accepting these bytes safe.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupervisorAttachConfig {
+    /// Echoed binding nonce — must equal `base.binding_nonce`.
+    pub binding_nonce: String,
+    /// Workload rootfs ext4 (`krun add_disk "root"`).
+    pub rootfs_path: String,
+    /// Per-tenant chain file name (`<audit_dir>/<tenant_id>.jsonl`).
+    pub tenant_id: String,
+    /// `~/.mvm/audit/` — chain files + per-VM subscriber sockets.
+    pub audit_dir: std::path::PathBuf,
+    /// `~/.mvm/audit/gateway-<vm>.sock` — per-VM subscriber socket.
+    pub gateway_audit_socket: std::path::PathBuf,
+    /// Vz-only ingest socket; ignored on libkrun (in-process bridge).
+    #[serde(default)]
+    pub gateway_events_socket: Option<std::path::PathBuf>,
+    /// JSON-encoded `SignedExecutionPlan` envelope — same carrier shape as
+    /// `SupervisorConfig.plan`. Required (the warm path always carries a plan).
+    pub plan: serde_json::Value,
+    /// JSON-encoded `PolicyBundle`, optional even when `plan` is set.
+    #[serde(default)]
+    pub bundle: Option<serde_json::Value>,
+}
+
+/// Failure modes of [`SupervisorConfig::from_base_and_attach`]. The plan
+/// re-verify failures live in `mvm_vm_host::prelaunch::AttachVerifyError` —
+/// this leaf crate can't depend on `mvm-core::plan`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AttachMergeError {
+    /// The attach's echoed binding nonce != the base's binding nonce.
+    BindingNonceMismatch,
+    /// The base already carried a rootfs — it would shadow the workload's.
+    BaseHasRootfs,
+}
+
+impl std::fmt::Display for AttachMergeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BindingNonceMismatch => {
+                f.write_str("attach binding nonce does not match the standby's")
+            }
+            Self::BaseHasRootfs => {
+                f.write_str("base config already carries a rootfs (would shadow the workload)")
+            }
+        }
+    }
+}
+impl std::error::Error for AttachMergeError {}
+
+impl SupervisorConfig {
+    /// Merge a prelaunched standby's [`SupervisorBaseConfig`] with the
+    /// [`SupervisorAttachConfig`] received over the control UDS, validating the
+    /// echoed binding nonce, into a whole `SupervisorConfig` the existing
+    /// `run_with_bridge` path consumes verbatim. Does **not** verify the plan
+    /// signature — that is `mvm_vm_host::prelaunch::verify_and_merge_attach`'s
+    /// job (this crate is a leaf with no `mvm-core` dep).
+    pub fn from_base_and_attach(
+        base: SupervisorBaseConfig,
+        attach: SupervisorAttachConfig,
+    ) -> Result<SupervisorConfig, AttachMergeError> {
+        if attach.binding_nonce != base.binding_nonce {
+            return Err(AttachMergeError::BindingNonceMismatch);
+        }
+        if base.krun.rootfs_path.is_some() {
+            return Err(AttachMergeError::BaseHasRootfs);
+        }
+        let mut krun = base.krun;
+        krun.rootfs_path = Some(attach.rootfs_path);
+        Ok(SupervisorConfig {
+            krun,
+            vm_state_dir: base.vm_state_dir,
+            pid_file_name: base.pid_file_name,
+            tenant_id: Some(attach.tenant_id),
+            audit_dir: Some(attach.audit_dir),
+            gateway_audit_socket: Some(attach.gateway_audit_socket),
+            gateway_events_socket: attach.gateway_events_socket,
+            signing_key_path: Some(base.signing_key_path),
+            plan: Some(attach.plan),
+            bundle: attach.bundle,
+            bridge_restart_policy: base.bridge_restart_policy,
+        })
+    }
+}
+
+#[cfg(test)]
+mod base_attach_tests {
+    use super::*;
+
+    fn base() -> SupervisorBaseConfig {
+        // Kernel-only base: a standby carries NO workload rootfs. Build a
+        // KrunContext then null the rootfs the new() constructor sets.
+        let mut krun = KrunContext::new("standby-0", "/k/vmlinux", "/placeholder");
+        krun.rootfs_path = None;
+        SupervisorBaseConfig {
+            krun,
+            vm_state_dir: "/run/mvm/standby-0".into(),
+            pid_file_name: None,
+            signing_key_path: "/keys/host-signer.ed25519".into(),
+            signer_id: "host:test".into(),
+            binding_nonce: "aa".repeat(32),
+            control_socket_path: "/run/mvm/standby-0/control-aa.sock".into(),
+            bridge_restart_policy: BridgeRestartPolicy::HardFail,
+        }
+    }
+
+    fn attach(nonce: &str) -> SupervisorAttachConfig {
+        SupervisorAttachConfig {
+            binding_nonce: nonce.to_string(),
+            rootfs_path: "/vol/rootfs.ext4".into(),
+            tenant_id: "tenant-a".into(),
+            audit_dir: "/audit".into(),
+            gateway_audit_socket: "/audit/gateway-standby-0.sock".into(),
+            gateway_events_socket: None,
+            plan: serde_json::json!({"envelope": "stub"}),
+            bundle: None,
+        }
+    }
+
+    #[test]
+    fn merge_happy_path_sets_rootfs_and_workload_fields() {
+        let cfg = SupervisorConfig::from_base_and_attach(base(), attach(&"aa".repeat(32))).unwrap();
+        assert_eq!(cfg.krun.rootfs_path.as_deref(), Some("/vol/rootfs.ext4"));
+        assert_eq!(cfg.tenant_id.as_deref(), Some("tenant-a"));
+        assert_eq!(
+            cfg.signing_key_path.as_deref().and_then(|p| p.to_str()),
+            Some("/keys/host-signer.ed25519")
+        );
+        assert_eq!(cfg.vm_state_dir, "/run/mvm/standby-0");
+        assert!(cfg.plan.is_some());
+    }
+
+    #[test]
+    fn merge_rejects_binding_nonce_mismatch() {
+        let err =
+            SupervisorConfig::from_base_and_attach(base(), attach(&"bb".repeat(32))).unwrap_err();
+        assert!(matches!(err, AttachMergeError::BindingNonceMismatch));
+    }
+
+    #[test]
+    fn merge_rejects_base_that_already_carries_a_rootfs() {
+        let mut b = base();
+        b.krun.rootfs_path = Some("/leftover.ext4".into());
+        let err =
+            SupervisorConfig::from_base_and_attach(b, attach(&"aa".repeat(32))).unwrap_err();
+        assert!(matches!(err, AttachMergeError::BaseHasRootfs));
+    }
+
+    #[test]
+    fn attach_config_denies_unknown_fields() {
+        let json = serde_json::json!({
+            "binding_nonce": "aa", "rootfs_path": "/r", "tenant_id": "t",
+            "audit_dir": "/a", "gateway_audit_socket": "/a/g.sock",
+            "plan": {}, "surprise": true
+        });
+        assert!(serde_json::from_value::<SupervisorAttachConfig>(json).is_err());
+    }
+
+    #[test]
+    fn base_and_whole_configs_are_serde_disjoint() {
+        // A bare (legacy) SupervisorConfig JSON must NOT parse as a base
+        // (missing binding_nonce/control_socket_path/signing_key_path/signer_id),
+        // so the bin's wrapper-key dispatch can never misroute legacy callers.
+        let whole = serde_json::json!({
+            "krun": serde_json::to_value(KrunContext::new("n", "/k", "/r")).unwrap(),
+            "vm_state_dir": "/s"
+        });
+        assert!(serde_json::from_value::<SupervisorBaseConfig>(whole).is_err());
+    }
+}
+
 /// `~/.mvm/keys/` resolver. Centralised so the signing-key
 /// validation in [`SupervisorConfig::validate_audit_substrate`]
 /// can be tested without env mutation across multiple sites.

--- a/crates/deps/libkrun-sys/src/lib.rs
+++ b/crates/deps/libkrun-sys/src/lib.rs
@@ -1637,8 +1637,7 @@ mod base_attach_tests {
     fn merge_rejects_base_that_already_carries_a_rootfs() {
         let mut b = base();
         b.krun.rootfs_path = Some("/leftover.ext4".into());
-        let err =
-            SupervisorConfig::from_base_and_attach(b, attach(&"aa".repeat(32))).unwrap_err();
+        let err = SupervisorConfig::from_base_and_attach(b, attach(&"aa".repeat(32))).unwrap_err();
         assert!(matches!(err, AttachMergeError::BaseHasRootfs));
     }
 

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -570,6 +570,12 @@ impl AnyBackend {
         self.inner().snapshot_capability()
     }
 
+    /// Borrow the wrapped backend as `&dyn VmBackend` — for callers (the warm-pool
+    /// orchestration helpers) that are generic over `VmBackend` rather than the enum.
+    pub fn as_vm_backend(&self) -> &dyn VmBackend {
+        self.inner()
+    }
+
     /// Plan 118 WS-1 1b — does this backend support a prelaunched-supervisor standby
     /// pool? See [`VmBackend::supports_standby_pool`]. Only libkrun does today.
     pub fn supports_standby_pool(&self) -> bool {

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -570,6 +570,30 @@ impl AnyBackend {
         self.inner().snapshot_capability()
     }
 
+    /// Plan 118 WS-1 1b — does this backend support a prelaunched-supervisor standby
+    /// pool? See [`VmBackend::supports_standby_pool`]. Only libkrun does today.
+    pub fn supports_standby_pool(&self) -> bool {
+        self.inner().supports_standby_pool()
+    }
+
+    /// Spawn a prelaunched standby. See [`VmBackend::spawn_standby`].
+    pub fn spawn_standby(
+        &self,
+        spec: &mvm_core::vm_backend::StandbySpec,
+    ) -> std::result::Result<mvm_core::vm_backend::StandbyHandle, mvm_core::vm_backend::StandbyError>
+    {
+        self.inner().spawn_standby(spec)
+    }
+
+    /// Claim an idle standby. See [`VmBackend::claim_standby`].
+    pub fn claim_standby(
+        &self,
+        handle: &mvm_core::vm_backend::StandbyHandle,
+        claim: &mvm_core::vm_backend::StandbyClaim,
+    ) -> std::result::Result<VmId, mvm_core::vm_backend::StandbyError> {
+        self.inner().claim_standby(handle, claim)
+    }
+
     /// Warm-start a VM at (at least) the requested snapshot tier. See
     /// [`VmBackend::warm_start`] — fails closed with a typed error on an
     /// over-request rather than degrading to a cold boot (plan 123 C4).

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -74,6 +74,9 @@ pub mod network_provider;
 pub mod providers;
 /// Plan 166 Phase 2 / ADR-072 — QEMU workload runtime backend (dev/test).
 pub mod qemu;
+/// Plan 118 WS-1 1b — backend-agnostic supervisor standby pool registry
+/// (`~/.mvm/pool/` state-dir; record/select-idle-by-kernel/remove/reap).
+pub mod standby_pool;
 /// Plan 129 — shared per-VM substitution-endpoint spawn/reap helpers used by
 /// the QEMU + Firecracker launch paths (one impl, no drift).
 pub(crate) mod substitution_spawn;

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -26,17 +26,22 @@
 use anyhow::{Result, anyhow, bail};
 use mvm_core::vm_backend::{
     BackendSecurityProfile, ClaimStatus, GuestChannelInfo, LayerCoverage, SnapshotCapability,
-    StartMode, VmBackend, VmCapabilities, VmId, VmInfo, VmStartConfig, VmStatus, WarmStartError,
+    StandbyClaim, StandbyError, StandbyHandle, StandbySpec, StandbyState, StartMode, VmBackend,
+    VmCapabilities, VmId, VmInfo, VmStartConfig, VmStatus, WarmStartError,
 };
 use mvm_storage::snapshot::SnapshotUpper;
 
 use crate::base::ui;
-use libkrun_sys::{KrunContext, SupervisorConfig};
+use libkrun_sys::{
+    BridgeRestartPolicy, KrunContext, SupervisorAttachConfig, SupervisorBaseConfig,
+    SupervisorConfig,
+};
 use mvm_core::config::{mvm_data_dir, vm_console_log, vm_libkrun_pid, vm_state_dir};
 use std::io::Write;
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 /// libkrun backend (Linux KVM / macOS Hypervisor.framework).
 pub struct LibkrunBackend;
@@ -98,6 +103,103 @@ const DEFAULT_CMDLINE: &str = "console=hvc0 root=/dev/vda rw init=/init";
 /// may carry secret bindings, env vars, or policy refs that resolve
 /// to credentials. They're opaque transport bytes; the supervisor
 /// re-verifies the signed envelope before trusting any decoded field.
+/// Workload-**independent** KrunContext: kernel + resources + cmdline + vsock wiring +
+/// the configured virtio-net gateway. **No rootfs** (the cold path sets the workload
+/// rootfs; a 1b prelaunched standby leaves it `None` until claim) and **no user volumes**.
+/// Shared verbatim by `build_supervisor_config` (cold) and `standby_base_config` (warm)
+/// so the two launch paths can't drift.
+fn krun_context_base(
+    name: &str,
+    kernel: &str,
+    vcpus: u8,
+    mem_mib: u32,
+    cmdline: &str,
+    state_dir: &Path,
+) -> KrunContext {
+    // KrunContext::new requires a rootfs arg; we null it immediately — the caller owns
+    // the rootfs decision (Some for cold boot, None for a standby).
+    let mut krun = KrunContext::new(name, kernel, "")
+        .with_resources(vcpus, mem_mib)
+        .with_cmdline(cmdline)
+        .with_vsock_socket_dir(state_dir.to_string_lossy().into_owned())
+        .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT)
+        // Plan 152 WS-A: workload exit-code capture (listen=false → host binds).
+        .add_host_listen_port(mvm_guest::vsock::WORKLOAD_EXIT_PORT);
+    krun.rootfs_path = None;
+    // Plan 87/88 / ADR-058 / Plan 123 L3-B — select the gateway through the same
+    // `resolve_networking_mode` the builder VM + cold path use (TSI is rejected by the
+    // claim-10 no-bypass bridge). Workload-independent, so it belongs in the base.
+    let scratch = state_dir.to_string_lossy().into_owned();
+    match mvm_build::libkrun_builder::resolve_networking_mode() {
+        mvm_build::libkrun_builder::NetworkingPreference::Gvproxy => {
+            krun.with_gvproxy(libkrun_sys::gvproxy::DEFAULT_GUEST_MAC, scratch)
+        }
+        mvm_build::libkrun_builder::NetworkingPreference::Passt => {
+            krun.with_passt(libkrun_sys::passt::DEFAULT_GUEST_MAC, scratch)
+        }
+    }
+}
+
+/// Translate a backend-agnostic [`StandbySpec`] into the 1a `SupervisorBaseConfig`
+/// (workload-independent) the prelaunched supervisor reads on stdin. `rootfs_path` stays
+/// `None` — the workload rootfs arrives in the attach at claim.
+fn standby_base_config(spec: &StandbySpec) -> SupervisorBaseConfig {
+    let krun = krun_context_base(
+        &spec.id,
+        &spec.kernel_path,
+        spec.vcpus,
+        spec.mem_mib,
+        DEFAULT_CMDLINE,
+        Path::new(&spec.vm_state_dir),
+    );
+    SupervisorBaseConfig {
+        krun,
+        vm_state_dir: spec.vm_state_dir.clone(),
+        pid_file_name: None,
+        signing_key_path: spec.signing_key_path.clone(),
+        signer_id: spec.signer_id.clone(),
+        binding_nonce: spec.binding_nonce.clone(),
+        control_socket_path: spec.control_socket.clone(),
+        bridge_restart_policy: BridgeRestartPolicy::HardFail,
+    }
+}
+
+/// Translate a [`StandbyClaim`] into the 1a `SupervisorAttachConfig`, echoing the
+/// standby's binding nonce. `plan_json`/`bundle_json` decode to `serde_json::Value`
+/// carriers (the same shape `SupervisorConfig.plan` uses).
+fn standby_attach_config(
+    claim: &StandbyClaim,
+    binding_nonce: String,
+) -> std::result::Result<SupervisorAttachConfig, StandbyError> {
+    let plan: serde_json::Value = serde_json::from_str(&claim.plan_json)
+        .map_err(|e| StandbyError::ClaimFailed(format!("decode plan_json: {e}")))?;
+    let bundle = match &claim.bundle_json {
+        Some(b) => Some(
+            serde_json::from_str(b)
+                .map_err(|e| StandbyError::ClaimFailed(format!("decode bundle_json: {e}")))?,
+        ),
+        None => None,
+    };
+    Ok(SupervisorAttachConfig {
+        binding_nonce,
+        rootfs_path: claim.rootfs_path.clone(),
+        tenant_id: claim.tenant_id.clone(),
+        audit_dir: claim.audit_dir.clone(),
+        gateway_audit_socket: claim.gateway_audit_socket.clone(),
+        gateway_events_socket: claim.gateway_events_socket.clone(),
+        plan,
+        bundle,
+    })
+}
+
+/// Seconds since the Unix epoch (best-effort; clamps a pre-epoch clock to 0).
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<SupervisorConfig> {
     let kernel = config
         .kernel_path
@@ -112,37 +214,18 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
         cmdline.push(' ');
         cmdline.push_str(&uvols);
     }
-    let krun = KrunContext::new(&config.name, kernel, &config.rootfs_path)
-        .with_resources(vcpus, config.memory_mib)
-        .with_cmdline(&cmdline)
-        .with_vsock_socket_dir(state_dir.to_string_lossy().into_owned())
-        .add_vsock_port(mvm_guest::vsock::GUEST_AGENT_PORT)
-        // Plan 152 WS-A: workload exit-code capture. listen=false means
-        // the HOST supervisor binds the Unix socket; libkrun proxies the
-        // guest's connect() to it. Guest /init connects and writes a
-        // 4-byte LE i32 before powering off; supervisor persists it to
-        // <vm_state_dir>/workload.exit.
-        .add_host_listen_port(mvm_guest::vsock::WORKLOAD_EXIT_PORT);
-    // Plan 87/88 / ADR-058 — configure the virtio-net gateway. TSI was removed
-    // (Plan 102 W6.A): it bypasses virtio-net, so the admitted gateway-audit
-    // bridge refuses it (claim-10 no-bypass). KrunContext defaults to TSI, so an
-    // unconfigured workload would be rejected by `run_supervisor_with_bridge`.
-    // The supervisor spawns the gateway from this declared mode.
-    //
-    // Plan 123 L3-B — select the gateway through the SAME `resolve_networking_mode`
-    // the builder VM uses, so a workload honours `MVM_NETWORKING` consistently
-    // (previously this site hardcoded `cfg!(macos)` and ignored the override).
-    // The default is unchanged (macOS→gvproxy, Linux→passt); an explicit
-    // `MVM_NETWORKING=passt` on macOS resolves to gvproxy (passt is Linux-only).
-    let scratch = state_dir.to_string_lossy().into_owned();
-    let krun = match mvm_build::libkrun_builder::resolve_networking_mode() {
-        mvm_build::libkrun_builder::NetworkingPreference::Gvproxy => {
-            krun.with_gvproxy(libkrun_sys::gvproxy::DEFAULT_GUEST_MAC, scratch)
-        }
-        mvm_build::libkrun_builder::NetworkingPreference::Passt => {
-            krun.with_passt(libkrun_sys::passt::DEFAULT_GUEST_MAC, scratch)
-        }
-    };
+    // Workload-independent KrunContext (kernel + resources + vsock + gateway), shared
+    // verbatim with the 1b standby spawn so the two paths can't drift. The cold path
+    // then sets the workload rootfs + user volumes below.
+    let mut krun = krun_context_base(
+        &config.name,
+        kernel,
+        vcpus,
+        config.memory_mib,
+        &cmdline,
+        state_dir,
+    );
+    krun.rootfs_path = Some(config.rootfs_path.clone());
 
     // User-supplied volumes (--volume / MVM_VOLUMES). A directory share
     // is a virtio-fs device; a disk image is an extra virtio-blk device.
@@ -157,7 +240,6 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
     // Rather than make a false ro promise, refuse it and point at the
     // hypervisor-enforced alternatives. (Vz/Firecracker enforce ro shares
     // natively; this restriction is libkrun-specific.)
-    let mut krun = krun;
     for (idx, vol) in config.volumes.iter().enumerate() {
         let tag = format!("uvol{idx}");
         krun = match vol.kind {
@@ -513,6 +595,81 @@ impl VmBackend for LibkrunBackend {
             .map_err(|e| WarmStartError::Failed(e.to_string()))
     }
 
+    fn supports_standby_pool(&self) -> bool {
+        true
+    }
+
+    fn spawn_standby(
+        &self,
+        spec: &StandbySpec,
+    ) -> std::result::Result<StandbyHandle, StandbyError> {
+        let base = standby_base_config(spec);
+        // Pre-create the control-UDS parent dir 0700 (the supervisor re-binds the socket
+        // itself; this only ensures the dir exists with the right mode).
+        if let Some(parent) = spec.control_socket.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| StandbyError::SpawnFailed(format!("create control dir: {e}")))?;
+            let _ = std::fs::set_permissions(
+                parent,
+                std::os::unix::fs::PermissionsExt::from_mode(0o700),
+            );
+        }
+        // The bin dispatches the prelaunch arm on the `prelaunch_base` wrapper key
+        // (1a); legacy callers send a bare SupervisorConfig and are unaffected.
+        let envelope = serde_json::to_vec(&serde_json::json!({ "prelaunch_base": base }))
+            .map_err(|e| StandbyError::SpawnFailed(format!("encode base config: {e}")))?;
+
+        let bin =
+            resolve_supervisor_path().map_err(|e| StandbyError::SpawnFailed(e.to_string()))?;
+        let mut child = Command::new(bin)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| StandbyError::SpawnFailed(format!("spawn supervisor: {e}")))?;
+        child
+            .stdin
+            .take()
+            .ok_or_else(|| StandbyError::SpawnFailed("supervisor stdin unavailable".into()))?
+            .write_all(&envelope)
+            .map_err(|e| StandbyError::SpawnFailed(format!("write base config: {e}")))?;
+        // Detached: do NOT wait — the bin blocks on the control UDS until claimed (or
+        // reaped). The dropped `Child` leaves the process running (no kill-on-drop).
+        let pid = child.id();
+
+        Ok(StandbyHandle {
+            id: spec.id.clone(),
+            control_socket: spec.control_socket.clone(),
+            pid,
+            kernel_sha256: spec.kernel_sha256.clone(),
+            vcpus: spec.vcpus,
+            mem_mib: spec.mem_mib,
+            binding_nonce: spec.binding_nonce.clone(),
+            spawned_unix_secs: now_unix_secs(),
+            state: StandbyState::Idle,
+        })
+    }
+
+    fn claim_standby(
+        &self,
+        handle: &StandbyHandle,
+        claim: &StandbyClaim,
+    ) -> std::result::Result<VmId, StandbyError> {
+        let attach = standby_attach_config(claim, handle.binding_nonce.clone())?;
+        let mut stream = UnixStream::connect(&handle.control_socket).map_err(|e| {
+            StandbyError::ClaimFailed(format!(
+                "connect control UDS {}: {e}",
+                handle.control_socket.display()
+            ))
+        })?;
+        libkrun_sys::framing::write_json_frame_sync(&mut stream, &attach)
+            .map_err(|e| StandbyError::ClaimFailed(format!("send attach: {e}")))?;
+        // The supervisor re-verifies the attach (1a) then start_enters, writing its pid
+        // into vm_state_dir. The VM is identified by the standby id (its state lives under
+        // vms/<id>/, so stop/status/console resolve it like any cold-booted VM).
+        Ok(VmId(handle.id.clone()))
+    }
+
     fn status(&self, id: &VmId) -> Result<VmStatus> {
         let pid_path = vm_libkrun_pid(&id.0);
         match read_pid(&pid_path) {
@@ -731,6 +888,69 @@ fn read_exit_status_from(state_dir: &std::path::Path) -> mvm_core::vm_backend::V
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_standby_spec() -> StandbySpec {
+        StandbySpec {
+            id: "standby-x".into(),
+            kernel_path: "/k/vmlinux".into(),
+            kernel_sha256: "a".repeat(64),
+            vcpus: 2,
+            mem_mib: 1024,
+            signing_key_path: "/keys/host-signer.ed25519".into(),
+            signer_id: "host:test".into(),
+            binding_nonce: "ab".repeat(32),
+            control_socket: "/p/standby-x/control-ab.sock".into(),
+            vm_state_dir: "/vms/standby-x".into(),
+        }
+    }
+
+    fn sample_standby_claim() -> StandbyClaim {
+        StandbyClaim {
+            rootfs_path: "/vol/rootfs.ext4".into(),
+            tenant_id: "tenant-a".into(),
+            audit_dir: "/audit".into(),
+            gateway_audit_socket: "/audit/g.sock".into(),
+            gateway_events_socket: None,
+            plan_json: r#"{"signed":"envelope"}"#.into(),
+            bundle_json: None,
+        }
+    }
+
+    #[test]
+    fn standby_spec_translates_to_base_config_with_no_rootfs() {
+        let spec = sample_standby_spec();
+        let base = standby_base_config(&spec);
+        // A standby carries NO workload rootfs — it arrives in the attach.
+        assert!(base.krun.rootfs_path.is_none());
+        assert_eq!(base.binding_nonce, spec.binding_nonce);
+        assert_eq!(base.signer_id, spec.signer_id);
+        assert_eq!(base.control_socket_path, spec.control_socket);
+        assert_eq!(base.krun.vcpus, 2);
+        assert_eq!(base.krun.ram_mib, 1024);
+        // The bin dispatches the prelaunch arm on the `prelaunch_base` wrapper key.
+        let env = serde_json::json!({ "prelaunch_base": base });
+        assert!(env.get("prelaunch_base").is_some());
+    }
+
+    #[test]
+    fn standby_claim_translates_to_attach_config_echoing_nonce() {
+        let attach = standby_attach_config(&sample_standby_claim(), "ab".repeat(32)).unwrap();
+        assert_eq!(attach.binding_nonce, "ab".repeat(32));
+        assert_eq!(attach.rootfs_path, "/vol/rootfs.ext4");
+        assert_eq!(attach.tenant_id, "tenant-a");
+        assert_eq!(attach.plan, serde_json::json!({"signed": "envelope"}));
+        assert!(attach.bundle.is_none());
+    }
+
+    #[test]
+    fn standby_claim_rejects_malformed_plan_json() {
+        let mut claim = sample_standby_claim();
+        claim.plan_json = "not json".into();
+        match standby_attach_config(&claim, "ab".repeat(32)) {
+            Err(StandbyError::ClaimFailed(_)) => {}
+            other => panic!("expected ClaimFailed, got {other:?}"),
+        }
+    }
 
     #[test]
     fn prod_console_attachment_has_no_input() {

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -343,6 +343,7 @@ mod tests {
             tenant_id: None,
             plan_json: None,
             bundle_json: None,
+            warm_pool_size: 0,
         }
     }
 

--- a/crates/mvm-backend/src/standby_pool.rs
+++ b/crates/mvm-backend/src/standby_pool.rs
@@ -9,7 +9,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use mvm_core::vm_backend::{StandbyHandle, StandbyState};
+use mvm_core::vm_backend::{StandbyCompat, StandbyHandle, StandbyState};
 
 /// Filename of the per-standby metadata JSON inside its dir.
 const HANDLE_FILE: &str = "standby.json";
@@ -66,22 +66,21 @@ impl SupervisorStandbyPool {
         Ok(out)
     }
 
-    /// Pick a live, idle standby whose kernel matches — the claim candidate. `None`
-    /// means "no compatible warm standby; cold-boot." Skips claimed and dead entries.
-    pub fn select_idle_for_kernel(&self, kernel_sha256: &str) -> Result<Option<StandbyHandle>> {
+    /// Pick a live, idle standby compatible with `want` (kernel + fixed resources) — the
+    /// claim candidate. `None` means "no compatible warm standby; cold-boot." Skips
+    /// claimed and dead entries.
+    pub fn select_idle_compatible(&self, want: &StandbyCompat) -> Result<Option<StandbyHandle>> {
         Ok(self.list()?.into_iter().find(|h| {
-            h.state == StandbyState::Idle && h.matches_kernel(kernel_sha256) && pid_alive(h.pid)
+            h.state == StandbyState::Idle && h.is_compatible(want) && pid_alive(h.pid)
         }))
     }
 
-    /// Count of live idle standbys for a kernel — drives replenish-to-target.
-    pub fn idle_count_for_kernel(&self, kernel_sha256: &str) -> Result<usize> {
+    /// Count of live idle standbys compatible with `want` — drives replenish-to-target.
+    pub fn idle_count_compatible(&self, want: &StandbyCompat) -> Result<usize> {
         Ok(self
             .list()?
             .into_iter()
-            .filter(|h| {
-                h.state == StandbyState::Idle && h.matches_kernel(kernel_sha256) && pid_alive(h.pid)
-            })
+            .filter(|h| h.state == StandbyState::Idle && h.is_compatible(want) && pid_alive(h.pid))
             .count())
     }
 
@@ -117,7 +116,7 @@ fn set_mode_0700(p: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mvm_core::vm_backend::{StandbyHandle, StandbyState};
+    use mvm_core::vm_backend::{StandbyCompat, StandbyHandle, StandbyState};
 
     fn handle(id: &str, kernel: &str, state: StandbyState) -> StandbyHandle {
         StandbyHandle {
@@ -125,9 +124,19 @@ mod tests {
             control_socket: format!("/p/{id}/control.sock").into(),
             pid: std::process::id(), // a live pid so liveness passes
             kernel_sha256: kernel.into(),
+            vcpus: 2,
+            mem_mib: 1024,
             binding_nonce: "ab".repeat(32),
             spawned_unix_secs: 1,
             state,
+        }
+    }
+
+    fn compat(kernel: &str) -> StandbyCompat {
+        StandbyCompat {
+            kernel_sha256: kernel.into(),
+            vcpus: 2,
+            mem_mib: 1024,
         }
     }
 
@@ -154,9 +163,19 @@ mod tests {
         pool.record(&handle("wrong-kernel", "bb", StandbyState::Idle))
             .unwrap();
 
-        let picked = pool.select_idle_for_kernel("aa").unwrap();
+        let picked = pool.select_idle_compatible(&compat("aa")).unwrap();
         assert_eq!(picked.unwrap().id, "good");
-        assert!(pool.select_idle_for_kernel("cc").unwrap().is_none());
+        assert!(pool.select_idle_compatible(&compat("cc")).unwrap().is_none());
+    }
+
+    #[test]
+    fn select_idle_skips_resource_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        let mut big = handle("big", "aa", StandbyState::Idle);
+        big.vcpus = 8; // same kernel, different cpus → not compatible
+        pool.record(&big).unwrap();
+        assert!(pool.select_idle_compatible(&compat("aa")).unwrap().is_none());
     }
 
     #[test]
@@ -176,6 +195,6 @@ mod tests {
         pool.record(&handle("a", "aa", StandbyState::Idle)).unwrap();
         pool.record(&handle("b", "aa", StandbyState::Claimed))
             .unwrap();
-        assert_eq!(pool.idle_count_for_kernel("aa").unwrap(), 1);
+        assert_eq!(pool.idle_count_compatible(&compat("aa")).unwrap(), 1);
     }
 }

--- a/crates/mvm-backend/src/standby_pool.rs
+++ b/crates/mvm-backend/src/standby_pool.rs
@@ -101,6 +101,38 @@ impl SupervisorStandbyPool {
             Err(e) => Err(e).with_context(|| format!("remove {}", dir.display())),
         }
     }
+
+    /// Reap standbys that are dead (pid gone) or expired (`now - spawned > ttl`). For a
+    /// still-live expired standby, SIGTERM the supervisor first, then remove its dir.
+    /// Returns the reaped ids. Idle entitled processes must never accumulate (Plan 118
+    /// §"B-ii residual risk" item 3) — `cache prune` calls this on a timer.
+    pub fn reap_stale(&self, ttl: std::time::Duration, now: u64) -> Result<Vec<String>> {
+        let ttl_secs = ttl.as_secs();
+        let mut reaped = Vec::new();
+        for h in self.list()? {
+            let alive = pid_alive(h.pid);
+            let expired = now.saturating_sub(h.spawned_unix_secs) > ttl_secs;
+            if !alive || expired {
+                if alive {
+                    // Live but expired — stop the entitled supervisor before dropping state.
+                    // SAFETY: SIGTERM to a pid this host spawned; a stale pid is a no-op.
+                    unsafe { libc::kill(h.pid as libc::pid_t, libc::SIGTERM) };
+                }
+                self.remove(&h.id)?;
+                reaped.push(h.id);
+            }
+        }
+        Ok(reaped)
+    }
+}
+
+/// Seconds since the Unix epoch (best-effort; clamps a pre-epoch clock to 0). The reaper's
+/// `now` argument so callers can inject a fixed clock in tests.
+pub fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 /// `kill(pid, 0)` liveness — 0 ⇒ the process exists (W1.2 reaper precedent).
@@ -198,6 +230,44 @@ mod tests {
         assert!(tmp.path().join("s1").exists());
         pool.remove("s1").unwrap();
         assert!(!tmp.path().join("s1").exists());
+    }
+
+    #[test]
+    fn reap_removes_dead_and_expired_keeps_live_recent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        let now = now_unix_secs();
+        // Live + recent (spawned now) → kept.
+        let mut keep = handle("keep", "aa", StandbyState::Idle);
+        keep.spawned_unix_secs = now;
+        pool.record(&keep).unwrap();
+        // Dead pid → reaped regardless of age.
+        let mut dead = handle("dead", "aa", StandbyState::Idle);
+        dead.pid = 999_999;
+        dead.spawned_unix_secs = now;
+        pool.record(&dead).unwrap();
+        // Live but spawned long ago → expired → reaped (SIGTERM'd then removed). Use a
+        // real throwaway child so the reaper's SIGTERM hits a safe pid, not the test runner.
+        let mut sleeper = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let mut old = handle("old", "aa", StandbyState::Idle);
+        old.pid = sleeper.id();
+        old.spawned_unix_secs = 1;
+        pool.record(&old).unwrap();
+
+        let reaped = pool
+            .reap_stale(std::time::Duration::from_secs(3600), now)
+            .unwrap();
+        assert!(reaped.contains(&"dead".to_string()));
+        assert!(reaped.contains(&"old".to_string()));
+        assert!(!reaped.contains(&"keep".to_string()));
+        assert!(pool.load("keep").is_ok());
+        assert!(pool.load("dead").is_err());
+        assert!(pool.load("old").is_err());
+        // The live-expired standby's supervisor was SIGTERM'd.
+        let _ = sleeper.wait();
     }
 
     #[test]

--- a/crates/mvm-backend/src/standby_pool.rs
+++ b/crates/mvm-backend/src/standby_pool.rs
@@ -1,0 +1,181 @@
+//! Plan 118 WS-1 1b — the backend-agnostic supervisor standby pool registry.
+//!
+//! Records each prelaunched standby as `<pool_root>/<id>/standby.json` (the control
+//! UDS lives alongside as `control-<nonce>.sock`, bound by the backend's spawn impl).
+//! Selection/liveness/removal are backend-agnostic; only `spawn_standby`/`claim_standby`
+//! on the `VmBackend` impl know how to actually launch. Default-off: with
+//! `warm_pool_size == 0` the orchestration never constructs a pool.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use mvm_core::vm_backend::{StandbyHandle, StandbyState};
+
+/// Filename of the per-standby metadata JSON inside its dir.
+const HANDLE_FILE: &str = "standby.json";
+
+/// A view over `~/.mvm/pool/` (or a test root). Cheap to construct; all state is on disk.
+pub struct SupervisorStandbyPool {
+    root: PathBuf,
+}
+
+impl SupervisorStandbyPool {
+    /// Open the pool at the real `~/.mvm/pool/` root.
+    pub fn open() -> Result<Self> {
+        Ok(Self::at(mvm_core::config::mvm_pool_dir()?))
+    }
+
+    /// Open at an explicit root (test seam).
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Persist (or update) a standby's handle under `<root>/<id>/standby.json`,
+    /// creating the dir `0700`.
+    pub fn record(&self, h: &StandbyHandle) -> Result<()> {
+        let dir = self.root.join(&h.id);
+        std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+        set_mode_0700(&dir)?;
+        let json = serde_json::to_vec_pretty(h)?;
+        std::fs::write(dir.join(HANDLE_FILE), json)
+            .with_context(|| format!("write {} handle", h.id))?;
+        Ok(())
+    }
+
+    /// Load one standby's handle by id.
+    pub fn load(&self, id: &str) -> Result<StandbyHandle> {
+        let path = self.root.join(id).join(HANDLE_FILE);
+        let bytes = std::fs::read(&path).with_context(|| format!("read {}", path.display()))?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    /// All recorded handles (ignoring unreadable/garbage dirs — they get reaped by
+    /// [`reap_stale`](Self::reap_stale) in 1b-ii).
+    pub fn list(&self) -> Result<Vec<StandbyHandle>> {
+        let mut out = Vec::new();
+        let rd = match std::fs::read_dir(&self.root) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(e).context("read pool root"),
+        };
+        for entry in rd.flatten() {
+            if let Ok(h) = self.load(&entry.file_name().to_string_lossy()) {
+                out.push(h);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Pick a live, idle standby whose kernel matches — the claim candidate. `None`
+    /// means "no compatible warm standby; cold-boot." Skips claimed and dead entries.
+    pub fn select_idle_for_kernel(&self, kernel_sha256: &str) -> Result<Option<StandbyHandle>> {
+        Ok(self.list()?.into_iter().find(|h| {
+            h.state == StandbyState::Idle && h.matches_kernel(kernel_sha256) && pid_alive(h.pid)
+        }))
+    }
+
+    /// Count of live idle standbys for a kernel — drives replenish-to-target.
+    pub fn idle_count_for_kernel(&self, kernel_sha256: &str) -> Result<usize> {
+        Ok(self
+            .list()?
+            .into_iter()
+            .filter(|h| {
+                h.state == StandbyState::Idle && h.matches_kernel(kernel_sha256) && pid_alive(h.pid)
+            })
+            .count())
+    }
+
+    /// Mark a standby `Claimed` (persisted) — so a concurrent launch won't double-claim.
+    pub fn mark_claimed(&self, id: &str) -> Result<()> {
+        let mut h = self.load(id)?;
+        h.state = StandbyState::Claimed;
+        self.record(&h)
+    }
+
+    /// Remove a standby's dir (after claim/boot, or when reaping a dead one).
+    pub fn remove(&self, id: &str) -> Result<()> {
+        let dir = self.root.join(id);
+        match std::fs::remove_dir_all(&dir) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("remove {}", dir.display())),
+        }
+    }
+}
+
+/// `kill(pid, 0)` liveness — 0 ⇒ the process exists (W1.2 reaper precedent).
+fn pid_alive(pid: u32) -> bool {
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+fn set_mode_0700(p: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("chmod 0700 {}", p.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::vm_backend::{StandbyHandle, StandbyState};
+
+    fn handle(id: &str, kernel: &str, state: StandbyState) -> StandbyHandle {
+        StandbyHandle {
+            id: id.into(),
+            control_socket: format!("/p/{id}/control.sock").into(),
+            pid: std::process::id(), // a live pid so liveness passes
+            kernel_sha256: kernel.into(),
+            binding_nonce: "ab".repeat(32),
+            spawned_unix_secs: 1,
+            state,
+        }
+    }
+
+    #[test]
+    fn record_then_load_roundtrips_under_pool_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&handle("s1", "aa", StandbyState::Idle)).unwrap();
+        let loaded = pool.load("s1").unwrap();
+        assert_eq!(loaded.id, "s1");
+        assert_eq!(loaded.state, StandbyState::Idle);
+    }
+
+    #[test]
+    fn select_idle_matches_kernel_and_skips_claimed_and_dead() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&handle("claimed", "aa", StandbyState::Claimed))
+            .unwrap();
+        let mut dead = handle("dead", "aa", StandbyState::Idle);
+        dead.pid = 999_999; // not a live pid
+        pool.record(&dead).unwrap();
+        pool.record(&handle("good", "aa", StandbyState::Idle)).unwrap();
+        pool.record(&handle("wrong-kernel", "bb", StandbyState::Idle))
+            .unwrap();
+
+        let picked = pool.select_idle_for_kernel("aa").unwrap();
+        assert_eq!(picked.unwrap().id, "good");
+        assert!(pool.select_idle_for_kernel("cc").unwrap().is_none());
+    }
+
+    #[test]
+    fn remove_deletes_the_standby_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&handle("s1", "aa", StandbyState::Idle)).unwrap();
+        assert!(tmp.path().join("s1").exists());
+        pool.remove("s1").unwrap();
+        assert!(!tmp.path().join("s1").exists());
+    }
+
+    #[test]
+    fn idle_count_for_kernel_counts_only_live_idle_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&handle("a", "aa", StandbyState::Idle)).unwrap();
+        pool.record(&handle("b", "aa", StandbyState::Claimed))
+            .unwrap();
+        assert_eq!(pool.idle_count_for_kernel("aa").unwrap(), 1);
+    }
+}

--- a/crates/mvm-backend/src/standby_pool.rs
+++ b/crates/mvm-backend/src/standby_pool.rs
@@ -70,9 +70,10 @@ impl SupervisorStandbyPool {
     /// claim candidate. `None` means "no compatible warm standby; cold-boot." Skips
     /// claimed and dead entries.
     pub fn select_idle_compatible(&self, want: &StandbyCompat) -> Result<Option<StandbyHandle>> {
-        Ok(self.list()?.into_iter().find(|h| {
-            h.state == StandbyState::Idle && h.is_compatible(want) && pid_alive(h.pid)
-        }))
+        Ok(self
+            .list()?
+            .into_iter()
+            .find(|h| h.state == StandbyState::Idle && h.is_compatible(want) && pid_alive(h.pid)))
     }
 
     /// Count of live idle standbys compatible with `want` — drives replenish-to-target.
@@ -144,7 +145,8 @@ mod tests {
     fn record_then_load_roundtrips_under_pool_root() {
         let tmp = tempfile::tempdir().unwrap();
         let pool = SupervisorStandbyPool::at(tmp.path());
-        pool.record(&handle("s1", "aa", StandbyState::Idle)).unwrap();
+        pool.record(&handle("s1", "aa", StandbyState::Idle))
+            .unwrap();
         let loaded = pool.load("s1").unwrap();
         assert_eq!(loaded.id, "s1");
         assert_eq!(loaded.state, StandbyState::Idle);
@@ -159,13 +161,18 @@ mod tests {
         let mut dead = handle("dead", "aa", StandbyState::Idle);
         dead.pid = 999_999; // not a live pid
         pool.record(&dead).unwrap();
-        pool.record(&handle("good", "aa", StandbyState::Idle)).unwrap();
+        pool.record(&handle("good", "aa", StandbyState::Idle))
+            .unwrap();
         pool.record(&handle("wrong-kernel", "bb", StandbyState::Idle))
             .unwrap();
 
         let picked = pool.select_idle_compatible(&compat("aa")).unwrap();
         assert_eq!(picked.unwrap().id, "good");
-        assert!(pool.select_idle_compatible(&compat("cc")).unwrap().is_none());
+        assert!(
+            pool.select_idle_compatible(&compat("cc"))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -175,14 +182,19 @@ mod tests {
         let mut big = handle("big", "aa", StandbyState::Idle);
         big.vcpus = 8; // same kernel, different cpus → not compatible
         pool.record(&big).unwrap();
-        assert!(pool.select_idle_compatible(&compat("aa")).unwrap().is_none());
+        assert!(
+            pool.select_idle_compatible(&compat("aa"))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
     fn remove_deletes_the_standby_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let pool = SupervisorStandbyPool::at(tmp.path());
-        pool.record(&handle("s1", "aa", StandbyState::Idle)).unwrap();
+        pool.record(&handle("s1", "aa", StandbyState::Idle))
+            .unwrap();
         assert!(tmp.path().join("s1").exists());
         pool.remove("s1").unwrap();
         assert!(!tmp.path().join("s1").exists());

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -192,6 +192,7 @@ impl Commands {
             Commands::Catalog(_) => "catalog",
             Commands::Console(_) => "console",
             Commands::Cache(_) => "cache",
+            Commands::Pool(_) => "pool",
             Commands::Reconcile(_) => "reconcile",
             Commands::Init(_) => "init",
             Commands::Run(_) => "run",

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -130,6 +130,8 @@ pub(in crate::commands) enum Commands {
     Console(vm::console::Args),
     /// Manage the XDG cache directory (~/.cache/mvm)
     Cache(ops::cache::Args),
+    /// Manage the supervisor warm pool (pre-spawned standbys for fast `up`)
+    Pool(pool::Args),
     /// Converge the VM name registry with on-disk runtime state
     Reconcile(ops::reconcile::Args),
     /// Scaffold a new project
@@ -342,6 +344,7 @@ pub fn run() -> Result<()> {
         Commands::Catalog(a) => catalog::run(&cli, a, &cfg),
         Commands::Console(a) => vm::console::run(&cli, a, &cfg),
         Commands::Cache(a) => ops::cache::run(&cli, a, &cfg),
+        Commands::Pool(a) => pool::run(&cli, a, &cfg),
         Commands::Reconcile(a) => ops::reconcile::run(&cli, a, &cfg),
         Commands::Init(a) => env::init::run(&cli, a, &cfg),
         Commands::Run(a) => vm::exec::run_secure(&cli, a, &cfg),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -8,11 +8,13 @@ mod image;
 mod kernel;
 mod manifest;
 mod ops;
-/// Plan 118 WS-1 1b — supervisor warm-pool launch glue (StandbySpec builder +
-/// claim-or-cold + warm-to-target). The consumers — the `mvmctl pool` command and the
-/// `up`/`run` auto-claim path — land in the 1b-ii follow-up, which shares the
-/// default-kernel + hypervisor resolution they need; the mechanism + helpers + unit tests
-/// ship here. `allow(dead_code)` until that wiring lands.
+/// Plan 118 WS-1 1b — supervisor warm-pool launch glue + the `mvmctl pool` command. The
+/// `mvmctl pool warm/status` command, the `StandbySpec` builder, and `warm_to_target` are
+/// live here. `claim_or_cold` (closure-ready for the per-standby audit substrate) is the
+/// last unwired piece: the `up`/`run` auto-claim needs an in-`up.rs` name-rebind (a
+/// claimed VM runs under its standby-id) + the gateway-bridge path confirmed working —
+/// scoped as a focused follow-up. `allow(dead_code)` covers `claim_or_cold`/`LaunchDecision`
+/// until then.
 #[allow(dead_code)]
 mod pool;
 mod qemu_bridge;

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -8,14 +8,9 @@ mod image;
 mod kernel;
 mod manifest;
 mod ops;
-/// Plan 118 WS-1 1b — supervisor warm-pool launch glue + the `mvmctl pool` command. The
-/// `mvmctl pool warm/status` command, the `StandbySpec` builder, and `warm_to_target` are
-/// live here. `claim_or_cold` (closure-ready for the per-standby audit substrate) is the
-/// last unwired piece: the `up`/`run` auto-claim needs an in-`up.rs` name-rebind (a
-/// claimed VM runs under its standby-id) + the gateway-bridge path confirmed working —
-/// scoped as a focused follow-up. `allow(dead_code)` covers `claim_or_cold`/`LaunchDecision`
-/// until then.
-#[allow(dead_code)]
+/// Plan 118 WS-1 1b — supervisor warm-pool: the `mvmctl pool warm/status` command + the
+/// launch glue (`try_warm_claim`/`replenish_after_launch`) the `up` path calls to claim a
+/// warm standby (auto-named, bridge-admitted launches) and top the pool back up.
 mod pool;
 mod qemu_bridge;
 mod shared;

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -8,6 +8,13 @@ mod image;
 mod kernel;
 mod manifest;
 mod ops;
+/// Plan 118 WS-1 1b — supervisor warm-pool launch glue (StandbySpec builder +
+/// claim-or-cold + warm-to-target). The consumers — the `mvmctl pool` command and the
+/// `up`/`run` auto-claim path — land in the 1b-ii follow-up, which shares the
+/// default-kernel + hypervisor resolution they need; the mechanism + helpers + unit tests
+/// ship here. `allow(dead_code)` until that wiring lands.
+#[allow(dead_code)]
+mod pool;
 mod qemu_bridge;
 mod shared;
 mod storage;

--- a/crates/mvm-cli/src/commands/ops/bench_probe.rs
+++ b/crates/mvm-cli/src/commands/ops/bench_probe.rs
@@ -92,14 +92,15 @@ pub fn admit_probe_plan(
 #[cfg(feature = "libkrun-live")]
 use crate::commands::ops::bench::BootMarks;
 
-/// Per-VM state dir the libkrun backend writes the supervisor PID file
-/// and host-side vsock socket into (`~/.mvm/vms/<name>`). Mirrors the
-/// backend's private `vm_state_dir`; kept in lockstep with it.
+/// Per-VM state dir the libkrun backend writes the supervisor PID file and host-side
+/// vsock socket into (`~/.mvm/vms/<name>`). Plan 118 WS-1 1b fix: delegate to the
+/// canonical `mvm_core::config::vm_state_dir` the backend itself uses, instead of building
+/// the path from `mvm_state_dir()` — that's the **XDG** state dir (`~/.local/state/mvm`),
+/// which the supervisor never writes to, so the `start_to_pid` mark never resolved and the
+/// probe timed out on every dev-host run.
 #[cfg(feature = "libkrun-live")]
 fn probe_state_dir(vm_name: &str) -> std::path::PathBuf {
-    std::path::PathBuf::from(mvm_core::config::mvm_state_dir())
-        .join("vms")
-        .join(vm_name)
+    mvm_core::config::vm_state_dir(vm_name)
 }
 
 /// Boot the canonical default-microvm image once through real
@@ -209,6 +210,25 @@ fn wait_for_ready(vm_name: &str) -> Result<(std::time::Instant, std::time::Insta
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Plan 118 WS-1 1b — the probe pid path must resolve under the backend's data dir
+    // (`~/.mvm`, honouring MVM_DATA_DIR), NOT the XDG state dir the supervisor never
+    // writes to. Regression guard for the `start_to_pid` timeout this fix closed.
+    #[cfg(feature = "libkrun-live")]
+    #[test]
+    fn probe_state_dir_resolves_under_mvm_data_dir_not_xdg_state() {
+        // SAFETY: single-threaded test process; we set then restore the override.
+        let prev = std::env::var("MVM_DATA_DIR").ok();
+        unsafe { std::env::set_var("MVM_DATA_DIR", "/tmp/mvm-bench-probe-test/.mvm") };
+        let dir = probe_state_dir("vm-x");
+        assert_eq!(dir, mvm_core::config::vm_state_dir("vm-x"));
+        assert!(dir.starts_with("/tmp/mvm-bench-probe-test/.mvm"));
+        assert!(!dir.to_string_lossy().contains(".local/state"));
+        match prev {
+            Some(v) => unsafe { std::env::set_var("MVM_DATA_DIR", v) },
+            None => unsafe { std::env::remove_var("MVM_DATA_DIR") },
+        }
+    }
 
     #[test]
     #[ignore = "touches ~/.cache/mvm; run on a host with the image cached"]

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -232,6 +232,33 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 }
             }
 
+            // Plan 118 WS-1 1b — reap stale supervisor standbys under `~/.mvm/pool/`.
+            // The TTL guards a fresh pool (only dead-pid or expired standbys go); a
+            // live-expired standby's entitled supervisor is SIGTERM'd before its dir is
+            // dropped, so idle entitled processes never accumulate (B-ii residual risk 3).
+            const STANDBY_POOL_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+            if dry_run {
+                if let Ok(pool) = mvm_backend::standby_pool::SupervisorStandbyPool::open()
+                    && let Ok(n) = pool.list().map(|v| v.len())
+                    && n > 0
+                {
+                    ui::info(&format!(
+                        "(dry-run) Would reap stale entries among {n} standby(s)."
+                    ));
+                }
+            } else {
+                match mvm_backend::standby_pool::SupervisorStandbyPool::open().and_then(|pool| {
+                    pool.reap_stale(STANDBY_POOL_TTL, mvm_backend::standby_pool::now_unix_secs())
+                }) {
+                    Ok(reaped) if !reaped.is_empty() => {
+                        removed += reaped.len() as u64;
+                        ui::info(&format!("Reaped {} stale standby(s).", reaped.len()));
+                    }
+                    Ok(_) => {}
+                    Err(e) => ui::warn(&format!("standby pool reap failed: {e}")),
+                }
+            }
+
             for entry in walkdir(path)? {
                 let entry_path = entry.path();
                 // Remove temp files (mvm-lima-*, .tmp)

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -178,6 +178,15 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
 
 /// The base-compat key a launch needs from its `VmStartConfig` (kernel sha256 + the fixed
 /// vcpus/mem). `None` if the config carries no kernel path.
+///
+/// **Known limitation (libkrun mkGuest):** a mkGuest workload image ships no kernel — its
+/// `kernel_path` `vmlinux` is materialized by libkrun (`extract_bundled_kernel`) only at
+/// `start_enter`, so it's **absent on disk here** and `kernel_sha256_hex` errors →
+/// `try_warm_claim` fails open to cold boot. A libkrun standby is in fact
+/// workload-*independent* (it pre-loads the bundled kernel; the rootfs arrives at attach),
+/// so the right key is the **bundled** kernel sha the standby actually loads, not the
+/// workload's kernel path. Wiring that (the bundled-kernel identity lives in `libkrun-sys`)
+/// is the follow-up that makes the libkrun warm claim fire end-to-end (SPRINT.md).
 fn compat_for_launch(cfg: &VmStartConfig) -> Result<Option<StandbyCompat>> {
     let Some(kernel) = cfg.kernel_path.as_ref() else {
         return Ok(None);

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -19,6 +19,7 @@ use mvm_backend::standby_pool::SupervisorStandbyPool;
 use mvm_core::user_config::MvmConfig;
 use mvm_core::vm_backend::{
     StandbyClaim, StandbyCompat, StandbyHandle, StandbySpec, StandbyState, VmBackend, VmId,
+    VmStartConfig,
 };
 use sha2::{Digest, Sha256};
 
@@ -173,6 +174,97 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
         }
     }
     Ok(spawned)
+}
+
+/// The base-compat key a launch needs from its `VmStartConfig` (kernel sha256 + the fixed
+/// vcpus/mem). `None` if the config carries no kernel path.
+fn compat_for_launch(cfg: &VmStartConfig) -> Result<Option<StandbyCompat>> {
+    let Some(kernel) = cfg.kernel_path.as_ref() else {
+        return Ok(None);
+    };
+    Ok(Some(StandbyCompat {
+        kernel_sha256: kernel_sha256_hex(Path::new(kernel))?,
+        vcpus: u8::try_from(cfg.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
+        mem_mib: cfg.memory_mib,
+    }))
+}
+
+/// Attempt a warm-pool claim for this launch. Returns the claimed `VmId` (the standby-id
+/// the VM now runs under) or `None` to cold-boot. **Fail-open**: anything not default-
+/// shaped, not bridge-admitted, or any error → `None` (the caller cold-boots as normal).
+///
+/// Eligibility (all required): `warm_pool_size > 0`, the launch is auto-named (no explicit
+/// `--name` — a claimed VM is named by its standby-id), no extra volumes (1a's attach
+/// threads only the rootfs), the backend supports the pool, and the **admitted plan +
+/// tenant** are threaded into the config — which only the gateway-bridge path
+/// (`MVM_GATEWAY_BRIDGE=1`) does, and which a claimed standby's `run_with_bridge` requires.
+pub fn try_warm_claim(
+    backend: &AnyBackend,
+    cfg: &VmStartConfig,
+    user_named: bool,
+) -> Result<Option<VmId>> {
+    if cfg.warm_pool_size == 0
+        || user_named
+        || !cfg.volumes.is_empty()
+        || !backend.supports_standby_pool()
+    {
+        return Ok(None);
+    }
+    let (Some(plan_json), Some(tenant)) = (cfg.plan_json.clone(), cfg.tenant_id.clone()) else {
+        // No admitted plan threaded in → not the bridge path → cold-boot.
+        return Ok(None);
+    };
+    let Some(want) = compat_for_launch(cfg)? else {
+        return Ok(None);
+    };
+    let rootfs = cfg.rootfs_path.clone();
+    let bundle_json = cfg.bundle_json.clone();
+    let pool = SupervisorStandbyPool::open()?;
+    let decision = claim_or_cold(&pool, backend.as_vm_backend(), &want, |handle| {
+        // The audit substrate (`gateway-<vm>.sock`) is name-keyed; the claimed VM runs
+        // under the standby-id, so compute it for `handle.id`.
+        let sub = mvm_backend::audit_substrate::compute_audit_substrate(&handle.id, Some(&tenant))?;
+        Ok(StandbyClaim {
+            rootfs_path: rootfs.clone(),
+            tenant_id: tenant.clone(),
+            audit_dir: sub.audit_dir.context("audit substrate missing audit_dir")?,
+            gateway_audit_socket: sub
+                .gateway_audit_socket
+                .context("audit substrate missing gateway_audit_socket")?,
+            gateway_events_socket: sub.gateway_events_socket,
+            plan_json: plan_json.clone(),
+            bundle_json: bundle_json.clone(),
+        })
+    })?;
+    Ok(match decision {
+        LaunchDecision::Claimed(id) => Some(id),
+        LaunchDecision::ColdBoot => None,
+    })
+}
+
+/// Top the pool back up toward `cfg.warm_pool_size` after a launch (the no-daemon
+/// replenish-on-use maintainer). Best-effort — failures are logged, never propagated.
+pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Result<u32> {
+    if cfg.warm_pool_size == 0 || !backend.supports_standby_pool() {
+        return Ok(0);
+    }
+    let Some(kernel) = cfg.kernel_path.as_ref() else {
+        return Ok(0);
+    };
+    let signer = host_signer::load_or_init()?;
+    let pool = SupervisorStandbyPool::open()?;
+    warm_to_target(
+        &pool,
+        &WarmParams {
+            backend: backend.as_vm_backend(),
+            kernel: Path::new(kernel),
+            vcpus: u8::try_from(cfg.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
+            mem_mib: cfg.memory_mib,
+            signer_id: &host_signer::host_signer_id(),
+            signing_key_path: &signer.secret_path,
+            target: cfg.warm_pool_size,
+        },
+    )
 }
 
 fn hex_lower(bytes: &[u8]) -> String {
@@ -394,6 +486,60 @@ mod tests {
             pool.load("s1").is_err(),
             "a failed standby is removed, not left idle"
         );
+    }
+
+    // try_warm_claim eligibility gates — each must cold-boot (return None) before touching
+    // the pool. A real libkrun AnyBackend (supports the pool, no I/O at construction) so the
+    // tested gate is the deciding one.
+    fn eligible_cfg() -> VmStartConfig {
+        VmStartConfig {
+            warm_pool_size: 2,
+            kernel_path: Some("/k/vmlinux".into()),
+            rootfs_path: "/vol/rootfs.ext4".into(),
+            cpus: 2,
+            memory_mib: 1024,
+            tenant_id: Some("tenant-a".into()),
+            plan_json: Some("{}".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn try_warm_claim_cold_when_pool_size_zero() {
+        let b = AnyBackend::from_hypervisor("libkrun");
+        let mut c = eligible_cfg();
+        c.warm_pool_size = 0;
+        assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);
+    }
+
+    #[test]
+    fn try_warm_claim_cold_when_user_named() {
+        let b = AnyBackend::from_hypervisor("libkrun");
+        assert_eq!(try_warm_claim(&b, &eligible_cfg(), true).unwrap(), None);
+    }
+
+    #[test]
+    fn try_warm_claim_cold_with_extra_volumes() {
+        use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+        let b = AnyBackend::from_hypervisor("libkrun");
+        let mut c = eligible_cfg();
+        c.volumes = vec![VmVolume {
+            host: "/h".into(),
+            guest: "/g".into(),
+            size: String::new(),
+            read_only: false,
+            kind: VmVolumeKind::DirShare,
+            encrypted: false,
+        }];
+        assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);
+    }
+
+    #[test]
+    fn try_warm_claim_cold_without_admitted_plan() {
+        let b = AnyBackend::from_hypervisor("libkrun");
+        let mut c = eligible_cfg();
+        c.plan_json = None; // not the gateway-bridge/admitted path → cold-boot
+        assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);
     }
 }
 

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -1,0 +1,374 @@
+//! Plan 118 WS-1 1b — warm-pool launch glue + the `mvmctl pool` command.
+//!
+//! Owns the bits that must live above the backend: the kernel-identity hash (part of the
+//! base-compat key), the per-spawn binding nonce, and the host signer identity/key path
+//! the standby re-verifies the attach plan against (claim 8). Builds a backend-agnostic
+//! `StandbySpec` and drives the `SupervisorStandbyPool` + `VmBackend` trait methods.
+//!
+//! v1 is default-shaped only: a standby is claimable by a launch whose kernel **and**
+//! resources match (`StandbyCompat`) and that carries no extra volumes (1a's attach only
+//! threads the rootfs). Anything else cold-boots. Multi-kernel keying + honouring an
+//! explicit `--name`/volumes for warm launches are deferred follow-ups (SPRINT.md).
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use mvm_backend::standby_pool::SupervisorStandbyPool;
+use mvm_core::vm_backend::{StandbyClaim, StandbyCompat, StandbySpec, VmBackend, VmId};
+use sha2::{Digest, Sha256};
+
+// NB: the `mvmctl pool` command (1b-ii) resolves `signer_id` via
+// `super::vm::host_signer::host_signer_id()` and passes it into these helpers; the
+// helpers themselves stay signer-agnostic (they take `signer_id` as a parameter).
+
+/// Lowercase-hex sha256 of a kernel image — part of the base-compat key.
+pub fn kernel_sha256_hex(kernel: &Path) -> Result<String> {
+    let bytes =
+        std::fs::read(kernel).with_context(|| format!("read kernel {}", kernel.display()))?;
+    Ok(hex_lower(&Sha256::digest(&bytes)))
+}
+
+/// 32 random bytes as lowercase hex — the per-spawn binding nonce.
+pub fn fresh_binding_nonce() -> String {
+    use rand::RngCore;
+    let mut buf = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut buf);
+    hex_lower(&buf)
+}
+
+/// Build a `StandbySpec` for a standby that pre-loads `kernel` with the given resources.
+/// The control UDS lives under `pool_root/<id>/control-<nonce>.sock` (nonce in the path —
+/// defense in depth); the VM's runtime state dir is the normal `vms_root/<id>/` so
+/// stop/status/console resolve it like any cold-booted VM.
+pub fn build_standby_spec(
+    pool_root: &Path,
+    vms_root: &Path,
+    kernel: &Path,
+    vcpus: u8,
+    mem_mib: u32,
+    signer_id: &str,
+    signing_key_path: &Path,
+) -> Result<StandbySpec> {
+    let nonce = fresh_binding_nonce();
+    let id = format!("standby-{}", &nonce[..16]);
+    Ok(StandbySpec {
+        kernel_path: kernel.to_string_lossy().into_owned(),
+        kernel_sha256: kernel_sha256_hex(kernel)?,
+        vcpus,
+        mem_mib,
+        signing_key_path: signing_key_path.to_path_buf(),
+        signer_id: signer_id.to_string(),
+        control_socket: pool_root.join(&id).join(format!("control-{nonce}.sock")),
+        vm_state_dir: vms_root.join(&id).to_string_lossy().into_owned(),
+        binding_nonce: nonce,
+        id,
+    })
+}
+
+/// Outcome of the warm-pool claim attempt on a launch.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LaunchDecision {
+    /// A standby was claimed and is booting under this VmId.
+    Claimed(VmId),
+    /// No compatible warm standby (or the claim failed) — caller must cold-boot.
+    ColdBoot,
+}
+
+/// Try to claim an idle standby compatible with `want`; **fail open to cold boot**. On a
+/// claim error the standby is removed (it's spent/broken), never left idle, so the next
+/// launch doesn't keep retrying a dead standby.
+pub fn claim_or_cold(
+    pool: &SupervisorStandbyPool,
+    backend: &dyn VmBackend,
+    want: &StandbyCompat,
+    claim: &StandbyClaim,
+) -> Result<LaunchDecision> {
+    if !backend.supports_standby_pool() {
+        return Ok(LaunchDecision::ColdBoot);
+    }
+    let Some(handle) = pool.select_idle_compatible(want)? else {
+        return Ok(LaunchDecision::ColdBoot);
+    };
+    // Reserve it so a concurrent launch won't double-claim.
+    pool.mark_claimed(&handle.id)?;
+    match backend.claim_standby(&handle, claim) {
+        Ok(vm_id) => {
+            // The standby has become the VM; drop its pool entry (the control UDS is
+            // one-shot). The VM now lives under its vms/<id> state dir.
+            let _ = pool.remove(&handle.id);
+            Ok(LaunchDecision::Claimed(vm_id))
+        }
+        Err(e) => {
+            tracing::warn!(standby = %handle.id, error = %e, "standby claim failed; cold-booting");
+            let _ = pool.remove(&handle.id); // spent/broken — never leave it idle
+            Ok(LaunchDecision::ColdBoot)
+        }
+    }
+}
+
+/// Parameters for [`warm_to_target`] — grouped to keep the signature small.
+pub struct WarmParams<'a> {
+    pub backend: &'a dyn VmBackend,
+    pub kernel: &'a Path,
+    pub vcpus: u8,
+    pub mem_mib: u32,
+    pub signer_id: &'a str,
+    pub signing_key_path: &'a Path,
+    pub target: u32,
+}
+
+/// Warm the pool toward `target` idle standbys for the given kernel+resources. Best-effort:
+/// spawn failures are logged, not fatal (warm pool is an optimization). Returns how many
+/// were newly spawned.
+pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Result<u32> {
+    if p.target == 0 || !p.backend.supports_standby_pool() {
+        return Ok(0);
+    }
+    let want = StandbyCompat {
+        kernel_sha256: kernel_sha256_hex(p.kernel)?,
+        vcpus: p.vcpus,
+        mem_mib: p.mem_mib,
+    };
+    let have = pool.idle_count_compatible(&want)? as u32;
+    let pool_root = mvm_core::config::mvm_pool_dir()?;
+    let vms_root = mvm_core::config::mvm_data_dir_strict()?.join("vms");
+    let mut spawned = 0;
+    for _ in have..p.target {
+        let spec = build_standby_spec(
+            &pool_root,
+            &vms_root,
+            p.kernel,
+            p.vcpus,
+            p.mem_mib,
+            p.signer_id,
+            p.signing_key_path,
+        )?;
+        match p.backend.spawn_standby(&spec) {
+            Ok(handle) => {
+                pool.record(&handle)?;
+                spawned += 1;
+            }
+            Err(e) => tracing::warn!(error = %e, "spawn standby failed; pool stays under target"),
+        }
+    }
+    Ok(spawned)
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::vm_backend::{
+        StandbyError, StandbyHandle, StandbyState, StartMode, VmCapabilities, VmInfo,
+        VmStartConfig, VmStatus,
+    };
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn sha256_hex_of(bytes: &[u8]) -> String {
+        hex_lower(&Sha256::digest(bytes))
+    }
+
+    #[test]
+    fn kernel_sha256_hex_is_64_lowercase_hex_of_known_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kp = tmp.path().join("vmlinux");
+        std::fs::write(&kp, b"hello-kernel").unwrap();
+        let hex = kernel_sha256_hex(&kp).unwrap();
+        assert_eq!(hex.len(), 64);
+        assert!(
+            hex.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+        assert_eq!(hex, sha256_hex_of(b"hello-kernel"));
+    }
+
+    #[test]
+    fn fresh_binding_nonce_is_64_hex_chars_and_varies() {
+        let a = fresh_binding_nonce();
+        let b = fresh_binding_nonce();
+        assert_eq!(a.len(), 64);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn standby_spec_puts_nonce_in_socket_path_and_state_under_vms() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kp = tmp.path().join("vmlinux");
+        std::fs::write(&kp, b"k").unwrap();
+        let pool_root = tmp.path().join("pool");
+        let vms_root = tmp.path().join("vms");
+        let spec = build_standby_spec(
+            &pool_root,
+            &vms_root,
+            &kp,
+            2,
+            1024,
+            "host:test",
+            &tmp.path().join("key"),
+        )
+        .unwrap();
+        assert!(
+            spec.control_socket
+                .to_string_lossy()
+                .contains(&spec.binding_nonce)
+        );
+        assert!(spec.control_socket.starts_with(&pool_root));
+        assert!(
+            spec.vm_state_dir
+                .starts_with(vms_root.to_string_lossy().as_ref())
+        );
+        assert_eq!(spec.kernel_sha256.len(), 64);
+        assert_eq!(spec.vcpus, 2);
+        assert_eq!(spec.mem_mib, 1024);
+    }
+
+    // A minimal VmBackend stub that opts into the standby pool and records calls, so the
+    // claim/cold decision is testable without a VM.
+    struct StubBackend {
+        claim_ok: bool,
+        claimed: AtomicBool,
+    }
+    impl StubBackend {
+        fn new(claim_ok: bool) -> Self {
+            Self {
+                claim_ok,
+                claimed: AtomicBool::new(false),
+            }
+        }
+    }
+    impl VmBackend for StubBackend {
+        fn name(&self) -> &str {
+            "stub"
+        }
+        fn capabilities(&self) -> VmCapabilities {
+            VmCapabilities::default()
+        }
+        fn supports_standby_pool(&self) -> bool {
+            true
+        }
+        fn claim_standby(
+            &self,
+            handle: &StandbyHandle,
+            _claim: &StandbyClaim,
+        ) -> std::result::Result<VmId, StandbyError> {
+            self.claimed.store(true, Ordering::SeqCst);
+            if self.claim_ok {
+                Ok(VmId(handle.id.clone()))
+            } else {
+                Err(StandbyError::ClaimFailed("stub refused".into()))
+            }
+        }
+        fn start_with_mode(&self, _: &VmStartConfig, _: StartMode) -> anyhow::Result<VmId> {
+            unreachable!("cold start is the caller's job, not claim_or_cold")
+        }
+        fn stop(&self, _: &VmId) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn stop_all(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn pause(&self, _: &VmId) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn resume(&self, _: &VmId) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn status(&self, _: &VmId) -> anyhow::Result<VmStatus> {
+            Ok(VmStatus::Stopped)
+        }
+        fn list(&self) -> anyhow::Result<Vec<VmInfo>> {
+            Ok(vec![])
+        }
+        fn logs(&self, _: &VmId, _: u32, _: bool) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+        fn is_available(&self) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+        fn install(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn idle_handle(id: &str, kernel: &str) -> StandbyHandle {
+        StandbyHandle {
+            id: id.into(),
+            control_socket: format!("/p/{id}.sock").into(),
+            pid: std::process::id(),
+            kernel_sha256: kernel.into(),
+            vcpus: 2,
+            mem_mib: 1024,
+            binding_nonce: "ab".repeat(32),
+            spawned_unix_secs: 1,
+            state: StandbyState::Idle,
+        }
+    }
+
+    fn compat(kernel: &str) -> StandbyCompat {
+        StandbyCompat {
+            kernel_sha256: kernel.into(),
+            vcpus: 2,
+            mem_mib: 1024,
+        }
+    }
+
+    fn sample_claim() -> StandbyClaim {
+        StandbyClaim {
+            rootfs_path: "/vol/rootfs.ext4".into(),
+            tenant_id: "tenant-a".into(),
+            audit_dir: "/audit".into(),
+            gateway_audit_socket: "/audit/g.sock".into(),
+            gateway_events_socket: None,
+            plan_json: "{}".into(),
+            bundle_json: None,
+        }
+    }
+
+    #[test]
+    fn claim_or_cold_claims_when_compatible_idle_standby_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&idle_handle("s1", "aa")).unwrap();
+        let backend = StubBackend::new(true);
+        let decision = claim_or_cold(&pool, &backend, &compat("aa"), &sample_claim()).unwrap();
+        assert_eq!(decision, LaunchDecision::Claimed(VmId("s1".into())));
+        assert!(backend.claimed.load(Ordering::SeqCst));
+        assert!(
+            pool.load("s1").is_err(),
+            "a claimed standby's pool entry is removed"
+        );
+    }
+
+    #[test]
+    fn claim_or_cold_cold_boots_when_no_standby() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        let backend = StubBackend::new(true);
+        let decision = claim_or_cold(&pool, &backend, &compat("aa"), &sample_claim()).unwrap();
+        assert_eq!(decision, LaunchDecision::ColdBoot);
+        assert!(!backend.claimed.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn claim_or_cold_cold_boots_and_removes_standby_when_claim_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&idle_handle("s1", "aa")).unwrap();
+        let backend = StubBackend::new(false);
+        let decision = claim_or_cold(&pool, &backend, &compat("aa"), &sample_claim()).unwrap();
+        assert_eq!(decision, LaunchDecision::ColdBoot);
+        assert!(
+            pool.load("s1").is_err(),
+            "a failed standby is removed, not left idle"
+        );
+    }
+}

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -634,6 +634,8 @@ fn run_warm(pool: &SupervisorStandbyPool, cfg: &MvmConfig, target: u32) -> Resul
             target,
         },
     )?;
+    // Plan 37 §6 — a state-changing verb emits one audit record per attempt.
+    mvm_core::audit_emit!(PoolWarm, "spawned={spawned} target={target}");
     if spawned == 0 {
         crate::ui::info(&format!("Pool already at or above target {target}."));
     } else {

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -18,7 +18,7 @@ use mvm_backend::backend::AnyBackend;
 use mvm_backend::standby_pool::SupervisorStandbyPool;
 use mvm_core::user_config::MvmConfig;
 use mvm_core::vm_backend::{
-    StandbyClaim, StandbyCompat, StandbySpec, StandbyState, VmBackend, VmId,
+    StandbyClaim, StandbyCompat, StandbyHandle, StandbySpec, StandbyState, VmBackend, VmId,
 };
 use sha2::{Digest, Sha256};
 
@@ -82,12 +82,20 @@ pub enum LaunchDecision {
 /// Try to claim an idle standby compatible with `want`; **fail open to cold boot**. On a
 /// claim error the standby is removed (it's spent/broken), never left idle, so the next
 /// launch doesn't keep retrying a dead standby.
-pub fn claim_or_cold(
+///
+/// `make_claim` builds the [`StandbyClaim`] **for the selected standby's id** — the audit
+/// substrate (`gateway-<vm>.sock`) is name-keyed, and a claimed VM runs under its
+/// standby-id, so the caller must compute those paths against `handle.id`. A `make_claim`
+/// error also fails open to cold boot (and reaps the reserved standby).
+pub fn claim_or_cold<F>(
     pool: &SupervisorStandbyPool,
     backend: &dyn VmBackend,
     want: &StandbyCompat,
-    claim: &StandbyClaim,
-) -> Result<LaunchDecision> {
+    make_claim: F,
+) -> Result<LaunchDecision>
+where
+    F: FnOnce(&StandbyHandle) -> Result<StandbyClaim>,
+{
     if !backend.supports_standby_pool() {
         return Ok(LaunchDecision::ColdBoot);
     }
@@ -96,7 +104,15 @@ pub fn claim_or_cold(
     };
     // Reserve it so a concurrent launch won't double-claim.
     pool.mark_claimed(&handle.id)?;
-    match backend.claim_standby(&handle, claim) {
+    let claim = match make_claim(&handle) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(standby = %handle.id, error = %e, "build claim failed; cold-booting");
+            let _ = pool.remove(&handle.id);
+            return Ok(LaunchDecision::ColdBoot);
+        }
+    };
+    match backend.claim_standby(&handle, &claim) {
         Ok(vm_id) => {
             // The standby has become the VM; drop its pool entry (the control UDS is
             // one-shot). The VM now lives under its vms/<id> state dir.
@@ -344,7 +360,8 @@ mod tests {
         let pool = SupervisorStandbyPool::at(tmp.path());
         pool.record(&idle_handle("s1", "aa")).unwrap();
         let backend = StubBackend::new(true);
-        let decision = claim_or_cold(&pool, &backend, &compat("aa"), &sample_claim()).unwrap();
+        let decision =
+            claim_or_cold(&pool, &backend, &compat("aa"), |_h| Ok(sample_claim())).unwrap();
         assert_eq!(decision, LaunchDecision::Claimed(VmId("s1".into())));
         assert!(backend.claimed.load(Ordering::SeqCst));
         assert!(
@@ -358,7 +375,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let pool = SupervisorStandbyPool::at(tmp.path());
         let backend = StubBackend::new(true);
-        let decision = claim_or_cold(&pool, &backend, &compat("aa"), &sample_claim()).unwrap();
+        let decision =
+            claim_or_cold(&pool, &backend, &compat("aa"), |_h| Ok(sample_claim())).unwrap();
         assert_eq!(decision, LaunchDecision::ColdBoot);
         assert!(!backend.claimed.load(Ordering::SeqCst));
     }
@@ -369,7 +387,8 @@ mod tests {
         let pool = SupervisorStandbyPool::at(tmp.path());
         pool.record(&idle_handle("s1", "aa")).unwrap();
         let backend = StubBackend::new(false);
-        let decision = claim_or_cold(&pool, &backend, &compat("aa"), &sample_claim()).unwrap();
+        let decision =
+            claim_or_cold(&pool, &backend, &compat("aa"), |_h| Ok(sample_claim())).unwrap();
         assert_eq!(decision, LaunchDecision::ColdBoot);
         assert!(
             pool.load("s1").is_err(),

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -13,13 +13,18 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use clap::{Args as ClapArgs, Subcommand};
+use mvm_backend::backend::AnyBackend;
 use mvm_backend::standby_pool::SupervisorStandbyPool;
-use mvm_core::vm_backend::{StandbyClaim, StandbyCompat, StandbySpec, VmBackend, VmId};
+use mvm_core::user_config::MvmConfig;
+use mvm_core::vm_backend::{
+    StandbyClaim, StandbyCompat, StandbySpec, StandbyState, VmBackend, VmId,
+};
 use sha2::{Digest, Sha256};
 
-// NB: the `mvmctl pool` command (1b-ii) resolves `signer_id` via
-// `super::vm::host_signer::host_signer_id()` and passes it into these helpers; the
-// helpers themselves stay signer-agnostic (they take `signer_id` as a parameter).
+use super::Cli;
+use super::env::apple_container::ensure_default_microvm_image;
+use super::vm::host_signer;
 
 /// Lowercase-hex sha256 of a kernel image — part of the base-compat key.
 pub fn kernel_sha256_hex(kernel: &Path) -> Result<String> {
@@ -371,4 +376,162 @@ mod tests {
             "a failed standby is removed, not left idle"
         );
     }
+}
+
+// ── `mvmctl pool` command (Plan 118 WS-1 1b) ────────────────────────────────────────
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub action: PoolAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum PoolAction {
+    /// Pre-spawn idle supervisor standbys for the default-microVM launch shape so a later
+    /// `up` is fast. Default count 1. Only the libkrun backend has a standby pool today.
+    Warm {
+        /// How many idle standbys to warm the pool toward (default 1).
+        count: Option<u32>,
+    },
+    /// Show the standby pool — recorded standbys and their idle/claimed state.
+    Status {
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// The default launch shape the warm pool targets: default-microVM kernel + the config's
+/// default cpus/mem + the effective hypervisor. Both `pool warm` and the `up` auto-claim
+/// resolve through the same pieces so a warmed standby is claimable by a default `up`.
+struct WarmShape {
+    backend: AnyBackend,
+    backend_name: String,
+    kernel: std::path::PathBuf,
+    vcpus: u8,
+    mem_mib: u32,
+}
+
+fn resolve_warm_shape(cfg: &MvmConfig) -> Result<WarmShape> {
+    let backend_name = super::shared::resolve_effective_hypervisor("firecracker");
+    let backend = AnyBackend::from_hypervisor(&backend_name);
+    let (kernel, _rootfs) = ensure_default_microvm_image(mvm_build::pipeline::BuildMode::Prod)
+        .context("resolve default-microvm kernel for the warm pool")?;
+    let vcpus = u8::try_from(cfg.default_cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);
+    Ok(WarmShape {
+        backend,
+        backend_name,
+        kernel: std::path::PathBuf::from(kernel),
+        vcpus,
+        mem_mib: cfg.default_memory_mib,
+    })
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
+    let pool = SupervisorStandbyPool::open()?;
+    match args.action {
+        PoolAction::Status { json } => run_status(&pool, json),
+        PoolAction::Warm { count } => run_warm(&pool, cfg, count.unwrap_or(1)),
+    }
+}
+
+fn run_warm(pool: &SupervisorStandbyPool, cfg: &MvmConfig, target: u32) -> Result<()> {
+    let shape = resolve_warm_shape(cfg)?;
+    if !shape.backend.supports_standby_pool() {
+        crate::ui::warn(&format!(
+            "backend '{}' has no supervisor standby pool (only libkrun does today); \
+             nothing warmed.",
+            shape.backend_name
+        ));
+        return Ok(());
+    }
+    // Ensure the host signer exists — the standby re-verifies the attach plan against it.
+    let signer = host_signer::load_or_init()?;
+    let spawned = warm_to_target(
+        pool,
+        &WarmParams {
+            backend: shape.backend.as_vm_backend(),
+            kernel: &shape.kernel,
+            vcpus: shape.vcpus,
+            mem_mib: shape.mem_mib,
+            signer_id: &host_signer::host_signer_id(),
+            signing_key_path: &signer.secret_path,
+            target,
+        },
+    )?;
+    if spawned == 0 {
+        crate::ui::info(&format!("Pool already at or above target {target}."));
+    } else {
+        crate::ui::success(&format!(
+            "Warmed {spawned} standby(s) toward target {target}."
+        ));
+    }
+    crate::ui::info(
+        "Note: a warm `up` claim boots through the gateway-bridge supervisor path \
+         (MVM_GATEWAY_BRIDGE=1); the default `up` cold-boots.",
+    );
+    Ok(())
+}
+
+/// Machine-readable `pool status --json` shape.
+#[derive(serde::Serialize)]
+struct PoolStatus {
+    idle: usize,
+    claimed: usize,
+    standbys: Vec<PoolStatusEntry>,
+}
+
+#[derive(serde::Serialize)]
+struct PoolStatusEntry {
+    id: String,
+    state: &'static str,
+    pid: u32,
+    kernel_sha256: String,
+    vcpus: u8,
+    mem_mib: u32,
+}
+
+fn run_status(pool: &SupervisorStandbyPool, json: bool) -> Result<()> {
+    let standbys = pool.list()?;
+    let idle = standbys
+        .iter()
+        .filter(|h| h.state == StandbyState::Idle)
+        .count();
+    let claimed = standbys.len() - idle;
+    let report = PoolStatus {
+        idle,
+        claimed,
+        standbys: standbys
+            .iter()
+            .map(|h| PoolStatusEntry {
+                id: h.id.clone(),
+                state: match h.state {
+                    StandbyState::Idle => "idle",
+                    StandbyState::Claimed => "claimed",
+                },
+                pid: h.pid,
+                kernel_sha256: h.kernel_sha256.clone(),
+                vcpus: h.vcpus,
+                mem_mib: h.mem_mib,
+            })
+            .collect(),
+    };
+    if json {
+        crate::json_out::emit_json(&report)?;
+        return Ok(());
+    }
+    println!("Supervisor standby pool: {idle} idle, {claimed} claimed");
+    for e in &report.standbys {
+        println!(
+            "  {} · {} · pid {} · {} vcpu / {} MiB · kernel {}",
+            e.id,
+            e.state,
+            e.pid,
+            e.vcpus,
+            e.mem_mib,
+            &e.kernel_sha256[..e.kernel_sha256.len().min(12)]
+        );
+    }
+    Ok(())
 }

--- a/crates/mvm-cli/src/commands/shared/mod.rs
+++ b/crates/mvm-cli/src/commands/shared/mod.rs
@@ -25,8 +25,8 @@ pub(super) use parse::{
     parse_port_specs, parse_volume_spec, vm_volume_from_spec_validated,
 };
 pub(super) use resolve::{
-    ManifestArgRef, resolve_flake_ref, resolve_manifest_arg, resolve_network_policy,
-    resolve_running_vm,
+    ManifestArgRef, resolve_effective_hypervisor, resolve_flake_ref, resolve_manifest_arg,
+    resolve_network_policy, resolve_running_vm,
 };
 pub(super) use start::VmStartParams;
 pub(super) use state::{CHILD_PIDS, IN_CONSOLE_MODE};

--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -182,3 +182,27 @@ pub fn resolve_network_policy(
 // user-global config / mvmd tenant config. Function deleted; the
 // `resolve_network_policy` form (always returns Some) is the only
 // remaining helper.
+
+/// Resolve the requested hypervisor to the effective one for this host. `firecracker`
+/// (the default `--hypervisor`) auto-detects: KVM → firecracker, macOS 26+ Apple Silicon
+/// → apple-container, macOS 13-25 + libkrun → libkrun, else docker. Any explicit value is
+/// returned as-is. Single source of truth, shared by `mvmctl up` and `mvmctl pool`
+/// (Plan 118 WS-1 1b) so they agree on which backend a launch uses.
+pub fn resolve_effective_hypervisor(requested: &str) -> String {
+    if requested != "firecracker" {
+        return requested.to_string();
+    }
+    let plat = mvm_core::platform::current();
+    if plat.has_kvm() {
+        "firecracker"
+    } else if plat.has_apple_containers() {
+        "apple-container"
+    } else if plat.has_libkrun() {
+        "libkrun"
+    } else if plat.has_docker() {
+        "docker"
+    } else {
+        "firecracker"
+    }
+    .to_string()
+}

--- a/crates/mvm-cli/src/commands/shared/start.rs
+++ b/crates/mvm-cli/src/commands/shared/start.rs
@@ -30,6 +30,8 @@ pub struct VmStartParams<'a> {
     pub config_files: &'a [microvm::DriveFile],
     pub secret_files: &'a [microvm::DriveFile],
     pub port_mappings: &'a [config::PortMapping],
+    /// Plan 118 WS-1 1b — warm-pool target (`--warm-pool-size`); 0 = off.
+    pub warm_pool_size: u32,
 }
 
 impl VmStartParams<'_> {
@@ -47,6 +49,7 @@ impl VmStartParams<'_> {
             cpus: self.cpus,
             memory_mib: self.memory_mib,
             mem_initial_mib: self.mem_initial_mib,
+            warm_pool_size: self.warm_pool_size,
             ports: self
                 .port_mappings
                 .iter()

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2420,6 +2420,30 @@ fn test_cache_prune() {
 }
 
 #[test]
+fn test_pool_warm_parses_optional_count() {
+    // Plan 118 WS-1 1b — `mvmctl pool warm` (default count) and `pool warm N`.
+    assert!(Cli::try_parse_from(["mvmctl", "pool", "warm"]).is_ok());
+    let cli = Cli::try_parse_from(["mvmctl", "pool", "warm", "3"]).unwrap();
+    match cli.command {
+        Commands::Pool(pool::Args {
+            action: pool::PoolAction::Warm { count },
+        }) => assert_eq!(count, Some(3)),
+        _ => panic!("Expected Pool Warm command"),
+    }
+}
+
+#[test]
+fn test_pool_status_parses_json_flag() {
+    let cli = Cli::try_parse_from(["mvmctl", "pool", "status", "--json"]).unwrap();
+    match cli.command {
+        Commands::Pool(pool::Args {
+            action: pool::PoolAction::Status { json },
+        }) => assert!(json),
+        _ => panic!("Expected Pool Status command"),
+    }
+}
+
+#[test]
 fn test_cache_prune_dry_run() {
     let cli = Cli::try_parse_from(["mvmctl", "cache", "prune", "--dry-run"]).unwrap();
     match cli.command {

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -829,6 +829,11 @@ pub(in crate::commands) struct Args {
     /// Bind a Prometheus metrics endpoint on this port (0 = disabled)
     #[arg(long, default_value = "0")]
     pub metrics_port: u16,
+    /// Plan 118 WS-1 1b — keep this many prelaunched supervisor standbys warm so the next
+    /// auto-named `up` claims one instead of cold-booting. 0 (default) = feature off. Only
+    /// the libkrun backend has a standby pool today; a claim uses the gateway-bridge path.
+    #[arg(long, default_value = "0")]
+    pub warm_pool_size: u32,
     /// Reload ~/.mvm/config.toml automatically when it changes
     #[arg(long)]
     pub watch_config: bool,
@@ -1131,6 +1136,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         env_vars: &args.env,
         forward: args.forward,
         metrics_port: args.metrics_port,
+        warm_pool_size: args.warm_pool_size,
         watch_config: args.watch_config,
         watch: args.watch,
         detach: args.detach || args.up_json,
@@ -1216,6 +1222,8 @@ pub(in crate::commands) struct RunParams<'a> {
     pub(super) env_vars: &'a [String],
     pub(super) forward: bool,
     pub(super) metrics_port: u16,
+    /// Plan 118 WS-1 1b — `--warm-pool-size`; 0 = off.
+    pub(super) warm_pool_size: u32,
     pub(super) watch_config: bool,
     pub(super) watch: bool,
     pub(super) detach: bool,
@@ -1282,6 +1290,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         env_vars,
         forward,
         metrics_port,
+        warm_pool_size,
         watch_config,
         watch,
         detach,
@@ -1811,7 +1820,8 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         });
     }
 
-    let vm_name_owned = vm_name.clone();
+    // `mut` so a warm-pool claim can rebind it to the claimed standby-id (Plan 118 WS-1 1b).
+    let mut vm_name_owned = vm_name.clone();
     let has_ports = !port_mappings.is_empty();
 
     // Stash the generated VM name so that if the Apple Container backend
@@ -1925,6 +1935,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             config_files: &config_files,
             secret_files: &secret_files,
             port_mappings: &port_mappings,
+            warm_pool_size,
         }
         .into_start_config();
         // Plan 124 C1 — attach the verity-sealed runtime overlay (Firecracker only, non-fatal).
@@ -1996,12 +2007,40 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         }
 
         enforce_shares_if(&admission_main, &start_config.volumes)?;
-        if let Err(e) = backend.start(&start_config) {
-            emit_failed_if(&admission_main, "backend-start", &e);
-            return Err(e);
+        // Plan 118 WS-1 1b — try a warm-pool claim first (auto-named + bridge-admitted
+        // launches only; fail-open to cold boot). A claimed VM runs under its standby-id,
+        // so rebind `vm_name_owned` for all downstream (agent wait, audit, readiness, stop).
+        let claimed: Option<String> =
+            match super::super::pool::try_warm_claim(&backend, &start_config, name.is_some()) {
+                Ok(Some(id)) => {
+                    ui::info(&format!(
+                        "Claimed a warm standby ({}) — skipping cold boot.",
+                        id.0
+                    ));
+                    Some(id.0)
+                }
+                Ok(None) => None,
+                Err(e) => {
+                    // try_warm_claim itself erroring (pool I/O, etc.) must not fail the launch.
+                    tracing::warn!(error = %e, "warm-claim attempt errored; cold-booting");
+                    None
+                }
+            };
+        match claimed {
+            Some(name) => vm_name_owned = name,
+            None => {
+                if let Err(e) = backend.start(&start_config) {
+                    emit_failed_if(&admission_main, "backend-start", &e);
+                    return Err(e);
+                }
+            }
         }
         emit_launched_if(&admission_main, effective_hypervisor);
         record_vm_readiness(&vm_name_owned, InstanceReadiness::LaunchAccepted);
+        // Replenish the pool toward target after launch — best-effort, no daemon.
+        if let Err(e) = super::super::pool::replenish_after_launch(&backend, &start_config) {
+            tracing::debug!(error = %e, "pool replenish skipped (best-effort)");
+        }
     }
 
     mvm_core::audit_emit!(VmStart, vm: &vm_name_owned);
@@ -2350,6 +2389,8 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 config_files: &w_config_files,
                 secret_files: &w_secret_files,
                 port_mappings: &w_port_mappings,
+                // `--wait` is a one-shot workload; no warm-pool claim on this path.
+                warm_pool_size: 0,
             }
             .into_start_config();
             // Plan 124 C1 — attach the verity-sealed runtime overlay (Firecracker only, non-fatal).

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1323,22 +1323,9 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
     // matches the rest of the codebase: native KVM → Apple Container
     // (macOS 26+) → libkrun (typical macOS 13-25 contributor box with
     // the slp/krun Homebrew tap) → Docker (Tier 3 fallback).
-    let effective_hypervisor = if hypervisor == "firecracker" {
-        let plat = mvm_core::platform::current();
-        if plat.has_kvm() {
-            "firecracker" // native KVM — production Tier 1
-        } else if plat.has_apple_containers() {
-            "apple-container" // macOS 26+ Apple Silicon
-        } else if plat.has_libkrun() {
-            "libkrun" // macOS 13-25 with libkrun installed
-        } else if plat.has_docker() {
-            "docker" // universal Tier 3 fallback (banner emitted)
-        } else {
-            "firecracker" // surfaces a clear "not available" error
-        }
-    } else {
-        hypervisor
-    };
+    // Shared with `mvmctl pool` (Plan 118 WS-1 1b) so both agree on the effective backend.
+    let effective_hypervisor_owned = super::super::shared::resolve_effective_hypervisor(hypervisor);
+    let effective_hypervisor: &str = &effective_hypervisor_owned;
 
     // ADR-002 / plan 53: emit a loud, suppressible banner when the
     // active backend is not a hardware-isolated microVM. Today this

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -178,6 +178,13 @@ struct WarmStartReport {
     /// `null` off Linux — the substrate backs Firecracker's live-memory path,
     /// which only runs on KVM; macOS reports per-backend tiers but N/A here.
     substrate: Option<WarmStartSubstrate>,
+    /// Plan 118 WS-1 1b — backend name → `supports_standby_pool()`. The standby pool
+    /// (pre-pay spawn/codesign latency) is a *different* axis from the snapshot tier above;
+    /// only libkrun implements it today.
+    standby_pool: BTreeMap<String, bool>,
+    /// Live count of idle standbys recorded under `~/.mvm/pool/` (best-effort; `None` if
+    /// the pool dir can't be read).
+    standby_pool_idle: Option<usize>,
 }
 
 /// Linux fast-resume substrate probe (plan 123 C2): the kernel pieces the
@@ -504,13 +511,26 @@ fn collect_warm_start_support() -> WarmStartReport {
         "vz",
     ];
     let mut backends = BTreeMap::new();
+    let mut standby_pool = BTreeMap::new();
     for name in names {
         let b = AnyBackend::from_hypervisor(name);
         backends.insert(b.name().to_string(), b.snapshot_capability().label());
+        standby_pool.insert(b.name().to_string(), b.supports_standby_pool());
     }
+    // Best-effort live idle count (Plan 118 WS-1 1b). A missing pool dir reads as 0.
+    let standby_pool_idle = mvm_backend::standby_pool::SupervisorStandbyPool::open()
+        .and_then(|p| p.list())
+        .ok()
+        .map(|v| {
+            v.iter()
+                .filter(|h| h.state == mvm_core::vm_backend::StandbyState::Idle)
+                .count()
+        });
     WarmStartReport {
         backends,
         substrate: collect_warm_start_substrate(),
+        standby_pool,
+        standby_pool_idle,
     }
 }
 
@@ -577,6 +597,25 @@ fn render_warm_start_support(r: &WarmStartReport) {
         }
         None => ui::status_line("  substrate (Linux fast-resume)", "N/A (Linux-only)"),
     }
+
+    // Plan 118 WS-1 1b — the standby pool (pre-pay spawn latency), a separate axis from
+    // the snapshot tiers above. Only libkrun implements it today.
+    let pool_title = "Standby pool (per backend)";
+    println!("\n{}", pool_title);
+    println!("{}", "-".repeat(pool_title.len()));
+    for (backend, supported) in &r.standby_pool {
+        ui::status_line(
+            &format!("  {backend}:"),
+            if *supported { "supported" } else { "—" },
+        );
+    }
+    ui::status_line(
+        "  idle standbys",
+        &match r.standby_pool_idle {
+            Some(n) => n.to_string(),
+            None => "unknown".to_string(),
+        },
+    );
 }
 
 // ── Active backend security posture (ADR-002 / plan 53) ──────
@@ -2727,6 +2766,16 @@ mod tests {
         assert_eq!(r.backends.get("qemu"), Some(&"disk-only"));
         // A backend with no warm-start support must not be silently dropped.
         assert_eq!(r.backends.get("docker"), Some(&"unsupported"));
+    }
+
+    #[test]
+    fn collect_warm_start_support_reports_standby_pool_per_backend() {
+        let r = collect_warm_start_support();
+        // Plan 118 WS-1 1b — only libkrun implements the standby pool today; the rest
+        // report honest `false` and must not be silently dropped.
+        assert_eq!(r.standby_pool.get("libkrun"), Some(&true));
+        assert_eq!(r.standby_pool.get("apple-container"), Some(&false));
+        assert_eq!(r.standby_pool.get("docker"), Some(&false));
     }
 
     #[test]

--- a/crates/mvm-core/Cargo.toml
+++ b/crates/mvm-core/Cargo.toml
@@ -70,6 +70,9 @@ schemars = { version = "0.8", optional = true }
 # -e no-dev` carries no `tokio` so this can't silently regress.
 [features]
 default = []
+# Expose `plan::signing::test_support` (shared `ExecutionPlan` fixtures) to
+# other crates' test builds without shipping the fixtures in a release build.
+test-support = []
 # The hostd IPC async transport in `protocol` (mvmd ↔ mvm-hostd control
 # channel: read/write_frame + send/recv request/response). The only
 # async surface in mvm-core besides `manifest-verify`; gated so the

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -339,6 +339,20 @@ pub fn vm_state_dir(name: &str) -> std::path::PathBuf {
         .join(name)
 }
 
+/// `<mvm_data_dir>/pool/` — the supervisor standby pool root (Plan 118 WS-1 1b).
+/// Each idle standby gets a `pool/<id>/` subdir holding its control UDS +
+/// `standby.json`. Uses the strict resolver so a missing `$HOME`/`MVM_DATA_DIR`
+/// surfaces as an error rather than silently writing entitled processes' state to
+/// `/tmp`.
+pub fn mvm_pool_dir() -> std::io::Result<std::path::PathBuf> {
+    Ok(mvm_data_dir_strict()?.join("pool"))
+}
+
+/// `<mvm_data_dir>/pool/<id>/` for a single standby.
+pub fn pool_standby_dir(id: &str) -> std::io::Result<std::path::PathBuf> {
+    Ok(mvm_pool_dir()?.join(id))
+}
+
 /// Filename of libkrun's per-port vsock listener socket: `vsock-<port>.sock`.
 /// The single source of truth for the name. Callers that already hold the
 /// per-VM dir (e.g. a `VsockTransport` constructed from an explicit dir)
@@ -622,6 +636,21 @@ mod tests {
         assert_eq!(
             mvm_data_dir_strict().unwrap(),
             std::path::PathBuf::from("/custom/data")
+        );
+        unsafe { std::env::remove_var("MVM_DATA_DIR") };
+    }
+
+    #[test]
+    fn pool_dirs_live_under_mvm_data_dir() {
+        let _g = env_lock();
+        unsafe { std::env::set_var("MVM_DATA_DIR", "/custom/data") };
+        assert_eq!(
+            mvm_pool_dir().unwrap(),
+            std::path::PathBuf::from("/custom/data/pool")
+        );
+        assert_eq!(
+            pool_standby_dir("standby-abc").unwrap(),
+            std::path::PathBuf::from("/custom/data/pool/standby-abc")
         );
         unsafe { std::env::remove_var("MVM_DATA_DIR") };
     }

--- a/crates/mvm-core/src/plan/signing.rs
+++ b/crates/mvm-core/src/plan/signing.rs
@@ -152,16 +152,21 @@ pub fn verify_plan(
     Ok(plan)
 }
 
-#[cfg(test)]
-mod tests {
+/// Test-support fixtures shared across crates. Gated so it never ships in a
+/// non-test build but is reachable from other crates' `#[cfg(test)]` code via
+/// the `test-support` feature (e.g. `mvm-vm-host`'s prelaunch verify tests need
+/// a valid `ExecutionPlan` to sign, and duplicating this ~50-line literal would
+/// drift). `mvm-core`'s own tests use it through `test` directly.
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
     use super::*;
     use crate::plan::types::*;
     use chrono::{TimeZone, Utc};
-    use ed25519_dalek::SigningKey;
-    use rand::rngs::OsRng;
     use std::collections::BTreeMap;
 
-    pub(crate) fn sample_plan() -> ExecutionPlan {
+    /// A minimal valid `ExecutionPlan` with a fixed validity window + nonce.
+    /// Callers override `valid_from`/`valid_until`/`nonce` for their scenario.
+    pub fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
             schema_version: SCHEMA_VERSION,
             plan_id: PlanId("01HXTESTPLAN000000000000".to_string()),
@@ -216,6 +221,15 @@ mod tests {
             shares: Vec::new(),
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::sample_plan;
+    use super::*;
+    use crate::plan::types::*;
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
 
     fn fresh_key() -> (SigningKey, VerifyingKey) {
         let sk = SigningKey::generate(&mut OsRng);

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -162,6 +162,11 @@ pub enum LocalAuditKind {
     /// Emitted by `mvmctl reconcile` and the cheap convergence pass run at
     /// CLI entry for state-touching commands.
     RegistryReconcile,
+    /// `mvmctl pool warm` pre-spawned supervisor standbys for the warm pool
+    /// (Plan 118 WS-1 1b). State-changing infra verb (spawns detached
+    /// supervisors + writes `~/.mvm/pool/`); the `detail` field carries
+    /// `spawned=<n> target=<n>`.
+    PoolWarm,
     // --- Sandbox SDK foundation (fs/proc/share/pause/TTL/tags) ---
     // The verbs below are state-changing CLI surfaces added by the
     // sandbox-SDK foundation work. Each kind names a single mutation

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -492,6 +492,92 @@ impl fmt::Display for WarmStartError {
 
 impl std::error::Error for WarmStartError {}
 
+// ---------------------------------------------------------------------------
+// Supervisor standby pool — Plan 118 WS-1 1b
+// ---------------------------------------------------------------------------
+
+/// How a prelaunched standby is to be set up (Plan 118 WS-1 1b). Backend-agnostic:
+/// the caller (the launch path) fills this in; the backend's [`VmBackend::spawn_standby`]
+/// translates it to its own wire config (libkrun → `SupervisorBaseConfig`).
+#[derive(Debug, Clone)]
+pub struct StandbySpec {
+    /// Stable id for this standby (also the `~/.mvm/pool/<id>/` dir name).
+    pub id: String,
+    /// Kernel image path the standby pre-loads.
+    pub kernel_path: String,
+    /// Lowercase-hex sha256 of the kernel image — the base-compat match key.
+    pub kernel_sha256: String,
+    /// Host-signer key path (claim 8) the standby re-verifies the attach plan against.
+    pub signing_key_path: std::path::PathBuf,
+    /// Expected envelope signer id (`host:{hostname}`) — the attach plan must match it.
+    pub signer_id: String,
+    /// Per-spawn binding nonce (hex of 32 random bytes); the attach must echo it.
+    pub binding_nonce: String,
+    /// Control UDS the standby binds and blocks on (0700 in a 0700 dir, nonce in path).
+    pub control_socket: std::path::PathBuf,
+    /// Per-VM state dir the standby writes its pid into.
+    pub vm_state_dir: String,
+}
+
+/// A recorded, live standby (persisted as `~/.mvm/pool/<id>/standby.json`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StandbyHandle {
+    pub id: String,
+    pub control_socket: std::path::PathBuf,
+    pub pid: u32,
+    pub kernel_sha256: String,
+    pub binding_nonce: String,
+    pub spawned_unix_secs: u64,
+    pub state: StandbyState,
+}
+
+impl StandbyHandle {
+    /// Base-compat: a launch may claim this standby only if its plan resolves to the
+    /// same kernel image. v1 is default-kernel-only; multi-kernel keying is deferred
+    /// (SPRINT.md). Exact sha256 match — no silent wrong-kernel boot.
+    pub fn matches_kernel(&self, kernel_sha256: &str) -> bool {
+        self.kernel_sha256 == kernel_sha256
+    }
+}
+
+/// Lifecycle state of a recorded standby.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StandbyState {
+    /// Spawned, blocked on its control UDS, not yet claimed.
+    Idle,
+    /// An attach was sent; the standby is booting or has booted.
+    Claimed,
+}
+
+/// What to attach to a claimed standby — the workload-specific half (the admitted,
+/// signed plan + rootfs + audit substrate). Backend-agnostic.
+#[derive(Debug, Clone)]
+pub struct StandbyClaim {
+    /// Workload rootfs ext4.
+    pub rootfs_path: String,
+    pub tenant_id: String,
+    pub audit_dir: std::path::PathBuf,
+    pub gateway_audit_socket: std::path::PathBuf,
+    pub gateway_events_socket: Option<std::path::PathBuf>,
+    /// JSON-encoded signed `ExecutionPlan` envelope (claim 8).
+    pub plan_json: String,
+    /// JSON-encoded `PolicyBundle`, if any.
+    pub bundle_json: Option<String>,
+}
+
+/// Why a standby spawn/claim failed. Fail-closed: every variant means the caller must
+/// fall back to a cold boot, never silently proceed without the workload.
+#[derive(Debug, thiserror::Error)]
+pub enum StandbyError {
+    #[error("{backend}: standby pool is not supported by this backend")]
+    Unsupported { backend: String },
+    #[error("spawn standby: {0}")]
+    SpawnFailed(String),
+    #[error("claim standby: {0}")]
+    ClaimFailed(String),
+}
+
 /// Snapshot of a VM's virtio-balloon state, returned by
 /// [`VmBackend::balloon_state`].
 ///
@@ -901,6 +987,33 @@ pub trait VmBackend: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn standby_handle_serde_roundtrip_and_kernel_match() {
+        let h = StandbyHandle {
+            id: "standby-abc".into(),
+            control_socket: "/p/standby-abc/control-deadbeef.sock".into(),
+            pid: 4242,
+            kernel_sha256: "a".repeat(64),
+            binding_nonce: "deadbeef".repeat(8),
+            spawned_unix_secs: 1_700_000_000,
+            state: StandbyState::Idle,
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        let back: StandbyHandle = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, "standby-abc");
+        assert_eq!(back.state, StandbyState::Idle);
+        assert!(back.matches_kernel(&"a".repeat(64)));
+        assert!(!back.matches_kernel(&"b".repeat(64)));
+    }
+
+    #[test]
+    fn standby_error_is_std_error() {
+        fn assert_err<E: std::error::Error>(_: &E) {}
+        assert_err(&StandbyError::Unsupported {
+            backend: "x".into(),
+        });
+    }
 
     #[test]
     fn snapshot_capability_defaults_to_unsupported() {

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -121,6 +121,11 @@ pub struct VmStartConfig {
     /// has no `.mvmpkg` pin (the common case). Same "do not log"
     /// rule as `plan_json`.
     pub bundle_json: Option<String>,
+    /// Plan 118 WS-1 1b — target warm-pool size. `0` (default) = feature off: no
+    /// standbys, no idle RAM, no control UDS, no behaviour change. A future
+    /// Firecracker standby reads the same field (it's why this lives on the
+    /// backend-agnostic config, not a libkrun-specific knob).
+    pub warm_pool_size: u32,
 }
 
 /// A host:guest port mapping, backend-agnostic.
@@ -813,6 +818,42 @@ pub trait VmBackend: Send + Sync {
         )))
     }
 
+    /// Does this backend support a prelaunched-supervisor standby pool (Plan 118
+    /// WS-1 1b)? Opt-in, default `false` — orthogonal to [`snapshot_capability`]
+    /// (snapshot = restore a booted VM; standby = pre-pay spawn/setup latency).
+    ///
+    /// [`snapshot_capability`]: Self::snapshot_capability
+    fn supports_standby_pool(&self) -> bool {
+        false
+    }
+
+    /// Spawn a prelaunched standby per `spec`, detached, blocked on its control UDS
+    /// before any boot. Returns a [`StandbyHandle`] the pool records. Fail-closed:
+    /// the default refuses so a backend opts in explicitly (mirrors [`warm_start`]).
+    ///
+    /// [`warm_start`]: Self::warm_start
+    fn spawn_standby(
+        &self,
+        _spec: &StandbySpec,
+    ) -> std::result::Result<StandbyHandle, StandbyError> {
+        Err(StandbyError::Unsupported {
+            backend: self.name().to_string(),
+        })
+    }
+
+    /// Claim an idle standby: send its one-shot attach (the admitted signed plan +
+    /// rootfs + audit substrate), which the supervisor re-verifies before boot.
+    /// Returns the booted VM's [`VmId`]. Fail-closed default.
+    fn claim_standby(
+        &self,
+        _handle: &StandbyHandle,
+        _claim: &StandbyClaim,
+    ) -> std::result::Result<VmId, StandbyError> {
+        Err(StandbyError::Unsupported {
+            backend: self.name().to_string(),
+        })
+    }
+
     /// Start a new VM from the given configuration.
     ///
     /// Returns the [`VmId`] assigned to the running VM.
@@ -1013,6 +1054,62 @@ mod tests {
         assert_err(&StandbyError::Unsupported {
             backend: "x".into(),
         });
+    }
+
+    fn sample_standby_spec() -> StandbySpec {
+        StandbySpec {
+            id: "standby-x".into(),
+            kernel_path: "/k/vmlinux".into(),
+            kernel_sha256: "a".repeat(64),
+            signing_key_path: "/keys/host-signer.ed25519".into(),
+            signer_id: "host:test".into(),
+            binding_nonce: "ab".repeat(32),
+            control_socket: "/p/standby-x/control.sock".into(),
+            vm_state_dir: "/p/standby-x".into(),
+        }
+    }
+
+    fn sample_standby_claim() -> StandbyClaim {
+        StandbyClaim {
+            rootfs_path: "/vol/rootfs.ext4".into(),
+            tenant_id: "tenant-a".into(),
+            audit_dir: "/audit".into(),
+            gateway_audit_socket: "/audit/g.sock".into(),
+            gateway_events_socket: None,
+            plan_json: "{}".into(),
+            bundle_json: None,
+        }
+    }
+
+    #[test]
+    fn standby_pool_defaults_are_fail_closed() {
+        // TierOnlyBackend opts into no standby pool — the trait defaults must refuse.
+        let b = TierOnlyBackend(SnapshotCapability::DiskOnly);
+        assert!(!b.supports_standby_pool());
+        match b.spawn_standby(&sample_standby_spec()) {
+            Err(StandbyError::Unsupported { backend }) => assert_eq!(backend, "tier-only"),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+        match b.claim_standby(
+            &StandbyHandle {
+                id: "s".into(),
+                control_socket: "/p/s.sock".into(),
+                pid: 1,
+                kernel_sha256: "a".repeat(64),
+                binding_nonce: "ab".repeat(32),
+                spawned_unix_secs: 1,
+                state: StandbyState::Idle,
+            },
+            &sample_standby_claim(),
+        ) {
+            Err(StandbyError::Unsupported { backend }) => assert_eq!(backend, "tier-only"),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn warm_pool_size_defaults_to_zero() {
+        assert_eq!(VmStartConfig::default().warm_pool_size, 0);
     }
 
     #[test]

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -1080,9 +1080,18 @@ mod tests {
         };
         assert!(back.is_compatible(&want));
         // wrong kernel, wrong cpus, and wrong mem each break compat.
-        assert!(!back.is_compatible(&StandbyCompat { kernel_sha256: "b".repeat(64), ..want.clone() }));
-        assert!(!back.is_compatible(&StandbyCompat { vcpus: 4, ..want.clone() }));
-        assert!(!back.is_compatible(&StandbyCompat { mem_mib: 2048, ..want }));
+        assert!(!back.is_compatible(&StandbyCompat {
+            kernel_sha256: "b".repeat(64),
+            ..want.clone()
+        }));
+        assert!(!back.is_compatible(&StandbyCompat {
+            vcpus: 4,
+            ..want.clone()
+        }));
+        assert!(!back.is_compatible(&StandbyCompat {
+            mem_mib: 2048,
+            ..want
+        }));
     }
 
     #[test]

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -510,8 +510,13 @@ pub struct StandbySpec {
     pub id: String,
     /// Kernel image path the standby pre-loads.
     pub kernel_path: String,
-    /// Lowercase-hex sha256 of the kernel image — the base-compat match key.
+    /// Lowercase-hex sha256 of the kernel image — part of the base-compat key.
     pub kernel_sha256: String,
+    /// vCPU count fixed at spawn (libkrun `set_vm_config` runs from the base
+    /// KrunContext, before attach — so a launch needing a different count cold-boots).
+    pub vcpus: u8,
+    /// Guest memory (MiB) fixed at spawn — same reasoning as `vcpus`.
+    pub mem_mib: u32,
     /// Host-signer key path (claim 8) the standby re-verifies the attach plan against.
     pub signing_key_path: std::path::PathBuf,
     /// Expected envelope signer id (`host:{hostname}`) — the attach plan must match it.
@@ -524,6 +529,18 @@ pub struct StandbySpec {
     pub vm_state_dir: String,
 }
 
+/// The base-compat key — everything a libkrun standby fixes at spawn and therefore must
+/// match the workload exactly, else the launch cold-boots. v1 is default-kernel +
+/// default-resources only; multi-kernel/multi-shape keying is deferred (SPRINT.md). The
+/// "no extra volumes" half of compat is enforced at the launch path (a standby declares
+/// none), not here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StandbyCompat {
+    pub kernel_sha256: String,
+    pub vcpus: u8,
+    pub mem_mib: u32,
+}
+
 /// A recorded, live standby (persisted as `~/.mvm/pool/<id>/standby.json`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StandbyHandle {
@@ -531,17 +548,27 @@ pub struct StandbyHandle {
     pub control_socket: std::path::PathBuf,
     pub pid: u32,
     pub kernel_sha256: String,
+    pub vcpus: u8,
+    pub mem_mib: u32,
     pub binding_nonce: String,
     pub spawned_unix_secs: u64,
     pub state: StandbyState,
 }
 
 impl StandbyHandle {
-    /// Base-compat: a launch may claim this standby only if its plan resolves to the
-    /// same kernel image. v1 is default-kernel-only; multi-kernel keying is deferred
-    /// (SPRINT.md). Exact sha256 match — no silent wrong-kernel boot.
-    pub fn matches_kernel(&self, kernel_sha256: &str) -> bool {
-        self.kernel_sha256 == kernel_sha256
+    /// The base-compat key this standby was spawned with.
+    pub fn compat(&self) -> StandbyCompat {
+        StandbyCompat {
+            kernel_sha256: self.kernel_sha256.clone(),
+            vcpus: self.vcpus,
+            mem_mib: self.mem_mib,
+        }
+    }
+
+    /// A launch may claim this standby only if its kernel **and** fixed resources match
+    /// exactly — no silent wrong-kernel or wrong-size boot.
+    pub fn is_compatible(&self, want: &StandbyCompat) -> bool {
+        &self.compat() == want
     }
 }
 
@@ -1030,12 +1057,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn standby_handle_serde_roundtrip_and_kernel_match() {
+    fn standby_handle_serde_roundtrip_and_compat_match() {
         let h = StandbyHandle {
             id: "standby-abc".into(),
             control_socket: "/p/standby-abc/control-deadbeef.sock".into(),
             pid: 4242,
             kernel_sha256: "a".repeat(64),
+            vcpus: 2,
+            mem_mib: 1024,
             binding_nonce: "deadbeef".repeat(8),
             spawned_unix_secs: 1_700_000_000,
             state: StandbyState::Idle,
@@ -1044,8 +1073,16 @@ mod tests {
         let back: StandbyHandle = serde_json::from_str(&json).unwrap();
         assert_eq!(back.id, "standby-abc");
         assert_eq!(back.state, StandbyState::Idle);
-        assert!(back.matches_kernel(&"a".repeat(64)));
-        assert!(!back.matches_kernel(&"b".repeat(64)));
+        let want = StandbyCompat {
+            kernel_sha256: "a".repeat(64),
+            vcpus: 2,
+            mem_mib: 1024,
+        };
+        assert!(back.is_compatible(&want));
+        // wrong kernel, wrong cpus, and wrong mem each break compat.
+        assert!(!back.is_compatible(&StandbyCompat { kernel_sha256: "b".repeat(64), ..want.clone() }));
+        assert!(!back.is_compatible(&StandbyCompat { vcpus: 4, ..want.clone() }));
+        assert!(!back.is_compatible(&StandbyCompat { mem_mib: 2048, ..want }));
     }
 
     #[test]
@@ -1061,6 +1098,8 @@ mod tests {
             id: "standby-x".into(),
             kernel_path: "/k/vmlinux".into(),
             kernel_sha256: "a".repeat(64),
+            vcpus: 2,
+            mem_mib: 1024,
             signing_key_path: "/keys/host-signer.ed25519".into(),
             signer_id: "host:test".into(),
             binding_nonce: "ab".repeat(32),
@@ -1096,6 +1135,8 @@ mod tests {
                 control_socket: "/p/s.sock".into(),
                 pid: 1,
                 kernel_sha256: "a".repeat(64),
+                vcpus: 2,
+                mem_mib: 1024,
                 binding_nonce: "ab".repeat(32),
                 spawned_unix_secs: 1,
                 state: StandbyState::Idle,

--- a/crates/mvm-hostd/src/framing.rs
+++ b/crates/mvm-hostd/src/framing.rs
@@ -236,8 +236,7 @@ mod tests {
         let mut framed = Vec::new();
         framed.extend_from_slice(&u32::MAX.to_be_bytes());
         let mut cursor = std::io::Cursor::new(framed);
-        let err =
-            read_json_frame_sync::<_, Msg>(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap_err();
+        let err = read_json_frame_sync::<_, Msg>(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap_err();
         assert!(matches!(
             err,
             FrameError::TooLarge {
@@ -253,8 +252,7 @@ mod tests {
         framed.extend_from_slice(&16u32.to_be_bytes());
         framed.extend_from_slice(b"abcd");
         let mut cursor = std::io::Cursor::new(framed);
-        let err =
-            read_json_frame_sync::<_, Msg>(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap_err();
+        let err = read_json_frame_sync::<_, Msg>(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap_err();
         assert!(matches!(err, FrameError::Io(_)));
     }
 }

--- a/crates/mvm-hostd/src/framing.rs
+++ b/crates/mvm-hostd/src/framing.rs
@@ -100,46 +100,11 @@ where
     serde_json::from_slice(&body).map_err(FrameError::Decode)
 }
 
-/// Synchronous sibling of [`write_json_frame`] for the same-uid UDS control
-/// channels that run *without* a tokio runtime. The libkrun supervisor's
-/// prelaunch accept path (Plan 118 WS-1 1a) runs before `start_enter`, so it
-/// can't park a runtime. Same wire format — 4-byte BE length + JSON body.
-pub fn write_json_frame_sync<W, T>(stream: &mut W, value: &T) -> Result<(), FrameError>
-where
-    W: std::io::Write + ?Sized,
-    T: serde::Serialize,
-{
-    let body = serde_json::to_vec(value).map_err(FrameError::Encode)?;
-    let len: u32 = body
-        .len()
-        .try_into()
-        .map_err(|_| FrameError::LengthOverflow)?;
-    stream.write_all(&len.to_be_bytes())?;
-    stream.write_all(&body)?;
-    Ok(())
-}
-
-/// Synchronous sibling of [`read_json_frame`]. Enforces `max_frame_bytes` on
-/// the length prefix **before** allocating the body — same gate-1 invariant as
-/// the async path (a hostile `length_prefix = u32::MAX` must not OOM the reader).
-pub fn read_json_frame_sync<R, T>(stream: &mut R, max_frame_bytes: usize) -> Result<T, FrameError>
-where
-    R: std::io::Read + ?Sized,
-    T: serde::de::DeserializeOwned,
-{
-    let mut len_buf = [0u8; FRAME_LEN_BYTES];
-    stream.read_exact(&mut len_buf)?;
-    let len = u32::from_be_bytes(len_buf) as usize;
-    if len > max_frame_bytes {
-        return Err(FrameError::TooLarge {
-            size: len,
-            cap: max_frame_bytes,
-        });
-    }
-    let mut body = vec![0u8; len];
-    stream.read_exact(&mut body)?;
-    serde_json::from_slice(&body).map_err(FrameError::Decode)
-}
+// NB: the *sync* length-prefixed framing the libkrun supervisor control channel uses
+// (Plan 118 WS-1 1a/1b) lives in `libkrun_sys::framing` — colocated with the
+// `Supervisor*Config` wire types it frames, and reachable by the `mvm-backend` writer
+// (`claim_standby`) which cannot depend on `mvm-hostd` (cycle). This module keeps the
+// async tokio variants its own same-uid channels use.
 
 #[cfg(test)]
 mod tests {
@@ -214,45 +179,5 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, FrameError::Decode(_)));
-    }
-
-    #[test]
-    fn sync_round_trips_a_json_frame() {
-        let msg = Msg {
-            kind: "ping".into(),
-            n: 7,
-        };
-        let mut buf = Vec::new();
-        write_json_frame_sync(&mut buf, &msg).unwrap();
-        let body_len = u32::from_be_bytes(buf[..4].try_into().unwrap()) as usize;
-        assert_eq!(body_len, buf.len() - FRAME_LEN_BYTES);
-        let mut cursor = std::io::Cursor::new(buf);
-        let got: Msg = read_json_frame_sync(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap();
-        assert_eq!(got, msg);
-    }
-
-    #[test]
-    fn sync_rejects_oversize_length_prefix_before_alloc() {
-        let mut framed = Vec::new();
-        framed.extend_from_slice(&u32::MAX.to_be_bytes());
-        let mut cursor = std::io::Cursor::new(framed);
-        let err = read_json_frame_sync::<_, Msg>(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap_err();
-        assert!(matches!(
-            err,
-            FrameError::TooLarge {
-                size,
-                cap: DEFAULT_MAX_FRAME_BYTES
-            } if size == u32::MAX as usize
-        ));
-    }
-
-    #[test]
-    fn sync_truncated_body_is_an_io_error() {
-        let mut framed = Vec::new();
-        framed.extend_from_slice(&16u32.to_be_bytes());
-        framed.extend_from_slice(b"abcd");
-        let mut cursor = std::io::Cursor::new(framed);
-        let err = read_json_frame_sync::<_, Msg>(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap_err();
-        assert!(matches!(err, FrameError::Io(_)));
     }
 }

--- a/crates/mvm-hostd/src/framing.rs
+++ b/crates/mvm-hostd/src/framing.rs
@@ -100,6 +100,47 @@ where
     serde_json::from_slice(&body).map_err(FrameError::Decode)
 }
 
+/// Synchronous sibling of [`write_json_frame`] for the same-uid UDS control
+/// channels that run *without* a tokio runtime. The libkrun supervisor's
+/// prelaunch accept path (Plan 118 WS-1 1a) runs before `start_enter`, so it
+/// can't park a runtime. Same wire format — 4-byte BE length + JSON body.
+pub fn write_json_frame_sync<W, T>(stream: &mut W, value: &T) -> Result<(), FrameError>
+where
+    W: std::io::Write + ?Sized,
+    T: serde::Serialize,
+{
+    let body = serde_json::to_vec(value).map_err(FrameError::Encode)?;
+    let len: u32 = body
+        .len()
+        .try_into()
+        .map_err(|_| FrameError::LengthOverflow)?;
+    stream.write_all(&len.to_be_bytes())?;
+    stream.write_all(&body)?;
+    Ok(())
+}
+
+/// Synchronous sibling of [`read_json_frame`]. Enforces `max_frame_bytes` on
+/// the length prefix **before** allocating the body — same gate-1 invariant as
+/// the async path (a hostile `length_prefix = u32::MAX` must not OOM the reader).
+pub fn read_json_frame_sync<R, T>(stream: &mut R, max_frame_bytes: usize) -> Result<T, FrameError>
+where
+    R: std::io::Read + ?Sized,
+    T: serde::de::DeserializeOwned,
+{
+    let mut len_buf = [0u8; FRAME_LEN_BYTES];
+    stream.read_exact(&mut len_buf)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > max_frame_bytes {
+        return Err(FrameError::TooLarge {
+            size: len,
+            cap: max_frame_bytes,
+        });
+    }
+    let mut body = vec![0u8; len];
+    stream.read_exact(&mut body)?;
+    serde_json::from_slice(&body).map_err(FrameError::Decode)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -173,5 +214,47 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, FrameError::Decode(_)));
+    }
+
+    #[test]
+    fn sync_round_trips_a_json_frame() {
+        let msg = Msg {
+            kind: "ping".into(),
+            n: 7,
+        };
+        let mut buf = Vec::new();
+        write_json_frame_sync(&mut buf, &msg).unwrap();
+        let body_len = u32::from_be_bytes(buf[..4].try_into().unwrap()) as usize;
+        assert_eq!(body_len, buf.len() - FRAME_LEN_BYTES);
+        let mut cursor = std::io::Cursor::new(buf);
+        let got: Msg = read_json_frame_sync(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap();
+        assert_eq!(got, msg);
+    }
+
+    #[test]
+    fn sync_rejects_oversize_length_prefix_before_alloc() {
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&u32::MAX.to_be_bytes());
+        let mut cursor = std::io::Cursor::new(framed);
+        let err =
+            read_json_frame_sync::<_, Msg>(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap_err();
+        assert!(matches!(
+            err,
+            FrameError::TooLarge {
+                size,
+                cap: DEFAULT_MAX_FRAME_BYTES
+            } if size == u32::MAX as usize
+        ));
+    }
+
+    #[test]
+    fn sync_truncated_body_is_an_io_error() {
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&16u32.to_be_bytes());
+        framed.extend_from_slice(b"abcd");
+        let mut cursor = std::io::Cursor::new(framed);
+        let err =
+            read_json_frame_sync::<_, Msg>(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap_err();
+        assert!(matches!(err, FrameError::Io(_)));
     }
 }

--- a/crates/mvm-vm-host/Cargo.toml
+++ b/crates/mvm-vm-host/Cargo.toml
@@ -60,6 +60,10 @@ mvm-build = { workspace = true }
 # libkrun bindings/wrapper; FFI linkage gated by the libkrun-sys feature.
 libkrun-sys = { workspace = true }
 anyhow = { workspace = true }
+# Plan 118 WS-1 1a — prelaunch attach verify: G4 validity window (`check_window`
+# takes `chrono::DateTime<Utc>`) + typed `AttachVerifyError`.
+chrono = { workspace = true }
+thiserror = "1"
 ed25519-dalek = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -122,11 +126,16 @@ objc2-virtualization = { version = "0.3", features = [
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# Shared ExecutionPlan fixtures (`plan::signing::test_support::sample_plan`) for
+# the prelaunch verify tests — feature-gated so it never ships in a release build.
+mvm-core = { workspace = true, features = ["test-support"] }
 
 [features]
 default = []
 # Build the libkrun supervisor bin against libkrun's FFI.
 libkrun-sys = ["libkrun-sys/libkrun-sys"]
+# Live-boot integration tests (dev host with libkrun). Never in CI's no-VM lanes.
+libkrun-live = ["libkrun-sys"]
 
 [lints]
 workspace = true

--- a/crates/mvm-vm-host/Cargo.toml
+++ b/crates/mvm-vm-host/Cargo.toml
@@ -136,6 +136,11 @@ libkrun-sys = { workspace = true }
 mvm-hostd = { workspace = true }
 serde_json = { workspace = true }
 ed25519-dalek = { workspace = true }
+# Plan 118 WS-1 1b standby_pool_live test — drive the real LibkrunBackend
+# spawn_standby/claim_standby through the trait (already a normal dep).
+mvm-backend = { workspace = true }
+# Standby liveness/reap (kill(pid,0)/SIGTERM) in the live test.
+libc = { workspace = true }
 
 [features]
 default = []

--- a/crates/mvm-vm-host/Cargo.toml
+++ b/crates/mvm-vm-host/Cargo.toml
@@ -129,6 +129,13 @@ tempfile = { workspace = true }
 # Shared ExecutionPlan fixtures (`plan::signing::test_support::sample_plan`) for
 # the prelaunch verify tests — feature-gated so it never ships in a release build.
 mvm-core = { workspace = true, features = ["test-support"] }
+# Prelaunch live/process integration test (tests/prelaunch_live.rs): build the
+# base/attach configs, frame the attach, sign a plan. All already normal deps —
+# re-listed here so the integration-test target (a separate crate) can use them.
+libkrun-sys = { workspace = true }
+mvm-hostd = { workspace = true }
+serde_json = { workspace = true }
+ed25519-dalek = { workspace = true }
 
 [features]
 default = []

--- a/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
@@ -233,7 +233,7 @@ fn run_prelaunched(base: SupervisorBaseConfig) -> ExitCode {
     // Read the length-prefixed attach frame, then re-encode to bytes for the
     // pure verifier (which owns the deny_unknown_fields decode + plan verify).
     let attach_value: serde_json::Value =
-        match mvm_hostd::framing::read_json_frame_sync(&mut stream, MAX_ATTACH_BYTES) {
+        match libkrun_sys::framing::read_json_frame_sync(&mut stream, MAX_ATTACH_BYTES) {
             Ok(v) => v,
             Err(e) => {
                 eprintln!("prelaunch: read attach frame: {e}");

--- a/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
@@ -212,7 +212,10 @@ fn run_prelaunched(base: SupervisorBaseConfig) -> ExitCode {
     let listener = match bind_control_socket(&sock_path) {
         Ok(l) => l,
         Err(e) => {
-            eprintln!("prelaunch: bind control socket {}: {e}", sock_path.display());
+            eprintln!(
+                "prelaunch: bind control socket {}: {e}",
+                sock_path.display()
+            );
             return ExitCode::from(3);
         }
     };
@@ -229,16 +232,14 @@ fn run_prelaunched(base: SupervisorBaseConfig) -> ExitCode {
 
     // Read the length-prefixed attach frame, then re-encode to bytes for the
     // pure verifier (which owns the deny_unknown_fields decode + plan verify).
-    let attach_value: serde_json::Value = match mvm_hostd::framing::read_json_frame_sync(
-        &mut stream,
-        MAX_ATTACH_BYTES,
-    ) {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("prelaunch: read attach frame: {e}");
-            return ExitCode::from(5);
-        }
-    };
+    let attach_value: serde_json::Value =
+        match mvm_hostd::framing::read_json_frame_sync(&mut stream, MAX_ATTACH_BYTES) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("prelaunch: read attach frame: {e}");
+                return ExitCode::from(5);
+            }
+        };
     let attach_bytes = match serde_json::to_vec(&attach_value) {
         Ok(b) => b,
         Err(e) => {

--- a/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
@@ -65,7 +65,13 @@ use mvm_hostd::supervisor::gateway_bridge::{
 
 /// Per-connection attach timeout. An abandoned connect must not wedge the
 /// standby (1a; pool size bounds the blast radius in 1b).
-const ATTACH_TIMEOUT: Duration = Duration::from_secs(30);
+// A prelaunched **pool** standby legitimately blocks a long time waiting to be claimed —
+// it's the warm pool's whole point. Its lifetime is bounded by the pool reaper TTL
+// (`mvmctl cache prune`, ~30 min), NOT a short self-timeout; a 30s value (Plan 118 WS-1 1a)
+// made standbys self-exit before a later `up` could claim them. The per-conn read timeout
+// (set on the accepted stream) still caps a connected-but-silent peer, so DoS protection is
+// unaffected. Keep this aligned with the reaper TTL.
+const ATTACH_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 /// Cap on the attach frame — workload config is small; reject hostile prefixes.
 const MAX_ATTACH_BYTES: usize = 1 << 20; // 1 MiB
 

--- a/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
@@ -42,22 +42,51 @@
 //! keeps resolving it.
 
 use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::process::ExitCode;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow};
+use chrono::Utc;
 use ed25519_dalek::SigningKey;
 use libkrun_sys::{
-    BridgeFds, LogLevel, SupervisorConfig, init_log, run_supervisor, run_supervisor_with_bridge,
-    set_log_level,
+    BridgeFds, LogLevel, SupervisorBaseConfig, SupervisorConfig, init_log, run_supervisor,
+    run_supervisor_with_bridge, set_log_level,
 };
-use mvm_core::plan::{ExecutionPlan, SignedExecutionPlan};
+use mvm_core::plan::{ExecutionPlan, NonceStore, SignedExecutionPlan};
 use mvm_core::policy::PolicyBundle;
 use mvm_hostd::supervisor::audit::AuditSigner;
 use mvm_hostd::supervisor::audit_file::FileAuditSigner;
 use mvm_hostd::supervisor::gateway_bridge::{
     AllowAll, BridgeConfig, BridgeEndpoints, spawn_bridge_thread,
 };
+
+/// Per-connection attach timeout. An abandoned connect must not wedge the
+/// standby (1a; pool size bounds the blast radius in 1b).
+const ATTACH_TIMEOUT: Duration = Duration::from_secs(30);
+/// Cap on the attach frame — workload config is small; reject hostile prefixes.
+const MAX_ATTACH_BYTES: usize = 1 << 20; // 1 MiB
+
+/// Stdin dispatch (Plan 118 WS-1 1a). The prelaunched producer wraps the base
+/// config under a unique `prelaunch_base` key; legacy callers emit a bare
+/// `SupervisorConfig` (no wrapper) and are byte-for-byte unchanged. Probed
+/// wrapper-first: a legacy config has no such key, so it falls through to the
+/// unchanged whole-config path. `deny_unknown_fields` + the disjoint required
+/// fields (`base_and_whole_configs_are_serde_disjoint` test in libkrun-sys)
+/// make this unambiguous — a botched prelaunch can never silently boot via the
+/// legacy arm (its `krun` is nested under `prelaunch_base`, so the bare-config
+/// fallback fails its required `krun` field too).
+///
+/// NB: a serde-tagged enum is deliberately avoided — `deny_unknown_fields` is
+/// unsupported on internally-tagged enums, and an `#[serde(untagged)]` fallback
+/// would silently route a malformed prelaunch to the permissive legacy arm.
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PrelaunchEnvelope {
+    prelaunch_base: SupervisorBaseConfig,
+}
 
 fn main() -> ExitCode {
     // macOS Hypervisor.framework rejects any process without
@@ -103,6 +132,13 @@ fn main() -> ExitCode {
         return ExitCode::from(2);
     }
 
+    // Prelaunch (warm-pool standby, Plan 118 WS-1 1a) vs legacy/cold (bare
+    // SupervisorConfig). The prelaunch producer wraps the base under a unique
+    // `prelaunch_base` key; legacy callers emit a bare config and route below
+    // unchanged.
+    if let Ok(env) = serde_json::from_str::<PrelaunchEnvelope>(&json) {
+        return run_prelaunched(env.prelaunch_base);
+    }
     let cfg: SupervisorConfig = match serde_json::from_str(&json) {
         Ok(c) => c,
         Err(e) => {
@@ -110,7 +146,14 @@ fn main() -> ExitCode {
             return ExitCode::from(2);
         }
     };
+    dispatch_config(cfg)
+}
 
+/// Shared tail: given a finalized `SupervisorConfig` (from the legacy stdin
+/// decode OR a verified prelaunch attach), bind the workload-exit control
+/// listener and route to the bridge/legacy boot path. Extracted so both
+/// entrypoints run identical post-config logic.
+fn dispatch_config(cfg: SupervisorConfig) -> ExitCode {
     // Plan 152 WS-A: bind the workload-exit control listener and capture
     // the guest's exit code on a background thread. Must bind BEFORE the
     // run dispatch (libkrun's listen=false proxy needs a live socket
@@ -126,7 +169,7 @@ fn main() -> ExitCode {
             .krun
             .vsock_socket_path(mvm_guest::vsock::WORKLOAD_EXIT_PORT);
         let _ = std::fs::remove_file(&control_sock);
-        match std::os::unix::net::UnixListener::bind(&control_sock) {
+        match UnixListener::bind(&control_sock) {
             Ok(listener) => {
                 std::thread::spawn(move || {
                     if let Err(e) = mvm_vm_host::exit_capture::capture_once(&listener, &state_dir) {
@@ -155,6 +198,112 @@ fn main() -> ExitCode {
         Err(e) => {
             eprintln!("supervisor failed: {e}");
             ExitCode::from(1)
+        }
+    }
+}
+
+/// Prelaunched-standby flow (Plan 118 WS-1 1a). `ensure_signed()` + the libkrun
+/// dylib are already warm (done in `main`). Bind the control UDS, accept ONE
+/// connection (per-conn timeout), read the attach frame, re-verify+merge, then
+/// hand the whole config to the existing bridge path. One-shot: any failure or
+/// timeout exits non-zero WITHOUT `start_enter`.
+fn run_prelaunched(base: SupervisorBaseConfig) -> ExitCode {
+    let sock_path = base.control_socket_path.clone();
+    let listener = match bind_control_socket(&sock_path) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("prelaunch: bind control socket {}: {e}", sock_path.display());
+            return ExitCode::from(3);
+        }
+    };
+    let mut stream = match accept_one_with_timeout(&listener, ATTACH_TIMEOUT) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("prelaunch: attach accept failed: {e}");
+            return ExitCode::from(4);
+        }
+    };
+    // Best-effort cleanup of the control socket — the workload-exit socket the
+    // bridge path binds is a different path under the state dir.
+    let _ = std::fs::remove_file(&sock_path);
+
+    // Read the length-prefixed attach frame, then re-encode to bytes for the
+    // pure verifier (which owns the deny_unknown_fields decode + plan verify).
+    let attach_value: serde_json::Value = match mvm_hostd::framing::read_json_frame_sync(
+        &mut stream,
+        MAX_ATTACH_BYTES,
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("prelaunch: read attach frame: {e}");
+            return ExitCode::from(5);
+        }
+    };
+    let attach_bytes = match serde_json::to_vec(&attach_value) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("prelaunch: re-encode attach: {e}");
+            return ExitCode::from(5);
+        }
+    };
+
+    let mut nonce_store = NonceStore::new();
+    let cfg = match mvm_vm_host::prelaunch::verify_and_merge_attach(
+        base,
+        &attach_bytes,
+        Utc::now(),
+        &mut nonce_store,
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            // SECURITY: refused — never start_enter.
+            eprintln!("prelaunch: attach refused: {e}");
+            return ExitCode::from(6);
+        }
+    };
+    dispatch_config(cfg)
+}
+
+/// Bind the control UDS at `path` with mode 0700, inside a 0700 parent dir.
+/// Mirrors the W1.2 vsock-proxy posture: same-uid only.
+fn bind_control_socket(path: &std::path::Path) -> std::io::Result<UnixListener> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+    }
+    let _ = std::fs::remove_file(path); // clear a stale socket
+    let listener = UnixListener::bind(path)?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    Ok(listener)
+}
+
+/// Accept exactly one connection within `timeout`, else error. Sets a read
+/// timeout on the accepted stream too, so a connected-but-silent peer can't
+/// wedge the standby.
+fn accept_one_with_timeout(
+    listener: &UnixListener,
+    timeout: Duration,
+) -> std::io::Result<UnixStream> {
+    listener.set_nonblocking(true)?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                stream.set_nonblocking(false)?;
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                stream.set_read_timeout(Some(remaining.max(Duration::from_millis(1))))?;
+                return Ok(stream);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "attach timeout",
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => return Err(e),
         }
     }
 }

--- a/crates/mvm-vm-host/src/lib.rs
+++ b/crates/mvm-vm-host/src/lib.rs
@@ -14,6 +14,10 @@
 pub mod exit_capture;
 pub mod firecracker_bridge;
 
+/// Plan 118 WS-1 1a — the prelaunched-supervisor attach verify+merge. Pure
+/// (no VM, no `start_enter`) so the rejection ladder is unit-testable.
+pub mod prelaunch;
+
 // Rust-native Vz supervisor objc2 bridge (Plan 152 WS-B). macOS-only — the
 // objc2 Virtualization.framework stack only exists there; the
 // `mvm-vz-supervisor` bin is the sole consumer. Kept in the lib (not inline in

--- a/crates/mvm-vm-host/src/prelaunch.rs
+++ b/crates/mvm-vm-host/src/prelaunch.rs
@@ -1,0 +1,209 @@
+//! Plan 118 WS-1 Layer 1a — prelaunched-supervisor attach verify+merge.
+//!
+//! The cold/legacy supervisor path extracts the admitted plan without
+//! re-verifying (host-trusted private stdin pipe, ADR-002). The warm path's
+//! control UDS is **same-uid-reachable**, so it is NOT a trusted private
+//! channel — this module re-verifies the signed `ExecutionPlan` (Ed25519
+//! signature + G4 window + nonce-replay) before the caller may `start_enter`.
+//! Reuses `mvm_core::plan::{verify_plan, check_window, NonceStore}`; no fork.
+
+use chrono::{DateTime, Utc};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use libkrun_sys::{SupervisorAttachConfig, SupervisorBaseConfig, SupervisorConfig};
+use mvm_core::plan::{NonceStore, SignedExecutionPlan, check_window, verify_plan};
+
+/// Why an attach was refused. Every variant means the caller must NOT
+/// `start_enter` — the standby exits non-zero.
+#[derive(Debug, thiserror::Error)]
+pub enum AttachVerifyError {
+    #[error("decode attach config: {0}")]
+    Decode(String),
+    #[error("merge base+attach: {0}")]
+    Merge(#[from] libkrun_sys::AttachMergeError),
+    #[error("read host signing key {0}: {1}")]
+    ReadKey(String, String),
+    #[error("host signing key is {0} bytes, expected 32")]
+    KeyLen(usize),
+    #[error("decode SignedExecutionPlan envelope: {0}")]
+    Envelope(String),
+    #[error("plan signature verify failed: {0}")]
+    PlanVerify(String),
+    #[error("plan validity (window/nonce): {0}")]
+    Validity(String),
+}
+
+/// Verify a control-UDS `attach` against a prelaunched standby's `base` and,
+/// on success, return the whole `SupervisorConfig` the caller hands to the
+/// existing `run_with_bridge` path. **Never boots** — the caller calls
+/// `start_enter` only on `Ok`.
+///
+/// Order mirrors `mvm_hostd::supervisor::aggregate::launch`:
+/// merge (binding-nonce echo) → signature → G4 window → nonce-replay.
+pub fn verify_and_merge_attach(
+    base: SupervisorBaseConfig,
+    attach_bytes: &[u8],
+    now: DateTime<Utc>,
+    nonce_store: &mut NonceStore,
+) -> Result<SupervisorConfig, AttachVerifyError> {
+    // Pull the bits we still need after `base`/`attach` are moved into the merge.
+    let signer_id = base.signer_id.clone();
+    let key_path = base.signing_key_path.clone();
+
+    let attach: SupervisorAttachConfig = serde_json::from_slice(attach_bytes)
+        .map_err(|e| AttachVerifyError::Decode(e.to_string()))?;
+    let plan_value = attach.plan.clone();
+
+    // Binding-nonce echo + field merge (also rejects a base carrying a rootfs).
+    let cfg = SupervisorConfig::from_base_and_attach(base, attach)?;
+
+    // Derive the host-signer PUBLIC key from the on-disk secret. The key is
+    // host-trusted state (claim 8); the secret never leaves this process. Same
+    // 32-byte read the cold path's audit signer performs.
+    let key_bytes = std::fs::read(&key_path)
+        .map_err(|e| AttachVerifyError::ReadKey(key_path.display().to_string(), e.to_string()))?;
+    let key_arr: [u8; 32] = key_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| AttachVerifyError::KeyLen(key_bytes.len()))?;
+    let vk: VerifyingKey = SigningKey::from_bytes(&key_arr).verifying_key();
+
+    // Re-verify the signature — the load-bearing warm-path invariant.
+    let signed: SignedExecutionPlan = serde_json::from_value(plan_value)
+        .map_err(|e| AttachVerifyError::Envelope(e.to_string()))?;
+    let plan = verify_plan(&signed, &[(signer_id.as_str(), &vk)])
+        .map_err(|e| AttachVerifyError::PlanVerify(e.to_string()))?;
+
+    // G4 validity window + per-signer nonce-replay.
+    check_window(&plan, now).map_err(|e| AttachVerifyError::Validity(e.to_string()))?;
+    nonce_store
+        .check_and_insert(&signed.0.signer_id, &plan)
+        .map_err(|e| AttachVerifyError::Validity(e.to_string()))?;
+
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, TimeZone, Utc};
+    use ed25519_dalek::SigningKey;
+    use libkrun_sys::{BridgeRestartPolicy, KrunContext, SupervisorAttachConfig, SupervisorBaseConfig};
+    use mvm_core::plan::signing::test_support::sample_plan;
+    use mvm_core::plan::{ExecutionPlan, NonceStore, sign_plan};
+    use std::io::Write;
+
+    const NONCE: &str = "binding-nonce-fixed-for-tests";
+
+    // A 32-byte ed25519 secret written to a tempfile; returns (path, signing key).
+    fn write_key(dir: &std::path::Path) -> (std::path::PathBuf, SigningKey) {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let path = dir.join("host-signer.ed25519");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(key.to_bytes().as_slice()).unwrap();
+        (path, key)
+    }
+
+    fn plan_around(now: chrono::DateTime<Utc>) -> ExecutionPlan {
+        let mut p = sample_plan();
+        p.valid_from = now - Duration::minutes(5);
+        p.valid_until = now + Duration::minutes(5);
+        p
+    }
+
+    fn base(key_path: std::path::PathBuf, signer_id: &str) -> SupervisorBaseConfig {
+        let mut krun = KrunContext::new("standby-0", "/k/vmlinux", "/placeholder");
+        krun.rootfs_path = None;
+        SupervisorBaseConfig {
+            krun,
+            vm_state_dir: "/run/mvm/standby-0".into(),
+            pid_file_name: None,
+            signing_key_path: key_path,
+            signer_id: signer_id.into(),
+            binding_nonce: NONCE.into(),
+            control_socket_path: "/run/mvm/standby-0/control.sock".into(),
+            bridge_restart_policy: BridgeRestartPolicy::HardFail,
+        }
+    }
+
+    fn attach_bytes(nonce: &str, plan_envelope: serde_json::Value) -> Vec<u8> {
+        let attach = SupervisorAttachConfig {
+            binding_nonce: nonce.into(),
+            rootfs_path: "/vol/rootfs.ext4".into(),
+            tenant_id: "tenant-a".into(),
+            audit_dir: "/audit".into(),
+            gateway_audit_socket: "/audit/g.sock".into(),
+            gateway_events_socket: None,
+            plan: plan_envelope,
+            bundle: None,
+        };
+        serde_json::to_vec(&attach).unwrap()
+    }
+
+    fn signed_envelope(plan: &ExecutionPlan, key: &SigningKey, signer_id: &str) -> serde_json::Value {
+        serde_json::to_value(sign_plan(plan, key, signer_id)).unwrap()
+    }
+
+    #[test]
+    fn happy_path_returns_admitted_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, key) = write_key(dir.path());
+        let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let plan = plan_around(now);
+        let bytes = attach_bytes(NONCE, signed_envelope(&plan, &key, "host:test"));
+        let mut store = NonceStore::new();
+        let cfg = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap();
+        assert_eq!(cfg.krun.rootfs_path.as_deref(), Some("/vol/rootfs.ext4"));
+        assert_eq!(cfg.tenant_id.as_deref(), Some("tenant-a"));
+    }
+
+    #[test]
+    fn rejects_wrong_binding_nonce() {
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, key) = write_key(dir.path());
+        let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let bytes = attach_bytes("WRONG", signed_envelope(&plan_around(now), &key, "host:test"));
+        let mut store = NonceStore::new();
+        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
+        assert!(matches!(err, AttachVerifyError::Merge(_)));
+    }
+
+    #[test]
+    fn rejects_unsigned_plan_wrong_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, _real) = write_key(dir.path());
+        let attacker = SigningKey::from_bytes(&[9u8; 32]); // not the on-disk key
+        let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let bytes = attach_bytes(NONCE, signed_envelope(&plan_around(now), &attacker, "host:test"));
+        let mut store = NonceStore::new();
+        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
+        assert!(matches!(err, AttachVerifyError::PlanVerify(_)));
+    }
+
+    #[test]
+    fn rejects_out_of_window_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, key) = write_key(dir.path());
+        let plan_now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let plan = plan_around(plan_now);
+        let bytes = attach_bytes(NONCE, signed_envelope(&plan, &key, "host:test"));
+        // Verify an hour after the window closed.
+        let later = plan_now + Duration::hours(1);
+        let mut store = NonceStore::new();
+        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, later, &mut store).unwrap_err();
+        assert!(matches!(err, AttachVerifyError::Validity(_)));
+    }
+
+    #[test]
+    fn rejects_replayed_nonce() {
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, key) = write_key(dir.path());
+        let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let plan = plan_around(now);
+        let bytes = attach_bytes(NONCE, signed_envelope(&plan, &key, "host:test"));
+        let mut store = NonceStore::new();
+        // First admit succeeds; second (same store, same plan) is a replay.
+        verify_and_merge_attach(base(kp.clone(), "host:test"), &bytes, now, &mut store).unwrap();
+        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
+        assert!(matches!(err, AttachVerifyError::Validity(_)));
+    }
+}

--- a/crates/mvm-vm-host/src/prelaunch.rs
+++ b/crates/mvm-vm-host/src/prelaunch.rs
@@ -87,7 +87,9 @@ mod tests {
     use super::*;
     use chrono::{Duration, TimeZone, Utc};
     use ed25519_dalek::SigningKey;
-    use libkrun_sys::{BridgeRestartPolicy, KrunContext, SupervisorAttachConfig, SupervisorBaseConfig};
+    use libkrun_sys::{
+        BridgeRestartPolicy, KrunContext, SupervisorAttachConfig, SupervisorBaseConfig,
+    };
     use mvm_core::plan::signing::test_support::sample_plan;
     use mvm_core::plan::{ExecutionPlan, NonceStore, sign_plan};
     use std::io::Write;
@@ -139,7 +141,11 @@ mod tests {
         serde_json::to_vec(&attach).unwrap()
     }
 
-    fn signed_envelope(plan: &ExecutionPlan, key: &SigningKey, signer_id: &str) -> serde_json::Value {
+    fn signed_envelope(
+        plan: &ExecutionPlan,
+        key: &SigningKey,
+        signer_id: &str,
+    ) -> serde_json::Value {
         serde_json::to_value(sign_plan(plan, key, signer_id)).unwrap()
     }
 
@@ -161,9 +167,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (kp, key) = write_key(dir.path());
         let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
-        let bytes = attach_bytes("WRONG", signed_envelope(&plan_around(now), &key, "host:test"));
+        let bytes = attach_bytes(
+            "WRONG",
+            signed_envelope(&plan_around(now), &key, "host:test"),
+        );
         let mut store = NonceStore::new();
-        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
+        let err =
+            verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
         assert!(matches!(err, AttachVerifyError::Merge(_)));
     }
 
@@ -173,9 +183,13 @@ mod tests {
         let (kp, _real) = write_key(dir.path());
         let attacker = SigningKey::from_bytes(&[9u8; 32]); // not the on-disk key
         let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
-        let bytes = attach_bytes(NONCE, signed_envelope(&plan_around(now), &attacker, "host:test"));
+        let bytes = attach_bytes(
+            NONCE,
+            signed_envelope(&plan_around(now), &attacker, "host:test"),
+        );
         let mut store = NonceStore::new();
-        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
+        let err =
+            verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
         assert!(matches!(err, AttachVerifyError::PlanVerify(_)));
     }
 
@@ -189,7 +203,8 @@ mod tests {
         // Verify an hour after the window closed.
         let later = plan_now + Duration::hours(1);
         let mut store = NonceStore::new();
-        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, later, &mut store).unwrap_err();
+        let err =
+            verify_and_merge_attach(base(kp, "host:test"), &bytes, later, &mut store).unwrap_err();
         assert!(matches!(err, AttachVerifyError::Validity(_)));
     }
 
@@ -203,7 +218,8 @@ mod tests {
         let mut store = NonceStore::new();
         // First admit succeeds; second (same store, same plan) is a replay.
         verify_and_merge_attach(base(kp.clone(), "host:test"), &bytes, now, &mut store).unwrap();
-        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
+        let err =
+            verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
         assert!(matches!(err, AttachVerifyError::Validity(_)));
     }
 }

--- a/crates/mvm-vm-host/tests/prelaunch_live.rs
+++ b/crates/mvm-vm-host/tests/prelaunch_live.rs
@@ -114,7 +114,11 @@ fn wrong_nonce_attach_is_refused_without_boot() {
 
     let code = wait_code(&mut child, Duration::from_secs(10));
     // ExitCode::from(6) — the prelaunch "attach refused" arm.
-    assert_eq!(code, Some(6), "wrong-nonce attach must be refused with exit 6");
+    assert_eq!(
+        code,
+        Some(6),
+        "wrong-nonce attach must be refused with exit 6"
+    );
 
     // No workload-exit control socket should ever have been bound (that only
     // happens in dispatch_config, which a refused attach never reaches).

--- a/crates/mvm-vm-host/tests/prelaunch_live.rs
+++ b/crates/mvm-vm-host/tests/prelaunch_live.rs
@@ -110,7 +110,7 @@ fn wrong_nonce_attach_is_refused_without_boot() {
         plan: serde_json::json!({ "ignored": "never-reached" }),
         bundle: None,
     };
-    mvm_hostd::framing::write_json_frame_sync(&mut stream, &attach).unwrap();
+    libkrun_sys::framing::write_json_frame_sync(&mut stream, &attach).unwrap();
 
     let code = wait_code(&mut child, Duration::from_secs(10));
     // ExitCode::from(6) — the prelaunch "attach refused" arm.

--- a/crates/mvm-vm-host/tests/prelaunch_live.rs
+++ b/crates/mvm-vm-host/tests/prelaunch_live.rs
@@ -1,0 +1,138 @@
+//! Plan 118 WS-1 1a — process-level integration for the prelaunched supervisor.
+//!
+//! Gated behind `libkrun-live` because spawning `mvm-libkrun-supervisor`
+//! requires the `libkrun-sys` feature (FFI link to libkrun). Two scenarios:
+//!
+//! 1. `wrong_nonce_attach_is_refused_without_boot` — runnable anywhere libkrun
+//!    links: the attach is refused at `verify_and_merge_attach` *before* any
+//!    `start_enter`, so it exercises the full stdin-dispatch → control-UDS bind
+//!    → accept → frame-read → refuse → exit(6) path with no VM.
+//! 2. `valid_attach_boots_and_agent_reachable` — `#[ignore]`: needs a real
+//!    kernel + rootfs + in-guest agent. Run manually on a libkrun-capable host;
+//!    model the boot/agent-ping on `examples/agent_ping` + the core-demo e2e.
+#![cfg(feature = "libkrun-live")]
+
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use libkrun_sys::{BridgeRestartPolicy, KrunContext, SupervisorAttachConfig, SupervisorBaseConfig};
+
+/// The supervisor bin built for this test target (cargo sets this because the
+/// bin's `required-features = ["libkrun-sys"]` are satisfied via libkrun-live).
+const SUPERVISOR_BIN: &str = env!("CARGO_BIN_EXE_mvm-libkrun-supervisor");
+
+fn base(dir: &Path, binding_nonce: &str) -> SupervisorBaseConfig {
+    // Kernel/rootfs paths are bogus — the refusal path never boots, so they are
+    // never read. `rootfs_path` is nulled (a standby carries no workload rootfs).
+    let mut krun = KrunContext::new("test-standby", "/nonexistent/kernel", "/nonexistent/rootfs");
+    krun.rootfs_path = None;
+    SupervisorBaseConfig {
+        krun,
+        vm_state_dir: dir.join("state").to_string_lossy().into_owned(),
+        pid_file_name: None,
+        signing_key_path: dir.join("host-signer.ed25519"),
+        signer_id: "host:test".into(),
+        binding_nonce: binding_nonce.into(),
+        control_socket_path: dir.join("control.sock"),
+        bridge_restart_policy: BridgeRestartPolicy::HardFail,
+    }
+}
+
+/// Poll-connect to the control UDS until the supervisor binds it (it binds only
+/// after reading stdin), or the deadline elapses.
+fn connect_with_retry(path: &Path, timeout: Duration) -> UnixStream {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(s) = UnixStream::connect(path) {
+            return s;
+        }
+        if Instant::now() >= deadline {
+            panic!("control socket {} never appeared", path.display());
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+/// Wait for `child` to exit within `timeout`, returning its exit code; kills it
+/// and panics on timeout so a wedged supervisor fails the test fast.
+fn wait_code(child: &mut std::process::Child, timeout: Duration) -> Option<i32> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("try_wait") {
+            return status.code();
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            panic!("supervisor did not exit within {timeout:?}");
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[test]
+fn wrong_nonce_attach_is_refused_without_boot() {
+    let dir = tempfile::tempdir().unwrap();
+    let base = base(dir.path(), "correct-binding-nonce");
+    let control_path = base.control_socket_path.clone();
+
+    let stdin_json = serde_json::to_string(&serde_json::json!({ "prelaunch_base": base })).unwrap();
+
+    let mut child = Command::new(SUPERVISOR_BIN)
+        // Skip the codesign re-exec (already signed in dev); keeps stdin piping
+        // deterministic for the test.
+        .env("MVM_SIGNED", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mvm-libkrun-supervisor");
+
+    {
+        let mut stdin = child.stdin.take().unwrap();
+        stdin.write_all(stdin_json.as_bytes()).unwrap();
+        // drop closes stdin → the bin's read_to_string returns.
+    }
+
+    let mut stream = connect_with_retry(&control_path, Duration::from_secs(5));
+
+    // Echo the WRONG binding nonce — from_base_and_attach rejects before any
+    // libkrun call, so the supervisor exits 6 without ever booting.
+    let attach = SupervisorAttachConfig {
+        binding_nonce: "totally-wrong-nonce".into(),
+        rootfs_path: "/nonexistent/rootfs.ext4".into(),
+        tenant_id: "tenant-a".into(),
+        audit_dir: dir.path().join("audit"),
+        gateway_audit_socket: dir.path().join("audit/g.sock"),
+        gateway_events_socket: None,
+        plan: serde_json::json!({ "ignored": "never-reached" }),
+        bundle: None,
+    };
+    mvm_hostd::framing::write_json_frame_sync(&mut stream, &attach).unwrap();
+
+    let code = wait_code(&mut child, Duration::from_secs(10));
+    // ExitCode::from(6) — the prelaunch "attach refused" arm.
+    assert_eq!(code, Some(6), "wrong-nonce attach must be refused with exit 6");
+
+    // No workload-exit control socket should ever have been bound (that only
+    // happens in dispatch_config, which a refused attach never reaches).
+    let workload_exit_sock = dir.path().join("state").join("vsock-5251.sock");
+    assert!(
+        !workload_exit_sock.exists(),
+        "refused attach must not have reached the boot path"
+    );
+}
+
+#[test]
+#[ignore = "needs a real kernel+rootfs+agent; run manually on a libkrun-capable host (model on examples/agent_ping)"]
+fn valid_attach_boots_and_agent_reachable() {
+    // Build a BaseConfig with a real kernel + the agent port in host_listen_ports,
+    // spawn the supervisor, connect to the control UDS, and write_json_frame_sync
+    // a SupervisorAttachConfig whose `plan` is a freshly-signed admitted envelope
+    // (sign with the same on-disk host key the base points at) + a real rootfs.
+    // Assert the agent answers a ping. Left as an explicit manual harness — the
+    // refusal path above + the Task 3 unit ladder cover the security logic.
+    unimplemented!("manual live-boot harness — see module docs");
+}

--- a/crates/mvm-vm-host/tests/standby_pool_live.rs
+++ b/crates/mvm-vm-host/tests/standby_pool_live.rs
@@ -1,0 +1,93 @@
+//! Plan 118 WS-1 1b — live integration for the libkrun standby pool, driving the **real**
+//! `LibkrunBackend::spawn_standby`/`claim_standby` through the `VmBackend` trait + the real
+//! `mvm-libkrun-supervisor` binary.
+//!
+//! Gated behind `libkrun-live` (needs libkrun to link + a supervisor bin on PATH/alongside).
+//! Two scenarios:
+//!
+//! 1. `spawn_standby_binds_control_socket` — runnable wherever libkrun links: a spawned
+//!    standby is a live process that binds its control UDS and blocks before any boot. No
+//!    guest kernel is touched until claim, so this proves the backend→bin spawn wiring with
+//!    no bootable image.
+//! 2. `valid_attach_boots_and_agent_reachable` — `#[ignore]`: the full spawn→claim→boot
+//!    happy path needs a real default-microvm kernel/rootfs + in-guest agent. Run manually
+//!    on a libkrun-capable host (model on `examples/agent_ping` + the 1a prelaunch harness);
+//!    the refusal logic + spawn wiring are covered by the unit ladder + scenario 1.
+#![cfg(feature = "libkrun-live")]
+
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use mvm_core::vm_backend::{StandbySpec, VmBackend};
+
+/// Build a StandbySpec that pre-loads a (bogus) kernel — the prelaunch supervisor blocks on
+/// the control UDS *before* loading the kernel, so the kernel path is never read until a
+/// claim, and this scenario never claims.
+fn spec(dir: &Path, nonce: &str) -> StandbySpec {
+    StandbySpec {
+        id: format!("standby-{nonce}"),
+        kernel_path: "/nonexistent/vmlinux".into(),
+        kernel_sha256: "a".repeat(64),
+        vcpus: 1,
+        mem_mib: 256,
+        signing_key_path: dir.join("host-signer.ed25519"),
+        signer_id: "host:test".into(),
+        binding_nonce: nonce.into(),
+        control_socket: dir.join(format!("control-{nonce}.sock")),
+        vm_state_dir: dir.join("state").to_string_lossy().into_owned(),
+    }
+}
+
+fn wait_for_socket(path: &Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if UnixStream::connect(path).is_ok() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    false
+}
+
+fn pid_alive(pid: u32) -> bool {
+    // SAFETY: kill(pid, 0) is a liveness probe with no signal delivered.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[test]
+fn spawn_standby_binds_control_socket() {
+    let dir = tempfile::tempdir().unwrap();
+    let backend = mvm_backend::libkrun::LibkrunBackend;
+    assert!(backend.supports_standby_pool());
+
+    let handle = backend
+        .spawn_standby(&spec(dir.path(), "deadbeef01"))
+        .expect("spawn_standby");
+
+    // The spawned supervisor is a live process that binds its control UDS and blocks there
+    // (before any boot). Both must hold for the warm-pool primitive to be claimable.
+    assert!(
+        wait_for_socket(&handle.control_socket, Duration::from_secs(10)),
+        "standby must bind its control UDS"
+    );
+    assert!(
+        pid_alive(handle.pid),
+        "standby supervisor must be alive and blocked"
+    );
+
+    // Cleanup: the standby would otherwise block until its attach timeout. Reap it.
+    // SAFETY: SIGTERM to a pid we just spawned.
+    unsafe { libc::kill(handle.pid as libc::pid_t, libc::SIGTERM) };
+}
+
+#[test]
+#[ignore = "needs a real kernel+rootfs+agent; run manually on a libkrun-capable host (model on examples/agent_ping)"]
+fn valid_attach_boots_and_agent_reachable() {
+    // Build a StandbySpec with the default-microvm kernel + the agent vsock port, spawn it,
+    // then `claim_standby` with a StandbyClaim whose plan_json is a freshly-signed admitted
+    // envelope (signed with the SAME on-disk host key the spec points at) + a real rootfs.
+    // Assert the guest boots and the agent answers a vsock ping. Left as a manual harness —
+    // scenario 1 + the unit ladder cover the spawn wiring and the claim/verify logic.
+    unimplemented!("manual live-boot harness — see module docs");
+}

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status — rollup checklist
 
-**Last updated: 2026-06-09**
+**Last updated: 2026-06-10**
 
 > MAINTENANCE: keep this file current. Whenever you land, merge, or descope a
 > workstream in any plan below, tick/strike the matching box here in the SAME
@@ -101,11 +101,13 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
   [x] WS-4 resumable + honest-cost dev-image download — PR #667
   [x] WS-5 E streamed exec (ExecEvent) — PR #712 (plan-172)
   [x] WS-5 E follow-up: enforce exec timeout_secs — plan-173
-  [~] WS-1 warm pool (Plan 118): 1a primitive (#748) + 1b-i mechanism (#751,
-      trait seam + registry + libkrun impl) + 1b-ii (reaper + cache-prune,
-      doctor standby column, `mvmctl pool warm/status`, bench state-dir fix)
-      landed; remaining: `up`/`run` auto-claim (name-rebind + bridge confirm),
-      `--warm-pool-size`, multi-kernel keying, committed bench delta (SPRINT.md)
+  [~] WS-1 warm pool (Plan 118): 1a primitive + 1b-i trait seam/registry/libkrun
+      + 1b-ii reaper/doctor/`mvmctl pool`/bench-fix + 1b-iii up auto-claim
+      (try_warm_claim/replenish/--warm-pool-size, fail-open) — landed (consolidated
+      PR off the #748/#751/#754/#756 stack). Bridge boot LIVE-VALIDATED (exit 7;
+      up.rs "bridge broken" comment stale). Remaining: bundled-kernel compat key so
+      the libkrun mkGuest warm claim fires (kernel absent pre-boot); multi-kernel
+      keying; honour --name/volumes; committed bench delta (SPRINT.md)
   [ ] WS-2 checkpoint+fork  (152 WS-B done; unblocked)
   [ ] WS-5 D verb renames; curl|sh installer; --json remainder
   [ ] signed delta-image distribution (unowned — needs a home)

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -101,7 +101,10 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
   [x] WS-4 resumable + honest-cost dev-image download — PR #667
   [x] WS-5 E streamed exec (ExecEvent) — PR #712 (plan-172)
   [x] WS-5 E follow-up: enforce exec timeout_secs — plan-173
-  [ ] WS-1 warm pool / WS-2 checkpoint+fork  (gated on 152 WS-B)
+  [~] WS-1 warm pool (Plan 118): 1a prelaunched-supervisor primitive landed
+      (base/attach split + attach-time plan re-verify + fuzz + a–e ladder,
+      feat/plan-118-ws1-layer1a); 1b pool/up-claim/bench remains
+  [ ] WS-2 checkpoint+fork  (152 WS-B done; unblocked)
   [ ] WS-5 D verb renames; curl|sh installer; --json remainder
   [ ] signed delta-image distribution (unowned — needs a home)
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -103,7 +103,7 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
   [x] WS-5 E follow-up: enforce exec timeout_secs — plan-173
   [~] WS-1 warm pool (Plan 118): 1a prelaunched-supervisor primitive landed
       (base/attach split + attach-time plan re-verify + fuzz + a–e ladder,
-      feat/plan-118-ws1-layer1a); 1b pool/up-claim/bench remains
+      PR #748); 1b pool/up-claim/bench remains
   [ ] WS-2 checkpoint+fork  (152 WS-B done; unblocked)
   [ ] WS-5 D verb renames; curl|sh installer; --json remainder
   [ ] signed delta-image distribution (unowned — needs a home)

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -101,9 +101,11 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
   [x] WS-4 resumable + honest-cost dev-image download — PR #667
   [x] WS-5 E streamed exec (ExecEvent) — PR #712 (plan-172)
   [x] WS-5 E follow-up: enforce exec timeout_secs — plan-173
-  [~] WS-1 warm pool (Plan 118): 1a prelaunched-supervisor primitive landed
-      (base/attach split + attach-time plan re-verify + fuzz + a–e ladder,
-      PR #748); 1b pool/up-claim/bench remains
+  [~] WS-1 warm pool (Plan 118): 1a primitive (#748) + 1b-i mechanism (#751,
+      trait seam + registry + libkrun impl) + 1b-ii (reaper + cache-prune,
+      doctor standby column, `mvmctl pool warm/status`, bench state-dir fix)
+      landed; remaining: `up`/`run` auto-claim (name-rebind + bridge confirm),
+      `--warm-pool-size`, multi-kernel keying, committed bench delta (SPRINT.md)
   [ ] WS-2 checkpoint+fork  (152 WS-B done; unblocked)
   [ ] WS-5 D verb renames; curl|sh installer; --json remainder
   [ ] signed delta-image distribution (unowned — needs a home)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2533,3 +2533,34 @@ Tracked as GitHub issues so they're individually grabbable:
 - [x] Docs parity maintenance — added a lifecycle-matrix SDK guide separating current CLI support, current Python/TypeScript SDK support, and runtime parity targets.
 - [x] Docs parity maintenance — added a control-surfaces architecture page covering CLI, SDKs, MCP stdio, console, guest RPC, and not-claimed local management surfaces.
 - [x] Docs parity maintenance — added a platform-support reference page covering Linux, macOS, Windows future work, Docker fallback, host/backend status, and guest target strings.
+
+### Plan 118 WS-1 1b — supervisor warm pool: deferred follow-ups
+
+1a (#748) + 1b-i (#751, mechanism) + 1b-ii (reaper + doctor column + `mvmctl pool
+warm/status` + bench state-dir fix) shipped. Remaining, individually grabbable:
+
+- [ ] **`up`/`run` auto-claim wiring.** `claim_or_cold` is closure-ready (it builds the
+  `StandbyClaim` per the selected standby so the name-keyed audit substrate
+  `gateway-<vm>.sock` resolves for the standby-id). The wiring is held back on two
+  coupled items: (a) a claimed VM runs under its **standby-id** (its vsock socket dir is
+  baked at spawn), so `up.rs` must rebind the ~40 downstream `vm_name` references for a
+  warm launch — risky surgery in the core command; (b) a claim forces the supervisor's
+  **`run_with_bridge`** path (the attach carries tenant+plan+audit), which `up.rs:~1906`
+  documents as not-working-by-default on libkrun ("gvproxy vfkit socket empty") — though
+  that comment predates Plan 123 Phase A (#727/#647) wiring egress policy *live* on the
+  libkrun bridge, so it may be stale. **First step: confirm a libkrun bridge-path boot
+  works end-to-end** (run the `#[ignore]`'d `valid_attach_boots_and_agent_reachable`), then
+  do the name-rebind. Until then `up` always cold-boots; `mvmctl pool warm` pre-spawns
+  standbys but nothing auto-claims them.
+- [ ] **`--warm-pool-size` flag on `up`** (threads to `VmStartConfig.warm_pool_size` +
+  replenish-on-use) — lands with the auto-claim, since replenish without claim only
+  accumulates unclaimed standbys.
+- [ ] **Multi-kernel pool keying.** v1 is default-kernel + default-resources only
+  (`StandbyCompat` = kernel sha256 + vcpus + mem; non-matching launches cold-boot).
+  Generalize to per-(kernel,shape) targets + eviction once a second shape is common.
+- [ ] **Honour an explicit `--name` / extra `--volume`s for warm launches.** v1 only
+  claims for auto-named, volume-less launches (1a's attach threads only the rootfs; a
+  claimed VM is named by standby-id).
+- [ ] **Committed bench baseline + cold-vs-warm delta.** The state-dir fix unblocks the
+  probe; a real baseline still needs a freshly-built `default-microvm` image (rides
+  PR-10a's deferral).

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2564,3 +2564,29 @@ warm/status` + bench state-dir fix) shipped. Remaining, individually grabbable:
 - [ ] **Committed bench baseline + cold-vs-warm delta.** The state-dir fix unblocks the
   probe; a real baseline still needs a freshly-built `default-microvm` image (rides
   PR-10a's deferral).
+
+#### Plan 118 WS-1 1b auto-claim — live validation findings (2026-06-10)
+
+The `up` auto-claim wiring shipped (try_warm_claim/replenish/--warm-pool-size, fail-open).
+A live libkrun bridge boot was confirmed: `MVM_GATEWAY_BRIDGE=1 mvmctl up --flake
+examples/exit_code --hypervisor libkrun --wait` → **exit 7** (the `up.rs` "bridge gvproxy
+broken" comment is STALE — `run_with_bridge` boots end-to-end today). Two real fixes/finds:
+
+- [x] **Standby attach timeout 30s → 30 min.** A pool standby legitimately waits to be
+  claimed; the 1a `ATTACH_TIMEOUT=30s` made standbys self-exit before a later `up` could
+  claim them. Bounded now by the pool reaper TTL, not a short self-timeout.
+- [ ] **Compat key can't be the workload kernel sha for libkrun mkGuest.** A mkGuest image
+  ships no kernel; libkrun materializes the *bundled* kernel at `start_enter`, so
+  `cfg.kernel_path` is **absent** when `try_warm_claim` runs → it always fails open to cold
+  boot. A libkrun standby is workload-independent (bundled kernel + resources; rootfs at
+  attach), so the compat key must be the **bundled kernel** sha (or just (vcpus, mem) for
+  libkrun), not the workload path. This is the last blocker to the libkrun warm claim
+  firing end-to-end; the bundled-kernel identity lives in `libkrun-sys`, so it needs a
+  small cross-layer helper. Everything else (eligibility, claim, name-rebind, replenish,
+  reaper) is wired + fail-open + validated.
+- [ ] **`pool status` lists dead-but-unreaped standbys as "idle"** (it shows recorded
+  state, not liveness). Cosmetic — `select_idle_compatible` correctly skips dead pids;
+  filter the display by `pid_alive` for accuracy.
+- [ ] Independent bug: `libkrun_sys::home_mvm_keys_dir()` hardcodes `$HOME/.mvm/keys` and
+  ignores `MVM_DATA_DIR`, so `validate_audit_substrate` rejects an isolated data dir. Route
+  it through `mvm_core::config`.

--- a/specs/notes/plan-118-ws1-layer1a-implementation-plan.md
+++ b/specs/notes/plan-118-ws1-layer1a-implementation-plan.md
@@ -1,0 +1,1131 @@
+# Plan 118 WS-1 Layer 1a — Prelaunched libkrun Supervisor: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (only if dispatched agents can run Bash/build/test/commit in this environment) or
+> superpowers:executing-plans (inline) to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+>
+> **Authoritative design:** `specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md`
+> and `specs/plans/118-supervisor-standby-pool-and-live-bench.md` §PR-10b.
+
+**Goal:** Add a *prelaunched* mode to `mvm-libkrun-supervisor` that does the
+workload-independent setup at spawn, blocks on a control UDS holding no rootfs/plan,
+and on a verified `attach` message re-verifies the signed `ExecutionPlan` and only
+then boots — the security-critical primitive a 1b warm pool is built from.
+
+**Architecture:** Split `SupervisorConfig` into a workload-independent
+`SupervisorBaseConfig` (spawned with) and a workload-specific `SupervisorAttachConfig`
+(arrives over the control UDS). A pure `verify_and_merge_attach` function performs the
+binding-nonce echo check, field merge, and the load-bearing plan re-verify
+(Ed25519 signature + G4 window + nonce-replay) — reusing `mvm_core::plan::{verify_plan,
+check_window, NonceStore}` verbatim, never forking a second verifier. The cold/legacy
+path (bare `SupervisorConfig` on stdin, no control UDS) is byte-for-byte unchanged.
+
+**Tech Stack:** Rust, `libkrun-sys` (FFI feature-gated), `mvm-core::plan` (signing +
+validity), `mvm-hostd::framing` (length-prefixed JSON), `ed25519-dalek`, `cargo-fuzz`.
+
+---
+
+## Why the security crux matters (read before coding)
+
+The cold path (`mvm-libkrun-supervisor.rs:204-217`) *deliberately skips* plan re-verify:
+the host admitted the plan and stdin is a private parent→child pipe, trusted under
+ADR-002 — it **extracts**, it does not verify. The warm path's control UDS is
+**same-uid-reachable**, so it is NOT a trusted private channel. The supervisor MUST
+independently re-verify before `start_enter`. This is the one new security invariant
+1a adds. Cross-standby replay is closed by a **per-spawn binding nonce** that the attach
+must echo (a standby with a different nonce rejects), combined with **one-shot attach**
+(accept exactly one connection, then boot-or-die) and the plan's G4 window. Within-standby
+replay is closed by the `NonceStore`.
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `crates/mvm-hostd/src/framing.rs` | Add sync `read_json_frame_sync`/`write_json_frame_sync` sharing `FrameError` + cap logic (the prelaunch accept path is sync — no tokio runtime before `start_enter`). | Modify |
+| `crates/deps/libkrun-sys/src/lib.rs` | `SupervisorBaseConfig`, `SupervisorAttachConfig`, `AttachMergeError`, `SupervisorConfig::from_base_and_attach`. No `mvm-core` dep (stays a leaf). | Modify (near `:1293`) |
+| `crates/mvm-vm-host/src/prelaunch.rs` | Pure `verify_and_merge_attach(base, attach_bytes, now, &mut NonceStore) -> Result<SupervisorConfig, AttachVerifyError>` — the unit-testable verify+merge (a–e rejection ladder, no VM). | Create |
+| `crates/mvm-vm-host/src/lib.rs` | `pub mod prelaunch;` | Modify |
+| `crates/mvm-vm-host/Cargo.toml` | Add `chrono`, `thiserror` deps. | Modify |
+| `crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs` | `PrelaunchEnvelope` stdin dispatch; `run_prelaunched`; control-socket bind/accept/read; extract `dispatch_config` tail shared with the legacy path. | Modify |
+| `crates/deps/libkrun-sys/fuzz/fuzz_targets/fuzz_attach_message.rs` | Fuzz the `SupervisorAttachConfig` decoder (only attacker-reachable-post-spawn surface). | Create |
+| `crates/deps/libkrun-sys/fuzz/Cargo.toml` | Register the new `[[bin]]`. | Modify |
+| `crates/mvm-vm-host/tests/prelaunch_live.rs` | `libkrun-live`-gated integration: prelaunch → valid attach boots + agent reachable; wrong-nonce attach refused, no boot. | Create |
+| `specs/REFACTOR-STATUS.md`, `specs/plans/118-...md`, design note | Tick the 1a boxes. | Modify |
+
+## Build/test commands (this repo's gotchas)
+
+- The supervisor bin is feature-gated and **not** rebuilt by plain `cargo build`/`test`.
+  Build it explicitly, with the rustup toolchain prepended to PATH (Homebrew rustc
+  shadows it → libkrun-sys bindgen E0514):
+  ```bash
+  PATH="$HOME/.rustup/toolchains/$(rustup show active-toolchain | awk '{print $1}')/bin:$PATH" \
+    cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys
+  ```
+- Unit tests (no libkrun FFI needed for Tasks 1–3, 5):
+  ```bash
+  cargo nextest run -p mvm-hostd -p libkrun-sys -p mvm-vm-host -E 'not package(mvm-backend)'
+  ```
+- Gates before any commit that closes a task: `cargo fmt --all -- --check`,
+  `cargo clippy --workspace -- -D warnings`, `cargo test --workspace --doc`.
+
+---
+
+## Task 1: Sync length-prefixed framing helpers
+
+The prelaunch accept loop is synchronous (the supervisor has no tokio runtime running
+before `start_enter`). Reuse the existing wire format by adding sync siblings to the
+async framing — single source of truth for the 4-byte BE length prefix + cap check.
+
+**Files:**
+- Modify: `crates/mvm-hostd/src/framing.rs`
+- Test: same file, `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `crates/mvm-hostd/src/framing.rs` `mod tests`:
+
+```rust
+    #[test]
+    fn sync_round_trips_a_json_frame() {
+        let msg = Msg { kind: "ping".into(), n: 7 };
+        let mut buf = Vec::new();
+        write_json_frame_sync(&mut buf, &msg).unwrap();
+        let body_len = u32::from_be_bytes(buf[..4].try_into().unwrap()) as usize;
+        assert_eq!(body_len, buf.len() - FRAME_LEN_BYTES);
+        let mut cursor = std::io::Cursor::new(buf);
+        let got: Msg = read_json_frame_sync(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap();
+        assert_eq!(got, msg);
+    }
+
+    #[test]
+    fn sync_rejects_oversize_length_prefix_before_alloc() {
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&u32::MAX.to_be_bytes());
+        let mut cursor = std::io::Cursor::new(framed);
+        let err = read_json_frame_sync::<_, Msg>(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap_err();
+        assert!(matches!(
+            err,
+            FrameError::TooLarge { size, cap: DEFAULT_MAX_FRAME_BYTES } if size == u32::MAX as usize
+        ));
+    }
+
+    #[test]
+    fn sync_truncated_body_is_an_io_error() {
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&16u32.to_be_bytes());
+        framed.extend_from_slice(b"abcd");
+        let mut cursor = std::io::Cursor::new(framed);
+        let err = read_json_frame_sync::<_, Msg>(&mut cursor, DEFAULT_MAX_FRAME_BYTES).unwrap_err();
+        assert!(matches!(err, FrameError::Io(_)));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -p mvm-hostd framing::tests::sync_`
+Expected: FAIL — `write_json_frame_sync`/`read_json_frame_sync` not found.
+
+- [ ] **Step 3: Add the sync helpers**
+
+Insert after `read_json_frame` (before `#[cfg(test)]`) in `crates/mvm-hostd/src/framing.rs`:
+
+```rust
+/// Synchronous sibling of [`write_json_frame`] for the same-uid UDS
+/// control channels that run *without* a tokio runtime (the libkrun
+/// supervisor's prelaunch accept path runs before `start_enter`, so it
+/// can't park a runtime). Same wire format — 4-byte BE length + JSON body.
+pub fn write_json_frame_sync<W, T>(stream: &mut W, value: &T) -> Result<(), FrameError>
+where
+    W: std::io::Write + ?Sized,
+    T: serde::Serialize,
+{
+    let body = serde_json::to_vec(value).map_err(FrameError::Encode)?;
+    let len: u32 = body.len().try_into().map_err(|_| FrameError::LengthOverflow)?;
+    stream.write_all(&len.to_be_bytes())?;
+    stream.write_all(&body)?;
+    Ok(())
+}
+
+/// Synchronous sibling of [`read_json_frame`]. Enforces `max_frame_bytes`
+/// on the length prefix **before** allocating the body — same gate-1
+/// invariant as the async path.
+pub fn read_json_frame_sync<R, T>(stream: &mut R, max_frame_bytes: usize) -> Result<T, FrameError>
+where
+    R: std::io::Read + ?Sized,
+    T: serde::de::DeserializeOwned,
+{
+    let mut len_buf = [0u8; FRAME_LEN_BYTES];
+    stream.read_exact(&mut len_buf)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > max_frame_bytes {
+        return Err(FrameError::TooLarge { size: len, cap: max_frame_bytes });
+    }
+    let mut body = vec![0u8; len];
+    stream.read_exact(&mut body)?;
+    serde_json::from_slice(&body).map_err(FrameError::Decode)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run -p mvm-hostd framing::tests::sync_`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-hostd/src/framing.rs
+git commit -m "feat(framing): sync length-prefixed JSON frame helpers for the supervisor prelaunch path"
+```
+
+---
+
+## Task 2: Config split + `from_base_and_attach` (libkrun-sys)
+
+Split the workload-independent vs workload-specific fields. `libkrun-sys` stays a leaf
+(no `mvm-core` dep) — so the *merge + nonce echo* live here, but the *plan re-verify*
+lives in Task 3 (which can depend on `mvm-core::plan`).
+
+**Files:**
+- Modify: `crates/deps/libkrun-sys/src/lib.rs` (add after `SupervisorConfig`'s `impl`,
+  near `:1293`)
+- Test: same file, in the existing `#[cfg(test)] mod tests` (or a new one if absent)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a test module near the `SupervisorConfig` definition (use a fresh
+`#[cfg(test)] mod base_attach_tests`):
+
+```rust
+#[cfg(test)]
+mod base_attach_tests {
+    use super::*;
+
+    fn base() -> SupervisorBaseConfig {
+        // Kernel-only base: a standby carries NO workload rootfs. Build a
+        // KrunContext then null the rootfs the new() constructor sets.
+        let mut krun = KrunContext::new("standby-0", "/k/vmlinux", "/placeholder");
+        krun.rootfs_path = None;
+        SupervisorBaseConfig {
+            krun,
+            vm_state_dir: "/run/mvm/standby-0".into(),
+            pid_file_name: None,
+            signing_key_path: "/keys/host-signer.ed25519".into(),
+            signer_id: "host:test".into(),
+            binding_nonce: "aa".repeat(32),
+            control_socket_path: "/run/mvm/standby-0/control-aa.sock".into(),
+            bridge_restart_policy: BridgeRestartPolicy::HardFail,
+        }
+    }
+
+    fn attach(nonce: &str) -> SupervisorAttachConfig {
+        SupervisorAttachConfig {
+            binding_nonce: nonce.to_string(),
+            rootfs_path: "/vol/rootfs.ext4".into(),
+            tenant_id: "tenant-a".into(),
+            audit_dir: "/audit".into(),
+            gateway_audit_socket: "/audit/gateway-standby-0.sock".into(),
+            gateway_events_socket: None,
+            plan: serde_json::json!({"envelope": "stub"}),
+            bundle: None,
+        }
+    }
+
+    #[test]
+    fn merge_happy_path_sets_rootfs_and_workload_fields() {
+        let cfg = SupervisorConfig::from_base_and_attach(base(), attach(&"aa".repeat(32))).unwrap();
+        assert_eq!(cfg.krun.rootfs_path.as_deref(), Some("/vol/rootfs.ext4"));
+        assert_eq!(cfg.tenant_id.as_deref(), Some("tenant-a"));
+        assert_eq!(cfg.signing_key_path.as_deref().and_then(|p| p.to_str()), Some("/keys/host-signer.ed25519"));
+        assert_eq!(cfg.vm_state_dir, "/run/mvm/standby-0");
+        assert!(cfg.plan.is_some());
+    }
+
+    #[test]
+    fn merge_rejects_binding_nonce_mismatch() {
+        let err = SupervisorConfig::from_base_and_attach(base(), attach("bb".repeat(32).as_str())).unwrap_err();
+        assert!(matches!(err, AttachMergeError::BindingNonceMismatch));
+    }
+
+    #[test]
+    fn merge_rejects_base_that_already_carries_a_rootfs() {
+        let mut b = base();
+        b.krun.rootfs_path = Some("/leftover.ext4".into());
+        let err = SupervisorConfig::from_base_and_attach(b, attach(&"aa".repeat(32))).unwrap_err();
+        assert!(matches!(err, AttachMergeError::BaseHasRootfs));
+    }
+
+    #[test]
+    fn attach_config_denies_unknown_fields() {
+        let json = serde_json::json!({
+            "binding_nonce": "aa", "rootfs_path": "/r", "tenant_id": "t",
+            "audit_dir": "/a", "gateway_audit_socket": "/a/g.sock",
+            "plan": {}, "surprise": true
+        });
+        assert!(serde_json::from_value::<SupervisorAttachConfig>(json).is_err());
+    }
+
+    #[test]
+    fn base_and_whole_configs_are_serde_disjoint() {
+        // A bare (legacy) SupervisorConfig JSON must NOT parse as a base
+        // (missing binding_nonce/control_socket_path/signing_key_path/signer_id),
+        // so the bin's wrapper-key dispatch can never misroute legacy callers.
+        let whole = serde_json::json!({
+            "krun": serde_json::to_value(KrunContext::new("n","/k","/r")).unwrap(),
+            "vm_state_dir": "/s"
+        });
+        assert!(serde_json::from_value::<SupervisorBaseConfig>(whole).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -p libkrun-sys base_attach_tests`
+Expected: FAIL — `SupervisorBaseConfig` / `SupervisorAttachConfig` / `AttachMergeError` /
+`from_base_and_attach` not found.
+
+- [ ] **Step 3: Add the types + merge**
+
+Insert immediately after the `impl SupervisorConfig { ... }` block (after
+`validate_audit_substrate`, near `:1420`) in `crates/deps/libkrun-sys/src/lib.rs`:
+
+```rust
+/// Workload-**independent** supervisor config — everything a prelaunched
+/// standby (Plan 118 WS-1 1a) sets up before it knows which workload it
+/// will run. Carries no rootfs and no plan; those arrive in the
+/// [`SupervisorAttachConfig`] over the control UDS. `krun.rootfs_path`
+/// MUST be `None` — [`SupervisorConfig::from_base_and_attach`] rejects a
+/// base that already carries one (it would shadow the workload rootfs).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupervisorBaseConfig {
+    /// Workload-independent guest config: kernel, vcpus/ram, vsock wiring,
+    /// console, host_listen_ports. `rootfs_path` must be `None`.
+    pub krun: KrunContext,
+    pub vm_state_dir: String,
+    #[serde(default)]
+    pub pid_file_name: Option<String>,
+    /// `~/.mvm/keys/host-signer.ed25519` — host signing key. Source of the
+    /// **public** key the attach-time plan re-verify checks against (claim 8;
+    /// no new key). Carried in base because it is host identity, not workload.
+    pub signing_key_path: std::path::PathBuf,
+    /// Expected envelope `signer_id` (`host:{hostname}`). The attach plan must
+    /// be signed by this id, else `verify_plan` reports `UnknownSigner`.
+    pub signer_id: String,
+    /// Per-spawn binding nonce (hex of 32 random bytes). The attach must echo
+    /// it; a standby with a different nonce rejects (cross-standby replay).
+    pub binding_nonce: String,
+    /// Control UDS the standby binds and blocks on. Mode `0700`, in a `0700`
+    /// dir, with the binding nonce embedded in the path.
+    pub control_socket_path: std::path::PathBuf,
+    #[serde(default)]
+    pub bridge_restart_policy: BridgeRestartPolicy,
+}
+
+/// Workload-**specific** supervisor config — the bytes that arrive over the
+/// control UDS at attach. The only attacker-reachable-post-spawn surface
+/// (fuzzed by `fuzz_attach_message`). The plan re-verify in
+/// `mvm_vm_host::prelaunch` is what makes accepting these bytes safe.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupervisorAttachConfig {
+    /// Echoed binding nonce — must equal `base.binding_nonce`.
+    pub binding_nonce: String,
+    /// Workload rootfs ext4 (`krun add_disk "root"`).
+    pub rootfs_path: String,
+    pub tenant_id: String,
+    pub audit_dir: std::path::PathBuf,
+    pub gateway_audit_socket: std::path::PathBuf,
+    #[serde(default)]
+    pub gateway_events_socket: Option<std::path::PathBuf>,
+    /// JSON-encoded `SignedExecutionPlan` envelope — same carrier shape as
+    /// `SupervisorConfig.plan`. Required (the warm path always carries a plan).
+    pub plan: serde_json::Value,
+    #[serde(default)]
+    pub bundle: Option<serde_json::Value>,
+}
+
+/// Failure modes of [`SupervisorConfig::from_base_and_attach`]. The plan
+/// re-verify failures live in `mvm_vm_host::prelaunch::AttachVerifyError` —
+/// this leaf crate can't depend on `mvm-core::plan`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AttachMergeError {
+    /// The attach's echoed binding nonce != the base's binding nonce.
+    BindingNonceMismatch,
+    /// The base already carried a rootfs — it would shadow the workload's.
+    BaseHasRootfs,
+}
+
+impl std::fmt::Display for AttachMergeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BindingNonceMismatch => f.write_str("attach binding nonce does not match the standby's"),
+            Self::BaseHasRootfs => f.write_str("base config already carries a rootfs (would shadow the workload)"),
+        }
+    }
+}
+impl std::error::Error for AttachMergeError {}
+
+impl SupervisorConfig {
+    /// Merge a prelaunched standby's [`SupervisorBaseConfig`] with the
+    /// [`SupervisorAttachConfig`] received over the control UDS, validating
+    /// the echoed binding nonce, into a whole `SupervisorConfig` the existing
+    /// `run_with_bridge` path consumes verbatim. Does **not** verify the plan
+    /// signature — that is `mvm_vm_host::prelaunch::verify_and_merge_attach`'s
+    /// job (this crate is a leaf with no `mvm-core` dep).
+    pub fn from_base_and_attach(
+        base: SupervisorBaseConfig,
+        attach: SupervisorAttachConfig,
+    ) -> Result<SupervisorConfig, AttachMergeError> {
+        if attach.binding_nonce != base.binding_nonce {
+            return Err(AttachMergeError::BindingNonceMismatch);
+        }
+        if base.krun.rootfs_path.is_some() {
+            return Err(AttachMergeError::BaseHasRootfs);
+        }
+        let mut krun = base.krun;
+        krun.rootfs_path = Some(attach.rootfs_path);
+        Ok(SupervisorConfig {
+            krun,
+            vm_state_dir: base.vm_state_dir,
+            pid_file_name: base.pid_file_name,
+            tenant_id: Some(attach.tenant_id),
+            audit_dir: Some(attach.audit_dir),
+            gateway_audit_socket: Some(attach.gateway_audit_socket),
+            gateway_events_socket: attach.gateway_events_socket,
+            signing_key_path: Some(base.signing_key_path),
+            plan: Some(attach.plan),
+            bundle: attach.bundle,
+            bridge_restart_policy: base.bridge_restart_policy,
+        })
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run -p libkrun-sys base_attach_tests`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/deps/libkrun-sys/src/lib.rs
+git commit -m "feat(libkrun-sys): SupervisorBaseConfig/AttachConfig split + from_base_and_attach merge"
+```
+
+---
+
+## Task 3: Pure `verify_and_merge_attach` (the security crux)
+
+The unit-testable heart: parse attach bytes → merge (nonce echo) → re-verify the signed
+plan (signature against the on-disk host key, G4 window, nonce-replay) — **never boots**.
+Lives in `mvm-vm-host` because it needs both `libkrun-sys` (for the merge) and
+`mvm-core::plan` (for verify). Reuses `verify_plan` + `check_window` + `NonceStore`.
+
+**Files:**
+- Modify: `crates/mvm-vm-host/Cargo.toml` (add `chrono`, `thiserror`)
+- Create: `crates/mvm-vm-host/src/prelaunch.rs`
+- Modify: `crates/mvm-vm-host/src/lib.rs` (`pub mod prelaunch;`)
+- Test: in `prelaunch.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Add deps + module declaration**
+
+In `crates/mvm-vm-host/Cargo.toml` `[dependencies]` add:
+
+```toml
+chrono = { workspace = true }
+thiserror = "1"
+```
+
+In `crates/mvm-vm-host/src/lib.rs`, add after `pub mod firecracker_bridge;`:
+
+```rust
+/// Plan 118 WS-1 1a — the prelaunched-supervisor attach verify+merge. Pure
+/// (no VM, no `start_enter`) so the rejection ladder is unit-testable.
+pub mod prelaunch;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `crates/mvm-vm-host/src/prelaunch.rs` with ONLY the test module first (the impl
+in Step 4 makes them compile + pass). Test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, TimeZone, Utc};
+    use ed25519_dalek::SigningKey;
+    use libkrun_sys::{BridgeRestartPolicy, KrunContext, SupervisorAttachConfig, SupervisorBaseConfig};
+    use mvm_core::plan::{sign_plan, ExecutionPlan, NonceStore};
+    use std::io::Write;
+
+    const NONCE: &str = "aa_aa_aa_aa_aa_aa_aa_aa_aa_aa_aa_aa"; // any stable hex-ish string
+
+    // A 32-byte ed25519 secret written to a tempfile; returns (path, signing key).
+    fn write_key(dir: &std::path::Path) -> (std::path::PathBuf, SigningKey) {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let path = dir.join("host-signer.ed25519");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(key.to_bytes().as_slice()).unwrap();
+        (path, key)
+    }
+
+    fn sample_plan(now: chrono::DateTime<Utc>) -> ExecutionPlan {
+        // Reuse the canonical sample then pin a window around `now`.
+        let mut p = mvm_core::plan::signing::test_support::sample_plan();
+        p.valid_from = now - Duration::minutes(5);
+        p.valid_until = now + Duration::minutes(5);
+        p
+    }
+
+    fn base(key_path: std::path::PathBuf, signer_id: &str) -> SupervisorBaseConfig {
+        let mut krun = KrunContext::new("standby-0", "/k/vmlinux", "/placeholder");
+        krun.rootfs_path = None;
+        SupervisorBaseConfig {
+            krun,
+            vm_state_dir: "/run/mvm/standby-0".into(),
+            pid_file_name: None,
+            signing_key_path: key_path,
+            signer_id: signer_id.into(),
+            binding_nonce: NONCE.into(),
+            control_socket_path: "/run/mvm/standby-0/control.sock".into(),
+            bridge_restart_policy: BridgeRestartPolicy::HardFail,
+        }
+    }
+
+    fn attach_bytes(nonce: &str, plan_envelope: serde_json::Value) -> Vec<u8> {
+        let attach = SupervisorAttachConfig {
+            binding_nonce: nonce.into(),
+            rootfs_path: "/vol/rootfs.ext4".into(),
+            tenant_id: "tenant-a".into(),
+            audit_dir: "/audit".into(),
+            gateway_audit_socket: "/audit/g.sock".into(),
+            gateway_events_socket: None,
+            plan: plan_envelope,
+            bundle: None,
+        };
+        serde_json::to_vec(&attach).unwrap()
+    }
+
+    fn signed_envelope(plan: &ExecutionPlan, key: &SigningKey, signer_id: &str) -> serde_json::Value {
+        serde_json::to_value(sign_plan(plan, key, signer_id)).unwrap()
+    }
+
+    #[test]
+    fn happy_path_returns_admitted_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, key) = write_key(dir.path());
+        let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let plan = sample_plan(now);
+        let bytes = attach_bytes(NONCE, signed_envelope(&plan, &key, "host:test"));
+        let mut store = NonceStore::new();
+        let cfg = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap();
+        assert_eq!(cfg.krun.rootfs_path.as_deref(), Some("/vol/rootfs.ext4"));
+        assert_eq!(cfg.tenant_id.as_deref(), Some("tenant-a"));
+    }
+
+    #[test]
+    fn rejects_wrong_binding_nonce() {
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, key) = write_key(dir.path());
+        let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let bytes = attach_bytes("WRONG", signed_envelope(&sample_plan(now), &key, "host:test"));
+        let mut store = NonceStore::new();
+        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
+        assert!(matches!(err, AttachVerifyError::Merge(_)));
+    }
+
+    #[test]
+    fn rejects_unsigned_plan_wrong_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, _real) = write_key(dir.path());
+        let attacker = SigningKey::from_bytes(&[9u8; 32]); // not the on-disk key
+        let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let bytes = attach_bytes(NONCE, signed_envelope(&sample_plan(now), &attacker, "host:test"));
+        let mut store = NonceStore::new();
+        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
+        assert!(matches!(err, AttachVerifyError::PlanVerify(_)));
+    }
+
+    #[test]
+    fn rejects_out_of_window_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, key) = write_key(dir.path());
+        let plan_now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let plan = sample_plan(plan_now);
+        let bytes = attach_bytes(NONCE, signed_envelope(&plan, &key, "host:test"));
+        // Verify an hour after the window closed.
+        let later = plan_now + Duration::hours(1);
+        let mut store = NonceStore::new();
+        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, later, &mut store).unwrap_err();
+        assert!(matches!(err, AttachVerifyError::Validity(_)));
+    }
+
+    #[test]
+    fn rejects_replayed_nonce() {
+        let dir = tempfile::tempdir().unwrap();
+        let (kp, key) = write_key(dir.path());
+        let now = Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap();
+        let plan = sample_plan(now);
+        let bytes = attach_bytes(NONCE, signed_envelope(&plan, &key, "host:test"));
+        let mut store = NonceStore::new();
+        // First admit succeeds; second (same store, same plan) is a replay.
+        verify_and_merge_attach(base(kp.clone(), "host:test"), &bytes, now, &mut store).unwrap();
+        let err = verify_and_merge_attach(base(kp, "host:test"), &bytes, now, &mut store).unwrap_err();
+        assert!(matches!(err, AttachVerifyError::Validity(_)));
+    }
+}
+```
+
+> **Note on `test_support::sample_plan`:** `mvm-core`'s sample plan currently lives in
+> `signing.rs`'s `#[cfg(test)]` module, which is not reachable cross-crate. Step 3 below
+> promotes it to a `pub` test-support helper so this crate can build valid plans without
+> duplicating the ~40-line literal.
+
+- [ ] **Step 3: Expose a cross-crate sample-plan helper in mvm-core**
+
+In `crates/mvm-core/src/plan/signing.rs`, move the `sample_plan()` body out of
+`#[cfg(test)] mod tests` into a always-compiled, test-only-gated public helper. Add near
+the top of the file (after imports):
+
+```rust
+/// Test-support fixtures shared across crates. Gated so it never ships in a
+/// non-test build but is reachable from other crates' `#[cfg(test)]` code.
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
+    use super::*;
+    use crate::plan::types::*;
+    use chrono::{TimeZone, Utc};
+    use std::collections::BTreeMap;
+
+    /// A minimal valid `ExecutionPlan` with a wide validity window. Callers
+    /// override `valid_from`/`valid_until`/`nonce` as their scenario needs.
+    pub fn sample_plan() -> ExecutionPlan {
+        // ... move the EXACT body currently in `mod tests::sample_plan()` here ...
+    }
+}
+```
+
+Then in `signing.rs`'s `mod tests`, replace the local `sample_plan` with
+`use super::test_support::sample_plan;`. Add the `test-support` feature to
+`crates/mvm-core/Cargo.toml` `[features]` (`test-support = []`) and, in
+`crates/mvm-vm-host/Cargo.toml` `[dev-dependencies]`, depend on it:
+
+```toml
+mvm-core = { workspace = true, features = ["test-support"] }
+```
+
+(If a `[dev-dependencies] mvm-core` line is absent, add it; the non-dev dep stays
+feature-free so production builds never compile the fixtures.)
+
+- [ ] **Step 4: Run tests to verify they fail (compile error / not-found)**
+
+Run: `cargo nextest run -p mvm-vm-host prelaunch::tests`
+Expected: FAIL — `verify_and_merge_attach` / `AttachVerifyError` not defined.
+
+- [ ] **Step 5: Write the implementation**
+
+Prepend to `crates/mvm-vm-host/src/prelaunch.rs` (above the test module):
+
+```rust
+//! Plan 118 WS-1 Layer 1a — prelaunched-supervisor attach verify+merge.
+//!
+//! The cold/legacy supervisor path extracts the admitted plan without
+//! re-verifying (host-trusted private stdin pipe, ADR-002). The warm path's
+//! control UDS is **same-uid-reachable**, so it is NOT a trusted private
+//! channel — this module re-verifies the signed `ExecutionPlan` (Ed25519
+//! signature + G4 window + nonce-replay) before the caller may `start_enter`.
+//! Reuses `mvm_core::plan::{verify_plan, check_window, NonceStore}`; no fork.
+
+use chrono::{DateTime, Utc};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use libkrun_sys::{SupervisorAttachConfig, SupervisorBaseConfig, SupervisorConfig};
+use mvm_core::plan::{check_window, verify_plan, NonceStore, SignedExecutionPlan};
+
+/// Why an attach was refused. Every variant means the caller must NOT
+/// `start_enter` — the standby exits non-zero.
+#[derive(Debug, thiserror::Error)]
+pub enum AttachVerifyError {
+    #[error("decode attach config: {0}")]
+    Decode(String),
+    #[error("merge base+attach: {0}")]
+    Merge(#[from] libkrun_sys::AttachMergeError),
+    #[error("read host signing key {0}: {1}")]
+    ReadKey(String, String),
+    #[error("host signing key is {0} bytes, expected 32")]
+    KeyLen(usize),
+    #[error("decode SignedExecutionPlan envelope: {0}")]
+    Envelope(String),
+    #[error("plan signature verify failed: {0}")]
+    PlanVerify(String),
+    #[error("plan validity (window/nonce): {0}")]
+    Validity(String),
+}
+
+/// Verify a control-UDS `attach` against a prelaunched standby's `base` and,
+/// on success, return the whole `SupervisorConfig` the caller hands to the
+/// existing `run_with_bridge` path. **Never boots.** The caller calls
+/// `start_enter` only on `Ok`.
+///
+/// Order mirrors `mvm_hostd::supervisor::aggregate::launch`:
+/// merge (binding-nonce echo) → signature → G4 window → nonce-replay.
+pub fn verify_and_merge_attach(
+    base: SupervisorBaseConfig,
+    attach_bytes: &[u8],
+    now: DateTime<Utc>,
+    nonce_store: &mut NonceStore,
+) -> Result<SupervisorConfig, AttachVerifyError> {
+    // Pull the bits we still need after `base`/`attach` are moved into the merge.
+    let signer_id = base.signer_id.clone();
+    let key_path = base.signing_key_path.clone();
+
+    let attach: SupervisorAttachConfig = serde_json::from_slice(attach_bytes)
+        .map_err(|e| AttachVerifyError::Decode(e.to_string()))?;
+    let plan_value = attach.plan.clone();
+
+    // Binding-nonce echo + field merge (also rejects a base carrying a rootfs).
+    let cfg = SupervisorConfig::from_base_and_attach(base, attach)?;
+
+    // Derive the host-signer PUBLIC key from the on-disk secret. The key is
+    // host-trusted state (claim 8); the secret never leaves this process. Same
+    // 32-byte read the cold path's audit signer performs.
+    let key_bytes = std::fs::read(&key_path)
+        .map_err(|e| AttachVerifyError::ReadKey(key_path.display().to_string(), e.to_string()))?;
+    let key_arr: [u8; 32] = key_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| AttachVerifyError::KeyLen(key_bytes.len()))?;
+    let vk: VerifyingKey = SigningKey::from_bytes(&key_arr).verifying_key();
+
+    // Re-verify the signature — the load-bearing warm-path invariant.
+    let signed: SignedExecutionPlan = serde_json::from_value(plan_value)
+        .map_err(|e| AttachVerifyError::Envelope(e.to_string()))?;
+    let plan = verify_plan(&signed, &[(signer_id.as_str(), &vk)])
+        .map_err(|e| AttachVerifyError::PlanVerify(e.to_string()))?;
+
+    // G4 validity window + per-signer nonce-replay.
+    check_window(&plan, now).map_err(|e| AttachVerifyError::Validity(e.to_string()))?;
+    nonce_store
+        .check_and_insert(&signed.0.signer_id, &plan)
+        .map_err(|e| AttachVerifyError::Validity(e.to_string()))?;
+
+    Ok(cfg)
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo nextest run -p mvm-vm-host prelaunch::tests`
+Expected: PASS (5 tests). Also run `cargo nextest run -p mvm-core signing::` to confirm
+the `test_support` move didn't break mvm-core's own tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/mvm-vm-host/Cargo.toml crates/mvm-vm-host/src/lib.rs \
+        crates/mvm-vm-host/src/prelaunch.rs crates/mvm-core/Cargo.toml \
+        crates/mvm-core/src/plan/signing.rs
+git commit -m "feat(supervisor): attach verify+merge with mandatory plan re-verify (Plan 118 WS-1 1a security crux)"
+```
+
+---
+
+## Task 4: Bin wiring — prelaunch dispatch + control socket
+
+Wire the pure function into the `mvm-libkrun-supervisor` bin: dispatch a `prelaunch_base`
+stdin envelope to the new path, bind the control UDS one-shot, read the attach frame,
+verify+merge, and hand off to the **existing** `run_with_bridge`. The legacy path stays
+byte-for-byte unchanged.
+
+**Files:**
+- Modify: `crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs`
+
+This bin only builds under `--features libkrun-sys`; verify with the explicit build
+command (Build/test section). No new unit test here — the verify logic is Task 3's pure
+function (already covered); the socket dance is covered by Task 6's live test.
+
+- [ ] **Step 1: Add imports + the stdin dispatch envelope**
+
+At the top of `main()`'s use-block region, add to the `libkrun_sys` import:
+`SupervisorBaseConfig`. Add `use std::os::unix::fs::PermissionsExt;`,
+`use std::time::{Duration, Instant};`, `use std::os::unix::net::{UnixListener, UnixStream};`,
+`use chrono::Utc;`, `use mvm_core::plan::NonceStore;`.
+
+Add above `fn main`:
+
+```rust
+/// Per-connection attach timeout. An abandoned connect must not wedge the
+/// standby (1a; pool-size bounds the blast radius in 1b).
+const ATTACH_TIMEOUT: Duration = Duration::from_secs(30);
+/// Cap on the attach frame — workload config is small; reject hostile prefixes.
+const MAX_ATTACH_BYTES: usize = 1 << 20; // 1 MiB
+
+/// Stdin dispatch (Plan 118 WS-1 1a). The prelaunched producer wraps the base
+/// config under a unique `prelaunch_base` key; legacy callers emit a bare
+/// `SupervisorConfig` (no wrapper) and are byte-for-byte unchanged. Probed
+/// wrapper-first: a legacy config has no such key, so it falls through to the
+/// unchanged whole-config path. `deny_unknown_fields` + the disjoint required
+/// fields (`base_and_whole_configs_are_serde_disjoint` test) make this
+/// unambiguous — a botched prelaunch can never silently boot via the legacy arm.
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PrelaunchEnvelope {
+    prelaunch_base: SupervisorBaseConfig,
+}
+```
+
+- [ ] **Step 2: Branch in `main()` after reading stdin**
+
+Replace the block from the `let cfg: SupervisorConfig = match serde_json::from_str(&json)`
+(lines ~106-112) **and** the exit-capture + routing tail (lines ~114-159) with a dispatch
+that routes prelaunch vs legacy, then shares a single `dispatch_config` tail:
+
+```rust
+    // Prelaunch (warm-pool standby) vs legacy/cold (bare SupervisorConfig).
+    if let Ok(env) = serde_json::from_str::<PrelaunchEnvelope>(&json) {
+        return run_prelaunched(env.prelaunch_base);
+    }
+    let cfg: SupervisorConfig = match serde_json::from_str(&json) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: parse SupervisorConfig JSON: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    dispatch_config(cfg)
+}
+
+/// Shared tail: given a finalized `SupervisorConfig` (from the legacy stdin
+/// decode OR a verified prelaunch attach), bind the workload-exit control
+/// listener and route to the bridge/legacy boot path. Extracted so both
+/// entrypoints run identical post-config logic.
+fn dispatch_config(cfg: SupervisorConfig) -> ExitCode {
+    // Plan 152 WS-A: bind the workload-exit control listener before run dispatch.
+    if cfg
+        .krun
+        .host_listen_ports
+        .contains(&mvm_guest::vsock::WORKLOAD_EXIT_PORT)
+    {
+        let state_dir = std::path::PathBuf::from(&cfg.vm_state_dir);
+        let control_sock = cfg.krun.vsock_socket_path(mvm_guest::vsock::WORKLOAD_EXIT_PORT);
+        let _ = std::fs::remove_file(&control_sock);
+        match std::os::unix::net::UnixListener::bind(&control_sock) {
+            Ok(listener) => {
+                std::thread::spawn(move || {
+                    if let Err(e) = mvm_vm_host::exit_capture::capture_once(&listener, &state_dir) {
+                        eprintln!("mvm-libkrun-supervisor: exit capture: {e}");
+                    }
+                });
+            }
+            Err(e) => eprintln!("mvm-libkrun-supervisor: bind control socket: {e}"),
+        }
+    }
+
+    let outcome = if cfg.tenant_id.is_some() {
+        run_with_bridge(cfg)
+    } else {
+        run_legacy(&cfg)
+    };
+    match outcome {
+        Err(e) => {
+            eprintln!("supervisor failed: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+```
+
+(The `ensure_signed()` + `MVM_KRUN_LOG` setup at the top of `main()` stays as-is — it
+runs for both paths before the dispatch.)
+
+- [ ] **Step 3: Add `run_prelaunched` + socket helpers**
+
+Append to the bin:
+
+```rust
+/// Prelaunched-standby flow (Plan 118 WS-1 1a). `ensure_signed()` + the libkrun
+/// dylib are already warm (done in `main`). Bind the control UDS, accept ONE
+/// connection (per-conn timeout), read the attach frame, re-verify+merge, then
+/// hand the whole config to the existing bridge path. One-shot: any failure or
+/// timeout exits non-zero WITHOUT `start_enter`.
+fn run_prelaunched(base: SupervisorBaseConfig) -> ExitCode {
+    let sock_path = base.control_socket_path.clone();
+    let listener = match bind_control_socket(&sock_path) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("prelaunch: bind control socket {}: {e}", sock_path.display());
+            return ExitCode::from(3);
+        }
+    };
+    let mut stream = match accept_one_with_timeout(&listener, ATTACH_TIMEOUT) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("prelaunch: attach accept failed: {e}");
+            return ExitCode::from(4);
+        }
+    };
+    // Best-effort cleanup of the control socket — the workload-exit socket the
+    // bridge path binds is a different path under the state dir.
+    let _ = std::fs::remove_file(&sock_path);
+
+    let attach_bytes: Vec<u8> =
+        match mvm_hostd::framing::read_json_frame_sync::<_, serde_json::Value>(&mut stream, MAX_ATTACH_BYTES) {
+            // Re-encode to bytes for the pure verifier (it owns the deny_unknown_fields decode).
+            Ok(v) => match serde_json::to_vec(&v) {
+                Ok(b) => b,
+                Err(e) => {
+                    eprintln!("prelaunch: re-encode attach: {e}");
+                    return ExitCode::from(5);
+                }
+            },
+            Err(e) => {
+                eprintln!("prelaunch: read attach frame: {e}");
+                return ExitCode::from(5);
+            }
+        };
+
+    let mut nonce_store = NonceStore::new();
+    let cfg = match mvm_vm_host::prelaunch::verify_and_merge_attach(
+        base,
+        &attach_bytes,
+        Utc::now(),
+        &mut nonce_store,
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            // SECURITY: refused — never start_enter.
+            eprintln!("prelaunch: attach refused: {e}");
+            return ExitCode::from(6);
+        }
+    };
+    dispatch_config(cfg)
+}
+
+/// Bind the control UDS at `path` with mode 0700, inside a 0700 parent dir.
+/// Mirrors the W1.2 vsock-proxy posture: same-uid only.
+fn bind_control_socket(path: &std::path::Path) -> std::io::Result<UnixListener> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+    }
+    let _ = std::fs::remove_file(path); // clear a stale socket
+    let listener = UnixListener::bind(path)?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    Ok(listener)
+}
+
+/// Accept exactly one connection within `timeout`, else error. Sets a read
+/// timeout on the accepted stream too, so a connected-but-silent peer can't
+/// wedge the standby.
+fn accept_one_with_timeout(listener: &UnixListener, timeout: Duration) -> std::io::Result<UnixStream> {
+    listener.set_nonblocking(true)?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                stream.set_nonblocking(false)?;
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                stream.set_read_timeout(Some(remaining.max(Duration::from_millis(1))))?;
+                return Ok(stream);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "attach timeout"));
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build the feature-gated bin**
+
+Run:
+```bash
+PATH="$HOME/.rustup/toolchains/$(rustup show active-toolchain | awk '{print $1}')/bin:$PATH" \
+  cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys
+```
+Expected: builds clean. Then `cargo clippy -p mvm-vm-host --features libkrun-sys -- -D warnings`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs
+git commit -m "feat(supervisor): prelaunched control-UDS attach path in mvm-libkrun-supervisor (Plan 118 WS-1 1a)"
+```
+
+---
+
+## Task 5: Fuzz the attach decoder
+
+The `SupervisorAttachConfig` decode is the only attacker-reachable-post-spawn surface.
+Sibling harness to `fuzz_supervisor_config`; goal "never panic on any input".
+
+**Files:**
+- Create: `crates/deps/libkrun-sys/fuzz/fuzz_targets/fuzz_attach_message.rs`
+- Modify: `crates/deps/libkrun-sys/fuzz/Cargo.toml`
+
+- [ ] **Step 1: Write the harness**
+
+Create `crates/deps/libkrun-sys/fuzz/fuzz_targets/fuzz_attach_message.rs`:
+
+```rust
+// Plan 118 WS-1 1a / ADR-055 §"New untrusted-input surfaces" — fuzz the
+// host-side `SupervisorAttachConfig` JSON parser.
+//
+// The prelaunched `mvm-libkrun-supervisor` reads this struct off a same-uid
+// control UDS — the only attacker-reachable surface after spawn. Any panic
+// here is a hard process death before `start_enter`. Sibling of
+// `fuzz_supervisor_config`; the harness goal is "never panic on any input"
+// (`serde_json::Error` is the expected outcome for malformed bytes).
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use libkrun_sys::SupervisorAttachConfig;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = serde_json::from_slice::<SupervisorAttachConfig>(data);
+});
+```
+
+- [ ] **Step 2: Register the bin**
+
+Append to `crates/deps/libkrun-sys/fuzz/Cargo.toml`:
+
+```toml
+[[bin]]
+name = "fuzz_attach_message"
+path = "fuzz_targets/fuzz_attach_message.rs"
+test = false
+doc = false
+bench = false
+```
+
+- [ ] **Step 3: Verify it compiles under cargo-fuzz**
+
+Run (from the fuzz dir; `cargo-fuzz` must be installed — skip the run, just check build):
+```bash
+cargo +nightly fuzz build fuzz_attach_message --fuzz-dir crates/deps/libkrun-sys/fuzz 2>&1 | tail -5 || \
+  echo "cargo-fuzz not installed locally — harness compiles in CI's security.yml fuzz job"
+```
+Expected: builds, or the documented skip (the `security.yml` fuzz job covers it).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/deps/libkrun-sys/fuzz/
+git commit -m "test(fuzz): fuzz_attach_message — the prelaunch attach decode surface (Plan 118 WS-1 1a)"
+```
+
+---
+
+## Task 6: `libkrun-live`-gated integration test
+
+A real boot on a dev host: prelaunch a supervisor, send a valid attach for an admitted
+plan, assert the guest boots + agent reachable; assert a wrong-nonce attach is refused
+with no boot. Gated behind the `libkrun-live` feature so it never runs in the
+no-FFI/no-VM CI lanes.
+
+**Files:**
+- Create: `crates/mvm-vm-host/tests/prelaunch_live.rs`
+- Modify: `crates/mvm-vm-host/Cargo.toml` (add a `libkrun-live` feature + test deps)
+
+> **Authoring note:** This test must reuse existing harness scaffolding — do **not**
+> hand-roll a KrunContext/plan from scratch. Before writing, grep for an existing
+> live-boot helper to model on (the agent-ping example + any `#[cfg(feature =
+> "libkrun-live")]` test in `mvm-backend`/`mvm-vm-host`):
+> `rg -l 'libkrun-live|agent_ping|examples/agent' crates tests examples`. Build the
+> `BaseConfig` (kernel only, `rootfs_path = None`, `host_listen_ports` incl. the agent
+> port), spawn `mvm-libkrun-supervisor` with `{"prelaunch_base": <base>}` on stdin, then
+> connect to `base.control_socket_path` and `write_json_frame_sync` a
+> `SupervisorAttachConfig` whose `plan` is a freshly-signed admitted envelope (sign with
+> the same on-disk host key the base points at). Assert the agent answers a ping; in the
+> wrong-nonce case assert the supervisor exits non-zero and no agent socket appears.
+
+- [ ] **Step 1: Add the feature + test scaffolding**
+
+In `crates/mvm-vm-host/Cargo.toml` `[features]`:
+
+```toml
+# Live-boot integration tests (dev host with libkrun). Never in CI's no-VM lanes.
+libkrun-live = ["libkrun-sys"]
+```
+
+Create `crates/mvm-vm-host/tests/prelaunch_live.rs` guarded by
+`#![cfg(feature = "libkrun-live")]`, implementing the two scenarios per the authoring
+note above (model the boot/agent-ping on the helper found by the grep).
+
+- [ ] **Step 2: Run on the dev host (Vz/libkrun available)**
+
+Run (uses an isolated cache to avoid racing parallel sessions — see the
+`MVM_CACHE_DIR/MVM_DATA_DIR` isolation note):
+```bash
+MVM_CACHE_DIR=$(mktemp -d) MVM_DATA_DIR=$(mktemp -d) \
+PATH="$HOME/.rustup/toolchains/$(rustup show active-toolchain | awk '{print $1}')/bin:$PATH" \
+  cargo test -p mvm-vm-host --features libkrun-live --test prelaunch_live -- --nocapture
+```
+Expected: both scenarios pass — valid attach boots + agent reachable; wrong-nonce attach
+refused, supervisor exits non-zero, no boot.
+
+> If the live boot can't be exercised on the dev host (the libkrun supervisor needs the
+> Homebrew krun trio; this Mac defaults to the Vz builder), mark the test `#[ignore]`
+> with a comment pointing at the gating note and lean on the Task 3 unit ladder + Task 5
+> fuzz for the merge-able CI signal. Do NOT delete the test — leave it runnable for a
+> libkrun-capable host.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/mvm-vm-host/Cargo.toml crates/mvm-vm-host/tests/prelaunch_live.rs
+git commit -m "test(supervisor): libkrun-live prelaunch boot + wrong-nonce-refused integration (Plan 118 WS-1 1a)"
+```
+
+---
+
+## Task 7: Tracking-doc updates
+
+**Files:**
+- Modify: `specs/plans/118-supervisor-standby-pool-and-live-bench.md`
+- Modify: `specs/REFACTOR-STATUS.md`
+- Modify: `specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md`
+
+- [ ] **Step 1: Tick the boxes**
+
+In Plan 118 §PR-10b (the supervisor primitive), check the boxes this PR lands (config
+split, prelaunched flow, attach re-verify, fuzz, unit ladder, live test). Add a one-line
+"1a landed in PR #<n>" note. In `specs/REFACTOR-STATUS.md`, tick the matching Plan 118
+WS-1 1a row and bump "Last updated" to today's date. In the design note, change the
+status banner to "Implemented (1a) — PR #<n>; 1b (pool) remains."
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add specs/plans/118-supervisor-standby-pool-and-live-bench.md \
+        specs/REFACTOR-STATUS.md specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md
+git commit -m "docs(plan-118): record WS-1 1a prelaunched supervisor primitive landed"
+```
+
+---
+
+## Final verification (before opening the PR)
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace -- -D warnings` (and `-p mvm-vm-host --features libkrun-sys`)
+- [ ] `cargo nextest run --workspace -E 'not package(mvm-backend)'`
+- [ ] `cargo test --workspace --doc`
+- [ ] `cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys` (rustup PATH)
+- [ ] Open the PR from `feat/plan-118-ws1-layer1a` — **no `Co-Authored-By: Claude` trailer**,
+      no Claude attribution in the body.
+
+## Out of scope (1b — separate PR)
+
+`warm_pool_size` / `--warm-pool-size`; `SupervisorStandbyPool` under `~/.mvm/pool/<id>/`;
+`up` claim + cold-boot fallback; base-compat (kernel match); reaper + `cache prune` TTL;
+replenish-on-use; the bench delta.

--- a/specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md
+++ b/specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md
@@ -1,0 +1,123 @@
+# Design — WS-1 Layer 1a: prelaunched libkrun supervisor (base/attach split)
+
+> **Status (2026-06-09):** Approved direction (brainstorm). First sub-project of
+> Plan 159 WS-1 (warm pool). Implements **Plan 118 PR-10b's supervisor primitive**
+> (`specs/plans/118-supervisor-standby-pool-and-live-bench.md`) — the security-
+> sensitive core — as its own PR. The pool + `up` claim (1b) builds on this.
+
+## Goal
+
+Add a **prelaunched** mode to `mvm-libkrun-supervisor`: it does all
+workload-*independent* setup at spawn (codesign re-exec, dylib load, `KrunContext`
+creation, kernel-image load) and then **blocks on a control UDS, holding no rootfs
+and no plan, before `start_enter`**. On an **attach** message it validates, merges
+the workload config, re-verifies the signed `ExecutionPlan`, and only *then* calls
+`start_enter`. This is the primitive a warm-pool standby is built from (1b).
+
+**Scope:** the supervisor primitive only. **No pool, no `up` integration, no
+`warm_pool_size`** — those are 1b. 1a is exercised by a test driver that sends an
+attach to a prelaunched supervisor.
+
+## Why (and why it's safe)
+
+`krun_start_enter` boots-and-`exit()`s the calling process, so a standby cannot be
+a booted VM awaiting a rootfs (`reference_libkrun_gotchas`). A prelaunched
+supervisor is the only libkrun-feasible warm primitive. It hides the
+supervisor-setup latency (spawn + codesign + `KrunContext`/kernel-load), **not** the
+guest boot (which is gated on the rootfs at attach).
+
+**Load-bearing security invariant:** the supervisor **independently re-verifies the
+signed `ExecutionPlan`** (Ed25519 signature + G4 time window + nonce-replay) before
+`start_enter` — the *same* gate `run_with_bridge` performs today. The control UDS is
+not an admission bypass: a same-uid attacker cannot boot a forged/unsigned workload
+without the host plan-signing key (claim 8; no new key introduced). Required
+mitigations (core, not optional):
+
+- **Replay across standbys** → a **per-supervisor binding nonce** (in `BaseConfig`,
+  unique per spawn) must be **echoed** in the attach; an attach minted for standby A
+  is rejected by standby B (whose fresh nonce ledger never saw the plan nonce).
+  Combined with **one-shot attach** (a standby accepts exactly one attach, then boots
+  or dies — no reject-and-wait loop) and the plan's G4 window, cross-standby replay is
+  closed.
+- **DoS** → per-connection attach timeout; an abandoned connect must not wedge the
+  standby (bounded by 1b's pool size).
+- **Idle entitled process** → liveness/TTL is a 1b concern (reaper + `cache prune`);
+  1a just exits cleanly on attach-timeout.
+
+Channel hardening: control UDS mode `0700`, parent dir `0700` (matches the W1.2
+vsock-proxy posture); the binding nonce also appears in the socket path.
+
+## Changes
+
+### 1. Config split — `crates/deps/libkrun-sys/src/lib.rs` (`SupervisorConfig` at :1293)
+
+- **`SupervisorBaseConfig`** — workload-*independent*: kernel path, vsock wiring,
+  control-UDS path, **binding nonce** (`[u8; 32]`/hex). Drives `KrunContext` creation.
+- **`SupervisorAttachConfig`** — workload-*specific*: `plan_json`, `bundle_json`,
+  `rootfs_path`, `tenant_id`, audit paths, the **echoed binding nonce**. The workload
+  subset of today's `SupervisorConfig`.
+- A `SupervisorConfig::from_base_and_attach(base, attach) -> Result<SupervisorConfig>`
+  merge (validates the echoed nonce == base nonce) so the existing `run_with_bridge`
+  path is reused verbatim after attach.
+- Both `#[serde(deny_unknown_fields)]`. The non-pool path is **unchanged** — it still
+  decodes a whole `SupervisorConfig` on stdin and never opens a control UDS.
+
+### 2. Prelaunched flow — `crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs`
+
+`main()` today: `ensure_signed()` → read `SupervisorConfig` on stdin (:101) →
+`run_legacy`/`run_with_bridge`. Add a **prelaunched** arm selected when stdin carries
+a `SupervisorBaseConfig` (a tagged enum `SupervisorStdin { Whole(SupervisorConfig),
+Base(SupervisorBaseConfig) }`, `deny_unknown_fields`, so the legacy path is
+untouched):
+
+1. `ensure_signed()` (codesign re-exec) + dylib load + `KrunContext` creation from the
+   base (the expensive workload-independent setup) — *before* blocking.
+2. Bind the control UDS (`0700`, in a `0700` dir, nonce in the path); accept **one**
+   connection with a per-connection timeout.
+3. Read the `SupervisorAttachConfig` (length-prefixed JSON, `deny_unknown_fields`).
+4. Verify: echoed binding nonce == base nonce; then the **existing plan re-verify**
+   (signature + G4 + nonce) that `run_with_bridge` already runs — reuse it, do not
+   fork a second verifier.
+5. Merge base+attach → `SupervisorConfig`; hand to the existing `run_with_bridge`
+   (which `start_enter`s). One-shot: any verification failure or timeout exits
+   non-zero **without** `start_enter`.
+
+### 3. Attach trust-boundary fuzz + tests
+
+- `fuzz_attach_message.rs` (sibling to `fuzz_supervisor_config`) — the attach struct
+  is the only attacker-reachable-post-spawn surface; fuzz its decoder for panic-freedom.
+- Negative-path tests (each asserts **`start_enter` is never reached**): (a) wrong
+  binding nonce; (b) a second attach on the same standby; (c) unsigned plan; (d)
+  expired/out-of-window plan (G4); (e) replayed nonce. Extract the verify+merge step as
+  a **pure function** (`base + attach bytes → Result<SupervisorConfig>`) so these are
+  unit-testable without a VM (no `start_enter`).
+
+## Out of scope (1b — the pool, separate PR)
+
+`warm_pool_size` / `--warm-pool-size`; `SupervisorStandbyPool` under `~/.mvm/pool/<id>/`;
+`up` claim + cold-boot fallback; base-compat (kernel match); reaper + `cache prune` TTL;
+replenish-on-use; the bench delta. **Open 1b decisions (deferred):** fill trigger
+(lean: explicit `mvmctl pool warm [N]` + claim-if-available, no auto-refill daemon in
+v1); base compatibility (v1 standbys pre-load the default kernel; non-default → cold-boot).
+
+## Testing
+
+- Unit: the pure verify+merge function (the (a)–(e) rejection ladder + the happy merge).
+- `cargo fuzz` attach decoder (panic-free on arbitrary bytes).
+- `libkrun-live`-gated integration (dev host): spawn a prelaunched supervisor with a
+  `BaseConfig`, send a valid attach for an admitted plan, assert the guest boots +
+  agent reachable; assert a wrong-nonce attach is refused with no boot.
+- Gates: `cargo clippy --workspace -- -D warnings`, `cargo nextest run --workspace -E
+  'not package(mvm-backend)'`, `cargo test --workspace --doc`, nightly `fmt --all --check`.
+- Claim posture: the prelaunched path runs the **same** plan re-verify as
+  `run_with_bridge`; no claim-8 weakening. The `mvm-libkrun-supervisor` bin is
+  feature-gated (`libkrun-sys`) + must be rebuilt explicitly
+  (`reference_libkrun_supervisor_separate_binary_rebuild`).
+
+## References
+
+- `specs/plans/118-supervisor-standby-pool-and-live-bench.md` PR-10b — authoritative design.
+- `specs/plans/159-vz-inspired-macos-dx.md` WS-1 — the warm-pool parent.
+- `crates/mvm-vm-host/src/bin/mvm-libkrun-supervisor.rs` — the bin (legacy + bridge paths).
+- `crates/deps/libkrun-sys/src/lib.rs:1293` — `SupervisorConfig` (+ the existing re-verify in `run_with_bridge`).
+- `reference_libkrun_gotchas` — `start_enter` exits the process (one supervisor per VM).

--- a/specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md
+++ b/specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md
@@ -75,9 +75,16 @@ untouched):
 2. Bind the control UDS (`0700`, in a `0700` dir, nonce in the path); accept **one**
    connection with a per-connection timeout.
 3. Read the `SupervisorAttachConfig` (length-prefixed JSON, `deny_unknown_fields`).
-4. Verify: echoed binding nonce == base nonce; then the **existing plan re-verify**
-   (signature + G4 + nonce) that `run_with_bridge` already runs — reuse it, do not
-   fork a second verifier.
+4. Verify: echoed binding nonce == base nonce; then **add** a plan re-verify on this
+   path. ⚠️ The cold path **deliberately skips** re-verify (`mvm-libkrun-supervisor.rs:204-217`:
+   the host admitted + the stdin pipe is a private parent→child channel, trusted under
+   ADR-002 — extract, don't re-verify). The warm path's control UDS is **same-uid-reachable**,
+   so it is *not* a trusted private channel: the supervisor MUST `mvm_core::plan::verify_plan`
+   (Ed25519 signature, against the host-signer **public** key derived from `signing_key_path`)
+   + the **G4 validity window** + **nonce-replay**, mirroring `mvm-hostd::supervisor::aggregate`'s
+   gate. This is the load-bearing invariant — Plan 118 named it but it is NOT yet implemented
+   (the cold path's extract-only is why). Reuse `verify_plan` + the aggregate G4/nonce logic;
+   do not fork a second verifier.
 5. Merge base+attach → `SupervisorConfig`; hand to the existing `run_with_bridge`
    (which `start_enter`s). One-shot: any verification failure or timeout exits
    non-zero **without** `start_enter`.

--- a/specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md
+++ b/specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md
@@ -1,9 +1,13 @@
 # Design — WS-1 Layer 1a: prelaunched libkrun supervisor (base/attach split)
 
-> **Status (2026-06-09):** Approved direction (brainstorm). First sub-project of
-> Plan 159 WS-1 (warm pool). Implements **Plan 118 PR-10b's supervisor primitive**
-> (`specs/plans/118-supervisor-standby-pool-and-live-bench.md`) — the security-
-> sensitive core — as its own PR. The pool + `up` claim (1b) builds on this.
+> **Status (2026-06-09): Implemented (1a)** on branch `feat/plan-118-ws1-layer1a`.
+> First sub-project of Plan 159 WS-1 (warm pool). Implements **Plan 118 PR-10b's
+> supervisor primitive** (`specs/plans/118-supervisor-standby-pool-and-live-bench.md`)
+> — the security-sensitive core — as its own PR: the base/attach config split, the
+> prelaunched control-UDS flow with the mandatory attach-time plan re-verify, the
+> `fuzz_attach_message` target, the (a)–(e) rejection ladder, and a `libkrun-live`
+> refusal integration. The pool + `up` claim + bench delta (**1b**) build on this.
+> Implementation plan: `specs/notes/plan-118-ws1-layer1a-implementation-plan.md`.
 
 ## Goal
 

--- a/specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md
+++ b/specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md
@@ -1,6 +1,6 @@
 # Design — WS-1 Layer 1a: prelaunched libkrun supervisor (base/attach split)
 
-> **Status (2026-06-09): Implemented (1a)** on branch `feat/plan-118-ws1-layer1a`.
+> **Status (2026-06-09): Implemented (1a)** — PR #748 (`feat/plan-118-ws1-layer1a`).
 > First sub-project of Plan 159 WS-1 (warm pool). Implements **Plan 118 PR-10b's
 > supervisor primitive** (`specs/plans/118-supervisor-standby-pool-and-live-bench.md`)
 > — the security-sensitive core — as its own PR: the base/attach config split, the

--- a/specs/plans/118-supervisor-standby-pool-and-live-bench.md
+++ b/specs/plans/118-supervisor-standby-pool-and-live-bench.md
@@ -378,8 +378,8 @@ process-spawn delta, not the headline number.
 
 ### PR-10b — supervisor standby pool
 
-> **1a landed** (the supervisor *primitive*) on branch
-> `feat/plan-118-ws1-layer1a` — config split, prelaunched flow with the
+> **1a landed** (the supervisor *primitive*) in PR #748
+> (`feat/plan-118-ws1-layer1a`) — config split, prelaunched flow with the
 > mandatory attach-time plan re-verify, fuzz target, and the (a)–(e) rejection
 > ladder. The boxes below tagged **(1a)** are done; the rest are **1b** (the
 > pool + `up` integration + bench delta). See

--- a/specs/plans/118-supervisor-standby-pool-and-live-bench.md
+++ b/specs/plans/118-supervisor-standby-pool-and-live-bench.md
@@ -378,19 +378,31 @@ process-spawn delta, not the headline number.
 
 ### PR-10b — supervisor standby pool
 
+> **1a landed** (the supervisor *primitive*) on branch
+> `feat/plan-118-ws1-layer1a` — config split, prelaunched flow with the
+> mandatory attach-time plan re-verify, fuzz target, and the (a)–(e) rejection
+> ladder. The boxes below tagged **(1a)** are done; the rest are **1b** (the
+> pool + `up` integration + bench delta). See
+> `specs/notes/plan-118-ws1-layer1a-implementation-plan.md`.
+
 - [ ] `warm_pool_size: u32` on `VmStartConfig`; `--warm-pool-size`
       CLI wrapper; library "ensure pool at target" entry point.
-- [ ] `SupervisorBaseConfig` (stdin) / `SupervisorAttachConfig`
-      (control UDS) split; both `deny_unknown_fields`.
-- [ ] Prelaunched supervisor: setup → block before `start_enter` →
+- [x] **(1a)** `SupervisorBaseConfig` (stdin) / `SupervisorAttachConfig`
+      (control UDS) split; both `deny_unknown_fields`;
+      `SupervisorConfig::from_base_and_attach` merge.
+- [x] **(1a)** Prelaunched supervisor: setup → block before `start_enter` →
       attach → verify (signature + G4 + nonce + binding nonce) →
-      `start_enter`. One-shot.
+      `start_enter`. One-shot. The attach-time **plan re-verify** (absent on the
+      cold path, which extract-only under ADR-002) is the security crux —
+      `mvm_vm_host::prelaunch::verify_and_merge_attach`.
 - [ ] `SupervisorStandbyPool` under `~/.mvm/pool/<id>/`; control UDS
       `0700` + binding-nonce in path; replenish-on-use; reaper +
-      `cache prune` integration.
-- [ ] `fuzz_attach_message.rs` fuzz target.
-- [ ] Security negative-path tests (a)–(e) above; none reach
-      `start_enter`.
+      `cache prune` integration. *(1a binds the UDS `0700`/nonce-in-path; the
+      pool that owns its lifecycle is 1b.)*
+- [x] **(1a)** `fuzz_attach_message.rs` fuzz target.
+- [x] **(1a)** Security negative-path tests (a)–(e) above; none reach
+      `start_enter` (pure `verify_and_merge_attach` unit ladder) + a
+      `libkrun-live` process-level refusal integration.
 - [ ] Bench delta demonstrated via PR-10a harness.
 - [ ] `warm_pool_size = 0` default-off verified (no standbys, no UDS).
 

--- a/specs/plans/176-supervisor-standby-pool-ws1-1b.md
+++ b/specs/plans/176-supervisor-standby-pool-ws1-1b.md
@@ -892,6 +892,20 @@ git commit -m "feat(cli): warm-pool StandbySpec builder — kernel sha256 + bind
 
 ## Task 7: Claim-on-launch + `--warm-pool-size` + `pool warm` (mvm-cli)
 
+> **RE-SCOPED DURING EXECUTION (2026-06-09).** `up.rs` turned out to have **five**
+> `backend.start` sites across direct-boot / re-exec / wait paths — wiring auto-claim into
+> that admission-heavy code is delicate and deserves isolated review, and both the
+> `mvmctl pool` command and the `up` auto-claim need the same default-kernel + hypervisor
+> resolution. So Task 7 was split:
+> - **Landed in 1b-i:** the orchestration *helpers* — `claim_or_cold` (fail-open to cold)
+>   + `warm_to_target` + the `StandbySpec` builder — unit-tested against a stub backend
+>   (`crates/mvm-cli/src/commands/pool.rs`, `#[allow(dead_code)]` until wired).
+> - **Moved to 1b-ii:** the `mvmctl pool warm [N]` / `pool status` **command**, the
+>   `--warm-pool-size` flag on `up`, and the **claim-on-launch + replenish wiring** into
+>   the `up`/`run` path (the fragile part, with the shared kernel/hypervisor resolution).
+>
+> The remainder of this task as originally written is the 1b-ii work.
+
 Wire it into the launch path: on `up`/`run`, if `warm_pool_size > 0` and a compatible idle
 standby exists, claim it; else cold-boot. After a successful launch, warm the pool toward
 target (the explicit-fill half of UX option A). Add `mvmctl pool warm [N]`.

--- a/specs/plans/176-supervisor-standby-pool-ws1-1b.md
+++ b/specs/plans/176-supervisor-standby-pool-ws1-1b.md
@@ -1,0 +1,1260 @@
+# Plan 176 — Supervisor Standby Pool (Plan 118 WS-1 Layer 1b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline)
+> or superpowers:subagent-driven-development to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+>
+> **This is Plan 118 WS-1 Layer 1b.** It is numbered 176 only because the
+> `check-spec-numbers` gate requires a unique integer prefix and `118` is taken; the
+> identity is "Plan 118 WS-1 1b". Parent design: `specs/plans/118-supervisor-standby-pool-and-live-bench.md`
+> §"Part B". Builds directly on **1a (PR #748)**:
+> `specs/notes/plan-118-ws1-layer1a-implementation-plan.md`.
+
+**Goal:** Turn the 1a prelaunched-supervisor *primitive* into an actual warm pool —
+spawn standbys, claim an idle one on launch (else cold-boot), and maintain the pool —
+all behind a **backend-agnostic `VmBackend` trait seam** so Firecracker / Vz /
+cloud-hypervisor implement the same methods, not one-offs.
+
+**Architecture:** A new opt-in, fail-closed trait seam on `VmBackend`
+(`supports_standby_pool` / `spawn_standby` / `claim_standby`) parallel to the existing
+snapshot axis (`snapshot_capability` / `warm_start`). Backend-agnostic `Standby*` types
+live in `mvm-core`. The `SupervisorStandbyPool` registry (state-dir under `~/.mvm/pool/`)
+and the libkrun impl live in `mvm-backend`; libkrun's impl translates to the 1a
+`SupervisorBaseConfig`/`SupervisorAttachConfig` wire types. Claim-on-launch + replenish
+orchestration + CLI live in `mvm-cli`. The pool **fails open to cold boot** — it never
+makes a launch fail that would otherwise succeed.
+
+**Tech Stack:** Rust, `VmBackend` trait (`mvm-core`), the 1a libkrun prelaunch primitive
+(`libkrun-sys` + `mvm-vm-host`), `mvm-hostd::framing` (sync length-prefixed JSON), `sha2`
+(kernel identity), `rand` (binding nonce), Clap (CLI).
+
+---
+
+## Two stacked PRs
+
+- **1b-i (core — Tasks 1–8):** trait seam + `Standby*` types + `warm_pool_size`; pool
+  registry + libkrun `spawn_standby`/`claim_standby`; claim-on-launch + cold fallback +
+  kernel-sha256 base-compat; `up --warm-pool-size N` + `mvmctl pool warm [N]`; default-off.
+  Proves the warm-up works end-to-end (completes the 1a `#[ignore]`'d live boot).
+- **1b-ii (lifecycle/ops — Tasks 9–14):** replenish-on-use; reaper TTL + `cache prune`;
+  `mvmctl pool status` + `doctor` column; bench state-dir fix + cold-vs-warm delta
+  (deferred baseline, then a time-boxed fresh-image baseline attempt); SPRINT.md
+  multi-kernel deferred note.
+
+Both PRs stack on `feat/plan-118-ws1-layer1b` (off the unmerged 1a branch
+`feat/plan-118-ws1-layer1a`). Worktree: `../mvm-ws1b`.
+
+## Build/test commands (repo gotchas)
+
+- libkrun bits need the rustup toolchain prepended to PATH (Homebrew rustc shadows it →
+  libkrun-sys bindgen E0514):
+  ```bash
+  RUSTUP="$HOME/.rustup/toolchains/$(rustup show active-toolchain | awk '{print $1}')/bin"
+  PATH="$RUSTUP:$PATH" cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys
+  ```
+- The supervisor bin is feature-gated + not rebuilt by plain `cargo build`/`test` — build
+  it explicitly when a live test needs the latest.
+- Unit tests (no FFI): `cargo nextest run -p mvm-core -p mvm-backend -p mvm-cli -E 'not package(mvm-backend)'`.
+  `mvm-backend` test bins codesign-SIGKILL on macOS — its *unit* tests run on Linux CI;
+  locally exercise pool logic via `mvm-core`/`mvm-cli` tests + the `libkrun-live` lane.
+- Gates before each commit closes a task: `cargo fmt --all -- --check`,
+  `cargo clippy --workspace -- -D warnings`, `cargo test --workspace --doc`.
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `crates/mvm-core/src/protocol/vm_backend.rs` | `StandbySpec`/`StandbyHandle`/`StandbyClaim`/`StandbyState`/`StandbyError`; `VmBackend::{supports_standby_pool, spawn_standby, claim_standby}` (fail-closed defaults); `warm_pool_size: u32` on `VmStartConfig`. | Modify |
+| `crates/mvm-core/src/config.rs` | `mvm_pool_dir()` + `pool_standby_dir(id)` helpers (next to `vm_state_dir`). | Modify |
+| `crates/mvm-backend/src/standby_pool.rs` | `SupervisorStandbyPool` registry: record/load/list/select-idle-by-kernel/remove under `~/.mvm/pool/`. Backend-agnostic. | Create |
+| `crates/mvm-backend/src/libkrun.rs` | libkrun `spawn_standby`/`claim_standby` impls + `supports_standby_pool`→true; translate to 1a `SupervisorBaseConfig`/`SupervisorAttachConfig`. | Modify |
+| `crates/mvm-backend/src/lib.rs` | `pub mod standby_pool;` | Modify |
+| `crates/mvm-cli/src/commands/pool.rs` | `mvmctl pool warm [N]` / `pool status`; `StandbySpec` builder (kernel sha256 + binding nonce + `host_signer_id()` + key path); claim-on-launch + replenish helpers. | Create |
+| `crates/mvm-cli/src/commands/<up/run>.rs` | Wire warm-pool claim-then-replenish into the launch path; `--warm-pool-size`. | Modify |
+| `crates/mvm-cli/src/commands/cache.rs` (1b-ii) | Reaper sweep of `~/.mvm/pool/` in `cache prune`. | Modify |
+| `crates/mvm-cli/src/doctor.rs` (1b-ii) | Standby-pool column next to the warm-start matrix. | Modify |
+| `crates/mvm-build/src/bench/…` (1b-ii) | Fix `~/.local/state` vs `~/.mvm` state-dir mismatch; cold-vs-warm delta span. | Modify |
+| `specs/SPRINT.md` (1b-ii) | Deferred-follow-up note: multi-kernel pool keying. | Modify |
+
+---
+
+# PR 1b-i — core warm pool
+
+## Task 1: Backend-agnostic `Standby*` types (mvm-core)
+
+**Files:**
+- Modify: `crates/mvm-core/src/protocol/vm_backend.rs` (next to `SnapshotCapability`/`WarmStartError`, ~:460)
+- Test: same file, `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn standby_handle_serde_roundtrip_and_kernel_match() {
+        let h = StandbyHandle {
+            id: "standby-abc".into(),
+            control_socket: "/p/standby-abc/control-deadbeef.sock".into(),
+            pid: 4242,
+            kernel_sha256: "a".repeat(64),
+            binding_nonce: "deadbeef".repeat(8),
+            spawned_unix_secs: 1_700_000_000,
+            state: StandbyState::Idle,
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        let back: StandbyHandle = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, "standby-abc");
+        assert_eq!(back.state, StandbyState::Idle);
+        assert!(back.matches_kernel(&"a".repeat(64)));
+        assert!(!back.matches_kernel(&"b".repeat(64)));
+    }
+
+    #[test]
+    fn standby_error_is_std_error() {
+        fn assert_err<E: std::error::Error>(_: &E) {}
+        assert_err(&StandbyError::Unsupported { backend: "x".into() });
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-core standby_`
+Expected: FAIL — `StandbyHandle`/`StandbyState`/`StandbyError` not found.
+
+- [ ] **Step 3: Add the types**
+
+Insert after `WarmStartError` (~:478):
+
+```rust
+/// How a prelaunched standby is to be set up (Plan 118 WS-1 1b). Backend-agnostic:
+/// the caller (the launch path) fills this in; the backend's `spawn_standby`
+/// translates it to its own wire config (libkrun → `SupervisorBaseConfig`).
+#[derive(Debug, Clone)]
+pub struct StandbySpec {
+    /// Stable id for this standby (also the `~/.mvm/pool/<id>/` dir name).
+    pub id: String,
+    /// Kernel image path the standby pre-loads.
+    pub kernel_path: String,
+    /// Lowercase-hex sha256 of the kernel image — the base-compat match key.
+    pub kernel_sha256: String,
+    /// Host-signer key path (claim 8) the standby re-verifies the attach plan against.
+    pub signing_key_path: std::path::PathBuf,
+    /// Expected envelope signer id (`host:{hostname}`) — the attach plan must match it.
+    pub signer_id: String,
+    /// Per-spawn binding nonce (hex of 32 random bytes); the attach must echo it.
+    pub binding_nonce: String,
+    /// Control UDS the standby binds and blocks on (0700 in a 0700 dir, nonce in path).
+    pub control_socket: std::path::PathBuf,
+    /// Per-VM state dir the standby writes its pid into.
+    pub vm_state_dir: String,
+}
+
+/// A recorded, live standby (persisted as `~/.mvm/pool/<id>/standby.json`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StandbyHandle {
+    pub id: String,
+    pub control_socket: std::path::PathBuf,
+    pub pid: u32,
+    pub kernel_sha256: String,
+    pub binding_nonce: String,
+    pub spawned_unix_secs: u64,
+    pub state: StandbyState,
+}
+
+impl StandbyHandle {
+    /// Base-compat: a launch may claim this standby only if its plan resolves to the
+    /// same kernel image. v1 is default-kernel-only; multi-kernel keying is deferred
+    /// (SPRINT.md). Exact sha256 match — no silent wrong-kernel boot.
+    pub fn matches_kernel(&self, kernel_sha256: &str) -> bool {
+        self.kernel_sha256 == kernel_sha256
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StandbyState {
+    /// Spawned, blocked on its control UDS, not yet claimed.
+    Idle,
+    /// An attach was sent; the standby is booting or has booted.
+    Claimed,
+}
+
+/// What to attach to a claimed standby — the workload-specific half (the admitted,
+/// signed plan + rootfs + audit substrate). Backend-agnostic.
+#[derive(Debug, Clone)]
+pub struct StandbyClaim {
+    /// Workload rootfs ext4.
+    pub rootfs_path: String,
+    pub tenant_id: String,
+    pub audit_dir: std::path::PathBuf,
+    pub gateway_audit_socket: std::path::PathBuf,
+    pub gateway_events_socket: Option<std::path::PathBuf>,
+    /// JSON-encoded signed `ExecutionPlan` envelope (claim 8).
+    pub plan_json: String,
+    /// JSON-encoded `PolicyBundle`, if any.
+    pub bundle_json: Option<String>,
+}
+
+/// Why a standby spawn/claim failed. Fail-closed: every variant means the caller must
+/// fall back to a cold boot, never silently proceed without the workload.
+#[derive(Debug, thiserror::Error)]
+pub enum StandbyError {
+    #[error("{backend}: standby pool is not supported by this backend")]
+    Unsupported { backend: String },
+    #[error("spawn standby: {0}")]
+    SpawnFailed(String),
+    #[error("claim standby: {0}")]
+    ClaimFailed(String),
+}
+```
+
+(`thiserror` is already a dep of mvm-core? confirm with `rg '^thiserror' crates/mvm-core/Cargo.toml`; if absent, add `thiserror = "1"`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo nextest run -p mvm-core standby_`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-core/src/protocol/vm_backend.rs
+git commit -m "feat(core): backend-agnostic Standby{Spec,Handle,Claim,State,Error} for the warm-pool trait seam (Plan 118 WS-1 1b)"
+```
+
+## Task 2: `VmBackend` trait seam + `warm_pool_size` (mvm-core)
+
+**Files:**
+- Modify: `crates/mvm-core/src/protocol/vm_backend.rs` (the `VmBackend` trait ~:681; `VmStartConfig` ~:30)
+- Test: same file
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn standby_pool_defaults_are_fail_closed() {
+        struct Bare;
+        impl VmBackend for Bare {
+            fn name(&self) -> &str { "bare" }
+            fn capabilities(&self) -> VmCapabilities { VmCapabilities::default() }
+            fn start_with_mode(&self, _: &VmStartConfig, _: StartMode) -> Result<VmId> { unreachable!() }
+            fn stop(&self, _: &VmId) -> Result<()> { Ok(()) }
+            fn status(&self, _: &VmId) -> Result<VmStatus> { unreachable!() }
+            fn list(&self) -> Result<Vec<VmInfo>> { Ok(vec![]) }
+        }
+        let b = Bare;
+        assert!(!b.supports_standby_pool());
+        let spec = sample_standby_spec();
+        match b.spawn_standby(&spec) {
+            Err(StandbyError::Unsupported { backend }) => assert_eq!(backend, "bare"),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn warm_pool_size_defaults_to_zero() {
+        assert_eq!(VmStartConfig::default().warm_pool_size, 0);
+    }
+```
+
+Add a `sample_standby_spec()` test helper returning a `StandbySpec` with dummy paths.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-core standby_pool_defaults warm_pool_size`
+Expected: FAIL — methods/field not found.
+
+- [ ] **Step 3: Add the trait methods + the config field**
+
+In `VmStartConfig` (before the closing `}` at ~:124):
+
+```rust
+    /// Plan 118 WS-1 1b — target warm-pool size. `0` (default) = feature off: no
+    /// standbys, no idle RAM, no control UDS. A future Firecracker standby reads the
+    /// same field (it's why this lives on the backend-agnostic config).
+    pub warm_pool_size: u32,
+```
+
+In the `VmBackend` trait (after `warm_start`, ~:728):
+
+```rust
+    /// Does this backend support a prelaunched-supervisor standby pool (Plan 118
+    /// WS-1 1b)? Opt-in, default `false` — orthogonal to `snapshot_capability`
+    /// (snapshot = restore a booted VM; standby = pre-pay spawn/setup latency).
+    fn supports_standby_pool(&self) -> bool { false }
+
+    /// Spawn a prelaunched standby per `spec`, detached, blocked on its control UDS
+    /// before any boot. Returns a [`StandbyHandle`] the pool records. Fail-closed:
+    /// the default refuses so a backend opts in explicitly.
+    fn spawn_standby(&self, _spec: &StandbySpec) -> std::result::Result<StandbyHandle, StandbyError> {
+        Err(StandbyError::Unsupported { backend: self.name().to_string() })
+    }
+
+    /// Claim an idle standby: send its one-shot attach (the admitted signed plan +
+    /// rootfs + audit substrate), which the supervisor re-verifies before boot.
+    /// Returns the booted VM's [`VmId`]. Fail-closed default.
+    fn claim_standby(
+        &self,
+        _handle: &StandbyHandle,
+        _claim: &StandbyClaim,
+    ) -> std::result::Result<VmId, StandbyError> {
+        Err(StandbyError::Unsupported { backend: self.name().to_string() })
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo nextest run -p mvm-core standby_pool_defaults warm_pool_size`
+Expected: PASS. Then `cargo build -p mvm-core` (a new non-defaulted `VmStartConfig` field
+compiles because the struct derives `Default`; any literal struct constructors in the
+workspace that don't use `..Default::default()` need the field — fix those in Step 4b).
+
+- [ ] **Step 4b: Fix any exhaustive `VmStartConfig { … }` literals**
+
+Run: `rg -n 'VmStartConfig \{' crates --type rust` and add `warm_pool_size: 0,` (or
+`..Default::default()`) to any literal that lists fields exhaustively. Re-run
+`cargo build --workspace`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-core/src/protocol/vm_backend.rs
+git commit -m "feat(core): VmBackend standby-pool trait seam + warm_pool_size (fail-closed, opt-in) (Plan 118 WS-1 1b)"
+```
+
+## Task 3: Pool dir config helpers (mvm-core)
+
+**Files:**
+- Modify: `crates/mvm-core/src/config.rs` (next to `vm_state_dir`, :336)
+- Test: same file
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn pool_dirs_live_under_mvm_data_dir() {
+        let _g = EnvGuard::set("MVM_DATA_DIR", "/tmp/mvm-test-home/.mvm");
+        assert_eq!(mvm_pool_dir().unwrap(), std::path::PathBuf::from("/tmp/mvm-test-home/.mvm/pool"));
+        assert_eq!(
+            pool_standby_dir("standby-abc").unwrap(),
+            std::path::PathBuf::from("/tmp/mvm-test-home/.mvm/pool/standby-abc")
+        );
+    }
+```
+
+(Use the file's existing env-guard pattern — `rg -n 'EnvGuard|fn.*env' crates/mvm-core/src/config.rs` to match it.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-core pool_dirs_live`
+Expected: FAIL — `mvm_pool_dir`/`pool_standby_dir` not found.
+
+- [ ] **Step 3: Add the helpers**
+
+After `vm_state_dir` (:336), mirroring its `mvm_data_dir_strict()` use:
+
+```rust
+/// `~/.mvm/pool/` — the supervisor standby pool root (Plan 118 WS-1 1b). Each idle
+/// standby gets a `pool/<id>/` subdir holding its control UDS + `standby.json`.
+pub fn mvm_pool_dir() -> anyhow::Result<std::path::PathBuf> {
+    Ok(mvm_data_dir_strict()?.join("pool"))
+}
+
+/// `~/.mvm/pool/<id>/` for a single standby.
+pub fn pool_standby_dir(id: &str) -> anyhow::Result<std::path::PathBuf> {
+    Ok(mvm_pool_dir()?.join(id))
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** — `cargo nextest run -p mvm-core pool_dirs_live` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-core/src/config.rs
+git commit -m "feat(core): mvm_pool_dir + pool_standby_dir helpers under ~/.mvm/pool (Plan 118 WS-1 1b)"
+```
+
+## Task 4: `SupervisorStandbyPool` registry (mvm-backend)
+
+The backend-agnostic state-dir registry: persist/load standby handles, select an idle one
+matching a kernel, remove a dead/claimed one. No libkrun specifics here.
+
+**Files:**
+- Create: `crates/mvm-backend/src/standby_pool.rs`
+- Modify: `crates/mvm-backend/src/lib.rs` (`pub mod standby_pool;`)
+- Test: in `standby_pool.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::protocol::vm_backend::{StandbyHandle, StandbyState};
+
+    fn handle(id: &str, kernel: &str, state: StandbyState) -> StandbyHandle {
+        StandbyHandle {
+            id: id.into(),
+            control_socket: format!("/p/{id}/control.sock").into(),
+            pid: std::process::id(), // a live pid so liveness passes
+            kernel_sha256: kernel.into(),
+            binding_nonce: "ab".repeat(32),
+            spawned_unix_secs: 1,
+            state,
+        }
+    }
+
+    #[test]
+    fn record_then_load_roundtrips_under_pool_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&handle("s1", "aa", StandbyState::Idle)).unwrap();
+        let loaded = pool.load("s1").unwrap();
+        assert_eq!(loaded.id, "s1");
+        assert_eq!(loaded.state, StandbyState::Idle);
+    }
+
+    #[test]
+    fn select_idle_matches_kernel_and_skips_claimed_and_dead() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&handle("claimed", "aa", StandbyState::Claimed)).unwrap();
+        let mut dead = handle("dead", "aa", StandbyState::Idle);
+        dead.pid = 999_999; // not a live pid
+        pool.record(&dead).unwrap();
+        pool.record(&handle("good", "aa", StandbyState::Idle)).unwrap();
+        pool.record(&handle("wrong-kernel", "bb", StandbyState::Idle)).unwrap();
+
+        let picked = pool.select_idle_for_kernel("aa").unwrap();
+        assert_eq!(picked.unwrap().id, "good");
+        assert!(pool.select_idle_for_kernel("cc").unwrap().is_none());
+    }
+
+    #[test]
+    fn remove_deletes_the_standby_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&handle("s1", "aa", StandbyState::Idle)).unwrap();
+        assert!(tmp.path().join("s1").exists());
+        pool.remove("s1").unwrap();
+        assert!(!tmp.path().join("s1").exists());
+    }
+
+    #[test]
+    fn idle_count_for_kernel_counts_only_live_idle_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        pool.record(&handle("a", "aa", StandbyState::Idle)).unwrap();
+        pool.record(&handle("b", "aa", StandbyState::Claimed)).unwrap();
+        assert_eq!(pool.idle_count_for_kernel("aa").unwrap(), 1);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mvm-backend -E 'test(standby_pool)' 2>/dev/null || cargo test -p mvm-backend standby_pool::tests`
+Expected: FAIL — `SupervisorStandbyPool` not found. (On macOS the mvm-backend *binary*
+SIGKILLs under `nextest --list`; use `cargo test -p mvm-backend standby_pool::tests` here,
+which runs the lib test directly.)
+
+- [ ] **Step 3: Implement the registry**
+
+```rust
+//! Plan 118 WS-1 1b — the backend-agnostic supervisor standby pool registry.
+//!
+//! Records each prelaunched standby as `<pool_root>/<id>/standby.json` (the control
+//! UDS lives alongside as `control-<nonce>.sock`, bound by the backend's spawn impl).
+//! Selection/liveness/removal are backend-agnostic; only `spawn_standby`/`claim_standby`
+//! on the `VmBackend` impl know how to actually launch. Default-off: with
+//! `warm_pool_size == 0` the orchestration never constructs a pool.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use mvm_core::protocol::vm_backend::{StandbyHandle, StandbyState};
+
+/// Filename of the per-standby metadata JSON inside its dir.
+const HANDLE_FILE: &str = "standby.json";
+
+/// A view over `~/.mvm/pool/` (or a test root). Cheap to construct; all state is on disk.
+pub struct SupervisorStandbyPool {
+    root: PathBuf,
+}
+
+impl SupervisorStandbyPool {
+    /// Open the pool at the real `~/.mvm/pool/` root.
+    pub fn open() -> Result<Self> {
+        Ok(Self::at(mvm_core::config::mvm_pool_dir()?))
+    }
+
+    /// Open at an explicit root (test seam).
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Persist (or update) a standby's handle under `<root>/<id>/standby.json`,
+    /// creating the dir `0700`.
+    pub fn record(&self, h: &StandbyHandle) -> Result<()> {
+        let dir = self.root.join(&h.id);
+        std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+        set_mode_0700(&dir)?;
+        let json = serde_json::to_vec_pretty(h)?;
+        std::fs::write(dir.join(HANDLE_FILE), json)
+            .with_context(|| format!("write {} handle", h.id))?;
+        Ok(())
+    }
+
+    /// Load one standby's handle by id.
+    pub fn load(&self, id: &str) -> Result<StandbyHandle> {
+        let path = self.root.join(id).join(HANDLE_FILE);
+        let bytes = std::fs::read(&path).with_context(|| format!("read {}", path.display()))?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    /// All recorded handles (ignoring unreadable/garbage dirs — they get reaped in 1b-ii).
+    pub fn list(&self) -> Result<Vec<StandbyHandle>> {
+        let mut out = Vec::new();
+        let rd = match std::fs::read_dir(&self.root) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(e).context("read pool root"),
+        };
+        for entry in rd.flatten() {
+            if let Ok(h) = self.load(&entry.file_name().to_string_lossy()) {
+                out.push(h);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Pick a live, idle standby whose kernel matches — the claim candidate. `None`
+    /// means "no compatible warm standby; cold-boot." Skips claimed and dead entries.
+    pub fn select_idle_for_kernel(&self, kernel_sha256: &str) -> Result<Option<StandbyHandle>> {
+        Ok(self
+            .list()?
+            .into_iter()
+            .find(|h| h.state == StandbyState::Idle && h.matches_kernel(kernel_sha256) && pid_alive(h.pid)))
+    }
+
+    /// Count of live idle standbys for a kernel — drives replenish-to-target (1b-ii).
+    pub fn idle_count_for_kernel(&self, kernel_sha256: &str) -> Result<usize> {
+        Ok(self
+            .list()?
+            .into_iter()
+            .filter(|h| h.state == StandbyState::Idle && h.matches_kernel(kernel_sha256) && pid_alive(h.pid))
+            .count())
+    }
+
+    /// Mark a standby `Claimed` (persisted) — so a concurrent launch won't double-claim.
+    pub fn mark_claimed(&self, id: &str) -> Result<()> {
+        let mut h = self.load(id)?;
+        h.state = StandbyState::Claimed;
+        self.record(&h)
+    }
+
+    /// Remove a standby's dir (after claim/boot, or when reaping a dead one).
+    pub fn remove(&self, id: &str) -> Result<()> {
+        let dir = self.root.join(id);
+        match std::fs::remove_dir_all(&dir) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("remove {}", dir.display())),
+        }
+    }
+}
+
+/// `kill(pid, 0)` liveness — 0 ⇒ the process exists (W1.2 reaper precedent).
+fn pid_alive(pid: u32) -> bool {
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+fn set_mode_0700(p: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("chmod 0700 {}", p.display()))
+}
+```
+
+Add `pub mod standby_pool;` to `crates/mvm-backend/src/lib.rs`. (`libc` is already a
+mvm-backend dep — confirm via `rg '^libc' crates/mvm-backend/Cargo.toml`.)
+
+- [ ] **Step 4: Run to verify it passes** — `cargo test -p mvm-backend standby_pool::tests` → PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-backend/src/standby_pool.rs crates/mvm-backend/src/lib.rs
+git commit -m "feat(backend): SupervisorStandbyPool registry — record/select-idle-by-kernel/remove under ~/.mvm/pool (Plan 118 WS-1 1b)"
+```
+
+## Task 5: libkrun `spawn_standby` / `claim_standby` (mvm-backend)
+
+Translate the backend-agnostic `Standby*` types to the 1a libkrun wire types and drive the
+prelaunch primitive: `spawn_standby` spawns `mvm-libkrun-supervisor` with a
+`{"prelaunch_base": …}` stdin envelope detached; `claim_standby` frames a
+`SupervisorAttachConfig` to the control UDS.
+
+**Files:**
+- Modify: `crates/mvm-backend/src/libkrun.rs`
+- Test: same file (pure translation unit tests; live boot is Task 8)
+
+- [ ] **Step 1: Write the failing tests** (pure translators — no spawn/boot)
+
+```rust
+    #[test]
+    fn standby_spec_translates_to_prelaunch_base_envelope() {
+        let spec = sample_standby_spec(); // kernel/key/nonce/control paths
+        let base = super::standby_base_config(&spec).expect("base");
+        assert!(base.krun.rootfs_path.is_none(), "a standby carries no workload rootfs");
+        assert_eq!(base.binding_nonce, spec.binding_nonce);
+        assert_eq!(base.signer_id, spec.signer_id);
+        assert_eq!(base.control_socket_path, spec.control_socket);
+        // The bin dispatches on the `prelaunch_base` wrapper key.
+        let env = serde_json::json!({ "prelaunch_base": base });
+        assert!(env.get("prelaunch_base").is_some());
+    }
+
+    #[test]
+    fn standby_claim_translates_to_attach_config_echoing_nonce() {
+        let attach = super::standby_attach_config(&sample_standby_claim(), "ab".repeat(32));
+        assert_eq!(attach.binding_nonce, "ab".repeat(32));
+        assert_eq!(attach.rootfs_path, "/vol/rootfs.ext4");
+        assert_eq!(attach.tenant_id, "tenant-a");
+        assert_eq!(attach.plan, serde_json::json!({"signed": "envelope"}));
+    }
+```
+
+(`sample_standby_spec`/`sample_standby_claim` test helpers in this module; the claim's
+`plan_json` is `r#"{"signed":"envelope"}"#`.)
+
+- [ ] **Step 2: Run to verify it fails** — `cargo test -p mvm-backend libkrun::tests::standby` → FAIL (functions not found).
+
+- [ ] **Step 3: Implement the translators + trait impls**
+
+Add free functions (pure, unit-testable) + wire the trait methods. In `libkrun.rs`:
+
+```rust
+use libkrun_sys::{
+    BridgeRestartPolicy, KrunContext, SupervisorAttachConfig, SupervisorBaseConfig,
+};
+use mvm_core::protocol::vm_backend::{StandbyClaim, StandbyError, StandbyHandle, StandbySpec, StandbyState};
+
+/// Build the 1a `SupervisorBaseConfig` (workload-independent) from a backend-agnostic
+/// `StandbySpec`. `rootfs_path` stays `None` — the workload rootfs arrives at claim.
+fn standby_base_config(spec: &StandbySpec) -> Result<SupervisorBaseConfig, StandbyError> {
+    // Kernel-only KrunContext: vsock wiring incl. the workload-exit + agent ports the
+    // bridge path expects. Reuse the same KrunContext the cold libkrun start() builds,
+    // minus the rootfs. (Factor the shared KrunContext assembly so this and start()
+    // don't drift — see `krun_context_for_kernel` below.)
+    let mut krun = krun_context_for_kernel(&spec.id, &spec.kernel_path, &spec.vm_state_dir)
+        .map_err(|e| StandbyError::SpawnFailed(format!("build KrunContext: {e}")))?;
+    krun.rootfs_path = None;
+    Ok(SupervisorBaseConfig {
+        krun,
+        vm_state_dir: spec.vm_state_dir.clone(),
+        pid_file_name: None,
+        signing_key_path: spec.signing_key_path.clone(),
+        signer_id: spec.signer_id.clone(),
+        binding_nonce: spec.binding_nonce.clone(),
+        control_socket_path: spec.control_socket.clone(),
+        bridge_restart_policy: BridgeRestartPolicy::HardFail,
+    })
+}
+
+/// Build the 1a `SupervisorAttachConfig` from a `StandbyClaim`, echoing the standby's
+/// binding nonce. `plan_json`/`bundle_json` are decoded to `serde_json::Value` carriers
+/// (the same shape `SupervisorConfig.plan` uses).
+fn standby_attach_config(claim: &StandbyClaim, binding_nonce: String) -> Result<SupervisorAttachConfig, StandbyError> {
+    let plan: serde_json::Value = serde_json::from_str(&claim.plan_json)
+        .map_err(|e| StandbyError::ClaimFailed(format!("decode plan_json: {e}")))?;
+    let bundle = match &claim.bundle_json {
+        Some(b) => Some(serde_json::from_str(b).map_err(|e| StandbyError::ClaimFailed(format!("decode bundle_json: {e}")))?),
+        None => None,
+    };
+    Ok(SupervisorAttachConfig {
+        binding_nonce,
+        rootfs_path: claim.rootfs_path.clone(),
+        tenant_id: claim.tenant_id.clone(),
+        audit_dir: claim.audit_dir.clone(),
+        gateway_audit_socket: claim.gateway_audit_socket.clone(),
+        gateway_events_socket: claim.gateway_events_socket.clone(),
+        plan,
+        bundle,
+    })
+}
+```
+
+> **Note (`krun_context_for_kernel`):** factor the existing rootfs+kernel KrunContext
+> assembly inside libkrun `start()` into a `fn krun_context_for_kernel(name, kernel,
+> state_dir) -> Result<KrunContext>` that sets vsock ports/console/networking the same way
+> `start()` does, and have both `start()` and `standby_base_config` call it (DRY — reuse,
+> don't fork). Grep the current `start()` for where it builds `KrunContext::new(...)` and
+> lift the shared part.
+
+Then the trait impls on the libkrun backend struct:
+
+```rust
+fn supports_standby_pool(&self) -> bool { true }
+
+fn spawn_standby(&self, spec: &StandbySpec) -> std::result::Result<StandbyHandle, StandbyError> {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    let base = standby_base_config(spec)?;
+    // Control UDS dir 0700 (the bin re-binds the socket itself; pre-create the dir).
+    if let Some(parent) = spec.control_socket.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| StandbyError::SpawnFailed(e.to_string()))?;
+        let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+    }
+    let envelope = serde_json::to_vec(&serde_json::json!({ "prelaunch_base": base }))
+        .map_err(|e| StandbyError::SpawnFailed(e.to_string()))?;
+
+    let bin = resolve_supervisor_path().map_err(|e| StandbyError::SpawnFailed(e.to_string()))?;
+    let mut child = std::process::Command::new(bin)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| StandbyError::SpawnFailed(format!("spawn supervisor: {e}")))?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| StandbyError::SpawnFailed("no stdin".into()))?
+        .write_all(&envelope)
+        .map_err(|e| StandbyError::SpawnFailed(format!("write base config: {e}")))?;
+    // Detached: do not wait. The bin blocks on the control UDS until claimed.
+    let pid = child.id();
+    Ok(StandbyHandle {
+        id: spec.id.clone(),
+        control_socket: spec.control_socket.clone(),
+        pid,
+        kernel_sha256: spec.kernel_sha256.clone(),
+        binding_nonce: spec.binding_nonce.clone(),
+        spawned_unix_secs: now_unix_secs(),
+        state: StandbyState::Idle,
+    })
+}
+
+fn claim_standby(&self, handle: &StandbyHandle, claim: &StandbyClaim) -> std::result::Result<VmId, StandbyError> {
+    let attach = standby_attach_config(claim, handle.binding_nonce.clone())?;
+    let mut stream = std::os::unix::net::UnixStream::connect(&handle.control_socket)
+        .map_err(|e| StandbyError::ClaimFailed(format!("connect control UDS: {e}")))?;
+    mvm_hostd::framing::write_json_frame_sync(&mut stream, &attach)
+        .map_err(|e| StandbyError::ClaimFailed(format!("send attach: {e}")))?;
+    // The supervisor re-verifies (1a) then start_enters; it writes its pid into the
+    // state dir. The VmId is the standby's name (the state-dir key), matching the cold
+    // path's VmId convention.
+    Ok(VmId::from(handle.id.clone()))
+}
+```
+
+Add small helpers `now_unix_secs()` (`std::time::SystemTime` since `UNIX_EPOCH`) if not
+present. `VmId::from` — confirm the constructor (`rg 'impl.*VmId' crates/mvm-core`); use
+the existing one.
+
+- [ ] **Step 4: Run to verify it passes** — `cargo test -p mvm-backend libkrun::tests::standby` → PASS. Then build the bin so a later live test uses the latest:
+  `PATH="$RUSTUP:$PATH" cargo build -p mvm-vm-host --bin mvm-libkrun-supervisor --features libkrun-sys`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-backend/src/libkrun.rs
+git commit -m "feat(backend): libkrun spawn_standby/claim_standby — drive the 1a prelaunch primitive behind the trait (Plan 118 WS-1 1b)"
+```
+
+## Task 6: Standby-spec builder + claim helper (mvm-cli)
+
+The launch-path glue that owns `host_signer_id()` + the key path + kernel sha256 + the
+binding nonce, and turns "I want to launch this workload" into either a claim or a cold boot.
+
+**Files:**
+- Create: `crates/mvm-cli/src/commands/pool.rs`
+- Modify: `crates/mvm-cli/src/commands/mod.rs` (`pub mod pool;`)
+- Test: in `pool.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kernel_sha256_hex_is_64_chars_of_known_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kp = tmp.path().join("vmlinux");
+        std::fs::write(&kp, b"hello-kernel").unwrap();
+        let hex = kernel_sha256_hex(&kp).unwrap();
+        assert_eq!(hex.len(), 64);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        // sha256("hello-kernel") is stable.
+        assert_eq!(hex, sha256_hex_of(b"hello-kernel"));
+    }
+
+    #[test]
+    fn fresh_binding_nonce_is_64_hex_chars_and_varies() {
+        let a = fresh_binding_nonce();
+        let b = fresh_binding_nonce();
+        assert_eq!(a.len(), 64);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn standby_spec_for_uses_pool_dir_and_nonce_in_socket_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kp = tmp.path().join("vmlinux");
+        std::fs::write(&kp, b"k").unwrap();
+        let spec = build_standby_spec(tmp.path(), &kp, "host:test", &tmp.path().join("key")).unwrap();
+        assert!(spec.control_socket.to_string_lossy().contains(&spec.binding_nonce));
+        assert!(spec.control_socket.starts_with(tmp.path()));
+        assert_eq!(spec.kernel_sha256.len(), 64);
+    }
+}
+```
+
+Provide a `sha256_hex_of(&[u8]) -> String` test helper (or compute inline).
+
+- [ ] **Step 2: Run to verify it fails** — `cargo nextest run -p mvm-cli pool::tests` → FAIL.
+
+- [ ] **Step 3: Implement the builder helpers**
+
+```rust
+//! Plan 118 WS-1 1b — warm-pool launch glue + the `mvmctl pool` command.
+//!
+//! Owns the bits that must live above the backend: the kernel-identity hash (base-compat
+//! key), the per-spawn binding nonce, and the host signer identity/key path that the
+//! standby re-verifies the attach plan against (claim 8). Builds a backend-agnostic
+//! `StandbySpec` and drives the `SupervisorStandbyPool` + `VmBackend` trait methods.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use mvm_core::protocol::vm_backend::StandbySpec;
+use sha2::{Digest, Sha256};
+
+use super::vm::host_signer::host_signer_id;
+
+/// Lowercase-hex sha256 of a kernel image — the base-compat match key.
+pub fn kernel_sha256_hex(kernel: &Path) -> Result<String> {
+    let bytes = std::fs::read(kernel).with_context(|| format!("read kernel {}", kernel.display()))?;
+    let digest = Sha256::digest(&bytes);
+    Ok(hex_lower(&digest))
+}
+
+/// 32 random bytes as lowercase hex — the per-spawn binding nonce.
+pub fn fresh_binding_nonce() -> String {
+    use rand::RngCore;
+    let mut buf = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut buf);
+    hex_lower(&buf)
+}
+
+/// Build a `StandbySpec` for a standby that pre-loads `kernel`. The control UDS lives
+/// under `pool_root/<id>/control-<nonce>.sock` (nonce in the path — defense in depth).
+pub fn build_standby_spec(
+    pool_root: &Path,
+    kernel: &Path,
+    signer_id: &str,
+    signing_key_path: &Path,
+) -> Result<StandbySpec> {
+    let nonce = fresh_binding_nonce();
+    let id = format!("standby-{}", &nonce[..16]);
+    let dir = pool_root.join(&id);
+    Ok(StandbySpec {
+        id: id.clone(),
+        kernel_path: kernel.to_string_lossy().into_owned(),
+        kernel_sha256: kernel_sha256_hex(kernel)?,
+        signing_key_path: signing_key_path.to_path_buf(),
+        signer_id: signer_id.to_string(),
+        control_socket: dir.join(format!("control-{nonce}.sock")),
+        binding_nonce: nonce,
+        vm_state_dir: dir.to_string_lossy().into_owned(),
+    })
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+```
+
+(`sha2` + `rand` are workspace deps — confirm in `crates/mvm-cli/Cargo.toml`; add if
+missing. `host_signer_id` import path: confirm with `rg 'pub fn host_signer_id' crates/mvm-cli`.)
+
+- [ ] **Step 4: Run to verify it passes** — `cargo nextest run -p mvm-cli pool::tests` → PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-cli/src/commands/pool.rs crates/mvm-cli/src/commands/mod.rs
+git commit -m "feat(cli): warm-pool StandbySpec builder — kernel sha256 + binding nonce + signer identity (Plan 118 WS-1 1b)"
+```
+
+## Task 7: Claim-on-launch + `--warm-pool-size` + `pool warm` (mvm-cli)
+
+Wire it into the launch path: on `up`/`run`, if `warm_pool_size > 0` and a compatible idle
+standby exists, claim it; else cold-boot. After a successful launch, warm the pool toward
+target (the explicit-fill half of UX option A). Add `mvmctl pool warm [N]`.
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/pool.rs` (claim/replenish orchestration + the `pool` subcommand)
+- Modify: the launch command (`rg -n 'fn .*up|warm_pool_size|backend.start' crates/mvm-cli/src/commands/` to find the `up`/`run` path) + the Clap arg struct for `--warm-pool-size`
+- Test: `pool.rs` (claim-vs-cold decision is unit-testable with a mock backend) + `crates/mvm-cli/tests/cli.rs` (flag parsing)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `pool.rs` (decision logic against a stub backend that records calls):
+
+```rust
+    #[test]
+    fn claim_or_cold_claims_when_idle_standby_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = mvm_backend::standby_pool::SupervisorStandbyPool::at(tmp.path());
+        pool.record(&idle_handle("s1", "aa")).unwrap();
+        let backend = RecordingBackend::new("aa"); // claim_standby returns VmId("s1")
+        let decision = claim_or_cold(&pool, &backend, "aa", &sample_claim()).unwrap();
+        assert_eq!(decision, LaunchDecision::Claimed(VmId::from("s1")));
+        assert!(backend.claimed());           // claim_standby called
+        assert!(!pool.load("s1").is_ok());     // claimed standby dir removed after boot
+    }
+
+    #[test]
+    fn claim_or_cold_falls_back_to_cold_when_no_standby() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = mvm_backend::standby_pool::SupervisorStandbyPool::at(tmp.path());
+        let backend = RecordingBackend::new("aa");
+        let decision = claim_or_cold(&pool, &backend, "aa", &sample_claim()).unwrap();
+        assert_eq!(decision, LaunchDecision::ColdBoot);
+        assert!(!backend.claimed());
+    }
+
+    #[test]
+    fn claim_or_cold_falls_back_to_cold_when_claim_errors() {
+        // A standby whose claim fails (e.g. it died / refused the attach) must NOT fail
+        // the launch — fall open to cold boot.
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = mvm_backend::standby_pool::SupervisorStandbyPool::at(tmp.path());
+        pool.record(&idle_handle("s1", "aa")).unwrap();
+        let backend = RecordingBackend::failing("aa");
+        let decision = claim_or_cold(&pool, &backend, "aa", &sample_claim()).unwrap();
+        assert_eq!(decision, LaunchDecision::ColdBoot);
+        assert!(!pool.load("s1").is_ok(), "a failed standby is removed, not left idle");
+    }
+```
+
+In `crates/mvm-cli/tests/cli.rs`:
+
+```rust
+    #[test]
+    fn up_accepts_warm_pool_size_flag() {
+        let cli = Cli::try_parse_from(["mvmctl", "up", "--flake", ".", "--warm-pool-size", "2"]).unwrap();
+        // assert the parsed value threads to the command's warm_pool_size (match the
+        // existing up-args assertion style in this file).
+    }
+
+    #[test]
+    fn pool_warm_parses_optional_count() {
+        assert!(Cli::try_parse_from(["mvmctl", "pool", "warm"]).is_ok());
+        assert!(Cli::try_parse_from(["mvmctl", "pool", "warm", "3"]).is_ok());
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cargo nextest run -p mvm-cli claim_or_cold up_accepts_warm_pool pool_warm_parses` → FAIL.
+
+- [ ] **Step 3: Implement the decision + replenish + the command**
+
+```rust
+/// Outcome of the warm-pool claim attempt on a launch.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LaunchDecision {
+    /// A standby was claimed and is booting under this VmId.
+    Claimed(mvm_core::protocol::vm_backend::VmId),
+    /// No compatible warm standby (or the claim failed) — caller must cold-boot.
+    ColdBoot,
+}
+
+/// Try to claim an idle standby for `kernel_sha256`; fail open to cold boot. On a
+/// claim error the standby is removed (it's spent/broken), never left idle.
+pub fn claim_or_cold(
+    pool: &mvm_backend::standby_pool::SupervisorStandbyPool,
+    backend: &dyn mvm_core::protocol::vm_backend::VmBackend,
+    kernel_sha256: &str,
+    claim: &mvm_core::protocol::vm_backend::StandbyClaim,
+) -> anyhow::Result<LaunchDecision> {
+    if !backend.supports_standby_pool() {
+        return Ok(LaunchDecision::ColdBoot);
+    }
+    let Some(handle) = pool.select_idle_for_kernel(kernel_sha256)? else {
+        return Ok(LaunchDecision::ColdBoot);
+    };
+    // Reserve it so a concurrent launch won't double-claim.
+    pool.mark_claimed(&handle.id)?;
+    match backend.claim_standby(&handle, claim) {
+        Ok(vm_id) => {
+            // The standby has become the VM; drop its pool entry (the control UDS is
+            // consumed one-shot).
+            let _ = pool.remove(&handle.id);
+            Ok(LaunchDecision::Claimed(vm_id))
+        }
+        Err(e) => {
+            tracing::warn!(standby = %handle.id, error = %e, "standby claim failed; cold-booting");
+            let _ = pool.remove(&handle.id); // spent/broken — never leave it idle
+            Ok(LaunchDecision::ColdBoot)
+        }
+    }
+}
+
+/// Warm the pool toward `target` idle standbys for `kernel`. Best-effort: spawn failures
+/// are logged, not fatal (warm pool is an optimization). Returns how many were spawned.
+pub fn warm_to_target(
+    pool: &mvm_backend::standby_pool::SupervisorStandbyPool,
+    backend: &dyn mvm_core::protocol::vm_backend::VmBackend,
+    kernel: &std::path::Path,
+    signer_id: &str,
+    signing_key_path: &std::path::Path,
+    target: u32,
+) -> anyhow::Result<u32> {
+    if target == 0 || !backend.supports_standby_pool() {
+        return Ok(0);
+    }
+    let kernel_sha = kernel_sha256_hex(kernel)?;
+    let have = pool.idle_count_for_kernel(&kernel_sha)? as u32;
+    let pool_root = mvm_core::config::mvm_pool_dir()?;
+    std::fs::create_dir_all(&pool_root)?;
+    let mut spawned = 0;
+    for _ in have..target {
+        let spec = build_standby_spec(&pool_root, kernel, signer_id, signing_key_path)?;
+        match backend.spawn_standby(&spec) {
+            Ok(handle) => { pool.record(&handle)?; spawned += 1; }
+            Err(e) => tracing::warn!(error = %e, "spawn standby failed; pool stays under target"),
+        }
+    }
+    Ok(spawned)
+}
+```
+
+Then: (a) add `warm_pool_size: u32` (Clap `#[arg(long, default_value_t = 0)]`) to the
+`up`/`run` arg struct, thread it into `VmStartConfig.warm_pool_size`; (b) in the launch
+path, before the cold `backend.start(&cfg)`, call `claim_or_cold(...)` and use the claimed
+`VmId` when `Claimed`, else `start`; **after** a successful launch call
+`warm_to_target(..., cfg.warm_pool_size)`; (c) add a `Pool { Warm { count: Option<u32> },
+Status }` subcommand whose `Warm` calls `warm_to_target` (default count = a small constant,
+e.g. 1, when omitted — document it).
+
+- [ ] **Step 4: Run to verify it passes** — the unit + CLI tests above → PASS; `cargo build -p mvm-cli`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-cli/src/commands/pool.rs crates/mvm-cli/src/commands/  # + the up/run + cli arg files touched
+git commit -m "feat(cli): claim-on-launch + cold fallback + replenish + --warm-pool-size/pool warm (Plan 118 WS-1 1b)"
+```
+
+## Task 8: `libkrun-live` end-to-end (completes the 1a `#[ignore]`)
+
+Spawn a real standby, claim it with a freshly-signed admitted plan, assert the guest boots
+and the agent answers — the happy path 1a left `#[ignore]`'d, now driven through the pool.
+
+**Files:**
+- Create: `crates/mvm-backend/tests/standby_pool_live.rs` (gated `#![cfg(feature = "libkrun-live")]`)
+- Modify: `crates/mvm-backend/Cargo.toml` (`libkrun-live` feature + dev-deps if needed)
+
+- [ ] **Step 1: Write the test** (model the boot/agent-ping on the 1a `prelaunch_live.rs`
+  refusal test + `examples/agent_ping`; grep `rg -l 'agent_ping|libkrun-live|ensure_default_microvm_image' crates examples`):
+
+  - Build a `StandbySpec` with the default microvm kernel (`ensure_default_microvm_image()`
+    path) + the agent port in vsock wiring; `spawn_standby`.
+  - Sign an admitted plan with the on-disk host key (`host_signer::load_or_init_at` +
+    `mvm_core::plan::sign_plan`), build a `StandbyClaim` (real rootfs + plan_json),
+    `claim_standby`.
+  - Assert the agent answers `vsock::ping` (Pong) within a timeout.
+  - Negative: a wrong-nonce attach (claim built against a *different* standby's nonce) is
+    refused and no boot occurs (reuses 1a's exit-6 behavior surfaced as a claim error).
+
+- [ ] **Step 2: Run on the dev host**
+
+```bash
+MVM_CACHE_DIR=$(mktemp -d) MVM_DATA_DIR=$(mktemp -d) PATH="$RUSTUP:$PATH" \
+  cargo test -p mvm-backend --features libkrun-live --test standby_pool_live -- --nocapture
+```
+Expected: claim boots + agent reachable; wrong-nonce refused. If the dev host can't boot
+the default image (stale-image / Vz-default issues per the memory notes), mark the happy
+path `#[ignore]` with a pointer and rely on Tasks 1–7 unit coverage + the 1a refusal
+integration — **do not delete it**.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/mvm-backend/tests/standby_pool_live.rs crates/mvm-backend/Cargo.toml
+git commit -m "test(backend): libkrun-live standby spawn->claim->boot + wrong-nonce refusal (Plan 118 WS-1 1b)"
+```
+
+### 1b-i finalization
+
+- [ ] Gates: `cargo fmt --all -- --check`; `cargo clippy --workspace -- -D warnings`;
+  `cargo nextest run --workspace -E 'not package(mvm-backend)'`; `cargo test -p mvm-backend
+  standby_pool::tests libkrun::tests::standby`; `cargo test --workspace --doc`; build the
+  feature-gated bin.
+- [ ] Push `feat/plan-118-ws1-layer1b`; open the **1b-i PR** with base
+  `feat/plan-118-ws1-layer1a` (stacked). No `Co-Authored-By: Claude` trailer.
+
+---
+
+# PR 1b-ii — lifecycle / ops
+
+> Continue on the same branch after 1b-i merges (or restack onto 1a if 1a merged first).
+
+## Task 9: Reaper TTL + `cache prune` integration
+
+**Files:**
+- Modify: `crates/mvm-backend/src/standby_pool.rs` (a `reap_stale(ttl)` method)
+- Modify: `crates/mvm-cli/src/commands/cache.rs` (sweep `~/.mvm/pool/` in `prune`)
+- Test: `standby_pool.rs` + `cache.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn reap_removes_dead_and_expired_keeps_live_recent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pool = SupervisorStandbyPool::at(tmp.path());
+        // live + recent → kept
+        pool.record(&handle("keep", "aa", StandbyState::Idle)).unwrap();
+        // dead pid → reaped regardless of age
+        let mut dead = handle("dead", "aa", StandbyState::Idle); dead.pid = 999_999;
+        pool.record(&dead).unwrap();
+        // live but expired (spawned long ago) → reaped
+        let mut old = handle("old", "aa", StandbyState::Idle); old.spawned_unix_secs = 1;
+        pool.record(&old).unwrap();
+
+        let reaped = pool.reap_stale(std::time::Duration::from_secs(3600), now_unix_secs()).unwrap();
+        assert!(reaped.contains(&"dead".to_string()));
+        assert!(reaped.contains(&"old".to_string()));
+        assert!(pool.load("keep").is_ok());
+        // reaping a dead standby also kills its pid if alive (no-op for already-dead).
+    }
+```
+
+- [ ] **Step 2: Run → FAIL** (`reap_stale` not found).
+
+- [ ] **Step 3: Implement `reap_stale`** — walk `list()`; for each handle, reap when
+  `!pid_alive(pid)` OR `now - spawned_unix_secs > ttl`; on reap, best-effort
+  `libc::kill(pid, SIGTERM)` if alive, then `remove(id)`; return the reaped ids. Then in
+  `cache prune` (extend the existing `--reap-orphans` sweep — `rg -n 'reap_orphans' crates/mvm-cli/src/commands/cache.rs`), call
+  `SupervisorStandbyPool::open()?.reap_stale(POOL_TTL, now)` and report counts. Pick
+  `POOL_TTL` (e.g. 30 min) as a named const with a comment.
+
+- [ ] **Step 4: Run → PASS.** **Step 5: Commit** `feat(backend): standby reaper TTL + cache-prune sweep of ~/.mvm/pool (Plan 118 WS-1 1b)`.
+
+## Task 10: `mvmctl pool status` + `doctor` standby-pool column
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/pool.rs` (`Status` arm: list standbys, idle/claimed counts, `--json`)
+- Modify: `crates/mvm-cli/src/doctor.rs` (a `standby pool` line: backend supports? + live idle count)
+- Test: `pool.rs` + `doctor.rs` (mirror `warm_start_substrate_*` doctor tests at :2734)
+
+- [ ] **Step 1–4:** TDD a `pool status` renderer over `SupervisorStandbyPool::list()`
+  (text + `--json`, matching the repo's shared `--json` pattern) and a doctor row that
+  reports `supports_standby_pool()` + `idle_count_for_kernel(default)`; assert the line
+  format like the existing warm-start matrix test. **Step 5: Commit**
+  `feat(cli): mvmctl pool status + doctor standby-pool column (Plan 118 WS-1 1b)`.
+
+## Task 11: Bench — fix the state-dir mismatch
+
+The `bench microvm-launch` probe polls the pid at `~/.local/state/mvm/...` while the
+supervisor writes `~/.mvm/...` — so the `start_to_pid_ms` span never resolves on the dev
+host.
+
+**Files:**
+- Modify: the bench probe (`rg -n 'local/state|start_to_pid|LibkrunProbe|pid' crates/mvm-build/src crates/mvm-cli/src -g '*bench*'`)
+- Test: the probe's path-resolution unit test
+
+- [ ] **Step 1:** Write a unit test asserting the probe resolves the pid path through
+  `mvm_core::config::vm_state_dir(name)` (i.e. under `MVM_DATA_DIR`/`~/.mvm`), not
+  `~/.local/state`. **Step 2:** Run → FAIL. **Step 3:** Replace the hardcoded
+  `~/.local/state/...` join with `mvm_core::config::vm_state_dir(name).join("libkrun.pid")`
+  (reuse the helper — never build the path inline). **Step 4:** Run → PASS. **Step 5:**
+  Commit `fix(bench): resolve microvm-launch pid via mvm-core config (~/.mvm), not ~/.local/state (Plan 118 WS-1 1b)`.
+
+## Task 12: Bench — cold-vs-warm delta span
+
+**Files:**
+- Modify: the bench probe (add a warm path that pre-warms a standby then claims, measuring `start_to_pid_ms` for both)
+- Test: `libkrun-live`-gated assertion that warm `start_to_pid_ms < cold`
+
+- [ ] **Step 1–4:** Extend the probe to optionally run a warm variant (`warm_to_target(…,1)`
+  then claim) and emit both spans into the existing `BootTimingReport`/host-span JSON; a
+  `libkrun-live` test asserts the warm `start_to_pid_ms` span is finite and strictly less
+  than cold (the spawn/codesign/dylib collapse). Keep the **committed regression baseline
+  JSON deferred** (it rides PR-10a's deferral — note it in the PR). **Step 5:** Commit
+  `feat(bench): cold-vs-warm start_to_pid delta in microvm-launch (Plan 118 WS-1 1b)`.
+
+## Task 13: Replenish-on-use already in Task 7 — verify + document
+
+Replenish (`warm_to_target` after launch) landed in 1b-i Task 7. In 1b-ii, add an
+integration assertion that a claim followed by replenish restores the idle count to target,
+and document the no-daemon model in the PR + plan 118 §"Replenish-on-use".
+
+- [ ] **Step 1–4:** `libkrun-live` (or a mock-backend unit) test: target=1, spawn 1, claim
+  it, run replenish, assert `idle_count_for_kernel == 1` again. **Step 5:** Commit
+  `test(cli): replenish-on-use restores pool to target after a claim (Plan 118 WS-1 1b)`.
+
+## Task 14: Docs + deferred-follow-up notes + fresh-image baseline attempt
+
+**Files:**
+- Modify: `specs/SPRINT.md` (multi-kernel deferred note), `specs/plans/118-...md` (tick PR-10b boxes), `specs/REFACTOR-STATUS.md`, `specs/notes/plan-118-ws1-layer1a-prelaunched-supervisor-design.md` (1b status)
+
+- [ ] **Step 1:** In `specs/SPRINT.md`, under the most relevant in-flight sprint, add a
+  `### deferred follow-ups` entry:
+  > - [ ] **Multi-kernel standby pool keying (Plan 118 WS-1 1b → later).** v1 is
+  >   default-kernel-only (`StandbyHandle::matches_kernel` exact sha256; non-default plans
+  >   cold-boot). Generalize the pool to hold standbys keyed by kernel identity with
+  >   per-kernel targets + eviction once a second kernel is common.
+- [ ] **Step 2:** Tick the PR-10b boxes in `specs/plans/118-...md` that 1b lands; update
+  `specs/REFACTOR-STATUS.md` Plan 159 WS-1 line to "1b landed"; bump "Last updated".
+- [ ] **Step 3 (time-boxed stretch — UX option B):** Attempt a fresh `default-microvm`
+  image build on this Vz Mac (`mvmctl` build path) to unblock the committed bench baseline;
+  if it boots cleanly, run `bench microvm-launch` cold+warm and commit the baseline JSON. If
+  it hits the known stale-image / Vz dev-VM-boot issues within the time box, leave the
+  baseline deferred (Task 12) and note the blocker in the PR. **Do not let this block the PR.**
+- [ ] **Step 4: Commit** `docs(plan-118): record WS-1 1b standby pool; defer multi-kernel keying`.
+
+### 1b-ii finalization
+
+- [ ] All gates green; push; open the **1b-ii PR** stacked on 1b-i (or on 1a if 1b-i merged).
+
+---
+
+## Self-Review
+
+**Spec coverage** (against the approved design): trait seam ✓ (T2), `Standby*` types ✓
+(T1), pool dir helpers ✓ (T3), registry select/record/remove ✓ (T4), libkrun
+spawn/claim behind the trait ✓ (T5), kernel-sha256 base-compat ✓ (T1 `matches_kernel` +
+T4 select + T6 hash), `warm_pool_size`/`--warm-pool-size`/`pool warm` ✓ (T2/T7),
+claim-on-launch + cold fallback ✓ (T7), replenish-on-use ✓ (T7/T13), default-off ✓
+(T2 default 0 + T7 `target==0` guard), live boot ✓ (T8), reaper + cache prune ✓ (T9),
+`pool status` + doctor ✓ (T10), bench state-dir fix ✓ (T11) + cold-vs-warm delta ✓
+(T12) + deferred baseline / fresh-image attempt ✓ (T12/T14), multi-kernel deferred note ✓
+(T14), fail-open-to-cold everywhere ✓ (T7 claim error → ColdBoot). No gaps.
+
+**Type consistency:** `StandbySpec{id,kernel_path,kernel_sha256,signing_key_path,signer_id,binding_nonce,control_socket,vm_state_dir}`,
+`StandbyHandle{id,control_socket,pid,kernel_sha256,binding_nonce,spawned_unix_secs,state}`,
+`StandbyClaim{rootfs_path,tenant_id,audit_dir,gateway_audit_socket,gateway_events_socket,plan_json,bundle_json}`,
+`StandbyState{Idle,Claimed}`, `StandbyError{Unsupported,SpawnFailed,ClaimFailed}` — used
+consistently T1→T8. `supports_standby_pool`/`spawn_standby`/`claim_standby` signatures match
+across T2 (trait), T5 (libkrun impl), T7 (caller). `SupervisorStandbyPool` methods
+(`at`/`open`/`record`/`load`/`list`/`select_idle_for_kernel`/`idle_count_for_kernel`/`mark_claimed`/`remove`/`reap_stale`)
+consistent T4/T7/T9. `LaunchDecision{Claimed(VmId),ColdBoot}` T7.
+
+**Placeholders:** none — every code step shows real signatures/bodies; the few "grep to
+find the exact call site" notes are lift-existing-code instructions (DRY reuse), not
+invent-it-later gaps, and each names the rg query + what to change.
+
+## Out of scope / deferred
+
+- **Multi-kernel pool keying** → SPRINT.md deferred follow-up (Task 14).
+- **Firecracker / Vz / cloud-hypervisor standby impls** → they implement the same three
+  trait methods later; the seam + registry + orchestration are backend-agnostic here.
+- **Committed bench regression baseline JSON** → rides PR-10a's deferral unless Task 14's
+  fresh-image attempt succeeds.
+- **mvmd/fleet wiring** → out of repo; the libkrun pool's v1 beneficiary is local `mvmctl up`.

--- a/specs/plans/176-supervisor-standby-pool-ws1-1b.md
+++ b/specs/plans/176-supervisor-standby-pool-ws1-1b.md
@@ -1116,6 +1116,15 @@ git commit -m "test(backend): libkrun-live standby spawn->claim->boot + wrong-no
 
 # PR 1b-ii — lifecycle / ops
 
+> **Status (2026-06-09):** **Landed** — Task 9 (reaper + cache-prune), Task 10 (doctor
+> standby column + `AnyBackend` delegates), Task 11 (bench state-dir fix), **plus** the
+> re-scoped `mvmctl pool warm/status` command + the shared `resolve_effective_hypervisor`.
+> `claim_or_cold` was made closure-ready (per-standby audit substrate). **Deferred to a
+> focused follow-up** (see SPRINT.md §"Plan 118 WS-1 1b"): the `up`/`run` auto-claim wiring
+> (needs an in-`up.rs` name-rebind — a claimed VM runs under its standby-id — and a
+> confirmed libkrun bridge boot), `--warm-pool-size` + replenish-on-use (Tasks 7/13),
+> multi-kernel keying, honour-`--name`/volumes, and the committed bench delta (Task 12).
+
 > Continue on the same branch after 1b-i merges (or restack onto 1a if 1a merged first).
 
 ## Task 9: Reaper TTL + `cache prune` integration

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -116,6 +116,12 @@ const CACHE_SUB: &[(&str, AuditPosture)] = &[
     ("prune", AuditPosture::Emits("CachePrune")),
 ];
 
+// Plan 118 WS-1 1b — `mvmctl pool`.
+const POOL_SUB: &[(&str, AuditPosture)] = &[
+    ("warm", AuditPosture::Emits("PoolWarm")),
+    ("status", AuditPosture::ReadOnly),
+];
+
 const IMAGE_SUB: &[(&str, AuditPosture)] = &[
     ("pull", AuditPosture::Emits("ImageFetch")),
     ("ls", AuditPosture::ReadOnly),
@@ -319,6 +325,7 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     ("audit", AuditPosture::ReadOnly),
     ("network", AuditPosture::DelegatesToSub(NETWORK_SUB)),
     ("cache", AuditPosture::DelegatesToSub(CACHE_SUB)),
+    ("pool", AuditPosture::DelegatesToSub(POOL_SUB)),
     // Plan 170 WS-A — reconcile-on-entry convergence. The non-dry-run
     // path emits one `RegistryReconcile` per healed drift item.
     ("reconcile", AuditPosture::Emits("RegistryReconcile")),
@@ -494,6 +501,7 @@ fn audit_posture_emits_entries_reference_known_audit_kinds() {
         "ManifestTagRemove",
         "NetworkCreate",
         "NetworkRemove",
+        "PoolWarm",
         "RegistryReconcile",
         "SecretGet",
         "SecretPut",


### PR DESCRIPTION
## Summary

Plan 118 WS-1 — the macOS "instant up" **supervisor warm pool**, end to end. This is the
**consolidation** of the four stacked PRs **#748 → #751 → #754 → #756** into one (because
`main` requires up-to-date branches and a 4-deep stack made serial merges impractical).
Identical code; rebased clean onto current `main`. The four are superseded and will be
closed pointing here.

Plans: `specs/plans/118-supervisor-standby-pool-and-live-bench.md` §"Part B",
`specs/plans/176-supervisor-standby-pool-ws1-1b.md`, and the 1a design/impl notes.

### 1a — prelaunched supervisor primitive (security core)
A `mvm-libkrun-supervisor` `prelaunch_base` mode: do the workload-independent setup at
spawn, block on a `0700` control UDS holding no rootfs/plan, and on a verified `attach`
**independently re-verify the signed `ExecutionPlan`** (Ed25519 + G4 window + nonce) before
`start_enter` — because the control UDS is same-uid-reachable, unlike the cold path's
trusted stdin pipe. `SupervisorBaseConfig`/`SupervisorAttachConfig` split + per-spawn
binding nonce + one-shot attach + `fuzz_attach_message` + the (a)–(e) rejection ladder.

### 1b-i — backend-agnostic trait seam
`VmBackend::{supports_standby_pool, spawn_standby, claim_standby}` (opt-in, fail-closed,
parallel to the existing `snapshot_capability`/`warm_start` axis) + `Standby{Spec,Handle,
Claim,Compat,…}` in `mvm-core`; the `SupervisorStandbyPool` registry (`~/.mvm/pool/`) +
libkrun impl in `mvm-backend`. Base-compat = kernel sha256 **+ vcpus + mem** (libkrun fixes
resources at spawn). Sync framing relocated to `libkrun_sys::framing` (mvm-backend can't
depend on mvm-hostd). Firecracker/Vz/cloud-hypervisor implement the same methods later — no
one-offs.

### 1b-ii — lifecycle / ops
Standby reaper TTL + `cache prune` sweep (SIGTERMs live-expired supervisors); `mvmctl pool
warm/status` (text + `--json`); `doctor` standby-pool column; **bench state-dir bug fix**
(probe polled XDG `~/.local/state` while the supervisor writes `~/.mvm`).

### 1b-iii — up auto-claim (+ live bridge-boot validation)
`try_warm_claim` claims a compatible idle standby (auto-named + bridge-admitted launches
only; **fail-open to cold boot**) and rebinds the VM name to the standby-id; `replenish_
after_launch` tops the pool up; `--warm-pool-size` (default 0 = off). **Live-validated** the
libkrun bridge path boots end-to-end (`MVM_GATEWAY_BRIDGE=1 up … --hypervisor libkrun
--wait` → **exit 7**), so the `up.rs` "bridge broken" comment is stale. Found+fixed: the 1a
30s standby attach timeout (→ 30 min, the reaper TTL) that made standbys self-exit before a
later `up` could claim them.

### Safety
`warm_pool_size = 0` (default) leaves every path byte-for-byte unchanged; the claim
fail-opens to cold everywhere, so it can never regress a launch.

## Known follow-up (documented, not blocking — SPRINT.md §"Plan 118 WS-1 1b")
The libkrun **mkGuest** warm claim doesn't *fire* yet: a mkGuest image ships no kernel —
libkrun materializes the *bundled* kernel at `start_enter`, so `cfg.kernel_path` is absent
when `try_warm_claim` computes the compat key → it fail-opens to cold. A libkrun standby is
workload-independent, so the key must be the **bundled** kernel sha (identity in
`libkrun-sys`). Everything else (eligibility, claim, name-rebind, replenish, reaper) is
wired + validated.

## Test Plan
- [x] `cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Touched-area suites green (standby/pool/prelaunch/framing/audit_total/base_attach/warm — 67 tests)
- [x] Audit-posture coverage fixed (new `PoolWarm` kind + emit + posture)
- [x] Live: libkrun bridge boot returns workload exit 7; replenish spawns standbys; 30-min
      timeout keeps standbys alive; fail-open cold-boots on the mkGuest kernel-read
- [ ] End-to-end libkrun mkGuest warm claim — bundled-kernel compat key follow-up