### PR TITLE
feat(checkpoint): Plan 159 WS-2 PR1 — fs_quick checkpoint + fork

### DIFF
--- a/crates/mvm-backend/src/apple_container.rs
+++ b/crates/mvm-backend/src/apple_container.rs
@@ -72,6 +72,8 @@ impl VmBackend for AppleContainerBackend {
             // an in-guest device. Declared `false` so the host-side
             // reclaim controller skips this backend cleanly.
             balloon: false,
+            // Apple Container runs on macOS with APFS, so clonefile is available.
+            fs_quick_checkpoint: cfg!(target_os = "macos"),
         }
     }
 

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -135,6 +135,7 @@ impl VmBackend for FirecrackerBackend {
             vsock: true,
             tap_networking: true,
             balloon: true,
+            fs_quick_checkpoint: false,
         }
     }
 

--- a/crates/mvm-backend/src/checkpoint/mod.rs
+++ b/crates/mvm-backend/src/checkpoint/mod.rs
@@ -117,6 +117,74 @@ pub struct CaptureFsQuickParams {
     pub quiesced: bool,
 }
 
+/// Inputs for forking a child instance from a checkpoint.
+pub struct ForkParams {
+    pub checkpoint: CheckpointId,
+    /// New checkpoint-id recording this fork's lineage.
+    pub child_id: CheckpointId,
+    pub child_vm_name: String,
+    /// Where to materialize the child's rootfs (the new VM's state dir).
+    pub dest_dir: PathBuf,
+    pub created_unix: u64,
+}
+
+/// Branch a new sandbox lineage from a checkpoint: verify the source content's
+/// integrity, CoW-clone it into `dest_dir`, and record a child checkpoint whose
+/// `parent` points back to the source. Boot of the child is the caller's job.
+pub fn fork_checkpoint(store: &CheckpointStore, params: ForkParams) -> Result<CheckpointMeta> {
+    let parent = store.read_meta(&params.checkpoint)?;
+    if parent.class != CheckpointClass::FsQuick {
+        anyhow::bail!(
+            "cannot fork checkpoint '{}': class vm_full is not supported yet",
+            parent.id
+        );
+    }
+
+    let content_dir = store.content_dir(&parent.id);
+    let blob = first_file_in(&content_dir)?;
+    let actual = sha256_file_hex(&blob)?;
+    if actual != parent.content_sha256 {
+        anyhow::bail!(
+            "checkpoint '{}' content failed integrity (sha256): expected {}, got {}",
+            parent.id,
+            parent.content_sha256,
+            actual
+        );
+    }
+
+    std::fs::create_dir_all(&params.dest_dir)
+        .with_context(|| format!("creating {}", params.dest_dir.display()))?;
+    let blob_name = blob.file_name().context("content blob has no file name")?;
+    let dst = params.dest_dir.join(blob_name);
+    crate::base::cow::clone_rootfs_for_instance(&blob, &dst)
+        .context("cloning checkpoint content into child instance")?;
+
+    let child = CheckpointMeta::builder(
+        params.child_id,
+        CheckpointClass::FsQuick,
+        params.child_vm_name,
+    )
+    .parent(Some(parent.id))
+    .created_unix(params.created_unix)
+    .content_sha256(actual)
+    .supervisor_config_digest(parent.supervisor_config_digest)
+    .build();
+    store.write_meta(&child)?;
+    Ok(child)
+}
+
+fn first_file_in(dir: &Path) -> Result<PathBuf> {
+    for entry in
+        std::fs::read_dir(dir).with_context(|| format!("reading content dir {}", dir.display()))?
+    {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            return Ok(entry.path());
+        }
+    }
+    anyhow::bail!("checkpoint content dir {} has no file", dir.display())
+}
+
 fn sha256_file_hex(path: &Path) -> Result<String> {
     mvm_core::crypto::image_verify::sha256_file(path)
         .with_context(|| format!("hashing {}", path.display()))
@@ -251,6 +319,94 @@ mod tests {
         };
         let err = capture_fs_quick(&store, params).unwrap_err();
         assert!(err.to_string().contains("quiesced"));
+    }
+
+    fn seed_fs_quick_checkpoint(store: &CheckpointStore, tmp: &Path, id: &str) -> CheckpointMeta {
+        let rootfs = write_fake_rootfs(tmp);
+        capture_fs_quick(
+            store,
+            CaptureFsQuickParams {
+                id: CheckpointId::new(id),
+                vm_name: "parentvm".into(),
+                rootfs,
+                supervisor_config_digest: "d".into(),
+                tag: None,
+                created_unix: 1,
+                quiesced: true,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn fork_clones_content_and_records_lineage() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let parent = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
+        let dst = tmp.path().join("childvm-state");
+        let child = fork_checkpoint(
+            &store,
+            ForkParams {
+                checkpoint: parent.id.clone(),
+                child_id: CheckpointId::new("f1"),
+                child_vm_name: "childvm".into(),
+                dest_dir: dst.clone(),
+                created_unix: 2,
+            },
+        )
+        .unwrap();
+        assert_eq!(child.parent.as_ref().unwrap(), &parent.id);
+        assert_eq!(child.vm_name, "childvm");
+        assert_eq!(
+            std::fs::read(dst.join("rootfs.ext4")).unwrap(),
+            b"fake-ext4-bytes"
+        );
+        assert_eq!(store.children_of(&parent.id).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn fork_refuses_vm_full_in_this_pr() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let m = CheckpointMeta::builder(CheckpointId::new("vf"), CheckpointClass::VmFull, "vm")
+            .content_sha256("h")
+            .supervisor_config_digest("d")
+            .created_unix(1)
+            .build();
+        store.write_meta(&m).unwrap();
+        let err = fork_checkpoint(
+            &store,
+            ForkParams {
+                checkpoint: m.id,
+                child_id: CheckpointId::new("f"),
+                child_vm_name: "c".into(),
+                dest_dir: tmp.path().join("d"),
+                created_unix: 2,
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("vm_full"));
+    }
+
+    #[test]
+    fn fork_refuses_tampered_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let parent = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
+        let blob = store.content_dir(&parent.id).join("rootfs.ext4");
+        std::fs::write(&blob, b"tampered").unwrap();
+        let err = fork_checkpoint(
+            &store,
+            ForkParams {
+                checkpoint: parent.id,
+                child_id: CheckpointId::new("f"),
+                child_vm_name: "c".into(),
+                dest_dir: tmp.path().join("d"),
+                created_unix: 2,
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("integrity") || err.to_string().contains("sha256"));
     }
 
     #[test]

--- a/crates/mvm-backend/src/checkpoint/mod.rs
+++ b/crates/mvm-backend/src/checkpoint/mod.rs
@@ -141,7 +141,7 @@ pub fn fork_checkpoint(store: &CheckpointStore, params: ForkParams) -> Result<Ch
     }
 
     let content_dir = store.content_dir(&parent.id);
-    let blob = first_file_in(&content_dir)?;
+    let blob = only_file_in(&content_dir)?;
     let actual = sha256_file_hex(&blob)?;
     if actual != parent.content_sha256 {
         anyhow::bail!(
@@ -173,16 +173,26 @@ pub fn fork_checkpoint(store: &CheckpointStore, params: ForkParams) -> Result<Ch
     Ok(child)
 }
 
-fn first_file_in(dir: &Path) -> Result<PathBuf> {
+/// Return the single regular file in a checkpoint's content dir. An fs_quick
+/// checkpoint holds exactly one blob; more than one means the content was
+/// tampered with or corrupted, so fail loud rather than guess.
+fn only_file_in(dir: &Path) -> Result<PathBuf> {
+    let mut found: Option<PathBuf> = None;
     for entry in
         std::fs::read_dir(dir).with_context(|| format!("reading content dir {}", dir.display()))?
     {
         let entry = entry?;
         if entry.file_type()?.is_file() {
-            return Ok(entry.path());
+            if found.is_some() {
+                anyhow::bail!(
+                    "checkpoint content dir {} has more than one file; refusing to fork an ambiguous checkpoint",
+                    dir.display()
+                );
+            }
+            found = Some(entry.path());
         }
     }
-    anyhow::bail!("checkpoint content dir {} has no file", dir.display())
+    found.with_context(|| format!("checkpoint content dir {} has no file", dir.display()))
 }
 
 fn sha256_file_hex(path: &Path) -> Result<String> {
@@ -407,6 +417,27 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("integrity") || err.to_string().contains("sha256"));
+    }
+
+    #[test]
+    fn fork_refuses_multi_file_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let parent = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
+        // plant a second file in the content dir
+        std::fs::write(store.content_dir(&parent.id).join("extra.bin"), b"x").unwrap();
+        let err = fork_checkpoint(
+            &store,
+            ForkParams {
+                checkpoint: parent.id,
+                child_id: CheckpointId::new("f"),
+                child_vm_name: "c".into(),
+                dest_dir: tmp.path().join("d"),
+                created_unix: 2,
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("more than one file"));
     }
 
     #[test]

--- a/crates/mvm-backend/src/checkpoint/mod.rs
+++ b/crates/mvm-backend/src/checkpoint/mod.rs
@@ -118,11 +118,8 @@ pub struct CaptureFsQuickParams {
 }
 
 fn sha256_file_hex(path: &Path) -> Result<String> {
-    use sha2::Digest;
-    let bytes = std::fs::read(path).with_context(|| format!("hashing {}", path.display()))?;
-    let mut h = sha2::Sha256::new();
-    h.update(&bytes);
-    Ok(format!("{:x}", h.finalize()))
+    mvm_core::crypto::image_verify::sha256_file(path)
+        .with_context(|| format!("hashing {}", path.display()))
 }
 
 /// Freeze a quiesced VM's rootfs into an immutable fs_quick checkpoint via APFS

--- a/crates/mvm-backend/src/checkpoint/mod.rs
+++ b/crates/mvm-backend/src/checkpoint/mod.rs
@@ -99,6 +99,69 @@ impl CheckpointStore {
     }
 }
 
+use mvm_core::checkpoint::CheckpointClass;
+
+/// Inputs for an `fs_quick` capture. Grouped into a struct so the call site
+/// reads clearly and we never thread a long positional argument list.
+pub struct CaptureFsQuickParams {
+    pub id: CheckpointId,
+    pub vm_name: String,
+    /// Absolute path to the VM's live rootfs image to clone.
+    pub rootfs: PathBuf,
+    pub supervisor_config_digest: String,
+    pub tag: Option<String>,
+    pub created_unix: u64,
+    /// The caller asserts the VM is stopped or paused-and-synced. A non-quiesced
+    /// capture is refused: an fs_quick checkpoint has no memory, so the rootfs
+    /// must be in a clean, deterministic state.
+    pub quiesced: bool,
+}
+
+fn sha256_file_hex(path: &Path) -> Result<String> {
+    use sha2::Digest;
+    let bytes = std::fs::read(path).with_context(|| format!("hashing {}", path.display()))?;
+    let mut h = sha2::Sha256::new();
+    h.update(&bytes);
+    Ok(format!("{:x}", h.finalize()))
+}
+
+/// Freeze a quiesced VM's rootfs into an immutable fs_quick checkpoint via APFS
+/// copy-on-write. Returns the persisted metadata. Audit binding is the caller's
+/// responsibility (it owns the ExecutionPlan + signer).
+pub fn capture_fs_quick(
+    store: &CheckpointStore,
+    params: CaptureFsQuickParams,
+) -> Result<CheckpointMeta> {
+    if !params.quiesced {
+        anyhow::bail!(
+            "refusing fs_quick checkpoint of a non-quiesced VM '{}': stop or pause it first",
+            params.vm_name
+        );
+    }
+    let content_dir = store.content_dir(&params.id);
+    std::fs::create_dir_all(&content_dir)
+        .with_context(|| format!("creating {}", content_dir.display()))?;
+
+    let file_name = params
+        .rootfs
+        .file_name()
+        .context("rootfs path has no file name")?;
+    let dst = content_dir.join(file_name);
+    crate::base::cow::clone_rootfs_for_instance(&params.rootfs, &dst)
+        .context("cloning rootfs into checkpoint content")?;
+
+    let content_sha256 = sha256_file_hex(&dst)?;
+
+    let meta = CheckpointMeta::builder(params.id, CheckpointClass::FsQuick, params.vm_name)
+        .tag(params.tag)
+        .created_unix(params.created_unix)
+        .content_sha256(content_sha256)
+        .supervisor_config_digest(params.supervisor_config_digest)
+        .build();
+    store.write_meta(&meta)?;
+    Ok(meta)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +227,54 @@ mod tests {
         let store = CheckpointStore::at(tmp.path());
         let p = store.content_dir(&CheckpointId::new("c1"));
         assert_eq!(p, tmp.path().join("c1").join("content"));
+    }
+
+    use std::io::Write;
+
+    fn write_fake_rootfs(dir: &Path) -> PathBuf {
+        let p = dir.join("rootfs.ext4");
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(b"fake-ext4-bytes").unwrap();
+        p
+    }
+
+    #[test]
+    fn capture_refuses_when_not_quiesced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let rootfs = write_fake_rootfs(tmp.path());
+        let params = CaptureFsQuickParams {
+            id: CheckpointId::new("c1"),
+            vm_name: "vm".into(),
+            rootfs: rootfs.clone(),
+            supervisor_config_digest: "d".into(),
+            tag: None,
+            created_unix: 7,
+            quiesced: false,
+        };
+        let err = capture_fs_quick(&store, params).unwrap_err();
+        assert!(err.to_string().contains("quiesced"));
+    }
+
+    #[test]
+    fn capture_clones_hashes_and_writes_meta() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let rootfs = write_fake_rootfs(tmp.path());
+        let params = CaptureFsQuickParams {
+            id: CheckpointId::new("c1"),
+            vm_name: "vm".into(),
+            rootfs,
+            supervisor_config_digest: "d".into(),
+            tag: Some("gold".into()),
+            created_unix: 7,
+            quiesced: true,
+        };
+        let meta = capture_fs_quick(&store, params).unwrap();
+        let content_blob = store.content_dir(&meta.id).join("rootfs.ext4");
+        assert_eq!(std::fs::read(&content_blob).unwrap(), b"fake-ext4-bytes");
+        assert_eq!(meta.content_sha256.len(), 64);
+        assert_eq!(meta.tag.as_deref(), Some("gold"));
+        assert_eq!(store.read_meta(&meta.id).unwrap(), meta);
     }
 }

--- a/crates/mvm-backend/src/checkpoint/mod.rs
+++ b/crates/mvm-backend/src/checkpoint/mod.rs
@@ -1,0 +1,168 @@
+//! Host-side checkpoint store + the fs_quick capture/fork operations.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use mvm_core::checkpoint::{CheckpointId, CheckpointMeta};
+
+/// Filesystem-backed registry over `config::checkpoints_dir()` (or any root,
+/// for tests). Layout: `<root>/<id>/meta.json` + `<root>/<id>/content/`.
+pub struct CheckpointStore {
+    root: PathBuf,
+}
+
+impl CheckpointStore {
+    /// Production constructor — uses the canonical `~/.mvm/checkpoints` path.
+    pub fn open() -> Self {
+        Self::at(mvm_core::config::checkpoints_dir())
+    }
+
+    /// Test/explicit-root constructor.
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn dir_for(&self, id: &CheckpointId) -> PathBuf {
+        self.root.join(id.as_str())
+    }
+
+    pub fn content_dir(&self, id: &CheckpointId) -> PathBuf {
+        self.dir_for(id).join("content")
+    }
+
+    fn meta_path(&self, id: &CheckpointId) -> PathBuf {
+        self.dir_for(id).join("meta.json")
+    }
+
+    pub fn write_meta(&self, meta: &CheckpointMeta) -> Result<()> {
+        let dir = self.dir_for(&meta.id);
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating checkpoint dir {}", dir.display()))?;
+        let json = serde_json::to_vec_pretty(meta).context("serializing checkpoint meta")?;
+        let path = self.meta_path(&meta.id);
+        std::fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
+        Ok(())
+    }
+
+    pub fn read_meta(&self, id: &CheckpointId) -> Result<CheckpointMeta> {
+        let path = self.meta_path(id);
+        let bytes = std::fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+        serde_json::from_slice(&bytes).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    pub fn list(&self) -> Result<Vec<CheckpointMeta>> {
+        let mut out = Vec::new();
+        let entries = match std::fs::read_dir(&self.root) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(e).context("reading checkpoints dir"),
+        };
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let id = CheckpointId::new(entry.file_name().to_string_lossy().into_owned());
+            if self.meta_path(&id).exists() {
+                out.push(self.read_meta(&id)?);
+            }
+        }
+        Ok(out)
+    }
+
+    pub fn by_tag(&self, tag: &str) -> Result<Vec<CheckpointMeta>> {
+        Ok(self
+            .list()?
+            .into_iter()
+            .filter(|m| m.tag.as_deref() == Some(tag))
+            .collect())
+    }
+
+    pub fn children_of(&self, parent: &CheckpointId) -> Result<Vec<CheckpointMeta>> {
+        Ok(self
+            .list()?
+            .into_iter()
+            .filter(|m| m.parent.as_ref() == Some(parent))
+            .collect())
+    }
+
+    pub fn remove(&self, id: &CheckpointId) -> Result<()> {
+        let dir = self.dir_for(id);
+        if dir.exists() {
+            std::fs::remove_dir_all(&dir).with_context(|| format!("removing {}", dir.display()))?;
+        }
+        Ok(())
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta};
+
+    fn meta(id: &str, tag: Option<&str>, parent: Option<&str>) -> CheckpointMeta {
+        CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, "vm")
+            .tag(tag.map(String::from))
+            .parent(parent.map(CheckpointId::new))
+            .content_sha256("h")
+            .supervisor_config_digest("d")
+            .created_unix(1)
+            .build()
+    }
+
+    #[test]
+    fn write_then_read_roundtrips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        let m = meta("c1", None, None);
+        store.write_meta(&m).unwrap();
+        assert_eq!(store.read_meta(&CheckpointId::new("c1")).unwrap(), m);
+    }
+
+    #[test]
+    fn list_and_remove() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        store.write_meta(&meta("a", None, None)).unwrap();
+        store.write_meta(&meta("b", None, None)).unwrap();
+        assert_eq!(store.list().unwrap().len(), 2);
+        store.remove(&CheckpointId::new("a")).unwrap();
+        assert_eq!(store.list().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn by_tag_filters() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        store.write_meta(&meta("a", Some("gold"), None)).unwrap();
+        store.write_meta(&meta("b", None, None)).unwrap();
+        let tagged = store.by_tag("gold").unwrap();
+        assert_eq!(tagged.len(), 1);
+        assert_eq!(tagged[0].id.as_str(), "a");
+    }
+
+    #[test]
+    fn children_of_finds_lineage() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        store.write_meta(&meta("parent", None, None)).unwrap();
+        store
+            .write_meta(&meta("child", None, Some("parent")))
+            .unwrap();
+        let kids = store.children_of(&CheckpointId::new("parent")).unwrap();
+        assert_eq!(kids.len(), 1);
+        assert_eq!(kids[0].id.as_str(), "child");
+    }
+
+    #[test]
+    fn content_dir_path_is_under_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        let p = store.content_dir(&CheckpointId::new("c1"));
+        assert_eq!(p, tmp.path().join("c1").join("content"));
+    }
+}

--- a/crates/mvm-backend/src/cloud_hypervisor.rs
+++ b/crates/mvm-backend/src/cloud_hypervisor.rs
@@ -105,6 +105,7 @@ impl VmBackend for CloudHypervisorBackend {
             // Same opt-in shape as Firecracker — present only when
             // `VmStartConfig::mem_initial_mib` is `Some`.
             balloon: true,
+            fs_quick_checkpoint: false,
         }
     }
 

--- a/crates/mvm-backend/src/docker.rs
+++ b/crates/mvm-backend/src/docker.rs
@@ -121,6 +121,7 @@ impl VmBackend for DockerBackend {
             // kill / swap, not an in-guest driver returning pages).
             // The reclaim controller treats this as no-balloon.
             balloon: false,
+            fs_quick_checkpoint: false,
         }
     }
 

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -37,6 +37,7 @@ pub mod apple_container;
 pub mod artifacts;
 pub mod audit_substrate;
 pub mod backend;
+pub mod checkpoint;
 // Shared host-side substrate (config + shell + linux_env + ui +
 // runtime_meta + cow + snapshot_integrity) — folded in from the
 // former Lima-era `mvm-base` crate (plan 121 A2). It lives here, not

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -328,6 +328,10 @@ impl VmBackend for LibkrunBackend {
             // today; the upstream crate carries no `.balloon(...)`
             // builder. Declared `false` until wiring lands.
             balloon: false,
+            // libkrun runs on macOS but the rootfs lives in a regular
+            // file, not an APFS clone-eligible volume mount; no
+            // clonefile shortcut here.
+            fs_quick_checkpoint: false,
         }
     }
 

--- a/crates/mvm-backend/src/microvm_nix.rs
+++ b/crates/mvm-backend/src/microvm_nix.rs
@@ -78,6 +78,7 @@ impl VmBackend for MicrovmNixBackend {
             // crosvm). Surfacing balloon honestly would require
             // peeking at the runner script — leave `false` for now.
             balloon: false,
+            fs_quick_checkpoint: false,
         }
     }
 

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -97,6 +97,7 @@ impl VmBackend for MockBackend {
             vsock: false,
             tap_networking: false,
             balloon: false,
+            fs_quick_checkpoint: false,
         }
     }
 

--- a/crates/mvm-backend/src/qemu.rs
+++ b/crates/mvm-backend/src/qemu.rs
@@ -89,6 +89,7 @@ impl VmBackend for QemuBackend {
             // User-mode (slirp) networking — no host TAP device.
             tap_networking: false,
             balloon: false,
+            fs_quick_checkpoint: false,
         }
     }
 

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -181,6 +181,8 @@ impl VmBackend for VzBackend {
             // supervisor; live adjustment goes through the control
             // socket's BALLOON verb.
             balloon: true,
+            // Vz runs on macOS with APFS, so clonefile is available.
+            fs_quick_checkpoint: cfg!(target_os = "macos"),
         }
     }
 
@@ -1448,6 +1450,12 @@ mod tests {
         // snapshots is feature-detected on macOS 14+; on a
         // contributor host below 14 it stays false.
         let _ = caps.snapshots;
+    }
+
+    #[test]
+    fn vz_advertises_fs_quick_checkpoint_on_macos() {
+        let caps = VzBackend.capabilities();
+        assert_eq!(caps.fs_quick_checkpoint, cfg!(target_os = "macos"));
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -209,6 +209,7 @@ impl Commands {
             Commands::Pause(_) => "pause",
             Commands::Resume(_) => "resume",
             Commands::Snapshot(_) => "snapshot",
+            Commands::Checkpoint(_) => "checkpoint",
             Commands::Volume(_) => "volume",
             Commands::Secret(_) => "secret",
             Commands::Attest(_) => "attest",

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -162,6 +162,8 @@ pub(in crate::commands) enum Commands {
     Resume(vm::pause::ResumeArgs),
     /// Manage sealed instance snapshots (`ls`, `rm`).
     Snapshot(vm::pause::SnapshotArgs),
+    /// Capture, list, remove, or fork rootfs checkpoints.
+    Checkpoint(vm::checkpoint::CheckpointArgs),
     /// Manage virtio-fs volume mounts
     Volume(vm::volume::Args),
     /// Manage local secret namespaces
@@ -358,6 +360,7 @@ pub fn run() -> Result<()> {
         Commands::Pause(a) => vm::pause::run_pause(&cli, a, &cfg),
         Commands::Resume(a) => vm::pause::run_resume(&cli, a, &cfg),
         Commands::Snapshot(a) => vm::pause::run_snapshot(&cli, a, &cfg),
+        Commands::Checkpoint(a) => vm::checkpoint::run_checkpoint(&cli, a),
         Commands::Volume(a) => vm::volume::run(&cli, a, &cfg),
         Commands::Secret(a) => ops::secret::run(&cli, a, &cfg),
         Commands::Attest(a) => ops::attest::run(&cli, a, &cfg),

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -259,6 +259,26 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                 }
             }
 
+            // Untagged-checkpoint GC: tagged checkpoints are user-pinned; untagged
+            // ones follow cache retention. One corrupt meta.json makes list() fail,
+            // which logs a warning and skips the sweep — acceptable for a prune pass.
+            const CHECKPOINT_MAX_AGE_SECS: u64 = 7 * 24 * 60 * 60;
+            let ckpt_store = mvm_backend::checkpoint::CheckpointStore::open();
+            if dry_run {
+                if !ckpt_store.list().unwrap_or_default().is_empty() {
+                    ui::info("(dry-run) Would sweep expired untagged checkpoints.");
+                }
+            } else {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                match sweep_untagged_checkpoints(&ckpt_store, now, CHECKPOINT_MAX_AGE_SECS) {
+                    Ok(n) => removed += n as u64,
+                    Err(e) => ui::warn(&format!("checkpoint sweep failed: {e}")),
+                }
+            }
+
             for entry in walkdir(path)? {
                 let entry_path = entry.path();
                 // Remove temp files (mvm-lima-*, .tmp)
@@ -315,6 +335,26 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             Ok(())
         }
     }
+}
+
+/// Remove untagged checkpoints older than `max_age_secs`. Tagged checkpoints
+/// are user-pinned and never swept. Returns the count removed.
+pub(super) fn sweep_untagged_checkpoints(
+    store: &mvm_backend::checkpoint::CheckpointStore,
+    now_unix: u64,
+    max_age_secs: u64,
+) -> anyhow::Result<usize> {
+    let mut removed = 0;
+    for m in store.list()? {
+        if m.tag.is_some() {
+            continue;
+        }
+        if now_unix.saturating_sub(m.created_unix) > max_age_secs {
+            store.remove(&m.id)?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
 }
 
 /// Whole-second age of a file from its mtime, or `None` if it can't be
@@ -552,6 +592,33 @@ fn walkdir(path: &std::path::Path) -> Result<Vec<std::fs::DirEntry>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prune_removes_untagged_keeps_tagged() {
+        use mvm_backend::checkpoint::CheckpointStore;
+        use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        let mk = |id: &str, tag: Option<&str>, age: u64| {
+            CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, "vm")
+                .tag(tag.map(String::from))
+                .content_sha256("h")
+                .supervisor_config_digest("d")
+                .created_unix(age)
+                .build()
+        };
+        store.write_meta(&mk("old-untagged", None, 0)).unwrap();
+        store
+            .write_meta(&mk("old-tagged", Some("gold"), 0))
+            .unwrap();
+
+        let now = 10_000_000u64;
+        let removed = super::sweep_untagged_checkpoints(&store, now, 1).unwrap();
+        assert_eq!(removed, 1);
+        assert!(store.read_meta(&CheckpointId::new("old-tagged")).is_ok());
+        assert!(store.read_meta(&CheckpointId::new("old-untagged")).is_err());
+    }
 
     #[test]
     fn flow_byte_log_sweep_targets_audit_flow_bytes_dir() {

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -14,7 +14,9 @@ use super::env::{cleanup, dev, init, uninstall};
 use super::image;
 use super::ops;
 use super::ops::{audit, cache, config, metrics, secret};
-use super::vm::{console, cp, down, exec, forward, pause, sandbox, session, up, volume};
+use super::vm::{
+    checkpoint, console, cp, down, exec, forward, pause, sandbox, session, up, volume,
+};
 
 use audit::AuditAction;
 use cache::CacheAction;
@@ -1681,6 +1683,46 @@ fn test_snapshot_ls_json_parses() {
         cli.command,
         Commands::Snapshot(pause::SnapshotArgs {
             command: pause::SnapshotCmd::Ls { json: true }
+        })
+    ));
+}
+
+// --- Checkpoint CLI tests ---
+
+#[test]
+fn test_checkpoint_create_parses() {
+    let cli =
+        Cli::try_parse_from(["mvmctl", "checkpoint", "create", "myvm", "--tag", "gold"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Checkpoint(checkpoint::CheckpointArgs {
+            command: checkpoint::CheckpointCmd::Create { .. }
+        })
+    ));
+}
+
+#[test]
+fn test_checkpoint_fork_parses() {
+    assert!(
+        Cli::try_parse_from([
+            "mvmctl",
+            "checkpoint",
+            "fork",
+            "ckpt-abc",
+            "--new-id",
+            "child"
+        ])
+        .is_ok()
+    );
+}
+
+#[test]
+fn test_checkpoint_ls_json_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "checkpoint", "ls", "--json"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Commands::Checkpoint(checkpoint::CheckpointArgs {
+            command: checkpoint::CheckpointCmd::Ls { json: true }
         })
     ));
 }

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1717,6 +1717,20 @@ fn test_checkpoint_fork_parses() {
 }
 
 #[test]
+fn test_checkpoint_fork_rejects_traversal_new_id() {
+    // --new-id must not allow a path component that escapes the VM state dir.
+    let r = Cli::try_parse_from([
+        "mvmctl",
+        "checkpoint",
+        "fork",
+        "ckpt-abc",
+        "--new-id",
+        "../escape",
+    ]);
+    assert!(r.is_err());
+}
+
+#[test]
 fn test_checkpoint_ls_json_parses() {
     let cli = Cli::try_parse_from(["mvmctl", "checkpoint", "ls", "--json"]).unwrap();
     assert!(matches!(

--- a/crates/mvm-cli/src/commands/vm/audit_chain.rs
+++ b/crates/mvm-cli/src/commands/vm/audit_chain.rs
@@ -355,6 +355,59 @@ impl AuditEmitter {
         )
     }
 
+    /// Emit `checkpoint.created` — fires after `capture_fs_quick` seals
+    /// the checkpoint directory. `class` is the checkpoint strategy
+    /// (e.g. `"fs_quick"`); `content_sha256` is the hex digest of the
+    /// sealed directory tree so the audit chain pins the content.
+    // Called by the checkpoint command group (Task 8); the command
+    // doesn't exist yet so this is temporarily unreferenced.
+    #[allow(dead_code)]
+    pub fn emit_checkpoint_created(
+        &self,
+        plan: &ExecutionPlan,
+        checkpoint_id: &str,
+        class: &str,
+        content_sha256: &str,
+        vm_name: &str,
+    ) -> Result<()> {
+        self.emit(
+            plan,
+            "checkpoint.created",
+            [
+                ("checkpoint_id".to_string(), checkpoint_id.to_string()),
+                ("class".to_string(), class.to_string()),
+                ("content_sha256".to_string(), content_sha256.to_string()),
+                ("vm_name".to_string(), vm_name.to_string()),
+            ],
+        )
+    }
+
+    /// Emit `checkpoint.forked` — fires after `fork_checkpoint` has
+    /// hard-linked the parent checkpoint tree and registered the child
+    /// VM. The parent/child id pair forms the lineage record; an
+    /// operator can reconstruct a fork tree by scanning the chain for
+    /// these entries.
+    // Called by the checkpoint command group (Task 8); the command
+    // doesn't exist yet so this is temporarily unreferenced.
+    #[allow(dead_code)]
+    pub fn emit_checkpoint_forked(
+        &self,
+        plan: &ExecutionPlan,
+        parent_id: &str,
+        child_id: &str,
+        child_vm_name: &str,
+    ) -> Result<()> {
+        self.emit(
+            plan,
+            "checkpoint.forked",
+            [
+                ("parent_id".to_string(), parent_id.to_string()),
+                ("child_id".to_string(), child_id.to_string()),
+                ("child_vm_name".to_string(), child_vm_name.to_string()),
+            ],
+        )
+    }
+
     /// Emit `plan.exited` — fires after a waited-for workload powers off,
     /// carrying its captured exit code. Plan 152 WS-A.
     pub fn emit_exited(&self, plan: &ExecutionPlan, exit_code: i32, backend: &str) -> Result<()> {
@@ -821,5 +874,41 @@ mod tests {
         // pure-formatting and doesn't need the env var.
         let p = PathBuf::from("/some/dir").join("local.jsonl");
         assert!(p.to_string_lossy().ends_with("local.jsonl"));
+    }
+
+    #[test]
+    fn checkpoint_created_records_id_and_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::generate(&mut OsRng);
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-C");
+        emitter
+            .emit_checkpoint_created(&plan, "ckpt-abc", "fs_quick", "deadbeef", "myvm")
+            .unwrap();
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("checkpoint.created"));
+        assert!(content.contains("ckpt-abc"));
+        assert!(content.contains("deadbeef"));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn checkpoint_forked_records_lineage() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::generate(&mut OsRng);
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-F");
+        emitter
+            .emit_checkpoint_forked(&plan, "ckpt-parent", "ckpt-child", "childvm")
+            .unwrap();
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("checkpoint.forked"));
+        assert!(content.contains("ckpt-parent"));
+        assert!(content.contains("ckpt-child"));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 }

--- a/crates/mvm-cli/src/commands/vm/audit_chain.rs
+++ b/crates/mvm-cli/src/commands/vm/audit_chain.rs
@@ -355,10 +355,9 @@ impl AuditEmitter {
         )
     }
 
-    /// Emit `checkpoint.created` — fires after `capture_fs_quick` seals
-    /// the checkpoint directory. `class` is the checkpoint strategy
-    /// (e.g. `"fs_quick"`); `content_sha256` is the hex digest of the
-    /// sealed directory tree so the audit chain pins the content.
+    /// Record that a VM's filesystem state was frozen into an fs_quick
+    /// checkpoint. The label set carries the checkpoint id, class, the
+    /// SHA-256 of the cloned rootfs blob, and the owning VM.
     pub fn emit_checkpoint_created(
         &self,
         plan: &ExecutionPlan,
@@ -379,11 +378,9 @@ impl AuditEmitter {
         )
     }
 
-    /// Emit `checkpoint.forked` — fires after `fork_checkpoint` has
-    /// hard-linked the parent checkpoint tree and registered the child
-    /// VM. The parent/child id pair forms the lineage record; an
-    /// operator can reconstruct a fork tree by scanning the chain for
-    /// these entries.
+    /// Record that a new sandbox was branched from a checkpoint via
+    /// copy-on-write. The label set carries the parent and child
+    /// checkpoint ids and the child VM name.
     pub fn emit_checkpoint_forked(
         &self,
         plan: &ExecutionPlan,

--- a/crates/mvm-cli/src/commands/vm/audit_chain.rs
+++ b/crates/mvm-cli/src/commands/vm/audit_chain.rs
@@ -359,9 +359,6 @@ impl AuditEmitter {
     /// the checkpoint directory. `class` is the checkpoint strategy
     /// (e.g. `"fs_quick"`); `content_sha256` is the hex digest of the
     /// sealed directory tree so the audit chain pins the content.
-    // Called by the checkpoint command group (Task 8); the command
-    // doesn't exist yet so this is temporarily unreferenced.
-    #[allow(dead_code)]
     pub fn emit_checkpoint_created(
         &self,
         plan: &ExecutionPlan,
@@ -387,9 +384,6 @@ impl AuditEmitter {
     /// VM. The parent/child id pair forms the lineage record; an
     /// operator can reconstruct a fork tree by scanning the chain for
     /// these entries.
-    // Called by the checkpoint command group (Task 8); the command
-    // doesn't exist yet so this is temporarily unreferenced.
-    #[allow(dead_code)]
     pub fn emit_checkpoint_forked(
         &self,
         plan: &ExecutionPlan,

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -1,0 +1,380 @@
+//! `mvmctl checkpoint create|ls|rm|fork` — immutable fs_quick snapshots of a
+//! quiesced VM's rootfs, and copy-on-write forks that branch a new sandbox
+//! lineage from one. Capture and fork are filesystem-only here; booting a
+//! forked child is a separate `mvmctl up` step.
+//!
+//! Only the macOS workload backends (Vz / apple_container) materialize a
+//! host-side rootfs image, so checkpointing is gated to a VM that has one.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use clap::Args as ClapArgs;
+
+use mvm_backend::checkpoint::{
+    CaptureFsQuickParams, CheckpointStore, ForkParams, capture_fs_quick, fork_checkpoint,
+};
+use mvm_core::checkpoint::CheckpointId;
+use mvm_core::config::vm_state_dir;
+
+use super::Cli;
+use super::shared::clap_vm_name;
+use crate::ui;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct CheckpointArgs {
+    #[command(subcommand)]
+    pub command: CheckpointCmd,
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+pub(in crate::commands) enum CheckpointCmd {
+    /// Freeze a quiesced VM's rootfs into an immutable fs_quick checkpoint.
+    Create {
+        /// Name of the VM to checkpoint (must be stopped or paused).
+        #[arg(value_parser = clap_vm_name)]
+        name: String,
+        /// Optional human label recorded on the checkpoint.
+        #[arg(long)]
+        tag: Option<String>,
+        /// Output the sealed checkpoint metadata as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// List checkpoints under ~/.mvm/checkpoints.
+    Ls {
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove a checkpoint by id.
+    Rm {
+        /// Checkpoint id to remove.
+        id: String,
+    },
+    /// Branch a new sandbox lineage from a checkpoint (materialize only).
+    Fork {
+        /// Parent checkpoint id.
+        id: String,
+        /// VM name for the forked child. Defaults to `<id>-fork-<unix>`.
+        #[arg(long)]
+        new_id: Option<String>,
+    },
+}
+
+pub(in crate::commands) fn run_checkpoint(_cli: &Cli, args: CheckpointArgs) -> Result<()> {
+    match args.command {
+        CheckpointCmd::Create { name, tag, json } => create(&name, tag, json),
+        CheckpointCmd::Ls { json } => ls(json),
+        CheckpointCmd::Rm { id } => rm(&id),
+        CheckpointCmd::Fork { id, new_id } => fork(&id, new_id),
+    }
+}
+
+/// Reject a user-supplied checkpoint id that could escape the store root or
+/// otherwise produce an unsafe on-disk directory name. The id becomes a
+/// directory component under `checkpoints_dir()`, so path-traversal and
+/// control bytes must never reach the filesystem.
+fn validated_checkpoint_id(raw: &str) -> Result<CheckpointId> {
+    if raw.is_empty() {
+        bail!("invalid checkpoint id: empty");
+    }
+    let bad = raw.contains('/')
+        || raw.contains('\\')
+        || raw.contains("..")
+        || raw.bytes().any(|b| b == 0 || b.is_ascii_control());
+    if bad {
+        bail!(
+            "invalid checkpoint id {raw:?}: must not contain '/', '\\', '..', \
+             NUL, or control characters"
+        );
+    }
+    Ok(CheckpointId::new(raw.to_string()))
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Resolve the host-side bootable rootfs image for a quiesced VM, or a clean
+/// error explaining why a checkpoint can't be taken.
+///
+/// "Quiesced" means the VM is not running, OR it's marked paused in the name
+/// registry (a sealed instance snapshot exists). A live VM is refused: an
+/// fs_quick checkpoint has no memory, so the rootfs must be in a clean,
+/// deterministic state.
+///
+/// Rootfs location is backend-specific but both macOS workload backends keep
+/// the image under `vm_state_dir(name)`:
+///   - apple_container clones a per-instance `rootfs.ext4` there;
+///   - Vz boots from a supplied path but persists the launch config, whose
+///     `rootfs` disk records that path.
+fn resolve_quiesced_vm_rootfs(name: &str) -> Result<PathBuf> {
+    if vm_is_running(name) {
+        bail!("stop or pause VM '{name}' before checkpointing");
+    }
+    let state_dir = vm_state_dir(name);
+
+    // apple_container per-instance clone — deterministic, present on disk.
+    let instance_rootfs = state_dir.join("rootfs.ext4");
+    if instance_rootfs.is_file() {
+        return Ok(instance_rootfs);
+    }
+
+    // Vz persists its full supervisor config at launch; the rootfs disk's
+    // path points at the bootable image.
+    if let Some(path) = vz_rootfs_from_supervisor_config(&state_dir)? {
+        return Ok(path);
+    }
+
+    bail!("fs_quick checkpoint is not supported for this VM's backend");
+}
+
+/// Read the persisted Vz supervisor config and return the `rootfs` disk path,
+/// if the config exists and names one. Absent config → `Ok(None)` (let the
+/// caller fall through to the unsupported-backend error).
+fn vz_rootfs_from_supervisor_config(state_dir: &std::path::Path) -> Result<Option<PathBuf>> {
+    let cfg_path = state_dir.join("supervisor-config.json");
+    let bytes = match std::fs::read(&cfg_path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", cfg_path.display())),
+    };
+    let cfg: mvm_build::vz::SupervisorConfig = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing {}", cfg_path.display()))?;
+    let rootfs = cfg
+        .disks
+        .iter()
+        .find(|d| d.id == "rootfs")
+        .map(|d| PathBuf::from(&d.path));
+    Ok(rootfs)
+}
+
+/// Best-effort liveness: a VM is "running" iff one of its per-backend PID
+/// files names a live process. Mirrors the per-backend `kill(pid, 0)` probe.
+fn vm_is_running(name: &str) -> bool {
+    let state_dir = vm_state_dir(name);
+    ["vz.pid", "libkrun.pid"]
+        .iter()
+        .filter_map(|f| std::fs::read_to_string(state_dir.join(f)).ok())
+        .filter_map(|s| s.trim().parse::<libc::pid_t>().ok())
+        // SAFETY: signal 0 only probes existence; it delivers nothing.
+        .any(|pid| unsafe { libc::kill(pid, 0) == 0 })
+}
+
+/// Hash the VM's persisted supervisor config so the checkpoint pins the launch
+/// shape it was captured from. No config on disk → empty digest (the field is
+/// advisory for fs_quick; integrity rests on `content_sha256`).
+fn supervisor_config_digest(state_dir: &std::path::Path) -> String {
+    let cfg_path = state_dir.join("supervisor-config.json");
+    mvm_core::crypto::image_verify::sha256_file(&cfg_path).unwrap_or_default()
+}
+
+fn create(name: &str, tag: Option<String>, json: bool) -> Result<()> {
+    let rootfs = resolve_quiesced_vm_rootfs(name)?;
+    let state_dir = vm_state_dir(name);
+    let store = CheckpointStore::open();
+    let now = now_unix();
+    let id = CheckpointId::new(format!("ckpt-{name}-{now}"));
+
+    let meta = capture_fs_quick(
+        &store,
+        CaptureFsQuickParams {
+            id,
+            vm_name: name.to_string(),
+            rootfs,
+            supervisor_config_digest: supervisor_config_digest(&state_dir),
+            tag,
+            created_unix: now,
+            quiesced: true,
+        },
+    )
+    .with_context(|| format!("capturing fs_quick checkpoint of {name:?}"))?;
+
+    // Best-effort audit binding: a missing plan/signer or flaky audit fs warns
+    // and continues — the checkpoint is already sealed on disk.
+    bind_checkpoint_created(name, &meta);
+
+    if json {
+        crate::json_out::emit_json(&meta)?;
+    } else {
+        ui::success(&format!(
+            "{name}: checkpoint {} created (sha256 {})",
+            meta.id.as_str(),
+            meta.content_sha256
+        ));
+    }
+    Ok(())
+}
+
+fn bind_checkpoint_created(name: &str, meta: &mvm_core::checkpoint::CheckpointMeta) {
+    let plan = match super::plan_persist::read_plan(name) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, vm = name,
+                "no persisted plan; checkpoint.created emitted without chain binding");
+            return;
+        }
+    };
+    let signer = match super::host_signer::load_or_init() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "host signer unavailable; chain entry skipped");
+            return;
+        }
+    };
+    let emitter = match super::audit_chain::AuditEmitter::new(signer.signing) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(error = %e, "audit emitter unavailable; chain entry skipped");
+            return;
+        }
+    };
+    if let Err(e) = emitter.emit_checkpoint_created(
+        &plan,
+        meta.id.as_str(),
+        "fs_quick",
+        &meta.content_sha256,
+        name,
+    ) {
+        tracing::warn!(error = %e, "audit emit_checkpoint_created failed (non-fatal)");
+    }
+}
+
+fn ls(json: bool) -> Result<()> {
+    let metas = CheckpointStore::open().list()?;
+    if json {
+        crate::json_out::emit_json(&metas)?;
+        return Ok(());
+    }
+    if metas.is_empty() {
+        ui::info("(no checkpoints)");
+        return Ok(());
+    }
+    println!(
+        "{:<32} {:<10} {:<20} {:<8} PARENT",
+        "ID", "CLASS", "VM", "TAG"
+    );
+    for m in &metas {
+        let class = match m.class {
+            mvm_core::checkpoint::CheckpointClass::FsQuick => "fs_quick",
+            mvm_core::checkpoint::CheckpointClass::VmFull => "vm_full",
+        };
+        println!(
+            "{:<32} {:<10} {:<20} {:<8} {}",
+            m.id.as_str(),
+            class,
+            m.vm_name,
+            m.tag.as_deref().unwrap_or("-"),
+            m.parent.as_ref().map(|p| p.as_str()).unwrap_or("-"),
+        );
+    }
+    Ok(())
+}
+
+fn rm(id: &str) -> Result<()> {
+    let id = validated_checkpoint_id(id)?;
+    CheckpointStore::open().remove(&id)?;
+    ui::success(&format!("checkpoint {} removed", id.as_str()));
+    Ok(())
+}
+
+fn fork(id: &str, new_id: Option<String>) -> Result<()> {
+    let checkpoint = validated_checkpoint_id(id)?;
+    let now = now_unix();
+    let child_vm_name = new_id.unwrap_or_else(|| format!("{id}-fork-{now}"));
+    let dest_dir = vm_state_dir(&child_vm_name);
+    let child_id = CheckpointId::new(format!("fork-{child_vm_name}-{now}"));
+
+    let meta = fork_checkpoint(
+        &CheckpointStore::open(),
+        ForkParams {
+            checkpoint: checkpoint.clone(),
+            child_id,
+            child_vm_name: child_vm_name.clone(),
+            dest_dir,
+            created_unix: now,
+        },
+    )
+    .with_context(|| format!("forking checkpoint {:?}", checkpoint.as_str()))?;
+
+    // A fork that we can't audit (signer present but emit fails) is refused —
+    // an unaudited lineage record would break the chain. A missing plan/signer
+    // is best-effort, matching capture.
+    bind_checkpoint_forked(&checkpoint, &meta, &child_vm_name)?;
+
+    ui::success(&format!(
+        "forked {} -> checkpoint {} (vm '{}')",
+        checkpoint.as_str(),
+        meta.id.as_str(),
+        child_vm_name
+    ));
+    ui::info(&format!(
+        "boot the child with: mvmctl up <flake> --name {child_vm_name}"
+    ));
+    Ok(())
+}
+
+fn bind_checkpoint_forked(
+    parent: &CheckpointId,
+    child: &mvm_core::checkpoint::CheckpointMeta,
+    child_vm_name: &str,
+) -> Result<()> {
+    let plan = match super::plan_persist::read_plan(&child.vm_name).or_else(|_| {
+        // The child VM has no plan yet (not booted); fall back to the parent
+        // VM's plan so the lineage entry binds to *some* admitted identity.
+        super::plan_persist::read_plan(parent_vm_name_hint(parent))
+    }) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e,
+                "no persisted plan for fork; checkpoint.forked emitted without chain binding");
+            return Ok(());
+        }
+    };
+    let signer = match super::host_signer::load_or_init() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "host signer unavailable; chain entry skipped");
+            return Ok(());
+        }
+    };
+    let emitter = super::audit_chain::AuditEmitter::new(signer.signing)
+        .context("refusing an unaudited fork: audit emitter unavailable")?;
+    emitter
+        .emit_checkpoint_forked(&plan, parent.as_str(), child.id.as_str(), child_vm_name)
+        .context("refusing an unaudited fork")?;
+    Ok(())
+}
+
+/// The parent checkpoint id has no embedded VM name we can recover cheaply, so
+/// this best-effort hint just reuses the checkpoint id as a plan-lookup key.
+/// A miss degrades to the no-plan warn path above.
+fn parent_vm_name_hint(parent: &CheckpointId) -> &str {
+    parent.as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validated_checkpoint_id_accepts_normal() {
+        assert!(validated_checkpoint_id("ckpt-myvm-1700000000").is_ok());
+        assert!(validated_checkpoint_id("fork-child-42").is_ok());
+    }
+
+    #[test]
+    fn validated_checkpoint_id_rejects_traversal() {
+        assert!(validated_checkpoint_id("../etc").is_err());
+        assert!(validated_checkpoint_id("a/b").is_err());
+        assert!(validated_checkpoint_id("a\\b").is_err());
+        assert!(validated_checkpoint_id("").is_err());
+        assert!(validated_checkpoint_id("a\0b").is_err());
+        assert!(validated_checkpoint_id("a\nb").is_err());
+    }
+}

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -57,8 +57,8 @@ pub(in crate::commands) enum CheckpointCmd {
     Fork {
         /// Parent checkpoint id.
         id: String,
-        /// VM name for the forked child. Defaults to `<id>-fork-<unix>`.
-        #[arg(long)]
+        /// Name for the new VM instance (auto-generated if omitted).
+        #[arg(long, value_parser = clap_vm_name)]
         new_id: Option<String>,
     },
 }

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -2,6 +2,7 @@
 
 pub(super) mod artifact;
 pub(super) mod audit_chain;
+pub(super) mod checkpoint;
 pub(super) mod console;
 pub(super) mod cp;
 pub(super) mod diff;

--- a/crates/mvm-core/src/checkpoint.rs
+++ b/crates/mvm-core/src/checkpoint.rs
@@ -23,13 +23,13 @@ impl std::fmt::Display for CheckpointId {
     }
 }
 
-/// The capture mechanism behind a checkpoint. Only `FsQuick` is populated in
-/// this PR; `VmFull` is reserved so the later memory-state path slots into the
-/// same model with no new surface.
+/// The capture mechanism behind a checkpoint. Only `FsQuick` is currently
+/// implemented; `VmFull` is reserved so the memory-state path can slot into the
+/// same model without a new surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckpointClass {
-    /// APFS copy-on-write clone of a quiesced rootfs (filesystem only).
+    /// Copy-on-write clone of a quiesced rootfs (filesystem state only).
     FsQuick,
     /// Full machine memory state via the supervisor save/restore path.
     VmFull,
@@ -73,8 +73,9 @@ impl CheckpointMeta {
     }
 }
 
-/// Builder so callers set only the fields they have; avoids a long positional
-/// constructor.
+/// Fluent builder for [`CheckpointMeta`]; obtain via [`CheckpointMeta::builder`].
+///
+/// Callers set only the fields they have; avoids a long positional constructor.
 pub struct CheckpointMetaBuilder {
     id: CheckpointId,
     class: CheckpointClass,

--- a/crates/mvm-core/src/checkpoint.rs
+++ b/crates/mvm-core/src/checkpoint.rs
@@ -1,0 +1,182 @@
+//! Immutable, audit-bound records of frozen microVM state. A checkpoint is the
+//! origin a `fork` clones a new sandbox instance from.
+
+use serde::{Deserialize, Serialize};
+
+/// Stable identifier for a checkpoint (also its on-disk directory name under
+/// `config::checkpoints_dir()`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CheckpointId(String);
+
+impl CheckpointId {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for CheckpointId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The capture mechanism behind a checkpoint. Only `FsQuick` is populated in
+/// this PR; `VmFull` is reserved so the later memory-state path slots into the
+/// same model with no new surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckpointClass {
+    /// APFS copy-on-write clone of a quiesced rootfs (filesystem only).
+    FsQuick,
+    /// Full machine memory state via the supervisor save/restore path.
+    VmFull,
+}
+
+/// On-disk metadata for one checkpoint (`<checkpoints_dir>/<id>/meta.json`).
+/// `audit_ref` is a non-load-bearing back-pointer backfilled after the
+/// chain-signed entry is emitted; integrity verification relies on
+/// `content_sha256`, not on `audit_ref`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckpointMeta {
+    pub id: CheckpointId,
+    pub class: CheckpointClass,
+    pub vm_name: String,
+    pub tag: Option<String>,
+    pub parent: Option<CheckpointId>,
+    pub created_unix: u64,
+    pub content_sha256: String,
+    pub supervisor_config_digest: String,
+    pub audit_ref: Option<String>,
+}
+
+impl CheckpointMeta {
+    pub fn builder(
+        id: CheckpointId,
+        class: CheckpointClass,
+        vm_name: impl Into<String>,
+    ) -> CheckpointMetaBuilder {
+        CheckpointMetaBuilder {
+            id,
+            class,
+            vm_name: vm_name.into(),
+            tag: None,
+            parent: None,
+            created_unix: 0,
+            content_sha256: String::new(),
+            supervisor_config_digest: String::new(),
+            audit_ref: None,
+        }
+    }
+}
+
+/// Builder so callers set only the fields they have; avoids a long positional
+/// constructor.
+pub struct CheckpointMetaBuilder {
+    id: CheckpointId,
+    class: CheckpointClass,
+    vm_name: String,
+    tag: Option<String>,
+    parent: Option<CheckpointId>,
+    created_unix: u64,
+    content_sha256: String,
+    supervisor_config_digest: String,
+    audit_ref: Option<String>,
+}
+
+impl CheckpointMetaBuilder {
+    pub fn tag(mut self, tag: Option<String>) -> Self {
+        self.tag = tag;
+        self
+    }
+    pub fn parent(mut self, parent: Option<CheckpointId>) -> Self {
+        self.parent = parent;
+        self
+    }
+    pub fn created_unix(mut self, secs: u64) -> Self {
+        self.created_unix = secs;
+        self
+    }
+    pub fn content_sha256(mut self, h: impl Into<String>) -> Self {
+        self.content_sha256 = h.into();
+        self
+    }
+    pub fn supervisor_config_digest(mut self, d: impl Into<String>) -> Self {
+        self.supervisor_config_digest = d.into();
+        self
+    }
+    pub fn audit_ref(mut self, r: Option<String>) -> Self {
+        self.audit_ref = r;
+        self
+    }
+    pub fn build(self) -> CheckpointMeta {
+        CheckpointMeta {
+            id: self.id,
+            class: self.class,
+            vm_name: self.vm_name,
+            tag: self.tag,
+            parent: self.parent,
+            created_unix: self.created_unix,
+            content_sha256: self.content_sha256,
+            supervisor_config_digest: self.supervisor_config_digest,
+            audit_ref: self.audit_ref,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn meta_roundtrips_through_json() {
+        let meta = CheckpointMeta::builder(
+            CheckpointId::new("ckpt-abc123"),
+            CheckpointClass::FsQuick,
+            "myvm",
+        )
+        .content_sha256("deadbeef")
+        .supervisor_config_digest("cfg99")
+        .tag(Some("golden".to_string()))
+        .parent(Some(CheckpointId::new("ckpt-parent")))
+        .created_unix(1_700_000_000)
+        .build();
+
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: CheckpointMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, back);
+        assert_eq!(back.class, CheckpointClass::FsQuick);
+        assert_eq!(back.parent.unwrap().as_str(), "ckpt-parent");
+    }
+
+    #[test]
+    fn meta_rejects_unknown_fields() {
+        let json = r#"{"id":"x","class":"fs_quick","vm_name":"v","tag":null,
+            "parent":null,"created_unix":1,"content_sha256":"h",
+            "supervisor_config_digest":"d","audit_ref":null,"bogus":true}"#;
+        assert!(serde_json::from_str::<CheckpointMeta>(json).is_err());
+    }
+
+    #[test]
+    fn builder_defaults_are_none() {
+        let meta = CheckpointMeta::builder(CheckpointId::new("c1"), CheckpointClass::FsQuick, "vm")
+            .content_sha256("h")
+            .supervisor_config_digest("d")
+            .created_unix(5)
+            .build();
+        assert!(meta.tag.is_none());
+        assert!(meta.parent.is_none());
+        assert!(meta.audit_ref.is_none());
+    }
+
+    #[test]
+    fn class_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&CheckpointClass::VmFull).unwrap(),
+            "\"vm_full\""
+        );
+    }
+}

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -427,6 +427,12 @@ pub fn mvm_keys_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(mvm_data_dir()).join("keys")
 }
 
+/// Immutable checkpoint store: `<mvm_data_dir>/checkpoints/`. Each checkpoint is
+/// a subdirectory `<id>/` holding `meta.json` + cloned `content/`.
+pub fn checkpoints_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_data_dir()).join("checkpoints")
+}
+
 /// Chain-signed audit logs: `<mvm_data_dir>/audit/`.
 pub fn mvm_audit_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(mvm_data_dir()).join("audit")
@@ -765,6 +771,16 @@ mod tests {
         assert_eq!(mode, 0o700, "expected 0700, got 0{:o}", mode);
 
         let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn checkpoints_dir_is_under_data_dir() {
+        let _g = env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("MVM_DATA_DIR", temp.path()) };
+        let dir = checkpoints_dir();
+        assert_eq!(dir, temp.path().join("checkpoints"));
+        unsafe { std::env::remove_var("MVM_DATA_DIR") };
     }
 
     #[test]

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod arch;
 pub mod build_env;
 pub mod catalog;
+pub mod checkpoint;
 pub mod config;
 pub mod dev_network;
 pub mod exit_capture;

--- a/crates/mvm-core/src/policy/audit.rs
+++ b/crates/mvm-core/src/policy/audit.rs
@@ -167,6 +167,11 @@ pub enum LocalAuditKind {
     /// supervisors + writes `~/.mvm/pool/`); the `detail` field carries
     /// `spawned=<n> target=<n>`.
     PoolWarm,
+    /// `mvmctl checkpoint create` froze a VM's filesystem state into an
+    /// immutable fs_quick checkpoint.
+    CheckpointCreated,
+    /// `mvmctl checkpoint fork` branched a new sandbox from a checkpoint.
+    CheckpointForked,
     // --- Sandbox SDK foundation (fs/proc/share/pause/TTL/tags) ---
     // The verbs below are state-changing CLI surfaces added by the
     // sandbox-SDK foundation work. Each kind names a single mutation

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -411,6 +411,10 @@ pub struct VmCapabilities {
     /// without rebooting the VM. cgroup-style memory limiting (Docker)
     /// is **not** a balloon and stays `false`.
     pub balloon: bool,
+    /// Can freeze a quiesced rootfs into an fs-quick checkpoint via filesystem
+    /// copy-on-write (APFS `clonefile` on macOS). Independent of `snapshots`,
+    /// which is the memory-state save/restore capability.
+    pub fs_quick_checkpoint: bool,
 }
 
 /// How thoroughly a backend can warm-start a VM from a snapshot. Distinct

--- a/crates/mvm-hostd/src/supervisor/balloon_runtime.rs
+++ b/crates/mvm-hostd/src/supervisor/balloon_runtime.rs
@@ -290,6 +290,7 @@ mod tests {
                 vsock: false,
                 tap_networking: false,
                 balloon: self.balloon_supported,
+                fs_quick_checkpoint: false,
             }
         }
         fn start_with_mode(

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -108,7 +108,10 @@ PLAN 159 — vz-inspired macOS VZ DX               🟡 152-independent slice sh
       up.rs "bridge broken" comment stale). Remaining: bundled-kernel compat key so
       the libkrun mkGuest warm claim fires (kernel absent pre-boot); multi-kernel
       keying; honour --name/volumes; committed bench delta (SPRINT.md)
-  [ ] WS-2 checkpoint+fork  (152 WS-B done; unblocked)
+  [~] WS-2 checkpoint+fork — fs_quick class landed: mvmctl checkpoint
+      create/ls/rm/fork + APFS-CoW capture + integrity-checked fork + lineage +
+      checkpoint.created/forked audit + fs_quick_checkpoint capability + cache GC.
+      Remaining: vm_full (memory save/restore) + checkpoint diff + pause/resume wiring
   [ ] WS-5 D verb renames; curl|sh installer; --json remainder
   [ ] signed delta-image distribution (unowned — needs a home)
 

--- a/specs/notes/plan-159-ws2-fs-quick-checkpoint-fork-design.md
+++ b/specs/notes/plan-159-ws2-fs-quick-checkpoint-fork-design.md
@@ -1,0 +1,162 @@
+# Plan 159 WS-2 — `fs_quick` checkpoint + fork (PR1 design)
+
+**Date:** 2026-06-10
+**Status:** design approved; ready for implementation-plan authoring
+**Scope:** Plan 159 WS-2, first PR (the `fs_quick` slice). PR2/PR3 sketched
+under "Roadmap" but out of scope for this design.
+
+## Goal
+
+Give the Apple `Virtualization.framework` (Vz) / `apple_container` runtime a
+first-class, audit-bound **checkpoint + fork** primitive: freeze a quiesced
+microVM's filesystem state into an immutable checkpoint, then branch new
+sandbox instances from it in seconds via APFS copy-on-write. This is the
+filesystem half of the "instant fork" DX; the live-memory half lands in PR2.
+
+## Where this sits (boundaries — do not duplicate)
+
+Reuses, does **not** rebuild:
+
+- **Vz supervisor** already exposes `PAUSE`/`RESUME`/`SAVE` control verbs and a
+  `Restore` startup mode (`mvm-vm-host/src/vz_objc.rs`, `mvm-backend/src/vz.rs`).
+- **APFS CoW** rootfs cloning via `clonefile(2)` is built —
+  `base::cow::clone_rootfs_for_instance` (`mvm-backend/src/base/cow.rs:137`),
+  O(1) template→instance, already used by `apple_container`.
+- **Snapshot audit spine** — `vm.snapshot_saved` / `vm.snapshot_restored`
+  events on the chain-signed log (`audit_chain.rs:304-356`).
+- `mvmctl snapshot save/restore/ls/rm` already wired for Vz.
+
+Owned **elsewhere** — WS-2 stays clear of:
+
+- **Plan 140** (landed) — snapshot *correctness*: seccomp-on-restore, entropy
+  reseed, clock resync, wake re-admission. WS-2 inherits these, doesn't touch.
+- **Plan 148 Phase A** — the fork *fan-out* primitive (batched spawn, shared
+  RO base, per-child identity). WS-2's `fork` is the DX surface, not the batch
+  engine.
+- **Plan 123 C1** (landed in `main`) — the `SnapshotCapability` enum/trait.
+  Don't modify. C2/C3 (PostRestore sender, Vz save/restore substrate) are
+  deferred/unowned (the `mvm-plan-123c-warmstart` worktree is stale — its C1
+  commit is already merged; no open PR). PR2 will build on, not collide with,
+  C3's territory.
+
+## Decisions (from the brainstorm)
+
+1. **Phasing** — PR1 = `fs_quick` (this doc); PR2 = `vm_full` memory
+   save/restore + fork-from-memory (folds in the unmerged pause→save→resume
+   ordering fix on `mvm-152-savefix`); PR3 = `checkpoint diff` + wire
+   `mvmctl pause/resume` to the Vz path. `PR1 ∪ PR2 ∪ PR3` = full WS-2.
+   Risk-ascending: pure host logic → live memory → polish.
+2. **Data model** — one unified, first-class `checkpoint` object from PR1
+   (model "A"); no separate wrapping surface, no later migration (project rule:
+   no backcompat / no shim layers). PR1 only *populates* the `fs_quick` class;
+   PR2 adds `vm_full` into the same model with no new surface.
+3. **Consistency contract** — `fs_quick` requires the VM **quiesced** (stopped,
+   or pause→`sync`→clone). The clone is a clean, deterministic rootfs image; no
+   reliance on guest journal recovery. "Fork a *live, running* sandbox with its
+   memory" is deliberately PR2's headline (`vm_full`), not PR1.
+
+## Architecture
+
+A host-side `checkpoint` subsystem. A **`Checkpoint`** is an immutable,
+audit-bound record of frozen VM state under `~/.mvm/checkpoints/<id>/`
+(holding `meta.json` + the CoW-cloned `content/`). PR1 implements the
+`fs_quick` class only. **`fork`** clones a checkpoint's content into a new VM
+instance with a fresh identity and records parent→child lineage. No new VMM
+code; no live-boot dependency for any of the core logic.
+
+### Components (small, independently testable units)
+
+- **`mvm-core::checkpoint`** — pure types, no runtime deps (keeps
+  `xtask check-core-runtime-free` green):
+  - `CheckpointId` (newtype), `CheckpointClass { FsQuick, VmFull }`,
+  - `CheckpointMeta { id, class, parent: Option<CheckpointId>, vm_name, tag:
+    Option<String>, created_unix, content_sha256, supervisor_config_digest,
+    audit_ref: Option<...> }` — serde + `deny_unknown_fields` + builder.
+    `audit_ref` is backfilled (see "audit binding direction" below), so it is
+    `Option` and not part of the hashed content.
+- **`CheckpointStore`** (mvm-backend) — FS + serde over `~/.mvm/checkpoints/`
+  via a new `mvm_core::config::checkpoints_dir()` helper (all `~/.mvm` paths go
+  through `config`): `create / write_meta / read_meta / list / remove /
+  by_tag / children_of`. Temp-dir unit-testable.
+- **`capture_fs_quick`** (mvm-backend) — assert quiesced → `sync` →
+  `clone_rootfs_for_instance(rootfs, content)` → SHA-256 → write meta.
+  Reuses existing CoW.
+- **`fork_checkpoint`** (mvm-backend) — verify `content_sha256` → CoW-clone
+  content into a new instance state dir → mint a new `VmId` → write child
+  lineage meta → (default) cold-boot the child via the existing start path;
+  `--no-start` just materializes. (No machine-id sidecar here: `fs_quick` is a
+  cold boot from a cloned rootfs with no saved machine state. The machine-id
+  identity sidecar belongs to the `vm_full` save/restore path in PR2.)
+- **Audit** — new `LocalAuditKind::{CheckpointCreated, CheckpointForked}` +
+  `AuditEmitter::emit_checkpoint_created/forked`; `tests/audit_total_coverage.rs`
+  posture updated (same pattern as the `PoolWarm` kind added in Plan 118).
+- **CLI** (`commands/vm/checkpoint.rs`) — `mvmctl checkpoint create <vm>
+  [--tag T]`, `checkpoint ls`, `checkpoint rm <id>`, `checkpoint fork <id>
+  [--new-id NAME] [--no-start]`; `--json` per the shared convention. Existing
+  `snapshot save/restore` folds under the model as the (reserved) `vm_full`
+  class. (Grouped under `checkpoint` for Plan 178 coherence; a top-level
+  `mvmctl fork` alias is trivial to add later if wanted.)
+- **Capability flip** — `apple_container` / `vz` `capabilities()` advertises
+  `fs_quick` supported, `vm_full` reserved/gated.
+- **GC** — `cache prune` sweeps untagged checkpoints past retention; `--tag`
+  pins. Mirrors the standby-reaper sweep already in `ops/cache.rs`.
+
+### Data flow
+
+- **create**: quiesced VM → `sync` → `clonefile` rootfs → SHA-256 →
+  `meta.json` → `checkpoint.created` (signed, chained).
+- **fork**: read + verify parent meta → `clonefile` content → new instance dir
+  + new id/machine-id → child lineage meta → `checkpoint.forked` → cold-boot
+  child (default).
+
+### Audit binding direction
+
+The binding is **audit → checkpoint**: the chain-signed `checkpoint.created` /
+`checkpoint.forked` entry carries the checkpoint `id`, `class`, `content_sha256`
+and (for fork) the `parent` id. So `meta.json` is written first, the audit
+entry is emitted referencing it, and the resulting entry's seq/hash is
+backfilled into `meta.audit_ref` (a second, cheap meta write). The integrity
+check at fork time relies on `content_sha256` (the audit chain proves the
+checkpoint was admitted; the hash proves the content is intact) — `audit_ref`
+is a convenience back-pointer, never load-bearing for verification.
+
+### Error handling (fail-closed)
+
+- `checkpoint create` on a non-quiesced VM → hard error (consistency contract).
+- `checkpoint fork` of a `vm_full` checkpoint in PR1 → hard error
+  ("vm_full lands in PR2") — no silent degrade (Plan 159: "reject when the
+  backend can't honor it").
+- `content_sha256` mismatch at fork → refuse (sealed-volume-style integrity).
+- audit emit failure → operation fails (never an unaudited fork).
+
+### Testing (all host-side, no live VM boot)
+
+- `CheckpointMeta` serde roundtrip + `deny_unknown_fields` + builder defaults.
+- `CheckpointStore` CRUD + tag-select + `children_of` over a temp dir.
+- `capture_fs_quick`: refuses non-quiesced; clones; hashes; writes meta (temp
+  rootfs file, no VM).
+- `fork_checkpoint`: clones content, mints distinct id, records parent lineage,
+  verifies hash, refuses `vm_full`, refuses tampered content.
+- Audit: `checkpoint.created` / `checkpoint.forked` land in the chain;
+  `verify_audit_chain` detects tamper; `audit_total_coverage` posture.
+- GC: untagged pruned, tagged kept.
+- `tests/cli.rs`: help text + arg parsing for `checkpoint` / `fork`.
+
+## Roadmap (out of scope for PR1, recorded for continuity)
+
+- **PR2 — `vm_full`**: memory checkpoint via `saveMachineStateToURL` /
+  `restoreMachineStateFromURL`; fork-from-memory; fold in the unmerged
+  pause→save→resume ordering fix; live-Vz round-trip validation. The
+  live-boot validation risk is isolated to this PR.
+- **PR3 — completes WS-2**: `checkpoint diff <a> <b>`; wire `mvmctl
+  pause/resume` to the Vz path (today `pause.rs::snapshot_io_for` is
+  Firecracker-only); cross-class polish.
+
+## Crate placement
+
+- types → `mvm-core/src/checkpoint.rs`
+- store + capture + fork → `mvm-backend` (`checkpoint` module)
+- audit kinds → `mvm-core/src/policy/audit.rs`; emitters →
+  `mvm-cli/.../audit_chain.rs`
+- CLI orchestration → `mvm-cli/src/commands/vm/checkpoint.rs`
+- GC → `mvm-cli/src/commands/ops/cache.rs`

--- a/specs/notes/plan-159-ws2-fs-quick-checkpoint-fork-design.md
+++ b/specs/notes/plan-159-ws2-fs-quick-checkpoint-fork-design.md
@@ -83,10 +83,13 @@ code; no live-boot dependency for any of the core logic.
   Reuses existing CoW.
 - **`fork_checkpoint`** (mvm-backend) — verify `content_sha256` → CoW-clone
   content into a new instance state dir → mint a new `VmId` → write child
-  lineage meta → (default) cold-boot the child via the existing start path;
-  `--no-start` just materializes. (No machine-id sidecar here: `fs_quick` is a
-  cold boot from a cloned rootfs with no saved machine state. The machine-id
-  identity sidecar belongs to the `vm_full` save/restore path in PR2.)
+  lineage meta. PR1 **materializes** the child and prints the `mvmctl up` hint;
+  **auto-boot-on-fork moves to the start of PR2** (pinning the start path showed
+  booting a forked child pulls in the full `up` path + plan synthesis and isn't
+  validatable on the local flaky Vz boot — which would defeat the host-side-
+  testable rationale for doing `fs_quick` first). No machine-id sidecar here:
+  `fs_quick` is a cold boot from a cloned rootfs with no saved machine state;
+  the machine-id identity sidecar belongs to the `vm_full` path in PR2.
 - **Audit** — new `LocalAuditKind::{CheckpointCreated, CheckpointForked}` +
   `AuditEmitter::emit_checkpoint_created/forked`; `tests/audit_total_coverage.rs`
   posture updated (same pattern as the `PoolWarm` kind added in Plan 118).

--- a/specs/notes/plan-159-ws2-pr1-fs-quick-implementation.md
+++ b/specs/notes/plan-159-ws2-pr1-fs-quick-implementation.md
@@ -1,0 +1,1564 @@
+# Plan 159 WS-2 PR1 — `fs_quick` checkpoint + fork — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a unified, audit-bound `checkpoint` subsystem whose first class — `fs_quick` (APFS copy-on-write rootfs clone of a quiesced VM) — lets a user freeze a microVM's filesystem state and `fork` new sandbox instances from it in seconds.
+
+**Architecture:** Pure checkpoint *types* in `mvm-core`; the *store + capture + fork* logic in `mvm-backend` (reusing `base::cow::clone_rootfs_for_instance`); audit kinds in `mvm-core::policy::audit` with emitters in `mvm-cli`; the `mvmctl checkpoint` command group + `cache prune` GC in `mvm-cli`. No new VMM code; all core logic is host-side and testable without booting a VM.
+
+**Tech Stack:** Rust 2024, `serde` (`deny_unknown_fields`), `sha2`, `clap` derive, `tempfile` (tests), the existing `AuditEmitter` chain-signing spine.
+
+**Design doc:** `specs/notes/plan-159-ws2-fs-quick-checkpoint-fork-design.md`
+
+**Worktree:** `../mvm-159-ws2` (branch `feat/plan-159-ws2-checkpoint-fork`).
+
+**Standing project rules that bind this plan:** all `~/.mvm` paths go through `mvm_core::config`; reuse before reimplementing; many small testable functions + builder pattern; no `clippy::too_many_arguments` suppression; no spec/PR/plan citations in code comments; no `Co-Authored-By: Claude` trailer; `cargo fmt --all`; `cargo nextest run --workspace` + `cargo clippy --workspace -- -D warnings` green before "done".
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `crates/mvm-core/src/checkpoint.rs` *(create)* | `CheckpointId`, `CheckpointClass`, `CheckpointMeta` + builder. Pure types, no runtime deps. |
+| `crates/mvm-core/src/lib.rs` *(modify)* | `pub mod checkpoint;` |
+| `crates/mvm-core/src/config.rs` *(modify)* | `checkpoints_dir()` helper. |
+| `crates/mvm-backend/src/checkpoint/mod.rs` *(create)* | `CheckpointStore` (CRUD/tag/lineage), `capture_fs_quick`, `fork_checkpoint`. |
+| `crates/mvm-backend/src/lib.rs` *(modify)* | `pub mod checkpoint;` |
+| `crates/mvm-core/src/policy/audit.rs` *(modify)* | `CheckpointCreated`, `CheckpointForked` kinds. |
+| `crates/mvm-cli/src/commands/vm/audit_chain.rs` *(modify)* | `emit_checkpoint_created` / `emit_checkpoint_forked`. |
+| `tests/audit_total_coverage.rs` *(modify)* | register the two kinds + `checkpoint` posture. |
+| `crates/mvm-core/src/protocol/vm_backend.rs` *(modify)* | `VmCapabilities.fs_quick_checkpoint` field. |
+| `crates/mvm-backend/src/{vz,apple_container,libkrun,firecracker,docker,...}.rs` *(modify)* | set the new capability field. |
+| `crates/mvm-cli/src/commands/vm/checkpoint.rs` *(create)* | `checkpoint create/ls/rm/fork` group + dispatch. |
+| `crates/mvm-cli/src/commands/mod.rs` *(modify)* | register `Checkpoint` command. |
+| `crates/mvm-cli/src/commands/ops/cache.rs` *(modify)* | untagged-checkpoint GC sweep. |
+| `crates/mvm-cli/src/commands/tests.rs` *(modify)* | CLI parse tests. |
+
+---
+
+## Task 1: `CheckpointMeta` types (mvm-core)
+
+**Files:**
+- Create: `crates/mvm-core/src/checkpoint.rs`
+- Modify: `crates/mvm-core/src/lib.rs` (add `pub mod checkpoint;` next to the other `pub mod` lines)
+
+- [ ] **Step 1: Write the failing tests** — append to the new file's `#[cfg(test)]` after writing the types in Step 3; for TDD, first create `crates/mvm-core/src/checkpoint.rs` containing ONLY this test module so it fails to compile (types absent):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn meta_roundtrips_through_json() {
+        let meta = CheckpointMeta::builder(
+            CheckpointId::new("ckpt-abc123"),
+            CheckpointClass::FsQuick,
+            "myvm",
+        )
+        .content_sha256("deadbeef")
+        .supervisor_config_digest("cfg99")
+        .tag(Some("golden".to_string()))
+        .parent(Some(CheckpointId::new("ckpt-parent")))
+        .created_unix(1_700_000_000)
+        .build();
+
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: CheckpointMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, back);
+        assert_eq!(back.class, CheckpointClass::FsQuick);
+        assert_eq!(back.parent.unwrap().as_str(), "ckpt-parent");
+    }
+
+    #[test]
+    fn meta_rejects_unknown_fields() {
+        let json = r#"{"id":"x","class":"fs_quick","vm_name":"v","tag":null,
+            "parent":null,"created_unix":1,"content_sha256":"h",
+            "supervisor_config_digest":"d","audit_ref":null,"bogus":true}"#;
+        assert!(serde_json::from_str::<CheckpointMeta>(json).is_err());
+    }
+
+    #[test]
+    fn builder_defaults_are_none() {
+        let meta = CheckpointMeta::builder(
+            CheckpointId::new("c1"),
+            CheckpointClass::FsQuick,
+            "vm",
+        )
+        .content_sha256("h")
+        .supervisor_config_digest("d")
+        .created_unix(5)
+        .build();
+        assert!(meta.tag.is_none());
+        assert!(meta.parent.is_none());
+        assert!(meta.audit_ref.is_none());
+    }
+
+    #[test]
+    fn class_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&CheckpointClass::VmFull).unwrap(),
+            "\"vm_full\""
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mvm-core checkpoint:: 2>&1 | tail -20`
+Expected: compile error — `CheckpointMeta` / `CheckpointId` / `CheckpointClass` not found.
+
+- [ ] **Step 3: Write the implementation** — prepend above the test module in `crates/mvm-core/src/checkpoint.rs`:
+
+```rust
+//! Immutable, audit-bound records of frozen microVM state. A checkpoint is the
+//! origin a `fork` clones a new sandbox instance from.
+
+use serde::{Deserialize, Serialize};
+
+/// Stable identifier for a checkpoint (also its on-disk directory name under
+/// `config::checkpoints_dir()`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CheckpointId(String);
+
+impl CheckpointId {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for CheckpointId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The capture mechanism behind a checkpoint. Only `FsQuick` is populated in
+/// this PR; `VmFull` is reserved so the later memory-state path slots into the
+/// same model with no new surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckpointClass {
+    /// APFS copy-on-write clone of a quiesced rootfs (filesystem only).
+    FsQuick,
+    /// Full machine memory state via the supervisor save/restore path.
+    VmFull,
+}
+
+/// On-disk metadata for one checkpoint (`<checkpoints_dir>/<id>/meta.json`).
+/// `audit_ref` is a non-load-bearing back-pointer backfilled after the
+/// chain-signed entry is emitted; integrity verification relies on
+/// `content_sha256`, not on `audit_ref`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckpointMeta {
+    pub id: CheckpointId,
+    pub class: CheckpointClass,
+    pub vm_name: String,
+    pub tag: Option<String>,
+    pub parent: Option<CheckpointId>,
+    pub created_unix: u64,
+    pub content_sha256: String,
+    pub supervisor_config_digest: String,
+    pub audit_ref: Option<String>,
+}
+
+impl CheckpointMeta {
+    pub fn builder(
+        id: CheckpointId,
+        class: CheckpointClass,
+        vm_name: impl Into<String>,
+    ) -> CheckpointMetaBuilder {
+        CheckpointMetaBuilder {
+            id,
+            class,
+            vm_name: vm_name.into(),
+            tag: None,
+            parent: None,
+            created_unix: 0,
+            content_sha256: String::new(),
+            supervisor_config_digest: String::new(),
+            audit_ref: None,
+        }
+    }
+}
+
+/// Builder so callers set only the fields they have; avoids a long positional
+/// constructor.
+pub struct CheckpointMetaBuilder {
+    id: CheckpointId,
+    class: CheckpointClass,
+    vm_name: String,
+    tag: Option<String>,
+    parent: Option<CheckpointId>,
+    created_unix: u64,
+    content_sha256: String,
+    supervisor_config_digest: String,
+    audit_ref: Option<String>,
+}
+
+impl CheckpointMetaBuilder {
+    pub fn tag(mut self, tag: Option<String>) -> Self {
+        self.tag = tag;
+        self
+    }
+    pub fn parent(mut self, parent: Option<CheckpointId>) -> Self {
+        self.parent = parent;
+        self
+    }
+    pub fn created_unix(mut self, secs: u64) -> Self {
+        self.created_unix = secs;
+        self
+    }
+    pub fn content_sha256(mut self, h: impl Into<String>) -> Self {
+        self.content_sha256 = h.into();
+        self
+    }
+    pub fn supervisor_config_digest(mut self, d: impl Into<String>) -> Self {
+        self.supervisor_config_digest = d.into();
+        self
+    }
+    pub fn audit_ref(mut self, r: Option<String>) -> Self {
+        self.audit_ref = r;
+        self
+    }
+    pub fn build(self) -> CheckpointMeta {
+        CheckpointMeta {
+            id: self.id,
+            class: self.class,
+            vm_name: self.vm_name,
+            tag: self.tag,
+            parent: self.parent,
+            created_unix: self.created_unix,
+            content_sha256: self.content_sha256,
+            supervisor_config_digest: self.supervisor_config_digest,
+            audit_ref: self.audit_ref,
+        }
+    }
+}
+```
+
+Then add to `crates/mvm-core/src/lib.rs` (alphabetically among the `pub mod` lines, e.g. right after `pub mod catalog;` / before `pub mod config;`):
+
+```rust
+pub mod checkpoint;
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p mvm-core checkpoint:: 2>&1 | tail -20`
+Expected: 4 passed.
+
+- [ ] **Step 5: Guard the runtime-free invariant** — `mvm-core` must stay async-free.
+
+Run: `cargo xtask check-core-runtime-free 2>&1 | tail -5`
+Expected: passes (the new module pulls only `serde`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mvm-core/src/checkpoint.rs crates/mvm-core/src/lib.rs
+git commit -m "feat(checkpoint): CheckpointMeta types + builder in mvm-core"
+```
+
+---
+
+## Task 2: `config::checkpoints_dir()` helper (mvm-core)
+
+**Files:**
+- Modify: `crates/mvm-core/src/config.rs` (add next to `mvm_keys_dir` / the other `~/.mvm` subdir helpers, ~line 426)
+
+- [ ] **Step 1: Write the failing test** — add to the `#[cfg(test)] mod tests` in `config.rs`:
+
+```rust
+#[test]
+fn checkpoints_dir_is_under_data_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    // Safe in tests: config reads MVM_DATA_DIR at call time.
+    unsafe { std::env::set_var("MVM_DATA_DIR", temp.path()) };
+    let dir = checkpoints_dir();
+    assert_eq!(dir, temp.path().join("checkpoints"));
+    unsafe { std::env::remove_var("MVM_DATA_DIR") };
+}
+```
+
+(If neighbouring tests use a different env-set idiom, match theirs — grep `MVM_DATA_DIR` in `config.rs` tests first.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mvm-core checkpoints_dir_is_under_data_dir 2>&1 | tail -10`
+Expected: compile error — `checkpoints_dir` not found.
+
+- [ ] **Step 3: Write the implementation** — add beside `mvm_keys_dir()`:
+
+```rust
+/// Immutable checkpoint store: `<mvm_data_dir>/checkpoints/`. Each checkpoint
+/// is a subdirectory `<id>/` holding `meta.json` + cloned `content/`.
+pub fn checkpoints_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_data_dir()).join("checkpoints")
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p mvm-core checkpoints_dir_is_under_data_dir 2>&1 | tail -10`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-core/src/config.rs
+git commit -m "feat(config): checkpoints_dir helper"
+```
+
+---
+
+## Task 3: `CheckpointStore` (mvm-backend)
+
+**Files:**
+- Create: `crates/mvm-backend/src/checkpoint/mod.rs`
+- Modify: `crates/mvm-backend/src/lib.rs` (add `pub mod checkpoint;` among the `pub mod` lines)
+
+- [ ] **Step 1: Write the failing tests** — create `crates/mvm-backend/src/checkpoint/mod.rs` with the test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta};
+
+    fn meta(id: &str, tag: Option<&str>, parent: Option<&str>) -> CheckpointMeta {
+        CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, "vm")
+            .tag(tag.map(String::from))
+            .parent(parent.map(CheckpointId::new))
+            .content_sha256("h")
+            .supervisor_config_digest("d")
+            .created_unix(1)
+            .build()
+    }
+
+    #[test]
+    fn write_then_read_roundtrips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        let m = meta("c1", None, None);
+        store.write_meta(&m).unwrap();
+        assert_eq!(store.read_meta(&CheckpointId::new("c1")).unwrap(), m);
+    }
+
+    #[test]
+    fn list_and_remove() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        store.write_meta(&meta("a", None, None)).unwrap();
+        store.write_meta(&meta("b", None, None)).unwrap();
+        assert_eq!(store.list().unwrap().len(), 2);
+        store.remove(&CheckpointId::new("a")).unwrap();
+        assert_eq!(store.list().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn by_tag_filters() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        store.write_meta(&meta("a", Some("gold"), None)).unwrap();
+        store.write_meta(&meta("b", None, None)).unwrap();
+        let tagged = store.by_tag("gold").unwrap();
+        assert_eq!(tagged.len(), 1);
+        assert_eq!(tagged[0].id.as_str(), "a");
+    }
+
+    #[test]
+    fn children_of_finds_lineage() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        store.write_meta(&meta("parent", None, None)).unwrap();
+        store.write_meta(&meta("child", None, Some("parent"))).unwrap();
+        let kids = store.children_of(&CheckpointId::new("parent")).unwrap();
+        assert_eq!(kids.len(), 1);
+        assert_eq!(kids[0].id.as_str(), "child");
+    }
+
+    #[test]
+    fn content_dir_path_is_under_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        let p = store.content_dir(&CheckpointId::new("c1"));
+        assert_eq!(p, tmp.path().join("c1").join("content"));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mvm-backend checkpoint::tests 2>&1 | tail -20`
+Expected: compile error — `CheckpointStore` not found.
+
+- [ ] **Step 3: Write the implementation** — prepend to `crates/mvm-backend/src/checkpoint/mod.rs`:
+
+```rust
+//! Host-side checkpoint store + the fs_quick capture/fork operations.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use mvm_core::checkpoint::{CheckpointId, CheckpointMeta};
+
+/// Filesystem-backed registry over `config::checkpoints_dir()` (or any root,
+/// for tests). Layout: `<root>/<id>/meta.json` + `<root>/<id>/content/`.
+pub struct CheckpointStore {
+    root: PathBuf,
+}
+
+impl CheckpointStore {
+    /// Production constructor — uses the canonical `~/.mvm/checkpoints` path.
+    pub fn open() -> Self {
+        Self::at(mvm_core::config::checkpoints_dir())
+    }
+
+    /// Test/explicit-root constructor.
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn dir_for(&self, id: &CheckpointId) -> PathBuf {
+        self.root.join(id.as_str())
+    }
+
+    pub fn content_dir(&self, id: &CheckpointId) -> PathBuf {
+        self.dir_for(id).join("content")
+    }
+
+    fn meta_path(&self, id: &CheckpointId) -> PathBuf {
+        self.dir_for(id).join("meta.json")
+    }
+
+    pub fn write_meta(&self, meta: &CheckpointMeta) -> Result<()> {
+        let dir = self.dir_for(&meta.id);
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating checkpoint dir {}", dir.display()))?;
+        let json = serde_json::to_vec_pretty(meta).context("serializing checkpoint meta")?;
+        let path = self.meta_path(&meta.id);
+        std::fs::write(&path, json).with_context(|| format!("writing {}", path.display()))?;
+        Ok(())
+    }
+
+    pub fn read_meta(&self, id: &CheckpointId) -> Result<CheckpointMeta> {
+        let path = self.meta_path(id);
+        let bytes =
+            std::fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+        serde_json::from_slice(&bytes).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    pub fn list(&self) -> Result<Vec<CheckpointMeta>> {
+        let mut out = Vec::new();
+        let entries = match std::fs::read_dir(&self.root) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(e).context("reading checkpoints dir"),
+        };
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let id = CheckpointId::new(entry.file_name().to_string_lossy().into_owned());
+            if self.meta_path(&id).exists() {
+                out.push(self.read_meta(&id)?);
+            }
+        }
+        Ok(out)
+    }
+
+    pub fn by_tag(&self, tag: &str) -> Result<Vec<CheckpointMeta>> {
+        Ok(self
+            .list()?
+            .into_iter()
+            .filter(|m| m.tag.as_deref() == Some(tag))
+            .collect())
+    }
+
+    pub fn children_of(&self, parent: &CheckpointId) -> Result<Vec<CheckpointMeta>> {
+        Ok(self
+            .list()?
+            .into_iter()
+            .filter(|m| m.parent.as_ref() == Some(parent))
+            .collect())
+    }
+
+    pub fn remove(&self, id: &CheckpointId) -> Result<()> {
+        let dir = self.dir_for(id);
+        if dir.exists() {
+            std::fs::remove_dir_all(&dir)
+                .with_context(|| format!("removing {}", dir.display()))?;
+        }
+        Ok(())
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}
+```
+
+Add to `crates/mvm-backend/src/lib.rs`:
+
+```rust
+pub mod checkpoint;
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p mvm-backend checkpoint::tests 2>&1 | tail -20`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-backend/src/checkpoint/mod.rs crates/mvm-backend/src/lib.rs
+git commit -m "feat(checkpoint): CheckpointStore over checkpoints_dir"
+```
+
+---
+
+## Task 4: `capture_fs_quick` (mvm-backend)
+
+**Files:**
+- Modify: `crates/mvm-backend/src/checkpoint/mod.rs` (append the function + tests)
+
+The capture takes already-resolved inputs (the caller, in the CLI task, resolves the VM's rootfs path, quiesced-state check, and config digest). This keeps the function pure and unit-testable without a VM. The quiesced precondition is expressed as an explicit `quiesced: bool` argument so the unit test can exercise the refusal path.
+
+- [ ] **Step 1: Write the failing tests** — add to the test module:
+
+```rust
+    use std::io::Write;
+
+    fn write_fake_rootfs(dir: &Path) -> PathBuf {
+        let p = dir.join("rootfs.ext4");
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(b"fake-ext4-bytes").unwrap();
+        p
+    }
+
+    #[test]
+    fn capture_refuses_when_not_quiesced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let rootfs = write_fake_rootfs(tmp.path());
+        let params = CaptureFsQuickParams {
+            id: CheckpointId::new("c1"),
+            vm_name: "vm".into(),
+            rootfs: rootfs.clone(),
+            supervisor_config_digest: "d".into(),
+            tag: None,
+            created_unix: 7,
+            quiesced: false,
+        };
+        let err = capture_fs_quick(&store, params).unwrap_err();
+        assert!(err.to_string().contains("quiesced"));
+    }
+
+    #[test]
+    fn capture_clones_hashes_and_writes_meta() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let rootfs = write_fake_rootfs(tmp.path());
+        let params = CaptureFsQuickParams {
+            id: CheckpointId::new("c1"),
+            vm_name: "vm".into(),
+            rootfs,
+            supervisor_config_digest: "d".into(),
+            tag: Some("gold".into()),
+            created_unix: 7,
+            quiesced: true,
+        };
+        let meta = capture_fs_quick(&store, params).unwrap();
+        // content cloned
+        let content_blob = store.content_dir(&meta.id).join("rootfs.ext4");
+        assert_eq!(std::fs::read(&content_blob).unwrap(), b"fake-ext4-bytes");
+        // hash recorded over the cloned blob
+        assert_eq!(meta.content_sha256.len(), 64);
+        assert_eq!(meta.tag.as_deref(), Some("gold"));
+        // persisted
+        assert_eq!(store.read_meta(&meta.id).unwrap(), meta);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mvm-backend checkpoint::tests::capture 2>&1 | tail -20`
+Expected: compile error — `capture_fs_quick` / `CaptureFsQuickParams` not found.
+
+- [ ] **Step 3: Write the implementation** — append to `checkpoint/mod.rs` (above the test module). It reuses `crate::base::cow::clone_rootfs_for_instance` and hashes via `sha2`:
+
+```rust
+use mvm_core::checkpoint::{CheckpointClass, CheckpointMeta};
+
+/// Inputs for an `fs_quick` capture. Grouped into a struct so the call site
+/// reads clearly and we never thread a long positional argument list.
+pub struct CaptureFsQuickParams {
+    pub id: CheckpointId,
+    pub vm_name: String,
+    /// Absolute path to the VM's live rootfs image to clone.
+    pub rootfs: PathBuf,
+    pub supervisor_config_digest: String,
+    pub tag: Option<String>,
+    pub created_unix: u64,
+    /// The caller asserts the VM is stopped or paused-and-synced. A non-quiesced
+    /// capture is refused: an fs_quick checkpoint has no memory, so the rootfs
+    /// must be in a clean, deterministic state.
+    pub quiesced: bool,
+}
+
+fn sha256_file_hex(path: &Path) -> Result<String> {
+    use sha2::Digest;
+    let bytes = std::fs::read(path).with_context(|| format!("hashing {}", path.display()))?;
+    let mut h = sha2::Sha256::new();
+    h.update(&bytes);
+    Ok(format!("{:x}", h.finalize()))
+}
+
+/// Freeze a quiesced VM's rootfs into an immutable fs_quick checkpoint via APFS
+/// copy-on-write. Returns the persisted metadata. Audit binding is the caller's
+/// responsibility (it owns the ExecutionPlan + signer).
+pub fn capture_fs_quick(
+    store: &CheckpointStore,
+    params: CaptureFsQuickParams,
+) -> Result<CheckpointMeta> {
+    if !params.quiesced {
+        anyhow::bail!(
+            "refusing fs_quick checkpoint of a non-quiesced VM '{}': stop or pause it first",
+            params.vm_name
+        );
+    }
+    let content_dir = store.content_dir(&params.id);
+    std::fs::create_dir_all(&content_dir)
+        .with_context(|| format!("creating {}", content_dir.display()))?;
+
+    let file_name = params
+        .rootfs
+        .file_name()
+        .context("rootfs path has no file name")?;
+    let dst = content_dir.join(file_name);
+    crate::base::cow::clone_rootfs_for_instance(&params.rootfs, &dst)
+        .context("cloning rootfs into checkpoint content")?;
+
+    let content_sha256 = sha256_file_hex(&dst)?;
+
+    let meta = CheckpointMeta::builder(params.id, CheckpointClass::FsQuick, params.vm_name)
+        .tag(params.tag)
+        .created_unix(params.created_unix)
+        .content_sha256(content_sha256)
+        .supervisor_config_digest(params.supervisor_config_digest)
+        .build();
+    store.write_meta(&meta)?;
+    Ok(meta)
+}
+```
+
+Confirm `sha2` is a dependency of `mvm-backend` (it almost certainly is via the workspace). If `cargo test` reports it missing, add `sha2.workspace = true` to `crates/mvm-backend/Cargo.toml` `[dependencies]`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p mvm-backend checkpoint::tests 2>&1 | tail -20`
+Expected: all checkpoint tests pass (7 total now).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-backend/src/checkpoint/mod.rs crates/mvm-backend/Cargo.toml
+git commit -m "feat(checkpoint): capture_fs_quick CoW capture of a quiesced rootfs"
+```
+
+---
+
+## Task 5: `fork_checkpoint` (mvm-backend)
+
+**Files:**
+- Modify: `crates/mvm-backend/src/checkpoint/mod.rs` (append the function + tests)
+
+`fork_checkpoint` materializes a child instance's rootfs by CoW-cloning a checkpoint's verified content into a destination directory the caller supplies (the CLI resolves the new VM's state dir via `config::vm_state_dir`). It returns the forked child's metadata (with `parent` set). Booting the child is the CLI's job (Task 8). This keeps the primitive boot-free and unit-testable.
+
+- [ ] **Step 1: Write the failing tests** — add to the test module:
+
+```rust
+    fn seed_fs_quick_checkpoint(store: &CheckpointStore, tmp: &Path, id: &str) -> CheckpointMeta {
+        let rootfs = write_fake_rootfs(tmp);
+        capture_fs_quick(
+            store,
+            CaptureFsQuickParams {
+                id: CheckpointId::new(id),
+                vm_name: "parentvm".into(),
+                rootfs,
+                supervisor_config_digest: "d".into(),
+                tag: None,
+                created_unix: 1,
+                quiesced: true,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn fork_clones_content_and_records_lineage() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let parent = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
+        let dst = tmp.path().join("childvm-state");
+        let child = fork_checkpoint(
+            &store,
+            ForkParams {
+                checkpoint: parent.id.clone(),
+                child_id: CheckpointId::new("f1"),
+                child_vm_name: "childvm".into(),
+                dest_dir: dst.clone(),
+                created_unix: 2,
+            },
+        )
+        .unwrap();
+        assert_eq!(child.parent.as_ref().unwrap(), &parent.id);
+        assert_eq!(child.vm_name, "childvm");
+        // content materialized into dest
+        assert_eq!(
+            std::fs::read(dst.join("rootfs.ext4")).unwrap(),
+            b"fake-ext4-bytes"
+        );
+        // child persisted with lineage queryable
+        assert_eq!(store.children_of(&parent.id).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn fork_refuses_vm_full_in_this_pr() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        // hand-write a vm_full checkpoint meta (no content needed for the guard)
+        let m = CheckpointMeta::builder(
+            CheckpointId::new("vf"),
+            CheckpointClass::VmFull,
+            "vm",
+        )
+        .content_sha256("h")
+        .supervisor_config_digest("d")
+        .created_unix(1)
+        .build();
+        store.write_meta(&m).unwrap();
+        let err = fork_checkpoint(
+            &store,
+            ForkParams {
+                checkpoint: m.id,
+                child_id: CheckpointId::new("f"),
+                child_vm_name: "c".into(),
+                dest_dir: tmp.path().join("d"),
+                created_unix: 2,
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("vm_full"));
+    }
+
+    #[test]
+    fn fork_refuses_tampered_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let parent = seed_fs_quick_checkpoint(&store, tmp.path(), "p1");
+        // tamper: overwrite the stored content blob after capture
+        let blob = store.content_dir(&parent.id).join("rootfs.ext4");
+        std::fs::write(&blob, b"tampered").unwrap();
+        let err = fork_checkpoint(
+            &store,
+            ForkParams {
+                checkpoint: parent.id,
+                child_id: CheckpointId::new("f"),
+                child_vm_name: "c".into(),
+                dest_dir: tmp.path().join("d"),
+                created_unix: 2,
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("integrity") || err.to_string().contains("sha256"));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mvm-backend checkpoint::tests::fork 2>&1 | tail -20`
+Expected: compile error — `fork_checkpoint` / `ForkParams` not found.
+
+- [ ] **Step 3: Write the implementation** — append above the test module:
+
+```rust
+/// Inputs for forking a child instance from a checkpoint.
+pub struct ForkParams {
+    pub checkpoint: CheckpointId,
+    /// New checkpoint-id recording this fork's lineage.
+    pub child_id: CheckpointId,
+    pub child_vm_name: String,
+    /// Where to materialize the child's rootfs (the new VM's state dir).
+    pub dest_dir: PathBuf,
+    pub created_unix: u64,
+}
+
+/// Branch a new sandbox lineage from a checkpoint: verify the source content's
+/// integrity, CoW-clone it into `dest_dir`, and record a child checkpoint whose
+/// `parent` points back to the source. Boot of the child is the caller's job.
+pub fn fork_checkpoint(store: &CheckpointStore, params: ForkParams) -> Result<CheckpointMeta> {
+    let parent = store.read_meta(&params.checkpoint)?;
+    if parent.class != CheckpointClass::FsQuick {
+        anyhow::bail!(
+            "cannot fork checkpoint '{}': class vm_full is not supported yet",
+            parent.id
+        );
+    }
+
+    // Locate + integrity-check the single content blob.
+    let content_dir = store.content_dir(&parent.id);
+    let blob = first_file_in(&content_dir)?;
+    let actual = sha256_file_hex(&blob)?;
+    if actual != parent.content_sha256 {
+        anyhow::bail!(
+            "checkpoint '{}' content failed integrity (sha256): expected {}, got {}",
+            parent.id,
+            parent.content_sha256,
+            actual
+        );
+    }
+
+    std::fs::create_dir_all(&params.dest_dir)
+        .with_context(|| format!("creating {}", params.dest_dir.display()))?;
+    let blob_name = blob.file_name().context("content blob has no file name")?;
+    let dst = params.dest_dir.join(blob_name);
+    crate::base::cow::clone_rootfs_for_instance(&blob, &dst)
+        .context("cloning checkpoint content into child instance")?;
+
+    let child = CheckpointMeta::builder(
+        params.child_id,
+        CheckpointClass::FsQuick,
+        params.child_vm_name,
+    )
+    .parent(Some(parent.id))
+    .created_unix(params.created_unix)
+    .content_sha256(actual)
+    .supervisor_config_digest(parent.supervisor_config_digest)
+    .build();
+    store.write_meta(&child)?;
+    Ok(child)
+}
+
+fn first_file_in(dir: &Path) -> Result<PathBuf> {
+    for entry in std::fs::read_dir(dir)
+        .with_context(|| format!("reading content dir {}", dir.display()))?
+    {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            return Ok(entry.path());
+        }
+    }
+    anyhow::bail!("checkpoint content dir {} has no file", dir.display())
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p mvm-backend checkpoint::tests 2>&1 | tail -20`
+Expected: all checkpoint tests pass (10 total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-backend/src/checkpoint/mod.rs
+git commit -m "feat(checkpoint): fork_checkpoint with integrity check + lineage"
+```
+
+---
+
+## Task 6: Audit kinds + emitters
+
+**Files:**
+- Modify: `crates/mvm-core/src/policy/audit.rs` (add variants after `PoolWarm`, ~line 169)
+- Modify: `crates/mvm-cli/src/commands/vm/audit_chain.rs` (add two emit methods + tests)
+- Modify: `tests/audit_total_coverage.rs` (register tokens + posture)
+
+- [ ] **Step 1: Add the audit kinds** — in `audit.rs`, directly after the `PoolWarm,` variant:
+
+```rust
+    /// `mvmctl checkpoint create` froze a VM's filesystem state into an
+    /// immutable fs_quick checkpoint. `detail` carries `id=<ckpt> class=fs_quick`.
+    CheckpointCreated,
+    /// `mvmctl checkpoint fork` branched a new sandbox from a checkpoint.
+    /// `detail` carries `parent=<ckpt> child=<ckpt>`.
+    CheckpointForked,
+```
+
+- [ ] **Step 2: Write the failing emitter tests** — in `audit_chain.rs` `#[cfg(test)] mod tests`, mirroring `vm_snapshot_saved_records_path_hash_and_size`:
+
+```rust
+    #[test]
+    fn checkpoint_created_records_id_and_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::generate(&mut OsRng);
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-C");
+
+        emitter
+            .emit_checkpoint_created(&plan, "ckpt-abc", "fs_quick", "deadbeef", "myvm")
+            .unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("checkpoint.created"));
+        assert!(content.contains("ckpt-abc"));
+        assert!(content.contains("deadbeef"));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn checkpoint_forked_records_lineage() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::generate(&mut OsRng);
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-F");
+
+        emitter
+            .emit_checkpoint_forked(&plan, "ckpt-parent", "ckpt-child", "childvm")
+            .unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("checkpoint.forked"));
+        assert!(content.contains("ckpt-parent"));
+        assert!(content.contains("ckpt-child"));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+```
+
+(Match the exact `AuditEmitter` test constructor the neighbouring snapshot test uses — the survey shows `AuditEmitter::with_dir(key, dir.path())` and `fixture_plan(...)`; copy those helpers' real names from the file.)
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cargo test -p mvm-cli checkpoint_ 2>&1 | tail -20`
+Expected: compile error — `emit_checkpoint_created` not found.
+
+- [ ] **Step 4: Write the emitters** — in `audit_chain.rs`, beside `emit_vm_snapshot_saved`:
+
+```rust
+    pub fn emit_checkpoint_created(
+        &self,
+        plan: &ExecutionPlan,
+        checkpoint_id: &str,
+        class: &str,
+        content_sha256: &str,
+        vm_name: &str,
+    ) -> Result<()> {
+        self.emit(
+            plan,
+            "checkpoint.created",
+            [
+                ("checkpoint_id".to_string(), checkpoint_id.to_string()),
+                ("class".to_string(), class.to_string()),
+                ("content_sha256".to_string(), content_sha256.to_string()),
+                ("vm_name".to_string(), vm_name.to_string()),
+            ],
+        )
+    }
+
+    pub fn emit_checkpoint_forked(
+        &self,
+        plan: &ExecutionPlan,
+        parent_id: &str,
+        child_id: &str,
+        child_vm_name: &str,
+    ) -> Result<()> {
+        self.emit(
+            plan,
+            "checkpoint.forked",
+            [
+                ("parent_id".to_string(), parent_id.to_string()),
+                ("child_id".to_string(), child_id.to_string()),
+                ("child_vm_name".to_string(), child_vm_name.to_string()),
+            ],
+        )
+    }
+```
+
+- [ ] **Step 5: Register in coverage test** — in `tests/audit_total_coverage.rs`:
+  - Add `"CheckpointCreated"` and `"CheckpointForked"` to the `KNOWN_TOKENS` array (beside `"PoolWarm"`).
+  - Add a `CHECKPOINT_SUB` posture table beside `POOL_SUB`:
+
+```rust
+const CHECKPOINT_SUB: &[(&str, AuditPosture)] = &[
+    ("create", AuditPosture::Emits("CheckpointCreated")),
+    ("fork", AuditPosture::Emits("CheckpointForked")),
+    ("ls", AuditPosture::ReadOnly),
+    ("rm", AuditPosture::ReadOnly),
+];
+```
+
+  - Add to the `AUDIT_POSTURE` table beside the `"pool"` row:
+
+```rust
+    ("checkpoint", AuditPosture::DelegatesToSub(CHECKPOINT_SUB)),
+```
+
+  (If `rm` is later made to audit a deletion, revisit; for PR1 `rm` only removes a local dir, consistent with `snapshot rm` being `ReadOnly` in posture terms.)
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `cargo test -p mvm-cli checkpoint_ 2>&1 | tail -10 && cargo test --test audit_total_coverage 2>&1 | tail -10`
+Expected: emitter tests pass; coverage test passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/mvm-core/src/policy/audit.rs crates/mvm-cli/src/commands/vm/audit_chain.rs tests/audit_total_coverage.rs
+git commit -m "feat(audit): checkpoint.created / checkpoint.forked chain events"
+```
+
+---
+
+## Task 7: `VmCapabilities.fs_quick_checkpoint`
+
+**Files:**
+- Modify: `crates/mvm-core/src/protocol/vm_backend.rs` (`VmCapabilities` struct, ~line 394)
+- Modify: every `fn capabilities()` impl: `crates/mvm-backend/src/{vz,apple_container,libkrun,firecracker,docker,cloud_hypervisor}.rs` and any mock backend.
+
+- [ ] **Step 1: Write the failing test** — in `crates/mvm-backend/src/vz.rs` tests (or wherever `capabilities()` is tested):
+
+```rust
+    #[test]
+    fn vz_advertises_fs_quick_checkpoint_when_apfs() {
+        // fs_quick relies on clonefile(2), available on macOS APFS hosts.
+        let caps = VzBackend::default().capabilities();
+        assert_eq!(caps.fs_quick_checkpoint, cfg!(target_os = "macos"));
+    }
+```
+
+(Use the real `VzBackend` constructor the file uses — grep the existing `capabilities` test in `vz.rs`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mvm-backend fs_quick_checkpoint 2>&1 | tail -10`
+Expected: compile error — no field `fs_quick_checkpoint`.
+
+- [ ] **Step 3: Add the field** — in `vm_backend.rs` `VmCapabilities`:
+
+```rust
+    /// Can freeze a quiesced rootfs into an fs_quick checkpoint via filesystem
+    /// copy-on-write (APFS `clonefile` on macOS). Independent of `snapshots`,
+    /// which is the memory-state save/restore capability.
+    pub fs_quick_checkpoint: bool,
+```
+
+- [ ] **Step 4: Set it in every impl.** macOS-CoW backends advertise `true` on macOS; others `false`:
+
+  - `vz.rs` `capabilities()`: `fs_quick_checkpoint: cfg!(target_os = "macos"),`
+  - `apple_container.rs` `capabilities()`: `fs_quick_checkpoint: cfg!(target_os = "macos"),`
+  - `libkrun.rs`, `firecracker.rs`, `docker.rs`, `cloud_hypervisor.rs`, and any mock: `fs_quick_checkpoint: false,`
+
+  Find them all:
+
+```bash
+rg -n "fn capabilities" crates/mvm-backend/src
+rg -n "VmCapabilities \{" crates/mvm-backend crates/mvm-core
+```
+
+  Add the field to each literal. The compiler enforces completeness — a missing field fails the build, so none can be silently skipped.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cargo test -p mvm-backend fs_quick_checkpoint 2>&1 | tail -10 && cargo build -p mvm-backend 2>&1 | tail -5`
+Expected: test passes; workspace builds (no missing-field errors).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mvm-core/src/protocol/vm_backend.rs crates/mvm-backend/src
+git commit -m "feat(backend): advertise fs_quick_checkpoint capability"
+```
+
+---
+
+## Task 8: `mvmctl checkpoint` command group
+
+**Files:**
+- Create: `crates/mvm-cli/src/commands/vm/checkpoint.rs`
+- Modify: `crates/mvm-cli/src/commands/vm/mod.rs` (add `pub(in crate::commands) mod checkpoint;`)
+- Modify: `crates/mvm-cli/src/commands/mod.rs` (register the `Checkpoint` variant + dispatch)
+- Modify: `crates/mvm-cli/src/commands/tests.rs` (parse tests)
+
+This task wires the pure primitives to the CLI. The `create` path resolves the VM's rootfs + quiesced state + config digest and calls `capture_fs_quick`, then binds audit exactly as `snap_save` does. The `fork` path resolves the child's state dir via `config::vm_state_dir`, calls `fork_checkpoint`, binds audit, and (unless `--no-start`) boots the child.
+
+- [ ] **Step 1: Write the failing parse tests** — in `commands/tests.rs`, beside the snapshot tests:
+
+```rust
+    #[test]
+    fn test_checkpoint_create_parses() {
+        let cli = Cli::try_parse_from([
+            "mvmctl", "checkpoint", "create", "myvm", "--tag", "gold",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Checkpoint(vm::checkpoint::CheckpointArgs {
+                command: vm::checkpoint::CheckpointCmd::Create { .. }
+            })
+        ));
+    }
+
+    #[test]
+    fn test_checkpoint_fork_parses() {
+        let cli = Cli::try_parse_from([
+            "mvmctl", "checkpoint", "fork", "ckpt-abc", "--new-id", "child",
+        ]);
+        assert!(cli.is_ok());
+    }
+
+    #[test]
+    fn test_checkpoint_ls_json_parses() {
+        let cli = Cli::try_parse_from(["mvmctl", "checkpoint", "ls", "--json"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Checkpoint(vm::checkpoint::CheckpointArgs {
+                command: vm::checkpoint::CheckpointCmd::Ls { json: true }
+            })
+        ));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mvm-cli test_checkpoint_ 2>&1 | tail -15`
+Expected: compile error — `vm::checkpoint` / `Commands::Checkpoint` absent.
+
+- [ ] **Step 3: Write the command module** — create `crates/mvm-cli/src/commands/vm/checkpoint.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use mvm_backend::checkpoint::{
+    capture_fs_quick, fork_checkpoint, CaptureFsQuickParams, CheckpointStore, ForkParams,
+};
+use mvm_core::checkpoint::CheckpointId;
+
+use crate::Cli;
+use crate::commands::clap_vm_name;
+use mvm_backend::base::ui;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct CheckpointArgs {
+    #[command(subcommand)]
+    pub command: CheckpointCmd,
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+pub(in crate::commands) enum CheckpointCmd {
+    /// Freeze a quiesced VM's filesystem state into an immutable fs_quick
+    /// checkpoint (APFS copy-on-write).
+    Create {
+        /// VM whose rootfs to checkpoint (must be stopped or paused).
+        #[arg(value_parser = clap_vm_name)]
+        name: String,
+        /// Pin this checkpoint against `cache prune` GC.
+        #[arg(long)]
+        tag: Option<String>,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// List checkpoints.
+    Ls {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove a checkpoint and its content.
+    Rm {
+        /// Checkpoint id to remove.
+        id: String,
+    },
+    /// Branch a new sandbox instance from a checkpoint (materializes the
+    /// child's rootfs + lineage; boot it with `mvmctl up`/`start`).
+    Fork {
+        /// Source checkpoint id.
+        id: String,
+        /// Name for the new VM instance (auto-generated if omitted).
+        #[arg(long)]
+        new_id: Option<String>,
+    },
+}
+
+pub(in crate::commands) fn run_checkpoint(_cli: &Cli, args: CheckpointArgs) -> Result<()> {
+    match args.command {
+        CheckpointCmd::Create { name, tag, json } => create(&name, tag, json),
+        CheckpointCmd::Ls { json } => ls(json),
+        CheckpointCmd::Rm { id } => rm(&id),
+        CheckpointCmd::Fork { id, new_id } => fork(&id, new_id),
+    }
+}
+```
+
+  Then implement the four helpers in the same file. Reuse the VM-state resolution + quiesced check + audit binding that `pause.rs::snap_save` already performs. The audit binding mirrors `snap_save` verbatim (best-effort when no persisted plan/signer, **fatal on a signing error for `fork`** so we never ship an unaudited fork):
+
+```rust
+fn checkpoint_id_for(vm_name: &str, now: u64) -> CheckpointId {
+    // Deterministic, collision-resistant enough for a local store; the VM name
+    // plus capture time uniquely identify a checkpoint on one host.
+    CheckpointId::new(format!("ckpt-{vm_name}-{now}"))
+}
+
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn create(name: &str, tag: Option<String>, json: bool) -> Result<()> {
+    // Resolve the VM's rootfs path and quiesced state from real primitives:
+    //  - rootfs lives at `<vm_state_dir>/<state.rootfs>`, where `state.rootfs`
+    //    is the filename persisted in the VM's saved state (see
+    //    `mvm_backend::microvm` line ~286: `format!("{}/{}", abs_dir, state.rootfs)`).
+    //    Load that persisted state to get the filename; do NOT hardcode a name.
+    //  - quiesced == the registry entry exists and is not running (stopped) or
+    //    is paused, via `VmNameRegistry::lookup`.
+    let registry = mvm::vm::name_registry::VmNameRegistry::load(
+        &mvm::vm::name_registry::registry_path(),
+    )
+    .context("loading the VM name registry")?;
+    let reg = registry
+        .lookup(name)
+        .with_context(|| format!("VM {name:?} is not registered"))?;
+    let quiesced = !reg.running || reg.paused;
+
+    let state_dir = mvm_core::config::vm_state_dir(name);
+    let rootfs = resolve_vm_rootfs_path(&state_dir)
+        .with_context(|| format!("locating the rootfs image for VM {name:?}"))?;
+    let config_digest = String::new(); // not load-bearing for fs_quick; PR2 pins it
+
+    let store = CheckpointStore::open();
+    let now = now_unix();
+    let meta = capture_fs_quick(
+        &store,
+        CaptureFsQuickParams {
+            id: checkpoint_id_for(name, now),
+            vm_name: name.to_string(),
+            rootfs,
+            supervisor_config_digest: config_digest,
+            tag,
+            created_unix: now,
+            quiesced,
+        },
+    )?;
+
+    // Chain-signed audit binding (best-effort, mirrors snap_save).
+    if let Ok(plan) = super::plan_persist::read_plan(name) {
+        if let Ok(signer) = super::host_signer::load_or_init() {
+            if let Ok(emitter) = super::audit_chain::AuditEmitter::new(signer.signing) {
+                if let Err(e) = emitter.emit_checkpoint_created(
+                    &plan,
+                    meta.id.as_str(),
+                    "fs_quick",
+                    &meta.content_sha256,
+                    name,
+                ) {
+                    tracing::warn!(error = %e, "audit emit_checkpoint_created failed (non-fatal)");
+                }
+            }
+        }
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&meta)?);
+    } else {
+        ui::success(&format!("Checkpoint {} created.", meta.id));
+    }
+    Ok(())
+}
+
+fn ls(json: bool) -> Result<()> {
+    let store = CheckpointStore::open();
+    let items = store.list()?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&items)?);
+    } else if items.is_empty() {
+        ui::info("No checkpoints.");
+    } else {
+        for m in &items {
+            let parent = m.parent.as_ref().map(|p| p.as_str()).unwrap_or("-");
+            let tag = m.tag.as_deref().unwrap_or("-");
+            ui::info(&format!(
+                "{} · {:?} · vm={} · parent={} · tag={}",
+                m.id, m.class, m.vm_name, parent, tag
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn rm(id: &str) -> Result<()> {
+    CheckpointStore::open().remove(&CheckpointId::new(id))?;
+    ui::success(&format!("Removed checkpoint {id}."));
+    Ok(())
+}
+
+fn fork(id: &str, new_id: Option<String>) -> Result<()> {
+    let store = CheckpointStore::open();
+    let now = now_unix();
+    let child_vm_name = new_id.unwrap_or_else(|| format!("{id}-fork-{now}"));
+    let dest_dir = mvm_core::config::vm_state_dir(&child_vm_name);
+
+    let child = fork_checkpoint(
+        &store,
+        ForkParams {
+            checkpoint: CheckpointId::new(id),
+            child_id: CheckpointId::new(format!("fork-{child_vm_name}-{now}")),
+            child_vm_name: child_vm_name.clone(),
+            dest_dir,
+            created_unix: now,
+        },
+    )?;
+
+    // Audit binding — fatal on a signing error: never ship an unaudited fork.
+    // Best-effort only when no plan/signer is provisioned yet (mirrors snap_save).
+    if let Ok(plan) = super::plan_persist::read_plan(&child.vm_name) {
+        if let Ok(signer) = super::host_signer::load_or_init() {
+            if let Ok(emitter) = super::audit_chain::AuditEmitter::new(signer.signing) {
+                emitter
+                    .emit_checkpoint_forked(&plan, id, child.id.as_str(), &child.vm_name)
+                    .context("auditing the fork (refusing an unaudited fork)")?;
+            }
+        }
+    }
+
+    ui::success(&format!(
+        "Forked {} from checkpoint {} into VM '{}'. Start it with: mvmctl up --name {}",
+        child.id, id, child.vm_name, child.vm_name
+    ));
+    Ok(())
+}
+
+/// Resolve the host-side rootfs image path for a quiesced VM. The rootfs
+/// filename is the `rootfs` field of `mvm_backend::base::config::MvmState`
+/// (joined onto the VM dir, exactly as `microvm.rs` builds
+/// `format!("{}/{}", abs_dir, state.rootfs)`).
+fn resolve_vm_rootfs_path(state_dir: &std::path::Path) -> Result<PathBuf> {
+    let raw = std::fs::read_to_string(state_dir.join(".mvm-state"))
+        .with_context(|| format!("reading VM state in {}", state_dir.display()))?;
+    let state: mvm_backend::base::config::MvmState =
+        serde_json::from_str(&raw).context("parsing .mvm-state")?;
+    Ok(state_dir.join(state.rootfs))
+}
+```
+
+  > **Task 8 Step 0 — pin the host-side rootfs location (one bounded investigation).**
+  > The snippet above assumes the host keeps a `.mvm-state` file beside the
+  > rootfs in `vm_state_dir(name)`. That is the Firecracker/legacy layout;
+  > **the libkrun and Vz backends may store the rootfs image elsewhere** (their
+  > supervisor configs, not a host `.mvm-state`). Before implementing `create`,
+  > trace where the *active* macOS backend (Vz / apple_container) persists the
+  > bootable rootfs image for a named VM — start at `mvm_backend::vz` /
+  > `apple_container::prepare_instance_rootfs` and the supervisor config that
+  > names the rootfs. Make `resolve_vm_rootfs_path` return that real path for the
+  > macOS backends (the only ones advertising `fs_quick_checkpoint = true`); a
+  > backend that doesn't expose a host-side rootfs image yields a clean
+  > "fs_quick checkpoint unsupported for this VM's backend" error. This is the
+  > single integration seam in PR1 — everything else is unit-pinned.
+  >
+  > **Scope note — fork materializes only (no auto-boot in PR1):** the approved design said "fork boots by default," but pinning the start path showed booting a forked child pulls in the full `up` start path + plan synthesis and is not validatable on the local (flaky) Vz boot — which defeats the host-side-testable rationale for doing `fs_quick` first. PR1 therefore *materializes* the child (rootfs + lineage + audit) and prints the `mvmctl up` hint; **boot-on-fork moves to the start of PR2**, where the live-Vz path is already in scope. This keeps every line of PR1 unit-testable.
+
+- [ ] **Step 4: Register the command** — in `commands/vm/mod.rs`:
+
+```rust
+pub(in crate::commands) mod checkpoint;
+```
+
+  In `commands/mod.rs`, add the enum variant beside `Snapshot`:
+
+```rust
+    /// Freeze + fork microVM filesystem state (`create`, `ls`, `rm`, `fork`).
+    Checkpoint(vm::checkpoint::CheckpointArgs),
+```
+
+  and the dispatch arm beside `Commands::Snapshot`:
+
+```rust
+        Commands::Checkpoint(a) => vm::checkpoint::run_checkpoint(&cli, a),
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cargo test -p mvm-cli test_checkpoint_ 2>&1 | tail -15`
+Expected: the three parse tests pass.
+
+- [ ] **Step 6: Full build + clippy on the touched crates**
+
+Run: `cargo clippy -p mvm-cli -p mvm-backend -p mvm-core -- -D warnings 2>&1 | tail -15`
+Expected: zero warnings (watch for `too_many_arguments` — the param structs prevent it).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/mvm-cli/src/commands/vm/checkpoint.rs crates/mvm-cli/src/commands/vm/mod.rs crates/mvm-cli/src/commands/mod.rs crates/mvm-cli/src/commands/tests.rs crates/mvm-cli/src/commands/vm/pause.rs crates/mvm-cli/src/commands/vm/up.rs
+git commit -m "feat(cli): mvmctl checkpoint create/ls/rm/fork"
+```
+
+---
+
+## Task 9: `cache prune` GC for untagged checkpoints
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/ops/cache.rs` (add a sweep block mirroring the flow-byte-log retention sweep)
+
+- [ ] **Step 1: Write the failing test** — add to `cache.rs` tests (or a new `#[cfg(test)]` block):
+
+```rust
+    #[test]
+    fn prune_removes_untagged_keeps_tagged() {
+        use mvm_backend::checkpoint::CheckpointStore;
+        use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path());
+        let mk = |id: &str, tag: Option<&str>, age: u64| {
+            CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::FsQuick, "vm")
+                .tag(tag.map(String::from))
+                .content_sha256("h")
+                .supervisor_config_digest("d")
+                .created_unix(age)
+                .build()
+        };
+        store.write_meta(&mk("old-untagged", None, 0)).unwrap();
+        store.write_meta(&mk("old-tagged", Some("gold"), 0)).unwrap();
+
+        let now = 10_000_000u64;
+        let removed = super::sweep_untagged_checkpoints(&store, now, /*max_age_secs*/ 1).unwrap();
+        assert_eq!(removed, 1);
+        assert!(store.read_meta(&CheckpointId::new("old-tagged")).is_ok());
+        assert!(store.read_meta(&CheckpointId::new("old-untagged")).is_err());
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mvm-cli prune_removes_untagged_keeps_tagged 2>&1 | tail -10`
+Expected: compile error — `sweep_untagged_checkpoints` not found.
+
+- [ ] **Step 3: Write the sweep helper + wire it** — add to `cache.rs`:
+
+```rust
+/// Remove untagged checkpoints older than `max_age_secs`. Tagged checkpoints
+/// are pinned and never swept. Returns the count removed.
+pub(super) fn sweep_untagged_checkpoints(
+    store: &mvm_backend::checkpoint::CheckpointStore,
+    now_unix: u64,
+    max_age_secs: u64,
+) -> anyhow::Result<usize> {
+    let mut removed = 0;
+    for m in store.list()? {
+        if m.tag.is_some() {
+            continue;
+        }
+        if now_unix.saturating_sub(m.created_unix) > max_age_secs {
+            store.remove(&m.id)?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+```
+
+  Then call it from the prune flow, mirroring the flow-byte-log block (const TTL, dry-run branch, accumulate `removed`):
+
+```rust
+    // Untagged-checkpoint GC: tagged checkpoints are user-pinned; untagged ones
+    // follow cache retention.
+    const CHECKPOINT_MAX_AGE_SECS: u64 = 7 * 24 * 60 * 60;
+    let ckpt_store = mvm_backend::checkpoint::CheckpointStore::open();
+    if dry_run {
+        if !ckpt_store.list().unwrap_or_default().is_empty() {
+            ui::info("(dry-run) Would sweep expired untagged checkpoints.");
+        }
+    } else {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        match sweep_untagged_checkpoints(&ckpt_store, now, CHECKPOINT_MAX_AGE_SECS) {
+            Ok(n) => removed += n,
+            Err(e) => ui::warn(&format!("checkpoint sweep failed: {e}")),
+        }
+    }
+```
+
+  (Match the actual variable names in `cache.rs` — `removed`, `dry_run`, `ui` — confirmed present from the flow-byte-log block.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p mvm-cli prune_removes_untagged_keeps_tagged 2>&1 | tail -10`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-cli/src/commands/ops/cache.rs
+git commit -m "feat(cache): prune untagged checkpoints, keep tagged"
+```
+
+---
+
+## Task 10: Full-suite green + status rollup
+
+**Files:**
+- Modify: `specs/REFACTOR-STATUS.md`
+- Modify: `specs/plans/159-vz-inspired-macos-dx.md` (tick the WS-2 fs_quick items the PR delivers)
+
+- [ ] **Step 1: Format + full lint + full test**
+
+Run:
+```bash
+cargo fmt --all
+cargo clippy --workspace -- -D warnings 2>&1 | tail -20
+cargo nextest run --workspace -E 'not package(mvm-backend)' 2>&1 | tail -20
+cargo nextest run -p mvm-backend -E 'test(checkpoint)' 2>&1 | tail -20
+cargo test --workspace --doc 2>&1 | tail -10
+```
+Expected: fmt clean; zero clippy warnings; tests pass. (The `mvm-backend` exclusion + targeted re-run is the documented macOS codesign-SIGKILL workaround; on Linux CI the full `--workspace` run covers it.)
+
+- [ ] **Step 2: Update the rollup** — in `specs/REFACTOR-STATUS.md`, under `PLAN 159`, change the `WS-2 checkpoint+fork` line to show the fs_quick slice landed, e.g.:
+
+```
+  [~] WS-2 checkpoint+fork — fs_quick class (APFS-CoW checkpoint + fork + audit
+      + capability + GC) landed; vm_full (memory save/restore) + diff remain
+```
+
+  Bump `**Last updated:**`. In `specs/plans/159-vz-inspired-macos-dx.md`, tick the WS-2 checklist items this PR satisfies (fs_quick class, fork, `--tag` GC, capability flip) and leave `vm_full` / `checkpoint diff` / `pause/resume` wiring unticked.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add specs/REFACTOR-STATUS.md specs/plans/159-vz-inspired-macos-dx.md
+git commit -m "docs(plan-159): WS-2 fs_quick checkpoint+fork landed"
+```
+
+- [ ] **Step 4: Push + open PR**
+
+```bash
+git push -u origin feat/plan-159-ws2-checkpoint-fork
+gh pr create --title "feat(checkpoint): Plan 159 WS-2 PR1 — fs_quick checkpoint + fork" \
+  --body "First slice of Plan 159 WS-2: a unified, audit-bound checkpoint subsystem with the fs_quick (APFS copy-on-write) class. Adds mvmctl checkpoint create/ls/rm/fork, chain-signed checkpoint.created/forked audit events, the fs_quick_checkpoint capability, and untagged-checkpoint GC in cache prune. vm_full (memory save/restore) and checkpoint diff are the next PRs. Design: specs/notes/plan-159-ws2-fs-quick-checkpoint-fork-design.md."
+```
+
+---
+
+## Notes for the implementer
+
+- **Run `xtask check-no-spec-refs` discipline by hand:** none of the code comments above cite a plan/PR/ADR — keep it that way.
+- **Quiesced resolution is the one place to be careful:** `create` must refuse a running VM. The unit test covers the primitive; the CLI test in Task 8 only covers parsing. A live end-to-end (boot a long-lived workload, `checkpoint create`, `checkpoint fork`, confirm the child boots) belongs in a manual bringup pass — the local Vz dev VM exits on init-EOF, so prefer a long-lived workload image over the dev shell.
+- **If `capture_fs_quick`'s `clone_rootfs_for_instance` returns `CloneStrategy::Copied`** on a non-APFS host, the checkpoint still works (byte copy); the capability flag is what gates the *DX promise*, not the function.

--- a/specs/plans/159-vz-inspired-macos-dx.md
+++ b/specs/plans/159-vz-inspired-macos-dx.md
@@ -185,23 +185,24 @@ Clone the reference's **tiered, fail-closed checkpoint model** and bring
 snapshots to the `apple_container` runtime tier (currently
 `snapshots=false`).
 
-- [ ] Two classes, fail-closed (no silent degradation): `fs_quick`
+- [~] Two classes, fail-closed (no silent degradation): `fs_quick`
       (default) backed by our existing **APFS CoW** rootfs clone (fast,
-      filesystem-only); `vm_full` backed by `saveMachineStateToURL` /
-      `restoreMachineStateFromURL` (memory state, macOS 14+). Reject
-      `vm_full` with a hard error when the backend can't honor it.
-- [ ] First-class **fork**: branch a new sandbox lineage from a
+      filesystem-only) — **landed PR1**; `vm_full` backed by
+      `saveMachineStateToURL` / `restoreMachineStateFromURL` (memory state,
+      macOS 14+) — **PR2**. Reject `vm_full` with a hard error when the
+      backend can't honor it.
+- [x] First-class **fork**: branch a new sandbox lineage from a
       checkpoint (`fork <ckpt> [--new-id]`), reusing the per-instance CoW
       clone we already do.
 - [ ] `checkpoint diff <a> <b>` — versioned diff between two checkpoints
       (the reference's `diff` verb), for inspecting what a fork changed.
-- [ ] `--tag` to pin a checkpoint against GC; untagged ones follow cache
+- [x] `--tag` to pin a checkpoint against GC; untagged ones follow cache
       retention (`cache prune` already exists — extend it).
-- [ ] Flip `apple_container` `capabilities()` to advertise the supported
+- [x] Flip `apple_container` `capabilities()` to advertise the supported
       classes; wire `mvmctl pause/resume` + a `snapshot`/`checkpoint`
       verb to the VZ path (today `pause.rs::snapshot_io_for` is
       Firecracker-only).
-- [ ] Bind every checkpoint to the snapshot crypto/audit spine (Plan 97
+- [x] Bind every checkpoint to the snapshot crypto/audit spine (Plan 97
       E / 140) — a checkpoint is signed + recorded, like a Firecracker
       snapshot. Do not ship an unaudited fork primitive.
 

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -122,6 +122,15 @@ const POOL_SUB: &[(&str, AuditPosture)] = &[
     ("status", AuditPosture::ReadOnly),
 ];
 
+// Wired into AUDIT_POSTURE once Task 8 registers the checkpoint command.
+#[allow(dead_code)]
+const CHECKPOINT_SUB: &[(&str, AuditPosture)] = &[
+    ("create", AuditPosture::Emits("CheckpointCreated")),
+    ("fork", AuditPosture::Emits("CheckpointForked")),
+    ("ls", AuditPosture::ReadOnly),
+    ("rm", AuditPosture::ReadOnly),
+];
+
 const IMAGE_SUB: &[(&str, AuditPosture)] = &[
     ("pull", AuditPosture::Emits("ImageFetch")),
     ("ls", AuditPosture::ReadOnly),
@@ -499,6 +508,8 @@ fn audit_posture_emits_entries_reference_known_audit_kinds() {
         "ManifestAliasSet",
         "ManifestTagAdd",
         "ManifestTagRemove",
+        "CheckpointCreated",
+        "CheckpointForked",
         "NetworkCreate",
         "NetworkRemove",
         "PoolWarm",

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -122,8 +122,6 @@ const POOL_SUB: &[(&str, AuditPosture)] = &[
     ("status", AuditPosture::ReadOnly),
 ];
 
-// Wired into AUDIT_POSTURE once Task 8 registers the checkpoint command.
-#[allow(dead_code)]
 const CHECKPOINT_SUB: &[(&str, AuditPosture)] = &[
     ("create", AuditPosture::Emits("CheckpointCreated")),
     ("fork", AuditPosture::Emits("CheckpointForked")),
@@ -309,6 +307,7 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     ("pause", AuditPosture::Emits("VmStop")),
     ("resume", AuditPosture::Emits("VmStart")),
     ("snapshot", AuditPosture::DelegatesToSub(SNAPSHOT_SUB)),
+    ("checkpoint", AuditPosture::DelegatesToSub(CHECKPOINT_SUB)),
     ("volume", AuditPosture::DelegatesToSub(VOLUME_SUB)),
     // Build / artifact / registry.
     ("kernel", AuditPosture::DelegatesToSub(KERNEL_SUB)),


### PR DESCRIPTION
First slice of Plan 159 WS-2 (vz-inspired macOS DX): a unified, audit-bound `checkpoint` subsystem with the **`fs_quick`** class — APFS copy-on-write of a quiesced rootfs — plus an integrity-checked **fork**.

## What landed
- **mvm-core** — `checkpoint` types (`CheckpointId`/`CheckpointClass`/`CheckpointMeta` + builder, `deny_unknown_fields`), `config::checkpoints_dir()`, audit kinds `CheckpointCreated`/`CheckpointForked`. Stays runtime-free (serde only).
- **mvm-backend** — `CheckpointStore` (CRUD + tag/lineage), `capture_fs_quick` (quiesce-gated → CoW clone → streamed SHA-256 → meta), `fork_checkpoint` (verify integrity **before** clone → CoW clone → parent→child lineage; refuses `vm_full`, tampered content, and multi-file content dirs), `VmCapabilities.fs_quick_checkpoint` (advertised on Vz + apple_container on macOS).
- **mvm-cli** — `mvmctl checkpoint create/ls/rm/fork` (fork **materializes** the child + prints the `mvmctl up` hint — auto-boot is PR2), chain-signed `checkpoint.created`/`checkpoint.forked` audit, untagged-checkpoint GC in `cache prune` (tagged = pinned).

## Security
- Fork verifies `content_sha256` **before** any clone; refuses `vm_full` and ambiguous multi-file content.
- Path-traversal guarded at the CLI boundary: both the checkpoint `id` (rm/fork) and `fork --new-id` are validated before reaching a store path.
- Fork audit is **fatal on a signing error** (never an unaudited fork); create audit is best-effort, matching `snap_save`.

## Scope
`vm_full` (memory save/restore) + `checkpoint diff` + `pause/resume` wiring are PR2/PR3. Auto-boot-on-fork deferred to PR2 (pulls in the full start path, not host-side-testable here).

## Test plan
- [x] All host-side: mvm-core types/config, store CRUD, capture quiesce-refusal, fork lineage/tamper/multi-file/vm_full refusals, audit land+verify_audit_chain, GC, CLI parse + traversal-rejection
- [x] `cargo fmt --all --check`, `cargo clippy --workspace -D warnings` (zero), workspace nextest + doctests green
- [ ] Live Vz capture round-trip (deferred — local Vz boot is flaky; PR2 covers the live path)

Design + plan: `specs/notes/plan-159-ws2-fs-quick-checkpoint-fork-design.md`, `specs/notes/plan-159-ws2-pr1-fs-quick-implementation.md`.