### PR TITLE
fix(dev): degraded builder store — fail fast + cache repair + doctor health (#640)

### DIFF
--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -401,6 +401,24 @@ pub enum BuilderVmError {
     #[error("nix build failed inside builder sandbox: {0}")]
     NixBuildFailed(String),
 
+    /// The persistent builder Nix store has a dangling/GC'd path — every build
+    /// re-evals to the same missing path and fails identically, so `dev up`
+    /// appears to "loop" (#640). Distinguished from a generic build failure so
+    /// the user gets the one-line recovery instead of an opaque nix error.
+    #[error(
+        "the builder VM's Nix store has a dangling/garbage-collected path — \
+         a previous `nix-collect-garbage` removed a store path the cached builder \
+         image still references, so every `dev up` fails identically.\n\
+         Recover with:\n    rm -rf {cache_dir}\n\
+         then re-run `mvmctl dev up` (the builder image rebuilds from scratch).\n\
+         Inner nix error: {detail}\nFull log: {log_path}"
+    )]
+    DegradedBuilderStore {
+        cache_dir: String,
+        log_path: String,
+        detail: String,
+    },
+
     /// Artifact extraction failed (missing rootfs, permissions,
     /// extraction-dir issue).
     #[error("extracting artifacts from builder sandbox: {0}")]
@@ -423,6 +441,29 @@ pub enum BuilderVmError {
         /// full pre- and post-panic kernel output is preserved.
         console_log_path: String,
     },
+}
+
+/// `~/.cache/mvm/builder-vm/` (honors `MVM_CACHE_DIR`) — the directory to clear
+/// to recover a degraded builder store (#640). Lives here (ungated) so the build
+/// error path can name the recovery dir; the `builder-vm`-gated builder modules
+/// delegate to this for a single source of truth.
+pub fn builder_vm_cache_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("builder-vm")
+}
+
+/// Detect nix's dangling-store-path signature in a build's stderr (#640): a
+/// `/nix/store/...` path the build references was garbage-collected, so the eval
+/// fails with `error: path '/nix/store/<hash>...' does not exist`. Matched
+/// precisely — a quoted `/nix/store/` path **and** "does not exist" on the same
+/// line — so an unrelated "does not exist" (a user's missing source file) does
+/// not trip the degraded-store recovery hint. Returns the matched line for the
+/// error `detail`.
+pub fn dangling_store_path_line(stderr: &str) -> Option<&str> {
+    stderr.lines().find(|line| {
+        line.contains("does not exist")
+            && line.contains("/nix/store/")
+            && (line.contains("path '") || line.contains("path \""))
+    })
 }
 
 /// Stub implementation. Every method returns
@@ -874,6 +915,53 @@ pub fn admit_overlay_aware(rootfs_dir: &Path) -> Result<(), anyhow::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dangling_store_line_matches_the_nix_gc_signature() {
+        // The exact #640 signature (single-quoted /nix/store path + does not exist).
+        let stderr = "building...\n\
+             error: path '/nix/store/0ccnxa25whszw7mgbgyzdm4nqc0zwnm8-source/flake.nix' does not exist\n\
+             error: build of '/nix/store/abc.drv' failed\n";
+        let line = dangling_store_path_line(stderr).expect("should match");
+        assert!(line.contains("0ccnxa25whszw7mgbgyzdm4nqc0zwnm8-source"));
+        // Double-quoted nix path form also matches.
+        assert!(
+            dangling_store_path_line("error: path \"/nix/store/xyz-source\" does not exist")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn dangling_store_line_ignores_unrelated_does_not_exist() {
+        // A workload's own missing source file must NOT trip the degraded-store
+        // recovery hint — no /nix/store path on the line.
+        assert!(dangling_store_path_line("error: file 'src/main.rs' does not exist").is_none());
+        // A /nix/store mention without "does not exist" is also not it.
+        assert!(
+            dangling_store_path_line("copying '/nix/store/abc-foo' to the binary cache").is_none()
+        );
+        assert!(dangling_store_path_line("").is_none());
+    }
+
+    #[test]
+    fn degraded_store_error_names_the_recovery_dir_and_command() {
+        let e = BuilderVmError::DegradedBuilderStore {
+            cache_dir: "/home/u/.cache/mvm/builder-vm".into(),
+            log_path: "/tmp/job/nix-stderr.log".into(),
+            detail: "error: path '/nix/store/x-source/flake.nix' does not exist".into(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("rm -rf /home/u/.cache/mvm/builder-vm"));
+        assert!(msg.contains("dev up"));
+        assert!(msg.contains("dangling")); // distinct from a generic build failure
+    }
+
+    #[test]
+    fn builder_vm_cache_dir_honors_mvm_cache_dir() {
+        // Reuse-first: the gated libkrun helper delegates here. Just assert the
+        // path ends in builder-vm (env-isolated check would need a lock).
+        assert!(builder_vm_cache_dir().ends_with("builder-vm"));
+    }
 
     #[test]
     fn pinned_image_is_namespaced() {

--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -409,8 +409,9 @@ pub enum BuilderVmError {
         "the builder VM's Nix store has a dangling/garbage-collected path — \
          a previous `nix-collect-garbage` removed a store path the cached builder \
          image still references, so every `dev up` fails identically.\n\
-         Recover with:\n    rm -rf {cache_dir}\n\
-         then re-run `mvmctl dev up` (the builder image rebuilds from scratch).\n\
+         Recover with:\n    mvmctl cache repair\n\
+         (or `rm -rf {cache_dir}`), then re-run `mvmctl dev up` — the builder \
+         image rebuilds from scratch.\n\
          Inner nix error: {detail}\nFull log: {log_path}"
     )]
     DegradedBuilderStore {
@@ -464,6 +465,69 @@ pub fn dangling_store_path_line(stderr: &str) -> Option<&str> {
             && line.contains("/nix/store/")
             && (line.contains("path '") || line.contains("path \""))
     })
+}
+
+/// Outcome of a builder-store repair (#640).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BuilderStoreRepair {
+    /// The builder-VM cache dir that was (or would be) cleared.
+    pub path: String,
+    /// Whether the dir existed (a fresh host has nothing to repair).
+    pub existed: bool,
+    /// Bytes that were (or, under `dry_run`, would be) freed.
+    pub bytes_freed: u64,
+    /// `true` when only reporting — nothing was removed.
+    pub dry_run: bool,
+}
+
+/// Recover a degraded builder Nix store (#640) by removing the builder-VM cache
+/// dir so the next `dev up` / `build` cold-rebuilds it clean — the documented
+/// `rm -rf ~/.cache/mvm/builder-vm` recovery as a first-class operation. The
+/// whole dir goes (store image + per-VM dirs + job dirs): the store image is the
+/// degraded piece, and the kernel/rootfs/jobs are all rebuildable. `dry_run`
+/// reports what would be freed without deleting.
+///
+/// Intended to run when builds are FAILING on a dangling-store error, so there
+/// is no healthy in-flight build to disturb — callers that auto-repair should
+/// only do so after a [`BuilderVmError::DegradedBuilderStore`].
+pub fn clear_builder_store(dry_run: bool) -> std::io::Result<BuilderStoreRepair> {
+    clear_builder_store_at(&builder_vm_cache_dir(), dry_run)
+}
+
+/// [`clear_builder_store`] with an explicit dir — the unit-testable core.
+pub fn clear_builder_store_at(
+    dir: &std::path::Path,
+    dry_run: bool,
+) -> std::io::Result<BuilderStoreRepair> {
+    let existed = dir.exists();
+    let bytes_freed = if existed { dir_size_bytes(dir) } else { 0 };
+    if existed && !dry_run {
+        std::fs::remove_dir_all(dir)?;
+    }
+    Ok(BuilderStoreRepair {
+        path: dir.display().to_string(),
+        existed,
+        bytes_freed,
+        dry_run,
+    })
+}
+
+/// Recursive on-disk size in bytes (best-effort: unreadable entries are
+/// skipped). Follows no symlinks — counts the link, not its target.
+fn dir_size_bytes(dir: &std::path::Path) -> u64 {
+    let mut total = 0u64;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let Ok(meta) = entry.metadata() else { continue };
+        if meta.is_dir() {
+            total = total.saturating_add(dir_size_bytes(&entry.path()));
+        } else {
+            total = total.saturating_add(meta.len());
+        }
+    }
+    total
 }
 
 /// Stub implementation. Every method returns
@@ -951,7 +1015,8 @@ mod tests {
             detail: "error: path '/nix/store/x-source/flake.nix' does not exist".into(),
         };
         let msg = e.to_string();
-        assert!(msg.contains("rm -rf /home/u/.cache/mvm/builder-vm"));
+        assert!(msg.contains("mvmctl cache repair")); // the first-class recovery
+        assert!(msg.contains("rm -rf /home/u/.cache/mvm/builder-vm")); // manual fallback
         assert!(msg.contains("dev up"));
         assert!(msg.contains("dangling")); // distinct from a generic build failure
     }
@@ -961,6 +1026,35 @@ mod tests {
         // Reuse-first: the gated libkrun helper delegates here. Just assert the
         // path ends in builder-vm (env-isolated check would need a lock).
         assert!(builder_vm_cache_dir().ends_with("builder-vm"));
+    }
+
+    #[test]
+    fn clear_builder_store_removes_the_dir_and_reports_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("builder-vm");
+        std::fs::create_dir_all(store.join("vms/x")).unwrap();
+        std::fs::write(store.join("nix-store.img"), vec![0u8; 4096]).unwrap();
+        std::fs::write(store.join("vms/x/console.log"), vec![0u8; 100]).unwrap();
+
+        // dry-run: reports freed bytes, removes nothing.
+        let dry = clear_builder_store_at(&store, true).unwrap();
+        assert!(dry.existed && dry.dry_run);
+        assert_eq!(dry.bytes_freed, 4196);
+        assert!(store.exists(), "dry-run must not delete");
+
+        // real: removes the dir, reports the same bytes.
+        let done = clear_builder_store_at(&store, false).unwrap();
+        assert!(done.existed && !done.dry_run);
+        assert_eq!(done.bytes_freed, 4196);
+        assert!(!store.exists(), "repair must remove the store dir");
+    }
+
+    #[test]
+    fn clear_builder_store_is_a_noop_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("builder-vm"); // never created
+        let r = clear_builder_store_at(&store, false).unwrap();
+        assert!(!r.existed && r.bytes_freed == 0);
     }
 
     #[test]

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -605,6 +605,22 @@ pub fn finalize_flake_job(
         let stderr_log = job_dir.join("nix-stderr.log");
         let derivation_tail = read_last_bytes_of(&stderr_log, 4 * 1024)
             .unwrap_or_else(|_| String::from("<nix-stderr.log not present on host>"));
+
+        // #640 — a dangling/GC'd store path makes every `dev up` fail identically
+        // (the user re-runs and "loops"). Detect that exact nix signature and
+        // return the one-line recovery instead of the opaque build error.
+        if let Some(line) = crate::builder_vm::dangling_store_path_line(&derivation_tail)
+            .or_else(|| crate::builder_vm::dangling_store_path_line(&result.stderr_tail))
+        {
+            return Err(BuilderVmError::DegradedBuilderStore {
+                cache_dir: crate::builder_vm::builder_vm_cache_dir()
+                    .display()
+                    .to_string(),
+                log_path: stderr_log.display().to_string(),
+                detail: line.trim().to_string(),
+            });
+        }
+
         return Err(BuilderVmError::NixBuildFailed(format!(
             "guest cmd.sh exited {} — full log: {}\n\
              outer stderr tail (cmd.sh ringbuffer):\n{}\n\

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1224,7 +1224,7 @@ pub(crate) fn host_arch_tag() -> &'static str {
 /// subdirs in one place. Created lazily by callers — this
 /// function does not touch the filesystem.
 pub(crate) fn builder_vm_cache_dir() -> PathBuf {
-    PathBuf::from(mvm_core::config::mvm_cache_dir()).join("builder-vm")
+    crate::builder_vm::builder_vm_cache_dir()
 }
 
 /// Filename of Stage 0's dedicated persistent Nix-store image,

--- a/crates/mvm-build/tests/app_deps_orchestrator.rs
+++ b/crates/mvm-build/tests/app_deps_orchestrator.rs
@@ -445,6 +445,15 @@ fn clone_builder_err(e: &BuilderVmError) -> BuilderVmError {
             requested: requested.clone(),
             reason: reason.clone(),
         },
+        BuilderVmError::DegradedBuilderStore {
+            cache_dir,
+            log_path,
+            detail,
+        } => BuilderVmError::DegradedBuilderStore {
+            cache_dir: cache_dir.clone(),
+            log_path: log_path.clone(),
+            detail: detail.clone(),
+        },
     }
 }
 

--- a/crates/mvm-cli/src/commands/ops/cache.rs
+++ b/crates/mvm-cli/src/commands/ops/cache.rs
@@ -45,6 +45,18 @@ pub(in crate::commands) enum CacheAction {
         #[arg(long)]
         json: bool,
     },
+    /// Repair a degraded builder VM store (#640). Clears
+    /// `~/.cache/mvm/builder-vm/` so the next `dev up`/`build` cold-rebuilds it.
+    /// Use this when `dev up` keeps failing with a dangling-store error
+    /// (`error: path '/nix/store/…-source/flake.nix' does not exist`).
+    Repair {
+        /// Print what would be freed without removing anything
+        #[arg(long)]
+        dry_run: bool,
+        /// Emit machine-readable JSON to stdout
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Structured output for `cache info --json`.
@@ -108,6 +120,39 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             // and the last Stage 0 source fingerprint.
             for line in &info.detail_lines {
                 println!("{line}");
+            }
+            Ok(())
+        }
+        CacheAction::Repair { dry_run, json } => {
+            let repair = mvm_build::builder_vm::clear_builder_store(dry_run)
+                .map_err(|e| anyhow::anyhow!("clearing builder store: {e}"))?;
+            if json {
+                crate::json_out::emit_json(&repair)?;
+                return Ok(());
+            }
+            if !repair.existed {
+                ui::info(&format!(
+                    "Builder store {} is already absent — nothing to repair.",
+                    repair.path
+                ));
+            } else if dry_run {
+                ui::info(&format!(
+                    "Would clear builder store {} ({}). Re-run without --dry-run to repair.",
+                    repair.path,
+                    human_bytes(repair.bytes_freed)
+                ));
+            } else {
+                mvm_core::audit_emit!(
+                    CachePrune,
+                    "op=builder_store_repair freed_bytes={} cache_dir={}",
+                    repair.bytes_freed,
+                    repair.path
+                );
+                ui::success(&format!(
+                    "Cleared builder store {} ({} freed). The next `mvmctl dev up` rebuilds it.",
+                    repair.path,
+                    human_bytes(repair.bytes_freed)
+                ));
             }
             Ok(())
         }

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -229,6 +229,32 @@ fn stage0_status_check() -> Check {
     }
 }
 
+/// Surface the builder VM store's on-disk presence + size (#640). Host-side we
+/// can't verify nix-store integrity (that needs booting the VM), so this is
+/// informational: present/absent + size, with the `cache repair` recovery path
+/// noted. `ok` is always true — an absent store just means a cold first build,
+/// and a present-but-degraded store isn't host-detectable without a build.
+fn builder_store_check() -> Check {
+    // The repair dry-run is a pure read: it returns (existed, bytes, path)
+    // without removing anything.
+    let info = match mvm_build::builder_vm::clear_builder_store(true) {
+        Ok(s) if s.existed => format!(
+            "present ({:.1} GiB) at {} — if `dev up` fails with a dangling-store \
+             error, run `mvmctl cache repair`",
+            s.bytes_freed as f64 / (1024.0 * 1024.0 * 1024.0),
+            s.path,
+        ),
+        Ok(s) => format!("absent ({} — first `dev up` builds it)", s.path),
+        Err(e) => format!("could not stat builder store: {e}"),
+    };
+    Check {
+        name: "builder store",
+        category: "tools",
+        ok: true,
+        info,
+    }
+}
+
 /// One-line summary of a dry-run convergence report for `doctor`
 /// (Plan 170 WS-A). Pure so it's testable without touching the registry.
 fn registry_drift_summary(report: &mvm::vm::reconcile::ConvergeReport) -> String {
@@ -313,6 +339,7 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
     checks.push(docker_check(plat));
     checks.push(ts_runner_check());
     checks.push(stage0_status_check());
+    checks.push(builder_store_check());
     checks.push(registry_drift_check());
 
     checks.push(disk_space_check(false));

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -114,6 +114,10 @@ const NETWORK_SUB: &[(&str, AuditPosture)] = &[
 const CACHE_SUB: &[(&str, AuditPosture)] = &[
     ("info", AuditPosture::ReadOnly),
     ("prune", AuditPosture::Emits("CachePrune")),
+    // #640 — clears a degraded builder store; emits CachePrune on the real run
+    // (op=builder_store_repair). A `--dry-run` is read-only, but the posture
+    // tracks the acting path.
+    ("repair", AuditPosture::Emits("CachePrune")),
 ];
 
 // Plan 118 WS-1 1b — `mvmctl pool`.


### PR DESCRIPTION
## #640 — degraded builder store: fail fast, `cache repair`, doctor health

A dangling/garbage-collected path in the persistent builder Nix store makes **every** `mvmctl dev up` fail identically (`error: path '/nix/store/<hash>-source/flake.nix' does not exist`); the user re-runs and it appears to **loop**, with only a manual `rm -rf ~/.cache/mvm/builder-vm` clearing it. This closes that out across the issue's three gaps.

### Part 1 — fail fast with a clear recovery hint
`finalize_flake_job` (the hypervisor-agnostic build-failure point) now detects the exact nix dangling-store signature (`dangling_store_path_line`: a quoted `/nix/store/` path **and** "does not exist" on one line — precise enough that an unrelated missing file doesn't trip it) and returns a new `BuilderVmError::DegradedBuilderStore` that names the recovery, instead of the opaque nix error.

### Part 3a — `mvmctl cache repair`
Clears `~/.cache/mvm/builder-vm/` (store image + per-VM/job dirs — all rebuildable) so the next `dev up`/`build` cold-rebuilds clean: the documented recovery as a first-class, audit-logged command. `--dry-run` reports bytes-freed without deleting; `--json` for scripts. Reusable core `mvm_build::builder_vm::clear_builder_store`.

### Part 3b — `doctor` builder-store health
A `builder store` line reporting the store's presence + size, pointing at `cache repair` on a dangling-store failure. Informational (host-side can't verify nix integrity without booting the VM).

### Part 2 — self-heal
The acceptance — *"heal a degraded builder store without a manual `rm -rf`"* — is met by `cache repair`, and the `DegradedBuilderStore` error now points straight at it. In-`dev up` auto-repair-and-retry is left as a follow-up (a riskier change to a box-validated path; the issue offers `cache repair` *or* auto-recovery as alternatives).

### Tests
9 new/updated unit tests: dangling-store signature match (incl. no-false-positive), the error names the recovery, `clear_builder_store` (dry-run vs real, no-op when absent), cache-dir helper. Plus a fix to the exhaustive `BuilderVmError` match in `tests/app_deps_orchestrator.rs` that the new variant required. Full `nextest` green; host + `cargo-zigbuild` Linux cross-build clean.

Closes #640 (auto-retry-in-`dev up` nicety noted as optional follow-up).
