### PR TITLE
docs(network): add rvproxy gateway ownership ADR and plan

### DIFF
--- a/specs/adrs/078-rvproxy-gateway-ownership.md
+++ b/specs/adrs/078-rvproxy-gateway-ownership.md
@@ -1,0 +1,152 @@
+# ADR-078 — First-party virtio-net gateway ownership via rvproxy
+
+**Status:** accepted 2026-06-10. Implemented by
+`specs/plans/179-rvproxy-gvproxy-replacement.md`. **Amends ADR-055** (the
+`gvproxy` backend remains the macOS/libkrun networking shape, but its
+implementation no longer has to be upstream `gvproxy`) and extends the
+claim-10 no-bypass posture in ADR-058 and the network-provider seam in
+ADR-064.
+
+## Context
+
+`mvm` currently claims a high degree of control over the runtime, builder, and
+network-policy surface. That claim is materially weakened on the macOS/libkrun
+path by one remaining third-party runtime dependency: the per-VM virtio-net
+gateway binary spawned from
+`crates/deps/libkrun-sys/src/gvproxy.rs`.
+
+Today the architecture is already close to what we want:
+
+- `mvm` owns VM lifecycle, per-VM supervisor processes, and backend selection.
+- `mvm` owns the gateway audit bridge and policy seam in
+  `crates/mvm-hostd/src/supervisor/gateway_bridge.rs`.
+- `mvm` intentionally removed TSI and requires a real virtio-net gateway on
+  both builder and workload libkrun paths (`passt` on Linux, `gvproxy` on
+  macOS) so claim-10 mediation always has a host-visible seam.
+
+The remaining gap is that macOS/libkrun guest egress is still implemented by
+an external Go binary whose lifecycle and feature surface `mvm` does not own.
+That creates four problems:
+
+1. the product claim "we own the runtime and network plane" is not literally
+   true on that path;
+2. `gvproxy` imposes behavior `mvm` does not want, most notably a mandatory
+   SSH-forward port;
+3. the gateway implementation is outside the repo's normal auditability and
+   iteration loop;
+4. `mvm` and `rvproxy` now already share a proven compatibility seam, so
+   continuing to defer ownership no longer buys much.
+
+`rvproxy` exists specifically to close that gap. It already proves the
+unchanged `mvm` gvproxy-compatibility gate on the vfkit/unixgram transport
+shape, DHCP round-trip, and daemon lifecycle contract.
+
+## Decision
+
+Adopt `rvproxy` as the **first-party implementation** of the macOS/libkrun
+`gvproxy` gateway contract, while preserving the existing `mvm` architecture.
+
+This is a **gateway implementation replacement**, not an architecture rewrite.
+`mvm` keeps:
+
+- the per-VM supervisor model;
+- the audit/policy bridge as the claim-10 mediation seam;
+- the existing builder/runtime gateway-selection flow;
+- the `NetworkingPreference` model (`passt` on Linux, `gvproxy`-shaped
+  unixgram gateway on macOS).
+
+The practical meaning of "replace gvproxy" is:
+
+1. `mvm` gains an explicit production gateway-binary override for the
+   macOS/libkrun `gvproxy` path.
+2. `rvproxy` is run in **gvproxy-compatible mode** as a constrained per-VM
+   daemon behind that seam.
+3. The integration target remains the current CLI + vfkit/unixgram + DHCP
+   contract, not a new control API.
+4. The first rollout target is **macOS/libkrun only**. Linux `passt` remains
+   unchanged unless a later ADR deliberately broadens scope.
+
+## Why this shape
+
+### Preserve the seam `mvm` already got right
+
+The key architectural fact is that `mvm` already treats the gateway as an
+implementation behind a stricter seam:
+
+- the libkrun launcher spawns a per-VM gateway and waits for a socket;
+- the bridge sits between guest virtio-net traffic and that gateway;
+- policy/audit stays in `mvm`, not in the gateway.
+
+That means we do not need a larger redesign to gain ownership. Replacing the
+gateway binary at that seam is enough.
+
+### Ownership without over-coupling
+
+`rvproxy` becomes first-party runtime code, but not the place where
+`mvm` centralizes plan admission or control-plane logic. The host-side trust
+boundary stays where `mvm` already places it: supervisor + bridge + vsock
+broker, with the gateway as a narrowly-scoped egress dataplane component.
+
+### Surface reduction, not expansion
+
+In compat mode `rvproxy` can accept `-ssh-port` without binding a real SSH
+listener and can avoid exposing its broader local API/control surface. That
+improves the current posture rather than widening it.
+
+## Security posture
+
+This decision does not reduce the claim-10 posture. It changes who owns the
+gateway implementation, not where mediation occurs.
+
+Security effects:
+
+- **Improved ownership:** the guest egress gateway on macOS/libkrun becomes
+  first-party Rust code in the same engineering loop as the rest of the
+  runtime.
+- **No-bypass preserved:** all traffic still traverses the existing bridge
+  seam; `rvproxy` is not allowed to bypass the supervisor or short-circuit
+  policy.
+- **SSH surface reduced:** unlike upstream `gvproxy`, `rvproxy` does not need
+  to bind a meaningful SSH-forward listener just to satisfy CLI compatibility.
+- **Control-plane surface constrained:** `mvm` must run `rvproxy` in its
+  gvproxy-compat mode with no separately exposed local API.
+
+What does not change:
+
+- guest↔host control traffic remains on the existing `mvm` channels (not a new
+  `rvproxy` control plane);
+- Linux `passt` remains a separate external dependency until deliberately
+  revisited;
+- upstream parser/runtime bugs are replaced by first-party parser/runtime bugs,
+  so the maintenance burden moves in-house.
+
+## Consequences
+
+- `mvm` can make a much tighter claim that it owns the macOS/libkrun runtime
+  and network plane end-to-end.
+- The builder VM and workload VM networking paths stay aligned because both
+  already share the same `resolve_networking_mode()` seam.
+- The integration can land incrementally because `rvproxy` already targets the
+  exact contract `mvm` invokes today.
+- The product claim must still be scoped honestly: adopting `rvproxy` on the
+  macOS/libkrun seam does **not** mean `mvm` owns every network backend
+  everywhere until Linux `passt` is addressed separately.
+
+## Alternatives considered
+
+- **Keep upstream `gvproxy` indefinitely.** Rejected. It keeps the weakest
+  point in the "we own the plane" story and preserves behavior `mvm` does not
+  want.
+- **Rewrite `mvm` around an `rvproxy` control API.** Rejected for now. Too much
+  churn for the immediate ownership win; the current seam is already good.
+- **Replace Linux `passt` and macOS `gvproxy` together.** Rejected as the first
+  step. It broadens scope and risk unnecessarily.
+- **Vendor upstream `gvproxy` into `mvm`.** Rejected. It increases ownership of
+  packaging, not of the gateway implementation or feature direction.
+
+## Out of scope
+
+- Replacing Linux `passt`.
+- Changing the vsock control-plane architecture.
+- Broadening `rvproxy` compat mode into the future `mvmd` control surface.
+- Windows or broader all-backend network-plane unification.

--- a/specs/plans/179-rvproxy-gvproxy-replacement.md
+++ b/specs/plans/179-rvproxy-gvproxy-replacement.md
@@ -1,0 +1,203 @@
+# Plan 179 — Replace macOS/libkrun gvproxy with rvproxy (Implementation Plan)
+
+> **Numbering:** 179 is the next free plan number after 178. Confirm still free
+> at merge.
+>
+> **Decision source:** [ADR-078](../adrs/078-rvproxy-gateway-ownership.md).
+
+**Goal:** Replace upstream `gvproxy` with `rvproxy` on the macOS/libkrun
+gateway seam so `mvm` owns the guest egress plane on that path without
+rewriting the surrounding supervisor, builder, or policy architecture.
+
+**Architecture:** The load-bearing production seam is the per-VM gateway spawn
+in `crates/deps/libkrun-sys/src/gvproxy.rs`, the shared builder/runtime
+gateway-selection flow in `crates/mvm-build/src/libkrun_builder.rs` and
+`crates/mvm-backend/src/libkrun.rs`, and the claim-10 mediation bridge in
+`crates/mvm-hostd/src/supervisor/gateway_bridge.rs`. `rvproxy` is adopted as a
+gvproxy-compatible binary behind that seam, not as a new control-plane owner.
+
+**Tech Stack:** Rust, libkrun supervisor path, `rvproxy` gvproxy-compat CLI,
+Unix datagram vfkit transport, existing bridge/audit pipeline.
+
+---
+
+## Guardrails (every task)
+
+- Do not weaken the claim-10 no-bypass posture. The bridge remains the
+  mandatory mediation seam.
+- No SSH-in-guest regressions. `rvproxy` may tolerate `-ssh-port`; `mvm` must
+  not start depending on SSH forwarding.
+- Keep Linux `passt` behavior unchanged unless a later plan explicitly broadens
+  scope.
+- Treat the builder VM and workload VM as one rollout surface; do not make them
+  diverge on gateway selection semantics.
+- Prefer an explicit binary-override seam over symlink/path hacks.
+- Production rollout requires end-to-end proof, not just the existing DHCP test.
+
+## File Structure
+
+New / modified likely:
+
+- `crates/deps/libkrun-sys/src/gvproxy.rs`
+- `crates/mvm-build/src/libkrun_builder.rs`
+- `crates/mvm-backend/src/libkrun.rs`
+- `crates/mvm-hostd/src/supervisor/gateway_bridge.rs`
+- `crates/mvm-cli/src/doctor.rs`
+- `public/src/content/docs/guides/networking.md`
+- `CLAUDE.md`
+- new docs for operator selection / install guidance if needed
+
+---
+
+## Phase 1 — Make the production seam configurable
+
+### Task 1: Add a real gateway-binary override for the gvproxy path
+**Files:** `crates/deps/libkrun-sys/src/gvproxy.rs`
+
+- [ ] Add an explicit binary-resolution path for the macOS/libkrun gvproxy
+      launcher, e.g. `MVM_GVPROXY_BIN`, before fallback to `which("gvproxy")`.
+- [ ] Preserve existing error messaging and install hints when no override is
+      set.
+- [ ] Cover override resolution with unit tests so the production path, not
+      just the bridge test, can target `rvproxy`.
+- [ ] Commit: `feat(network): allow overriding gvproxy-compatible gateway binary`
+
+### Task 2: Keep the semantic mode name stable
+**Files:** `crates/mvm-build/src/libkrun_builder.rs`,
+`crates/mvm-backend/src/libkrun.rs`
+
+- [ ] Confirm `NetworkingPreference::Gvproxy` remains the correct semantic name
+      for "vfkit/unixgram gvproxy-shaped gateway mode", even when the binary is
+      `rvproxy`.
+- [ ] Do **not** introduce a parallel `Rvproxy` networking mode yet unless a
+      hard production reason appears; prefer binary selection over mode
+      duplication.
+- [ ] Add comments clarifying that the mode name describes the transport
+      contract, not necessarily the upstream implementation.
+- [ ] Commit: `docs(network): clarify gvproxy mode is a contract, not a vendor`
+
+### Task 3: Extend doctor/install messaging
+**Files:** `crates/mvm-cli/src/doctor.rs`, docs
+
+- [ ] Update doctor output to distinguish:
+      - active gateway contract (`gvproxy`-compatible unixgram path)
+      - selected binary (upstream `gvproxy` or overridden `rvproxy`)
+- [ ] Make install guidance truthful for both the default upstream path and the
+      first-party `rvproxy` path.
+- [ ] Commit: `feat(doctor): report gvproxy-compatible gateway selection`
+
+---
+
+## Phase 2 — Prove rvproxy at the existing compatibility gate
+
+### Task 4: Make the existing acceptance gate exercise the production override
+**Files:** tests/docs only if needed
+
+- [ ] Keep the authoritative acceptance test unchanged in substance:
+      `gvproxy_dhcp_offer_roundtrips_through_bridge`.
+- [ ] Add a repo-managed command path that runs the same gate against the
+      production override, not only `MVM_GATEWAY_BIN` in test code.
+- [ ] Record the control case against upstream `gvproxy` and the pass case
+      against `rvproxy`.
+- [ ] Commit: `test(network): exercise gvproxy bridge gate through production override`
+
+### Task 5: Validate daemon lifecycle parity
+**Files:** `crates/deps/libkrun-sys/src/gvproxy.rs`, test coverage
+
+- [ ] Prove the per-VM lifecycle assumptions still hold when the binary is
+      `rvproxy`:
+      - socket appears within the existing wait window
+      - stale socket cleanup still works
+      - SIGTERM/SIGKILL shutdown behavior remains valid
+      - orphan reaping behavior remains acceptable
+- [ ] Encode any missing lifecycle assertions in tests or smoke scripts.
+- [ ] Commit: `test(network): verify rvproxy lifecycle on gvproxy seam`
+
+---
+
+## Phase 3 — End-to-end builder and workload proof
+
+### Task 6: Builder VM proof on macOS/libkrun with rvproxy
+**Files:** builder docs/tests/scripts as needed
+
+- [ ] Run the real builder path on macOS with the gateway override pointed at
+      `rvproxy`.
+- [ ] Prove the builder can:
+      - acquire DHCP
+      - resolve DNS
+      - fetch from the network
+      - complete a representative build or image bootstrap path
+- [ ] Capture operator-facing evidence and document the exact invocation.
+- [ ] Commit: `docs(network): record rvproxy-backed builder proof`
+
+### Task 7: Workload VM proof on macOS/libkrun with rvproxy
+**Files:** workload smoke tests/docs as needed
+
+- [ ] Run the real workload libkrun path with the same override.
+- [ ] Prove guest egress beyond DHCP:
+      - DNS
+      - TCP/UDP forwarding
+      - policy/audit bridge still emits expected events
+- [ ] Confirm no guest-control-plane regressions from the gateway swap.
+- [ ] Commit: `docs(network): record rvproxy-backed workload proof`
+
+---
+
+## Phase 4 — Productize the first-party gateway path
+
+### Task 8: Decide defaulting policy
+**Files:** launch path + docs
+
+- [ ] Decide whether first release behavior is:
+      - explicit opt-in override only, or
+      - default-to-`rvproxy` on supported macOS/libkrun hosts
+- [ ] Prefer opt-in first if production evidence is still thin; flip default
+      only after builder + workload proof is routine.
+- [ ] Commit: `feat(network): default macOS libkrun gateway to rvproxy`
+      or document why the default stays deferred.
+
+### Task 9: Fix stale networking documentation
+**Files:** `public/src/content/docs/guides/networking.md`, `CLAUDE.md`
+
+- [ ] Remove stale references that still describe libkrun macOS networking as
+      TSI/host-loopback.
+- [ ] Replace them with the current truth:
+      - Linux libkrun path uses `passt`
+      - macOS libkrun path uses a `gvproxy`-compatible vfkit/unixgram gateway
+      - `rvproxy` is the first-party implementation when selected
+- [ ] Commit: `docs(network): align macOS libkrun networking docs with rvproxy path`
+
+---
+
+## Phase 5 — Close the ownership claim honestly
+
+### Task 10: Restate the product claim precisely
+**Files:** docs/specs as needed
+
+- [ ] Update product/spec language so the claim is precise:
+      - after this plan, `mvm` owns the macOS/libkrun guest egress gateway
+        implementation
+      - Linux `passt` remains a separate external dependency unless and until a
+        later plan replaces it
+- [ ] Cross-link ADR-078 from the relevant runtime/network architecture docs.
+- [ ] Commit: `docs(architecture): state first-party network-plane ownership precisely`
+
+### Task 11: Follow-on decision point for Linux
+- [ ] After macOS/libkrun is stable on `rvproxy`, write the follow-on decision:
+      keep Linux `passt` as an intentional exception, or start a separate plan
+      to replace it.
+- [ ] Do not let that decision silently ride inside this plan.
+
+---
+
+## Self-review / success criteria
+
+- [ ] `mvm` can point its production macOS/libkrun gvproxy seam at `rvproxy`
+      without code-path hacks.
+- [ ] The unchanged bridge DHCP compatibility gate passes against `rvproxy`.
+- [ ] Builder VM networking works end-to-end on the `rvproxy` path.
+- [ ] Workload VM networking works end-to-end on the `rvproxy` path.
+- [ ] Claim-10 bridge mediation remains intact; no TSI/no-bypass regression.
+- [ ] The docs no longer claim stale TSI behavior on macOS/libkrun.
+- [ ] The product claim is tighter and more truthful: `mvm` owns the macOS
+      libkrun guest egress gateway implementation.


### PR DESCRIPTION
## Summary
- add ADR-078 for first-party macOS/libkrun guest egress gateway ownership via rvproxy
- add Plan 179 for the production override, compatibility proof, and staged rollout
- scope the claim honestly so Linux passt remains a separate follow-on decision

## Testing
- not run (docs/specs only)