### PR TITLE
feat(secrets): undeclared-secret/PII egress redaction mechanism — entropy + IBAN + names + per-destination (plan 129 E1 Step 2)

### DIFF
--- a/crates/mvm-core/src/policy/mod.rs
+++ b/crates/mvm-core/src/policy/mod.rs
@@ -16,6 +16,7 @@ pub mod security;
 // consumes the resolver + bundle types via the facade.
 pub mod bundle;
 pub mod policies;
+pub mod redaction;
 pub mod resolver;
 pub mod signing;
 pub mod toml_loader;
@@ -24,6 +25,9 @@ pub use bundle::{PolicyBundle, PolicyId, SCHEMA_VERSION, TenantOverlay};
 pub use policies::{
     ArtifactPolicy, AuditPolicy, DEFAULT_BODY_CAP_BYTES, EgressPolicy, FlowByteLogDirections,
     FlowByteLogSpec, KeyPolicy, L4RuleSpec, NetworkPolicy, PiiPolicy, ToolPolicy,
+};
+pub use redaction::{
+    EntropyMode, NameMode, RedactionAction, RedactionPolicy, RedactionProfile, SecretAction,
 };
 pub use resolver::{EffectivePolicy, EmergencyDeny, resolve};
 pub use signing::{BundleVerifyError, SignedPolicyBundle, sign_bundle, verify_bundle};

--- a/crates/mvm-core/src/policy/redaction.rs
+++ b/crates/mvm-core/src/policy/redaction.rs
@@ -52,9 +52,16 @@ pub enum SecretAction {
 #[serde(deny_unknown_fields, default)]
 pub struct RedactionAction {
     pub entropy: EntropyMode,
-    /// Structured-regex PII (email/ssn/cc/phone/iban) — reuse the existing knob.
+    /// RESERVED — parsed and resolved but not yet consumed by the redactor,
+    /// which currently applies the always-on structured-PII ruleset regardless
+    /// of this value. Per-destination PII mode/categories interact with that
+    /// always-on pass and need their own semantic pass before this knob takes
+    /// effect; until then a value here has no runtime effect.
     pub pii: PiiPolicy,
     pub names: NameMode,
+    /// RESERVED — parsed and resolved but not yet consumed; curated secrets are
+    /// always masked (Block-equivalent) regardless of this value. Wiring it is a
+    /// tracked follow-up.
     pub secrets: SecretAction,
 }
 

--- a/crates/mvm-core/src/policy/redaction.rs
+++ b/crates/mvm-core/src/policy/redaction.rs
@@ -38,6 +38,7 @@ pub enum NameMode {
 
 /// Curated `SecretsScanner` disposition. Default Block — a known secret prefix
 /// on egress is always a fail.
+// allow(secret-debug): data-free disposition enum (audit/redact/block); carries no key material
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SecretAction {

--- a/crates/mvm-core/src/policy/redaction.rs
+++ b/crates/mvm-core/src/policy/redaction.rs
@@ -1,0 +1,118 @@
+//! Per-destination egress redaction policy. Pure data; the destination
+//! resolver lives in mvm-hostd (it needs `mvm_sdk::ir::host_matches`, which
+//! sits above mvm-core). Default is today's curated-only baseline: structured
+//! PII per the workload `PiiPolicy`, curated secrets block, entropy + names off.
+
+use serde::{Deserialize, Serialize};
+
+use crate::policy::PiiPolicy;
+
+/// Entropy detection disposition for a destination.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EntropyMode {
+    /// No entropy scanning (default everywhere unless a profile opts in).
+    #[default]
+    Off,
+    /// Detect + audit, never mask (the safe first opt-in).
+    Audit {
+        min_bits_per_char: f64,
+        min_run_len: usize,
+    },
+    /// Detect + mask.
+    Redact {
+        min_bits_per_char: f64,
+        min_run_len: usize,
+    },
+}
+
+/// Name detection disposition. Names never block (false-positive risk).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum NameMode {
+    #[default]
+    Off,
+    Audit,
+    Redact,
+}
+
+/// Curated `SecretsScanner` disposition. Default Block — a known secret prefix
+/// on egress is always a fail.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SecretAction {
+    Audit,
+    Redact,
+    #[default]
+    Block,
+}
+
+/// What to do at one destination.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct RedactionAction {
+    pub entropy: EntropyMode,
+    /// Structured-regex PII (email/ssn/cc/phone/iban) — reuse the existing knob.
+    pub pii: PiiPolicy,
+    pub names: NameMode,
+    pub secrets: SecretAction,
+}
+
+/// One host-pattern → action mapping.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RedactionProfile {
+    /// Host or `*.`-wildcard, matched by `host_matches` at resolve time.
+    pub host: String,
+    pub action: RedactionAction,
+}
+
+/// A workload's per-destination redaction policy. Absent / default ⇒ the
+/// `default` curated-only action applies to every destination.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct RedactionPolicy {
+    pub default: RedactionAction,
+    pub profiles: Vec<RedactionProfile>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redaction_policy_roundtrips_and_defaults_to_curated_only() {
+        let json = r#"{
+            "default": { "entropy": {"action":"off"}, "names": "off" },
+            "profiles": [
+              { "host": "*.untrusted.example",
+                "action": { "entropy": {"action":"redact","min_bits_per_char":4.0,"min_run_len":20},
+                            "names": "audit" } }
+            ]
+        }"#;
+        let p: RedactionPolicy = serde_json::from_str(json).unwrap();
+        assert_eq!(p.profiles.len(), 1);
+        assert_eq!(p.profiles[0].host, "*.untrusted.example");
+        // default action: entropy off, names off — today's curated-only baseline.
+        assert!(matches!(p.default.entropy, EntropyMode::Off));
+        assert!(matches!(p.default.names, NameMode::Off));
+        // round-trip
+        let s = serde_json::to_string(&p).unwrap();
+        let p2: RedactionPolicy = serde_json::from_str(&s).unwrap();
+        assert_eq!(p, p2);
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let json = r#"{ "default": {}, "bogus": 1 }"#;
+        assert!(serde_json::from_str::<RedactionPolicy>(json).is_err());
+    }
+
+    #[test]
+    fn empty_policy_default_is_all_off() {
+        let p = RedactionPolicy::default();
+        assert!(p.profiles.is_empty());
+        assert!(matches!(p.default.entropy, EntropyMode::Off));
+        assert!(matches!(p.default.names, NameMode::Off));
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/entropy_scanner.rs
+++ b/crates/mvm-hostd/src/supervisor/entropy_scanner.rs
@@ -1,0 +1,164 @@
+//! `EntropyScanner` — mask undeclared high-entropy tokens on egress.
+//!
+//! Complements the curated `SecretsScanner`: that matches known vendor
+//! prefixes; this catches unknown-shape high-entropy tokens (random API keys,
+//! session blobs) the curated rules miss. Deliberately additive and
+//! audit-first — high-entropy false positives (JWTs, UUIDs, base64 uploads,
+//! hashes) must degrade, not break, and operators observe hits before masking.
+
+use crate::supervisor::pii_redactor::REDACTION_MASK;
+
+/// True for bytes that can be part of a secret-like token run: the
+/// base64url/hex alphabet plus `+` and `/` from standard base64. `=` is
+/// deliberately excluded — it appears in the wild as a `key=value` delimiter,
+/// so treating it as a token byte would weld the `key=` prose onto the value
+/// and mask the operator's context away. Base64 `=` padding is trailing and
+/// low-information, so dropping it from the run costs no real detection.
+fn is_token_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'+' | b'/' | b'_' | b'-')
+}
+
+/// One detected high-entropy run, as a half-open byte range. Carries NO bytes:
+/// the matched value never leaves the host, not even into a struct that might
+/// reach a log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntropyHit {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// Shannon-entropy scanner over token runs.
+pub struct EntropyScanner {
+    min_run_len: usize,
+    min_bits_per_char: f64,
+}
+
+impl EntropyScanner {
+    /// `min_run_len` keeps short prose words out; the `min_bits_per_char`
+    /// threshold keeps natural-language runs out (English is ~3-4 bits/char;
+    /// uniform base64 is 6, hex is 4).
+    pub fn new(min_run_len: usize, min_bits_per_char: f64) -> Self {
+        Self {
+            min_run_len,
+            min_bits_per_char,
+        }
+    }
+
+    /// Defaults tuned for low false-positive on prose: 20-char minimum run,
+    /// 4.0 bits/char. Audit-first means operators retune before enabling masking.
+    pub fn with_defaults() -> Self {
+        Self::new(20, 4.0)
+    }
+
+    /// Return every token run whose entropy clears the threshold.
+    pub fn scan(&self, body: &[u8]) -> Vec<EntropyHit> {
+        let mut hits = Vec::new();
+        let mut i = 0usize;
+        while i < body.len() {
+            if !is_token_byte(body[i]) {
+                i += 1;
+                continue;
+            }
+            let start = i;
+            while i < body.len() && is_token_byte(body[i]) {
+                i += 1;
+            }
+            let run = &body[start..i];
+            if run.len() >= self.min_run_len && shannon_bits_per_char(run) >= self.min_bits_per_char
+            {
+                hits.push(EntropyHit { start, end: i });
+            }
+        }
+        hits
+    }
+
+    /// Mask each high-entropy run with [`REDACTION_MASK`]; return the rewritten
+    /// bytes and the number of runs masked. Right-to-left so earlier offsets
+    /// stay valid as the buffer shrinks.
+    pub fn redact(&self, body: &[u8]) -> (Vec<u8>, usize) {
+        let hits = self.scan(body);
+        if hits.is_empty() {
+            return (body.to_vec(), 0);
+        }
+        let mut out = body.to_vec();
+        for h in hits.iter().rev() {
+            out.splice(h.start..h.end, REDACTION_MASK.iter().copied());
+        }
+        (out, hits.len())
+    }
+}
+
+/// Shannon entropy of a byte run, in bits per character. Empty run -> 0.0.
+fn shannon_bits_per_char(run: &[u8]) -> f64 {
+    if run.is_empty() {
+        return 0.0;
+    }
+    let mut counts = [0u32; 256];
+    for &b in run {
+        counts[b as usize] += 1;
+    }
+    let len = run.len() as f64;
+    let mut h = 0.0f64;
+    for &c in counts.iter() {
+        if c == 0 {
+            continue;
+        }
+        let p = c as f64 / len;
+        h -= p * p.log2();
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_a_high_entropy_token_run() {
+        let s = EntropyScanner::with_defaults();
+        let body = b"token=Xa9Kf2pQ7vL0mZ3rT8wB1nC4yH6dJ5sG2eU0iO9 end";
+        let hits = s.scan(body);
+        assert_eq!(hits.len(), 1, "expected one high-entropy run, got {hits:?}");
+    }
+
+    #[test]
+    fn ignores_low_entropy_prose() {
+        let s = EntropyScanner::with_defaults();
+        let body = b"the quick brown fox jumps over the lazy dog repeatedly today";
+        assert!(s.scan(body).is_empty(), "prose wrongly flagged");
+    }
+
+    #[test]
+    fn ignores_runs_below_min_length() {
+        let s = EntropyScanner::with_defaults();
+        let body = b"id=Xa9Kf2pQ end";
+        assert!(s.scan(body).is_empty(), "short run wrongly flagged");
+    }
+
+    #[test]
+    fn redact_masks_without_echoing_the_token() {
+        let s = EntropyScanner::with_defaults();
+        let token = "Xa9Kf2pQ7vL0mZ3rT8wB1nC4yH6dJ5sG2eU0iO9";
+        let body = format!("token={token} end").into_bytes();
+        let (out, n) = s.redact(&body);
+        let rendered = String::from_utf8_lossy(&out);
+        assert_eq!(n, 1);
+        assert!(
+            !rendered.contains(token),
+            "token leaked into output: {rendered}"
+        );
+        assert!(rendered.contains("XXX"), "no mask present: {rendered}");
+        assert!(
+            rendered.contains("token="),
+            "context wrongly removed: {rendered}"
+        );
+    }
+
+    #[test]
+    fn clean_body_passes_through_unchanged() {
+        let s = EntropyScanner::with_defaults();
+        let (out, n) = s.redact(b"hello world");
+        assert_eq!(out, b"hello world");
+        assert_eq!(n, 0);
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -75,6 +75,7 @@ pub mod pii_redactor;
 pub mod policy_tool_gate;
 pub mod proxy;
 pub mod reaper;
+pub mod redaction_resolve;
 /// Plan 129 / ADR-067 §4 + claim 13 — chain-signed `secret.substituted` /
 /// `secret.placeholder_dropped` audit events (metadata only, never the value).
 pub mod secret_audit;

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -42,6 +42,7 @@ pub mod balloon_runtime;
 pub mod circuit_breaker;
 pub mod destination;
 pub mod egress;
+pub mod entropy_scanner;
 pub mod event_bus;
 pub mod firewall;
 // Plan 102 W6.A commit 4 — per-VM gateway flow-event subscriber sink.

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -64,6 +64,8 @@ pub mod instance_sampler;
 pub mod keystore;
 pub mod l7_proxy;
 pub mod lifecycle_hooks;
+pub mod name_scanner;
+pub mod names_gazetteer;
 // Plan 113 / ADR-064 — Observer trait + Pipeline builder for the
 // gateway audit substrate. Observers consume `&FlowEvent` references
 // inside `signer_task` (fan-out before chain signing). Host-allowlisted

--- a/crates/mvm-hostd/src/supervisor/name_scanner.rs
+++ b/crates/mvm-hostd/src/supervisor/name_scanner.rs
@@ -1,0 +1,202 @@
+//! `NameScanner` — redact personal names on egress, no ML.
+//!
+//! Names have no regex shape, so we catch the leaks that actually matter — the
+//! ones with context. Three signals: a name-like field label, a census
+//! gazetteer pair, or a capitalized pair adjacent to other PII. Freeform
+//! unlabeled names with no nearby PII are out of scope (would need NER).
+
+use crate::supervisor::names_gazetteer::{FIRST_NAMES, SURNAMES, in_list};
+use crate::supervisor::pii_redactor::REDACTION_MASK;
+use regex::bytes::Regex;
+use std::sync::OnceLock;
+
+/// JSON/form field keys whose value is a personal name.
+const NAME_LABELS: &[&str] = &[
+    "name",
+    "first_name",
+    "firstname",
+    "last_name",
+    "lastname",
+    "full_name",
+    "fullname",
+    "customer",
+    "patient",
+    "cardholder",
+    "given_name",
+    "surname",
+];
+
+fn label_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        // `"key":"value"` (JSON) or `key=value` (form) or `Key: value` (prose).
+        // The key alternation is built from NAME_LABELS; the value capture (1)
+        // is what we mask.
+        let keys = NAME_LABELS.join("|");
+        Regex::new(&format!(
+            r#"(?i)(?:"(?:{keys})"\s*:\s*"|(?:{keys})\s*[:=]\s*"?)([A-Za-z][A-Za-z .'\-]{{1,60}})"#
+        ))
+        .expect("name-label regex compiles")
+    })
+}
+
+/// A capitalized word run: `[A-Z][a-z]+`. Used for the gazetteer + co-occurrence
+/// signals.
+fn cap_words() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"[A-Z][a-z]{1,}").expect("cap-word regex compiles"))
+}
+
+pub struct NameScanner {
+    /// Max byte gap between a capitalized pair and a PII span for the
+    /// co-occurrence signal to fire.
+    cooccur_window: usize,
+}
+
+impl NameScanner {
+    pub fn new(cooccur_window: usize) -> Self {
+        Self { cooccur_window }
+    }
+    pub fn with_defaults() -> Self {
+        Self::new(40)
+    }
+
+    /// Mask names in `body`. `pii_spans` are byte ranges of structured-PII hits
+    /// from a prior pass (empty if none). Returns the rewritten bytes + the
+    /// number of name spans masked.
+    pub fn redact(&self, body: &[u8], pii_spans: &[(usize, usize)]) -> (Vec<u8>, usize) {
+        let mut spans: Vec<(usize, usize)> = Vec::new();
+
+        // (a) labeled fields: mask capture group 1 (the value).
+        for caps in label_regex().captures_iter(body) {
+            if let Some(m) = caps.get(1) {
+                spans.push((m.start(), m.end()));
+            }
+        }
+
+        // Collect capitalized words once for (b) and (c).
+        let words: Vec<(usize, usize)> = cap_words()
+            .find_iter(body)
+            .map(|m| (m.start(), m.end()))
+            .collect();
+
+        // (b) gazetteer pairs: adjacent capitalized words, first in FIRST_NAMES
+        //     OR surname list, second in SURNAMES OR first list.
+        for pair in words.windows(2) {
+            let (a, b) = (pair[0], pair[1]);
+            if !adjacent_words(body, a, b) {
+                continue;
+            }
+            let wa = std::str::from_utf8(&body[a.0..a.1]).unwrap_or("");
+            let wb = std::str::from_utf8(&body[b.0..b.1]).unwrap_or("");
+            if (in_list(FIRST_NAMES, wa) || in_list(SURNAMES, wa))
+                && (in_list(SURNAMES, wb) || in_list(FIRST_NAMES, wb))
+            {
+                spans.push((a.0, b.1));
+            }
+        }
+
+        // (c) co-occurrence: a capitalized pair within `cooccur_window` bytes of
+        //     any PII span (the "row" case — a name bound to other PII).
+        if !pii_spans.is_empty() {
+            for pair in words.windows(2) {
+                let (a, b) = (pair[0], pair[1]);
+                if !adjacent_words(body, a, b) {
+                    continue;
+                }
+                if pii_spans
+                    .iter()
+                    .any(|&(ps, pe)| near(b.1, ps, pe, self.cooccur_window))
+                {
+                    spans.push((a.0, b.1));
+                }
+            }
+        }
+
+        if spans.is_empty() {
+            return (body.to_vec(), 0);
+        }
+        // Dedup + sort, mask right-to-left so offsets stay valid.
+        spans.sort_unstable();
+        spans.dedup();
+        let merged = merge_overlapping(spans);
+        let count = merged.len();
+        let mut out = body.to_vec();
+        for (s, e) in merged.into_iter().rev() {
+            out.splice(s..e, REDACTION_MASK.iter().copied());
+        }
+        (out, count)
+    }
+}
+
+/// Two capitalized words are a "pair" iff separated by exactly one space.
+fn adjacent_words(body: &[u8], a: (usize, usize), b: (usize, usize)) -> bool {
+    b.0 == a.1 + 1 && body.get(a.1) == Some(&b' ')
+}
+
+/// True iff byte offset `at` is within `window` of the [ps, pe) span.
+fn near(at: usize, ps: usize, pe: usize, window: usize) -> bool {
+    let lo = ps.saturating_sub(window);
+    at >= lo && at <= pe + window
+}
+
+/// Merge sorted, possibly-overlapping spans.
+fn merge_overlapping(sorted: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
+    let mut out: Vec<(usize, usize)> = Vec::with_capacity(sorted.len());
+    for (s, e) in sorted {
+        match out.last_mut() {
+            Some(last) if s <= last.1 => last.1 = last.1.max(e),
+            _ => out.push((s, e)),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_a_labeled_name_field_json() {
+        let s = NameScanner::with_defaults();
+        let body = br#"{"first_name":"Jonathan","city":"Denver"}"#;
+        let (out, n) = s.redact(body, &[]);
+        let r = String::from_utf8_lossy(&out);
+        assert!(n >= 1);
+        assert!(!r.contains("Jonathan"), "labeled name not redacted: {r}");
+        assert!(r.contains("Denver"), "non-name value wrongly touched: {r}");
+    }
+
+    #[test]
+    fn redacts_a_gazetteer_name_pair() {
+        let s = NameScanner::with_defaults();
+        let body = b"contact John Smith about the order";
+        let (out, n) = s.redact(body, &[]);
+        let r = String::from_utf8_lossy(&out);
+        assert!(n >= 1, "gazetteer pair not redacted: {r}");
+        assert!(!r.contains("John Smith"), "name pair not masked: {r}");
+    }
+
+    #[test]
+    fn redacts_capitalized_pair_adjacent_to_pii_span() {
+        let s = NameScanner::with_defaults();
+        // "Zephyr Quibblesworth" is not in the gazetteer, but it abuts a PII
+        // span (passed in) → the co-occurrence signal fires.
+        let body = b"Zephyr Quibblesworth ssn 123-45-6789";
+        let pii_spans = [(21usize, 32usize)]; // the ssn span
+        let (out, n) = s.redact(body, &pii_spans);
+        let r = String::from_utf8_lossy(&out);
+        assert!(n >= 1, "co-occurrence name not redacted: {r}");
+        assert!(!r.contains("Zephyr Quibblesworth"), "name not masked: {r}");
+    }
+
+    #[test]
+    fn leaves_unanchored_non_gazetteer_capitalized_words() {
+        let s = NameScanner::with_defaults();
+        // Capitalized but not a known name, not labeled, no nearby PII.
+        let body = b"The Eiffel Tower is tall";
+        let (out, n) = s.redact(body, &[]);
+        assert_eq!(n, 0, "false positive on non-name capitalized words");
+        assert_eq!(out, body);
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/names_gazetteer.rs
+++ b/crates/mvm-hostd/src/supervisor/names_gazetteer.rs
@@ -1,0 +1,46 @@
+//! Census-derived name gazetteer (US Census public-domain frequency lists).
+//! Sorted lowercase; looked up by binary search. Curated toward names whose
+//! name-frequency dominates their common-word-frequency to bound false
+//! positives. Data, not an ML model — no runtime dependency.
+
+/// Sorted, lowercase. Common given names.
+pub const FIRST_NAMES: &[&str] = &[
+    "alice", "bob", "carol", "david", "emma", "james", "john", "jonathan", "maria", "michael",
+    "robert", "sarah", "william",
+];
+
+/// Sorted, lowercase. Common surnames.
+pub const SURNAMES: &[&str] = &[
+    "brown", "davis", "garcia", "johnson", "jones", "miller", "smith", "williams", "wilson",
+];
+
+/// True iff `token` (any case) is in `list` (which must be sorted lowercase).
+pub fn in_list(list: &[&str], token: &str) -> bool {
+    let lower = token.to_ascii_lowercase();
+    list.binary_search(&lower.as_str()).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lists_are_sorted_and_lowercase() {
+        for list in [FIRST_NAMES, SURNAMES] {
+            for w in list {
+                assert_eq!(*w, w.to_ascii_lowercase(), "not lowercase: {w}");
+            }
+            let mut sorted = list.to_vec();
+            sorted.sort_unstable();
+            assert_eq!(list, sorted.as_slice(), "list not sorted");
+        }
+    }
+
+    #[test]
+    fn in_list_is_case_insensitive() {
+        assert!(in_list(FIRST_NAMES, "John"));
+        assert!(in_list(FIRST_NAMES, "JOHN"));
+        assert!(in_list(SURNAMES, "Smith"));
+        assert!(!in_list(SURNAMES, "Eiffel"));
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/network/stages.rs
+++ b/crates/mvm-hostd/src/supervisor/network/stages.rs
@@ -88,11 +88,17 @@ pub struct RedactingSubstitution {
 pub struct RedactionHits {
     pub secrets: Vec<&'static str>,
     pub pii: Vec<&'static str>,
+    /// Count of high-entropy runs that fired (entropy carries no stable rule
+    /// name — it's a shape, not a labeled pattern — so it's a count, not a
+    /// `Vec<&'static str>`).
+    pub entropy: usize,
+    /// Count of name spans that fired.
+    pub names: usize,
 }
 
 impl RedactionHits {
     pub fn is_empty(&self) -> bool {
-        self.secrets.is_empty() && self.pii.is_empty()
+        self.secrets.is_empty() && self.pii.is_empty() && self.entropy == 0 && self.names == 0
     }
 
     /// Fold another pass's categories in (used when redacting several fields —
@@ -100,6 +106,8 @@ impl RedactionHits {
     pub fn merge(&mut self, other: RedactionHits) {
         self.secrets.extend(other.secrets);
         self.pii.extend(other.pii);
+        self.entropy += other.entropy;
+        self.names += other.names;
     }
 }
 
@@ -125,11 +133,83 @@ impl RedactingSubstitution {
     pub fn redact_bytes(&self, payload: &[u8]) -> Option<(Vec<u8>, RedactionHits)> {
         let (after_secrets, secrets) = self.secrets.redact(payload, REDACTION_MASK);
         let (after_pii, pii) = self.pii.redact(&after_secrets);
-        let hits = RedactionHits { secrets, pii };
+        let hits = RedactionHits {
+            secrets,
+            pii,
+            ..Default::default()
+        };
         if hits.is_empty() {
             return None; // clean payload — pass through unchanged.
         }
         Some((after_pii, hits))
+    }
+
+    /// Per-destination redaction. Curated secrets always run; entropy and names
+    /// run only when the resolved action opts in. Returns `None` when nothing
+    /// fired. `secrets`/`pii` come from the existing curated rulesets; entropy
+    /// + names from the new detectors.
+    pub fn redact_bytes_for(
+        &self,
+        payload: &[u8],
+        action: &mvm_core::policy::RedactionAction,
+    ) -> Option<(Vec<u8>, RedactionHits)> {
+        use crate::supervisor::entropy_scanner::EntropyScanner;
+        use crate::supervisor::name_scanner::NameScanner;
+        use mvm_core::policy::{EntropyMode, NameMode};
+
+        let (after_secrets, secrets) = self.secrets.redact(payload, REDACTION_MASK);
+        let (after_pii, pii) = self.pii.redact(&after_secrets);
+        let mut buf = after_pii;
+        let mut hits = RedactionHits {
+            secrets,
+            pii,
+            entropy: 0,
+            names: 0,
+        };
+
+        match &action.entropy {
+            EntropyMode::Off => {}
+            EntropyMode::Audit {
+                min_bits_per_char,
+                min_run_len,
+            } => {
+                // Audit: counted, not masked.
+                hits.entropy += EntropyScanner::new(*min_run_len, *min_bits_per_char)
+                    .scan(&buf)
+                    .len();
+            }
+            EntropyMode::Redact {
+                min_bits_per_char,
+                min_run_len,
+            } => {
+                let (out, n) = EntropyScanner::new(*min_run_len, *min_bits_per_char).redact(&buf);
+                buf = out;
+                hits.entropy += n;
+            }
+        }
+
+        match action.names {
+            NameMode::Off => {}
+            NameMode::Audit => {
+                // Count without masking: the scanner masks, so dry-redact a copy
+                // for the count and drop the buffer. Live PII match-span plumbing
+                // into co-occurrence is a follow-up — pass empty spans, so the
+                // labeled + gazetteer name signals still fire.
+                let (_, n) = NameScanner::with_defaults().redact(&buf, &[]);
+                hits.names += n;
+            }
+            NameMode::Redact => {
+                let (out, n) = NameScanner::with_defaults().redact(&buf, &[]);
+                buf = out;
+                hits.names += n;
+            }
+        }
+
+        if hits.is_empty() {
+            None
+        } else {
+            Some((buf, hits))
+        }
     }
 }
 
@@ -554,6 +634,27 @@ mod tests {
             "secret survived redaction: {masked}"
         );
         assert!(masked.contains("XXX"), "no mask present: {masked}");
+    }
+
+    #[test]
+    fn redact_bytes_for_applies_entropy_when_action_opts_in() {
+        use mvm_core::policy::{EntropyMode, RedactionAction};
+        let r = RedactingSubstitution::with_default_rules();
+        let body = b"k=Xa9Kf2pQ7vL0mZ3rT8wB1nC4yH6dJ5sG2eU0iO9 e";
+        // default action: entropy off → no hit
+        let off = RedactionAction::default();
+        assert!(r.redact_bytes_for(body, &off).is_none());
+        // opt in → entropy redacts the run
+        let on = RedactionAction {
+            entropy: EntropyMode::Redact {
+                min_bits_per_char: 4.0,
+                min_run_len: 20,
+            },
+            ..Default::default()
+        };
+        let (out, hits) = r.redact_bytes_for(body, &on).expect("entropy hit");
+        assert_eq!(hits.entropy, 1);
+        assert!(!String::from_utf8_lossy(&out).contains("Xa9Kf2pQ7vL0mZ3rT8wB1nC4yH6dJ5sG2eU0iO9"));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/pii_redactor.rs
+++ b/crates/mvm-hostd/src/supervisor/pii_redactor.rs
@@ -81,6 +81,7 @@ pub struct PiiRule {
 #[derive(Debug, Clone, Copy)]
 pub enum PiiValidator {
     Luhn,
+    Iban,
 }
 
 /// Default curated PII ruleset. Each rule is high-precision; an
@@ -121,6 +122,14 @@ pub const DEFAULT_RULES: &[PiiRule] = &[
         // matching every 10-digit run on the planet.
         pattern: r"\+\d{7,15}",
         validator: None,
+    },
+    PiiRule {
+        name: "iban",
+        // Country (2 alpha) + 2 check digits + 11-30 BBAN chars. mod-97
+        // validated post-match so a random alnum run of the right shape
+        // doesn't fire.
+        pattern: r"\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b",
+        validator: Some(PiiValidator::Iban),
     },
 ];
 
@@ -250,7 +259,7 @@ impl PiiRedactor {
 /// Matches `DEFAULT_RULES.iter().map(|r| r.name)` order. Public so
 /// callers (the W5 resolver and mvmd-facing policy tooling) can
 /// enumerate the valid names.
-pub const PII_CATEGORY_NAMES: &[&str] = &["email", "us_ssn", "credit_card", "e164_phone"];
+pub const PII_CATEGORY_NAMES: &[&str] = &["email", "us_ssn", "credit_card", "e164_phone", "iban"];
 
 /// Errors from [`PiiRedactor::from_policy`]. Each variant names the
 /// offending value + the list of valid alternatives so a single
@@ -343,7 +352,7 @@ pub const REDACTION_MASK: &[u8] = b"XXX";
 fn rule_passes_validator(rule: &PiiRule, re: &Regex, body: &[u8]) -> bool {
     match rule.validator {
         None => true,
-        Some(PiiValidator::Luhn) => re
+        Some(_) => re
             .find_iter(body)
             .any(|m| match_passes_validator(rule, m.as_bytes())),
     }
@@ -356,6 +365,7 @@ fn match_passes_validator(rule: &PiiRule, m: &[u8]) -> bool {
     match rule.validator {
         None => true,
         Some(PiiValidator::Luhn) => luhn_valid(m),
+        Some(PiiValidator::Iban) => iban_valid(m),
     }
 }
 
@@ -383,6 +393,31 @@ fn luhn_valid(digits: &[u8]) -> bool {
         alt = !alt;
     }
     sum.is_multiple_of(10)
+}
+
+/// ISO 7064 mod-97-10 IBAN checksum: move the first 4 chars to the end, map
+/// letters to two-digit numbers (A=10 … Z=35), and check the integer ≡ 1
+/// (mod 97). Computed digit-by-digit to avoid bignum. Case-insensitive.
+fn iban_valid(iban: &[u8]) -> bool {
+    if iban.len() < 15 || iban.len() > 34 {
+        return false;
+    }
+    let rearranged = iban[4..].iter().chain(iban[..4].iter());
+    let mut remainder: u32 = 0;
+    for &b in rearranged {
+        let val = match b {
+            b'0'..=b'9' => u32::from(b - b'0'),
+            b'A'..=b'Z' => u32::from(b - b'A') + 10,
+            b'a'..=b'z' => u32::from(b - b'a') + 10,
+            _ => return false,
+        };
+        if val >= 10 {
+            remainder = (remainder * 100 + val) % 97;
+        } else {
+            remainder = (remainder * 10 + val) % 97;
+        }
+    }
+    remainder == 1
 }
 
 #[async_trait]
@@ -643,5 +678,35 @@ mod tests {
         assert!(r.inspect(&mut c).await.is_allow());
         let mut c = ctx_with_body(b"900-12-3456");
         assert!(r.inspect(&mut c).await.is_allow());
+    }
+
+    #[test]
+    fn iban_valid_is_masked_invalid_is_left() {
+        let r = PiiRedactor::with_default_rules();
+        let body = b"pay GB82WEST12345698765432 not GB82WEST12345698765431 ok";
+        let (out, fired) = r.redact(body);
+        let s = String::from_utf8_lossy(&out);
+        assert!(
+            !s.contains("GB82WEST12345698765432"),
+            "valid IBAN not masked: {s}"
+        );
+        assert!(
+            s.contains("GB82WEST12345698765431"),
+            "invalid IBAN wrongly masked: {s}"
+        );
+        assert!(fired.contains(&"iban"), "fired={fired:?}");
+    }
+
+    #[test]
+    fn iban_category_is_listed() {
+        assert!(PII_CATEGORY_NAMES.contains(&"iban"));
+    }
+
+    #[test]
+    fn iban_checker_accepts_known_good_and_rejects_bad() {
+        assert!(iban_valid(b"GB82WEST12345698765432"));
+        assert!(iban_valid(b"DE89370400440532013000"));
+        assert!(!iban_valid(b"GB82WEST12345698765431"));
+        assert!(!iban_valid(b"XX00"));
     }
 }

--- a/crates/mvm-hostd/src/supervisor/redaction_resolve.rs
+++ b/crates/mvm-hostd/src/supervisor/redaction_resolve.rs
@@ -1,0 +1,78 @@
+//! Resolve a destination host to its `RedactionAction`. Lives here, not in
+//! mvm-core, because host matching is `mvm_sdk::ir::host_matches` and mvm-sdk
+//! sits above mvm-core in the dependency graph.
+
+use mvm_core::policy::{RedactionAction, RedactionPolicy};
+use mvm_sdk::ir::host_matches;
+
+/// First profile whose `host` pattern matches `dest` wins; else the policy
+/// default. First-match-wins gives operators precedence control by ordering.
+pub fn resolve<'a>(policy: &'a RedactionPolicy, dest: &str) -> &'a RedactionAction {
+    policy
+        .profiles
+        .iter()
+        .find(|p| host_matches(&p.host, dest))
+        .map(|p| &p.action)
+        .unwrap_or(&policy.default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::policy::{
+        EntropyMode, NameMode, RedactionAction, RedactionPolicy, RedactionProfile,
+    };
+
+    fn entropy_redact() -> RedactionAction {
+        RedactionAction {
+            entropy: EntropyMode::Redact {
+                min_bits_per_char: 4.0,
+                min_run_len: 20,
+            },
+            names: NameMode::Redact,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn first_matching_wildcard_wins_else_default() {
+        let pol = RedactionPolicy {
+            default: RedactionAction::default(),
+            profiles: vec![RedactionProfile {
+                host: "*.openai.com".into(),
+                action: entropy_redact(),
+            }],
+        };
+        // matches the wildcard
+        assert!(matches!(
+            resolve(&pol, "api.openai.com").entropy,
+            EntropyMode::Redact { .. }
+        ));
+        // no match → default (Off)
+        assert!(matches!(
+            resolve(&pol, "example.com").entropy,
+            EntropyMode::Off
+        ));
+    }
+
+    #[test]
+    fn earlier_profile_wins_on_overlap() {
+        let pol = RedactionPolicy {
+            default: RedactionAction::default(),
+            profiles: vec![
+                RedactionProfile {
+                    host: "api.openai.com".into(),
+                    action: entropy_redact(),
+                },
+                RedactionProfile {
+                    host: "*.openai.com".into(),
+                    action: RedactionAction::default(),
+                },
+            ],
+        };
+        assert!(matches!(
+            resolve(&pol, "api.openai.com").entropy,
+            EntropyMode::Redact { .. }
+        ));
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -282,6 +282,9 @@ pub struct SubstitutionService {
     /// terminator mints per-SNI leaves under. `None` ⇒ no TLS leg (Stage 1b
     /// `http`-only). Set from `EndpointConfig.tls_intermediate` at assemble.
     tls_intermediate: Option<Arc<mvm_core::crypto::egress_ca::VmIntermediate>>,
+    /// Per-destination redaction policy. Default = curated baseline (entropy +
+    /// names off); a profile opts a destination into entropy/name redaction.
+    redaction_policy: mvm_core::policy::RedactionPolicy,
 }
 
 impl SubstitutionService {
@@ -297,7 +300,16 @@ impl SubstitutionService {
             redactor: RedactingSubstitution::with_default_rules(),
             recorder: None,
             tls_intermediate: None,
+            redaction_policy: mvm_core::policy::RedactionPolicy::default(),
         }
+    }
+
+    /// Attach a per-destination redaction policy. Default leaves entropy + names
+    /// off everywhere (curated-only baseline); a policy opts specific
+    /// destinations into entropy/name redaction.
+    pub fn with_redaction_policy(mut self, policy: mvm_core::policy::RedactionPolicy) -> Self {
+        self.redaction_policy = policy;
+        self
     }
 
     /// Attach a chain-signed audit recorder; each substitution then emits a
@@ -648,6 +660,32 @@ impl SubstitutionService {
         // the destination) before `prepare_request` consumes `req`.
         let destination = destination_host(&req.url).ok();
         let substituted = collect_substituted_meta(&endpoint, &req.headers);
+        // Resolve the per-destination redaction action; clone so it outlives
+        // `req` (which `redact_outbound` then `prepare_request` consume).
+        let action = destination
+            .as_deref()
+            .map(|d| {
+                crate::supervisor::redaction_resolve::resolve(&self.redaction_policy, d).clone()
+            })
+            .unwrap_or_default();
+        let redaction_active = !matches!(action.entropy, mvm_core::policy::EntropyMode::Off)
+            || !matches!(action.names, mvm_core::policy::NameMode::Off);
+        if redaction_active {
+            // Fail closed: a body we can't scan in cleartext is a silent bypass.
+            // A compressed body, or one over the scan cap, is refused before any
+            // forward leg runs.
+            let compressed = req
+                .headers
+                .iter()
+                .any(|(k, _)| k.eq_ignore_ascii_case("content-encoding"));
+            if compressed || req.body.len() as u64 > mvm_core::policy::DEFAULT_BODY_CAP_BYTES {
+                return WireResponse::Refused {
+                    message: "egress redaction enabled for destination but body is \
+                              compressed or over the scan cap; refusing (fail-closed)"
+                        .into(),
+                };
+            }
+        }
         // Whether the request smuggled a host placeholder at all — decides if a
         // refusal is a claim-12 placeholder drop (audited) or a plain bad request.
         let carried_placeholder = req
@@ -659,7 +697,7 @@ impl SubstitutionService {
         // host-reserved) survives to be substituted, while an undeclared secret
         // the guest put in the body or a non-placeholder header is masked and
         // never reaches the wire.
-        let (req, redaction_hits) = self.redact_outbound(req);
+        let (req, redaction_hits) = self.redact_outbound(req, &action);
         let prepared = match prepare_request(&endpoint, req) {
             Ok(p) => p,
             Err(e) => {
@@ -700,18 +738,22 @@ impl SubstitutionService {
     /// placeholder is not secret-shaped); every other header value and the body
     /// are scrubbed. Returns the rewritten request plus the categories that
     /// fired, for the claim-13 audit. Plan 129 Phase E / ADR-067.
-    fn redact_outbound(&self, mut req: ProxyRequest) -> (ProxyRequest, RedactionHits) {
+    fn redact_outbound(
+        &self,
+        mut req: ProxyRequest,
+        action: &mvm_core::policy::RedactionAction,
+    ) -> (ProxyRequest, RedactionHits) {
         let mut hits = RedactionHits::default();
         for (_, value) in req.headers.iter_mut() {
             if find_placeholder(value).is_some() {
                 continue; // declared placeholder — substituted next, never masked.
             }
-            if let Some((masked, h)) = self.redactor.redact_bytes(value.as_bytes()) {
+            if let Some((masked, h)) = self.redactor.redact_bytes_for(value.as_bytes(), action) {
                 *value = String::from_utf8_lossy(&masked).into_owned();
                 hits.merge(h);
             }
         }
-        if let Some((masked, h)) = self.redactor.redact_bytes(&req.body) {
+        if let Some((masked, h)) = self.redactor.redact_bytes_for(&req.body, action) {
             req.body = masked;
             hits.merge(h);
         }
@@ -728,12 +770,18 @@ impl SubstitutionService {
         let (Some(recorder), Some(dest)) = (&self.recorder, destination) else {
             return;
         };
-        let mut categories: Vec<&str> = hits
+        let mut categories: Vec<String> = hits
             .secrets
             .iter()
             .chain(hits.pii.iter())
-            .copied()
+            .map(|s| s.to_string())
             .collect();
+        if hits.entropy > 0 {
+            categories.push("entropy".into());
+        }
+        if hits.names > 0 {
+            categories.push("name".into());
+        }
         categories.sort_unstable();
         categories.dedup();
         if let Err(e) = emit_secret_redacted(recorder, dest, &categories.join(",")).await {
@@ -1042,6 +1090,21 @@ mod server_tests {
         Arc<MockForwarder>,
         tempfile::TempDir,
     ) {
+        service_with_policy(value, hosts, None)
+    }
+
+    /// Like [`service_with`], but attaches `policy` (when `Some`) so a test can
+    /// exercise the destination-aware redaction / fail-closed gate.
+    fn service_with_policy(
+        value: &str,
+        hosts: &[&str],
+        policy: Option<mvm_core::policy::RedactionPolicy>,
+    ) -> (
+        Arc<SubstitutionService>,
+        String,
+        Arc<MockForwarder>,
+        tempfile::TempDir,
+    ) {
         let dir = tempdir().unwrap();
         let store = FileSecretStore::with_dir(dir.path());
         store
@@ -1058,12 +1121,11 @@ mod server_tests {
         let forwarder = Arc::new(MockForwarder {
             seen: Mutex::new(None),
         });
-        let service = Arc::new(SubstitutionService::new(
-            Arc::new(reg),
-            resolver,
-            forwarder.clone(),
-        ));
-        (service, ph, forwarder, dir)
+        let mut service = SubstitutionService::new(Arc::new(reg), resolver, forwarder.clone());
+        if let Some(policy) = policy {
+            service = service.with_redaction_policy(policy);
+        }
+        (Arc::new(service), ph, forwarder, dir)
     }
 
     /// End-to-end over a **real AF_VSOCK** connection (Linux vsock loopback,
@@ -1349,6 +1411,51 @@ mod server_tests {
 
         assert!(matches!(resp, WireResponse::Refused { .. }));
         // claim 12: an unbound destination never reaches the forward leg.
+        assert!(forwarder.seen.lock().unwrap().is_none());
+        server.abort();
+    }
+
+    /// Fail-closed: a `content-encoding`-bearing request to a destination opted
+    /// into entropy redaction can't be scanned in cleartext, so it's refused and
+    /// never forwarded — a body we can't read is a silent bypass.
+    #[tokio::test]
+    async fn compressed_body_to_redaction_destination_is_refused() {
+        use mvm_core::policy::{EntropyMode, RedactionAction, RedactionPolicy, RedactionProfile};
+        let policy = RedactionPolicy {
+            default: RedactionAction::default(),
+            profiles: vec![RedactionProfile {
+                host: "api.openai.com".into(),
+                action: RedactionAction {
+                    entropy: EntropyMode::Redact {
+                        min_bits_per_char: 4.0,
+                        min_run_len: 20,
+                    },
+                    ..Default::default()
+                },
+            }],
+        };
+        let (service, ph, forwarder, dir) =
+            service_with_policy("sk-live-zzz", &["api.openai.com"], Some(policy));
+        let sock = dir.path().join("subst.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = tokio::spawn(Arc::clone(&service).serve(listener));
+        let mut client = UnixStream::connect(&sock).await.unwrap();
+        let wire = WireRequest {
+            method: "POST".into(),
+            url: "https://api.openai.com/v1".into(),
+            headers: vec![
+                ("content-encoding".into(), "gzip".into()),
+                ("authorization".into(), format!("Bearer {ph}")),
+            ],
+            body_b64: B64.encode(b"\x1f\x8b compressed bytes"),
+        };
+        write_json_frame(&mut client, &wire).await.unwrap();
+        let resp: WireResponse = read_json_frame(&mut client, MAX_FRAME_BYTES).await.unwrap();
+        assert!(
+            matches!(resp, WireResponse::Refused { .. }),
+            "compressed body must fail closed: {resp:?}"
+        );
+        // The unscannable request never reached the forward leg.
         assert!(forwarder.seen.lock().unwrap().is_none());
         server.abort();
     }

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -678,7 +678,16 @@ impl SubstitutionService {
                 .headers
                 .iter()
                 .any(|(k, _)| k.eq_ignore_ascii_case("content-encoding"));
-            if compressed || req.body.len() as u64 > mvm_core::policy::DEFAULT_BODY_CAP_BYTES {
+            let oversize = req.body.len() as u64 > mvm_core::policy::DEFAULT_BODY_CAP_BYTES;
+            if compressed || oversize {
+                // Distinct reasons so the audit names which condition fired;
+                // compressed wins when both hold (it's the harder bypass).
+                let reason = if compressed {
+                    "fail_closed_compressed"
+                } else {
+                    "fail_closed_oversize"
+                };
+                self.audit_fail_closed(destination.as_deref(), reason).await;
                 return WireResponse::Refused {
                     message: "egress redaction enabled for destination but body is \
                               compressed or over the scan cap; refusing (fail-closed)"
@@ -817,6 +826,18 @@ impl SubstitutionService {
         };
         if let Err(e) = emit_secret_placeholder_dropped(recorder, dest).await {
             tracing::warn!(error = %e, "secret.placeholder_dropped audit emit failed");
+        }
+    }
+
+    /// Emit one audit entry when a request to a redaction-opted-in destination
+    /// is refused fail-closed (compressed or over-cap body we can't scan in
+    /// cleartext). Metadata only — the reason + destination, never the body.
+    async fn audit_fail_closed(&self, destination: Option<&str>, reason: &str) {
+        let (Some(recorder), Some(dest)) = (&self.recorder, destination) else {
+            return;
+        };
+        if let Err(e) = emit_secret_redacted(recorder, dest, reason).await {
+            tracing::warn!(error = %e, "fail-closed audit emit failed");
         }
     }
 }
@@ -1457,6 +1478,103 @@ mod server_tests {
         );
         // The unscannable request never reached the forward leg.
         assert!(forwarder.seen.lock().unwrap().is_none());
+        server.abort();
+    }
+
+    /// A fail-closed refusal (compressed/over-cap body to a redaction-opted-in
+    /// destination) is observable: it lands one metadata-only audit entry naming
+    /// the destination, and never the body bytes.
+    #[tokio::test]
+    async fn fail_closed_refusal_is_audited() {
+        use crate::supervisor::audit_file::FileAuditSigner;
+        use crate::supervisor::audit_recorder::Recorder;
+        use ed25519_dalek::SigningKey;
+        use mvm_core::plan::TenantId;
+        use mvm_core::policy::{EntropyMode, RedactionAction, RedactionPolicy, RedactionProfile};
+
+        let dir = tempdir().unwrap();
+        let store = FileSecretStore::with_dir(dir.path().join("secrets"));
+        store
+            .put(
+                "local",
+                "openai",
+                &SecretBox::new(Box::new("sk-live-zzz".to_string())),
+            )
+            .unwrap();
+        let resolver: Arc<dyn SecretResolver> =
+            Arc::new(LocalResolver::new("local", Arc::new(store)));
+        let mut reg = SubstitutionRegistry::new();
+        let ph = reg
+            .mint(bearer_ref("openai", &["api.openai.com"]))
+            .as_str()
+            .to_string();
+        let forwarder = Arc::new(MockForwarder {
+            seen: Mutex::new(None),
+        });
+
+        let policy = RedactionPolicy {
+            default: RedactionAction::default(),
+            profiles: vec![RedactionProfile {
+                host: "api.openai.com".into(),
+                action: RedactionAction {
+                    entropy: EntropyMode::Redact {
+                        min_bits_per_char: 4.0,
+                        min_run_len: 20,
+                    },
+                    ..Default::default()
+                },
+            }],
+        };
+
+        let chain = dir.path().join("audit.jsonl");
+        let signer =
+            FileAuditSigner::open_file(SigningKey::from_bytes(&[9u8; 32]), &chain).unwrap();
+        let recorder = Recorder::new(Arc::new(signer), TenantId("local".into()));
+
+        let service = Arc::new(
+            SubstitutionService::new(Arc::new(reg), resolver, Arc::clone(&forwarder) as _)
+                .with_redaction_policy(policy)
+                .with_recorder(recorder),
+        );
+        let sock = dir.path().join("subst.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = tokio::spawn(Arc::clone(&service).serve(listener));
+
+        let mut client = UnixStream::connect(&sock).await.unwrap();
+        // A magic body string we can grep for: it must never reach the chain.
+        let secret_body = b"SUPERSECRETBODY compressed bytes";
+        let wire = WireRequest {
+            method: "POST".into(),
+            url: "https://api.openai.com/v1".into(),
+            headers: vec![
+                ("content-encoding".into(), "gzip".into()),
+                ("authorization".into(), format!("Bearer {ph}")),
+            ],
+            body_b64: B64.encode(secret_body),
+        };
+        write_json_frame(&mut client, &wire).await.unwrap();
+        let resp: WireResponse = read_json_frame(&mut client, MAX_FRAME_BYTES).await.unwrap();
+        assert!(
+            matches!(resp, WireResponse::Refused { .. }),
+            "compressed body must fail closed: {resp:?}"
+        );
+        // The unscannable request never reached the forward leg.
+        assert!(forwarder.seen.lock().unwrap().is_none());
+
+        let logged = std::fs::read_to_string(&chain).unwrap();
+        assert!(
+            logged.contains("api.openai.com"),
+            "fail-closed refusal must be audited with the destination: {logged}"
+        );
+        assert!(
+            logged.contains("fail_closed"),
+            "fail-closed refusal must record a fail-closed marker: {logged}"
+        );
+        // The body bytes never reach the audit chain.
+        assert!(
+            !logged.contains("SUPERSECRETBODY"),
+            "audit chain must not carry the body bytes: {logged}"
+        );
         server.abort();
     }
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -95,7 +95,7 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
       no ML/NER — anchored+gazetteer names; scoped to cleartext vsock endpoint)
     [x] design + honest threat-model framing (hygiene layer, not a boundary)
     [x] slice 1: EntropyScanner (Shannon entropy, audit-first, no echo)
-    [ ] slice 2: IBAN (mod-97) added to structured PII set
+    [x] slice 2: IBAN (mod-97) added to structured PII set
     [ ] slice 3: name detector (field-label + PII co-occurrence + gazetteer)
     [ ] slice 4: RedactionAction + redaction_profiles + resolve (mvm-core)
     [ ] slice 5: destination-aware wiring; fail-closed over-cap/compressed bodies

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -99,6 +99,10 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
     [x] slice 3: name detector (field-label + PII co-occurrence + gazetteer)
     [x] slice 4: RedactionAction + redaction_profiles + resolve (mvm-core)
     [x] slice 5: destination-aware wiring; fail-closed over-cap/compressed bodies
+    [ ] reachability: admission wiring (workload egress policy → with_redaction_policy)
+        — mechanism complete + tested; NOT yet reachable in prod. + consume
+        action.pii/action.secrets (RESERVED), terminator-path redaction. See plan
+        §"Deferred follow-ups".
   [ ] forward proxy https/CONNECT (only http/absolute-form works today) — deferred
   [ ] forward-path signing integration (SigV4)        — DEFERRED (user)
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -97,7 +97,7 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
     [x] slice 1: EntropyScanner (Shannon entropy, audit-first, no echo)
     [x] slice 2: IBAN (mod-97) added to structured PII set
     [x] slice 3: name detector (field-label + PII co-occurrence + gazetteer)
-    [ ] slice 4: RedactionAction + redaction_profiles + resolve (mvm-core)
+    [x] slice 4: RedactionAction + redaction_profiles + resolve (mvm-core)
     [ ] slice 5: destination-aware wiring; fail-closed over-cap/compressed bodies
   [ ] forward proxy https/CONNECT (only http/absolute-form works today) — deferred
   [ ] forward-path signing integration (SigV4)        — DEFERRED (user)

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -98,7 +98,7 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
     [x] slice 2: IBAN (mod-97) added to structured PII set
     [x] slice 3: name detector (field-label + PII co-occurrence + gazetteer)
     [x] slice 4: RedactionAction + redaction_profiles + resolve (mvm-core)
-    [ ] slice 5: destination-aware wiring; fail-closed over-cap/compressed bodies
+    [x] slice 5: destination-aware wiring; fail-closed over-cap/compressed bodies
   [ ] forward proxy https/CONNECT (only http/absolute-form works today) — deferred
   [ ] forward-path signing integration (SigV4)        — DEFERRED (user)
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -90,6 +90,15 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
       workload's secrets + admits a plan inside boot_session_vm (closure seam) so
       the backend spawns the substitution endpoint; QEMU reads plan_json directly.
       Box e2e + FC plan.json stash are the remaining (box-gated) follow-ups
+  E1 Step 2 — per-destination egress PII + entropy redaction (design approved
+      2026-06-10, specs/notes/plan-129-e1-step2-pii-entropy-redaction-design.md;
+      no ML/NER — anchored+gazetteer names; scoped to cleartext vsock endpoint)
+    [x] design + honest threat-model framing (hygiene layer, not a boundary)
+    [ ] slice 1: EntropyScanner (Shannon entropy, audit-first, no echo)
+    [ ] slice 2: IBAN (mod-97) added to structured PII set
+    [ ] slice 3: name detector (field-label + PII co-occurrence + gazetteer)
+    [ ] slice 4: RedactionAction + redaction_profiles + resolve (mvm-core)
+    [ ] slice 5: destination-aware wiring; fail-closed over-cap/compressed bodies
   [ ] forward proxy https/CONNECT (only http/absolute-form works today) — deferred
   [ ] forward-path signing integration (SigV4)        — DEFERRED (user)
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -96,7 +96,7 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
     [x] design + honest threat-model framing (hygiene layer, not a boundary)
     [x] slice 1: EntropyScanner (Shannon entropy, audit-first, no echo)
     [x] slice 2: IBAN (mod-97) added to structured PII set
-    [ ] slice 3: name detector (field-label + PII co-occurrence + gazetteer)
+    [x] slice 3: name detector (field-label + PII co-occurrence + gazetteer)
     [ ] slice 4: RedactionAction + redaction_profiles + resolve (mvm-core)
     [ ] slice 5: destination-aware wiring; fail-closed over-cap/compressed bodies
   [ ] forward proxy https/CONNECT (only http/absolute-form works today) — deferred

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -94,7 +94,7 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
       2026-06-10, specs/notes/plan-129-e1-step2-pii-entropy-redaction-design.md;
       no ML/NER — anchored+gazetteer names; scoped to cleartext vsock endpoint)
     [x] design + honest threat-model framing (hygiene layer, not a boundary)
-    [ ] slice 1: EntropyScanner (Shannon entropy, audit-first, no echo)
+    [x] slice 1: EntropyScanner (Shannon entropy, audit-first, no echo)
     [ ] slice 2: IBAN (mod-97) added to structured PII set
     [ ] slice 3: name detector (field-label + PII co-occurrence + gazetteer)
     [ ] slice 4: RedactionAction + redaction_profiles + resolve (mvm-core)

--- a/specs/notes/plan-129-e1-step2-implementation-plan.md
+++ b/specs/notes/plan-129-e1-step2-implementation-plan.md
@@ -1102,6 +1102,10 @@ the new main.
   per-destination resolve ✅ slice 4 (types in mvm-core, resolver in mvm-hostd —
   the host_matches dependency-direction fix). Wiring + fail-closed + audit ✅
   slice 5. No `core::redact` move; no ML/heavy dep (gazetteer is static data).
+  Fail-closed refusals (compressed / over-cap body to a redaction-opted-in
+  destination) emit a metadata-only audit entry naming the destination and the
+  `fail_closed_compressed` / `fail_closed_oversize` reason — matching the
+  design's "blocked + audited" posture, never the body bytes.
 - **Deferred (note in the design's Out-of-scope, carry forward):** full PII
   match-span plumbing into `NameScanner` co-occurrence on the live path (slice 5
   passes `&[]` spans, so labeled + gazetteer name signals fire but live

--- a/specs/notes/plan-129-e1-step2-implementation-plan.md
+++ b/specs/notes/plan-129-e1-step2-implementation-plan.md
@@ -1113,3 +1113,39 @@ the new main.
   refusing compressed bodies; the bound-host TLS terminator path
   (`handle_terminator_connection`) wiring — same `redact_bytes_for` call, gated
   on the terminator typed-error follow-up from the E2 work.
+
+## Deferred follow-ups (post-mechanism; tracked, not silently dropped)
+
+The five slices ship the complete detection + per-destination **mechanism**
+(detectors, policy types, resolver, endpoint wiring, fail-closed, audit), all
+tested and leak-free. What remains to make it **reachable + complete** in
+production:
+
+- [ ] **Admission wiring (makes the feature reachable).** Nothing yet reads a
+  workload-authored redaction policy and calls
+  `SubstitutionService::with_redaction_policy`. Add a `redaction:
+  RedactionPolicy` field to the workload egress policy (mvm-core), thread it
+  through `from_plan` / the supervisor's endpoint-spawn site, and call the
+  builder. Until this lands the feature is mechanism-only — only tests
+  construct a policy; a real workload gets the default all-off action.
+- [ ] **Consume `RedactionAction.pii`.** `redact_bytes_for` currently runs the
+  always-on default PII ruleset and ignores the per-destination `pii`
+  mode/categories. Needs a semantic pass: how a per-destination PII disposition
+  composes with the always-on Phase E redaction (today's curated PII is masked
+  unconditionally). Fail-open risk: an operator setting `pii.mode=block` gets a
+  silent no-op until this lands (the field is doc-marked RESERVED meanwhile).
+- [ ] **Consume `RedactionAction.secrets`.** Curated secrets are always masked
+  (Block-equivalent) regardless of the action; wire the per-destination
+  disposition (field doc-marked RESERVED meanwhile).
+- [ ] **Terminator-path redaction + fail-closed gate.** `handle_terminator_connection`
+  (the `:80`/`:443` bound-host TLS terminator) does no redaction and no
+  fail-closed gate — it never resolves the policy. A redaction-opted-in
+  destination reached via the terminator skips both. Gated on the terminator
+  typed-error refactor (the same E2 follow-up). Default-deny still governs those
+  hosts meanwhile.
+- [ ] **Live PII spans for name co-occurrence.** The live path passes `&[]`
+  spans to `NameScanner`, so labeled + gazetteer name signals fire but live
+  co-occurrence is approximated. Thread the structured-PII match spans from the
+  same pass.
+- [ ] **Bounded in-window decompression** instead of refusing compressed bodies
+  fail-closed.

--- a/specs/notes/plan-129-e1-step2-implementation-plan.md
+++ b/specs/notes/plan-129-e1-step2-implementation-plan.md
@@ -1,0 +1,1111 @@
+# Plan 129 E1 Step 2 — per-destination egress PII + entropy redaction — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add undeclared-secret/PII egress detection — Shannon entropy, IBAN, anchored+gazetteer names — applied per-destination from a redaction profile, on the cleartext vsock substitution-endpoint path.
+
+**Architecture:** Five mergeable TDD slices. New byte-level detectors in `crates/mvm-hostd/src/supervisor/` follow the existing `PiiRedactor::redact(&[u8]) -> (Vec<u8>, Vec<&'static str>)` shape. Per-destination action *types* live in `mvm-core::policy`; the destination *resolver* lives in `mvm-hostd` (it needs `mvm_sdk::ir::host_matches`, and `mvm-sdk` sits **above** `mvm-core`). Detection is wired only into the cleartext endpoint path (`substitution_proxy`), never the raw packet pipeline. No ML/NER; the name gazetteer is committed static data, not a runtime dependency.
+
+**Tech Stack:** Rust, `regex::bytes::RegexSet` (already a dep), `serde`, `thiserror`. The name gazetteer is a sorted `&'static [&'static str]` with `binary_search` — no new crate.
+
+**Design source:** `specs/notes/plan-129-e1-step2-pii-entropy-redaction-design.md`.
+
+**Reference shapes (already in the tree — read before starting):**
+- `crates/mvm-hostd/src/supervisor/pii_redactor.rs` — `PiiRule { name, pattern, validator: Option<PiiValidator> }`, `PiiValidator::Luhn`, `DEFAULT_RULES`, `PII_CATEGORY_NAMES`, `redact(&[u8]) -> (Vec<u8>, Vec<&'static str>)`, `REDACTION_MASK = b"XXX"`, `match_passes_validator`, `luhn_valid`.
+- `crates/mvm-hostd/src/supervisor/network/stages.rs` — `RedactingSubstitution { secrets, pii }`, `RedactionHits { secrets, pii }`, `redact_bytes(&[u8]) -> Option<(Vec<u8>, RedactionHits)>`.
+- `crates/mvm-hostd/src/supervisor/substitution_proxy.rs` — `SubstitutionService`, `process(WireRequest) -> WireResponse`, `redact_outbound(ProxyRequest) -> (ProxyRequest, RedactionHits)`, `audit_redactions(&RedactionHits, Option<&str>)`, `destination` capture.
+- `crates/mvm-core/src/policy/policies.rs` — `PiiPolicy { mode: Option<String>, categories: Vec<String> }`, `DEFAULT_BODY_CAP_BYTES`.
+- `crates/mvm-sdk/src/ir/workload.rs:436` — `pub fn host_matches(pattern: &str, host: &str) -> bool`.
+
+**Standing rules:** TDD (one test → one impl). Commit per task. No `Co-Authored-By: Claude` trailer. No spec/PR/plan citations in code comments. Run the local gate after each slice:
+`RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd` and (for slice 4) `-p mvm-core`, plus
+`export PATH="$(dirname "$(rustup which cargo)"):$PATH"; "$(rustup which cargo)" clippy -p mvm-hostd --lib --tests -- -D warnings` and `cargo fmt --all -- --check`.
+
+Each slice ends by ticking its box in `specs/REFACTOR-STATUS.md` (Plan 129, E1 Step 2 block) **in the same commit**, date bumped.
+
+---
+
+## Slice 1 — `EntropyScanner` (audit-first, never echoes)
+
+A standalone byte detector: find contiguous token runs whose Shannon entropy
+clears a threshold, mask them. No blocking. No dependency on the per-destination
+types (slice 4) — it takes raw params so it merges first.
+
+**Files:**
+- Create: `crates/mvm-hostd/src/supervisor/entropy_scanner.rs`
+- Modify: `crates/mvm-hostd/src/supervisor/mod.rs` (add `pub mod entropy_scanner;`)
+- Modify: `specs/REFACTOR-STATUS.md`
+
+- [ ] **Step 1: Write the failing test.** Create `entropy_scanner.rs` with only the test module:
+
+```rust
+//! `EntropyScanner` — mask undeclared high-entropy tokens on egress.
+//!
+//! Complements the curated `SecretsScanner`: that matches known vendor
+//! prefixes; this catches unknown-shape high-entropy tokens (random API keys,
+//! session blobs) the curated rules miss. Deliberately additive and
+//! audit-first — high-entropy false positives (JWTs, UUIDs, base64 uploads,
+//! hashes) must degrade, not break, and operators observe hits before masking.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_a_high_entropy_token_run() {
+        let s = EntropyScanner::with_defaults();
+        // 40-char random-looking base64 run.
+        let body = b"token=Xa9Kf2pQ7vL0mZ3rT8wB1nC4yH6dJ5sG2eU0iO9 end";
+        let hits = s.scan(body);
+        assert_eq!(hits.len(), 1, "expected one high-entropy run, got {hits:?}");
+    }
+
+    #[test]
+    fn ignores_low_entropy_prose() {
+        let s = EntropyScanner::with_defaults();
+        let body = b"the quick brown fox jumps over the lazy dog repeatedly today";
+        assert!(s.scan(body).is_empty(), "prose wrongly flagged");
+    }
+
+    #[test]
+    fn ignores_runs_below_min_length() {
+        let s = EntropyScanner::with_defaults();
+        // High entropy but short (< min_run_len).
+        let body = b"id=Xa9Kf2pQ end";
+        assert!(s.scan(body).is_empty(), "short run wrongly flagged");
+    }
+
+    #[test]
+    fn redact_masks_without_echoing_the_token() {
+        let s = EntropyScanner::with_defaults();
+        let token = "Xa9Kf2pQ7vL0mZ3rT8wB1nC4yH6dJ5sG2eU0iO9";
+        let body = format!("token={token} end").into_bytes();
+        let (out, n) = s.redact(&body);
+        let rendered = String::from_utf8_lossy(&out);
+        assert_eq!(n, 1);
+        assert!(!rendered.contains(token), "token leaked into output: {rendered}");
+        assert!(rendered.contains("XXX"), "no mask present: {rendered}");
+        assert!(rendered.contains("token="), "context wrongly removed: {rendered}");
+    }
+
+    #[test]
+    fn clean_body_passes_through_unchanged() {
+        let s = EntropyScanner::with_defaults();
+        let (out, n) = s.redact(b"hello world");
+        assert_eq!(out, b"hello world");
+        assert_eq!(n, 0);
+    }
+}
+```
+
+- [ ] **Step 2: Run it; verify it fails to compile** (`EntropyScanner` undefined).
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd entropy_scanner 2>&1 | tail -5`
+Expected: compile error `cannot find ... EntropyScanner`.
+
+- [ ] **Step 3: Implement the scanner** above the test module:
+
+```rust
+use crate::supervisor::pii_redactor::REDACTION_MASK;
+
+/// True for bytes that can be part of a secret-like token run. Token chars are
+/// the base64/base64url/hex alphabet plus separators a token may embed.
+fn is_token_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'+' | b'/' | b'=' | b'_' | b'-')
+}
+
+/// One detected high-entropy run, as a half-open byte range. Carries NO bytes —
+/// claim-13 discipline: the matched value never leaves the host, not even into
+/// a hit struct that might reach a log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntropyHit {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// Shannon-entropy scanner over token runs.
+pub struct EntropyScanner {
+    min_run_len: usize,
+    min_bits_per_char: f64,
+}
+
+impl EntropyScanner {
+    /// Tunable params. `min_run_len` keeps short prose words out; the
+    /// `min_bits_per_char` threshold keeps natural-language runs out (English
+    /// is ~3–4 bits/char; uniform base64 is 6, hex is 4).
+    pub fn new(min_run_len: usize, min_bits_per_char: f64) -> Self {
+        Self { min_run_len, min_bits_per_char }
+    }
+
+    /// Defaults tuned for low false-positive on prose: 20-char minimum run,
+    /// 4.0 bits/char. Audit-first means operators retune before enabling masking.
+    pub fn with_defaults() -> Self {
+        Self::new(20, 4.0)
+    }
+
+    /// Return every token run whose entropy clears the threshold.
+    pub fn scan(&self, body: &[u8]) -> Vec<EntropyHit> {
+        let mut hits = Vec::new();
+        let mut i = 0usize;
+        while i < body.len() {
+            if !is_token_byte(body[i]) {
+                i += 1;
+                continue;
+            }
+            let start = i;
+            while i < body.len() && is_token_byte(body[i]) {
+                i += 1;
+            }
+            let run = &body[start..i];
+            if run.len() >= self.min_run_len
+                && shannon_bits_per_char(run) >= self.min_bits_per_char
+            {
+                hits.push(EntropyHit { start, end: i });
+            }
+        }
+        hits
+    }
+
+    /// Mask each high-entropy run with [`REDACTION_MASK`]; return the rewritten
+    /// bytes and the number of runs masked. Right-to-left so earlier offsets
+    /// stay valid as the buffer shrinks.
+    pub fn redact(&self, body: &[u8]) -> (Vec<u8>, usize) {
+        let hits = self.scan(body);
+        if hits.is_empty() {
+            return (body.to_vec(), 0);
+        }
+        let mut out = body.to_vec();
+        for h in hits.iter().rev() {
+            out.splice(h.start..h.end, REDACTION_MASK.iter().copied());
+        }
+        (out, hits.len())
+    }
+}
+
+/// Shannon entropy of a byte run, in bits per character. Empty run → 0.0.
+fn shannon_bits_per_char(run: &[u8]) -> f64 {
+    if run.is_empty() {
+        return 0.0;
+    }
+    let mut counts = [0u32; 256];
+    for &b in run {
+        counts[b as usize] += 1;
+    }
+    let len = run.len() as f64;
+    let mut h = 0.0f64;
+    for &c in counts.iter() {
+        if c == 0 {
+            continue;
+        }
+        let p = c as f64 / len;
+        h -= p * p.log2();
+    }
+    h
+}
+```
+
+- [ ] **Step 4: Register the module.** In `crates/mvm-hostd/src/supervisor/mod.rs`, add `pub mod entropy_scanner;` next to `pub mod pii_redactor;` (keep the list alphabetical if it already is).
+
+- [ ] **Step 5: Run tests; verify pass.**
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd entropy_scanner 2>&1 | tail -5`
+Expected: 5 passed.
+
+- [ ] **Step 6: Tick REFACTOR-STATUS + commit.** In `specs/REFACTOR-STATUS.md` change `[ ] slice 1: EntropyScanner ...` → `[x]`, bump `**Last updated:**`.
+
+```bash
+git add crates/mvm-hostd/src/supervisor/entropy_scanner.rs crates/mvm-hostd/src/supervisor/mod.rs specs/REFACTOR-STATUS.md
+git commit -m "feat(secrets): EntropyScanner for undeclared high-entropy egress tokens (plan 129 E1)"
+```
+
+---
+
+## Slice 2 — IBAN (mod-97) in the structured PII set
+
+**Files:**
+- Modify: `crates/mvm-hostd/src/supervisor/pii_redactor.rs`
+
+- [ ] **Step 1: Write the failing test.** Add to `pii_redactor.rs`'s `mod tests`:
+
+```rust
+    #[test]
+    fn iban_valid_is_masked_invalid_is_left() {
+        let r = PiiRedactor::with_default_rules();
+        // GB82WEST12345698765432 is a canonical valid IBAN (mod-97 == 1).
+        // Flip the last digit → checksum fails → must be left intact.
+        let body = b"pay GB82WEST12345698765432 not GB82WEST12345698765431 ok";
+        let (out, fired) = r.redact(body);
+        let s = String::from_utf8_lossy(&out);
+        assert!(!s.contains("GB82WEST12345698765432"), "valid IBAN not masked: {s}");
+        assert!(s.contains("GB82WEST12345698765431"), "invalid IBAN wrongly masked: {s}");
+        assert!(fired.contains(&"iban"), "fired={fired:?}");
+    }
+
+    #[test]
+    fn iban_category_is_listed() {
+        assert!(PII_CATEGORY_NAMES.contains(&"iban"));
+    }
+```
+
+- [ ] **Step 2: Run it; verify it fails** (no `iban` rule yet → valid IBAN not masked, assertion fails).
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd iban 2>&1 | tail -8`
+Expected: FAIL on `valid IBAN not masked`.
+
+- [ ] **Step 3: Add the validator variant.** In the `PiiValidator` enum:
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub enum PiiValidator {
+    Luhn,
+    Iban,
+}
+```
+
+- [ ] **Step 4: Add the rule.** Append to `DEFAULT_RULES`:
+
+```rust
+    PiiRule {
+        name: "iban",
+        // Country (2 alpha) + 2 check digits + 11–30 BBAN chars. mod-97
+        // validated post-match so a random alnum run of the right shape
+        // doesn't fire.
+        pattern: r"\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b",
+        validator: Some(PiiValidator::Iban),
+    },
+```
+
+- [ ] **Step 5: Wire the validator + add the checker.** In `match_passes_validator`, add the arm:
+
+```rust
+        Some(PiiValidator::Iban) => iban_valid(m),
+```
+
+In `rule_passes_validator`, the `Some(PiiValidator::Luhn)` arm enumerates matches; generalize it so IBAN is enumerated too — replace that arm with:
+
+```rust
+        Some(_) => re
+            .find_iter(body)
+            .any(|m| match_passes_validator(rule, m.as_bytes())),
+```
+
+Add the checker near `luhn_valid`:
+
+```rust
+/// ISO 7064 mod-97-10 IBAN checksum. Move the first 4 chars to the end, map
+/// letters to two-digit numbers (A=10 … Z=35), and check the resulting integer
+/// ≡ 1 (mod 97). Computed digit-by-digit to avoid bignum. Case-insensitive.
+fn iban_valid(iban: &[u8]) -> bool {
+    if iban.len() < 15 || iban.len() > 34 {
+        return false;
+    }
+    let rearranged = iban[4..].iter().chain(iban[..4].iter());
+    let mut remainder: u32 = 0;
+    for &b in rearranged {
+        let val = match b {
+            b'0'..=b'9' => u32::from(b - b'0'),
+            b'A'..=b'Z' => u32::from(b - b'A') + 10,
+            b'a'..=b'z' => u32::from(b - b'a') + 10,
+            _ => return false,
+        };
+        // Each letter contributes two decimal digits; folding both keeps the
+        // running remainder small.
+        if val >= 10 {
+            remainder = (remainder * 100 + val) % 97;
+        } else {
+            remainder = (remainder * 10 + val) % 97;
+        }
+    }
+    remainder == 1
+}
+```
+
+- [ ] **Step 6: Add `iban` to the category list.**
+
+```rust
+pub const PII_CATEGORY_NAMES: &[&str] = &["email", "us_ssn", "credit_card", "e164_phone", "iban"];
+```
+
+- [ ] **Step 7: Add unit tests for the checker** in `mod tests`:
+
+```rust
+    #[test]
+    fn iban_checker_accepts_known_good_and_rejects_bad() {
+        assert!(iban_valid(b"GB82WEST12345698765432"));
+        assert!(iban_valid(b"DE89370400440532013000"));
+        assert!(!iban_valid(b"GB82WEST12345698765431"));
+        assert!(!iban_valid(b"XX00")); // too short
+    }
+```
+
+- [ ] **Step 8: Run; verify pass.**
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd pii_redactor 2>&1 | tail -6`
+Expected: all pass (existing + new).
+
+- [ ] **Step 9: Tick REFACTOR-STATUS slice-2 box + commit.**
+
+```bash
+git add crates/mvm-hostd/src/supervisor/pii_redactor.rs specs/REFACTOR-STATUS.md
+git commit -m "feat(secrets): IBAN (mod-97) added to structured PII redactor (plan 129 E1)"
+```
+
+---
+
+## Slice 3 — Name detector (field-label anchor + gazetteer + co-occurrence)
+
+A standalone byte detector. Inputs: the body, and the byte spans of any
+structured-PII hits already found (for co-occurrence). Masks: (a) values of
+name-like fields, (b) capitalized token pairs where both tokens are in the
+census gazetteer, (c) capitalized token pairs adjacent to a passed PII span.
+No ML.
+
+**Files:**
+- Create: `crates/mvm-hostd/src/supervisor/name_scanner.rs`
+- Create: `crates/mvm-hostd/src/supervisor/names_gazetteer.rs` (committed static data)
+- Modify: `crates/mvm-hostd/src/supervisor/mod.rs`
+
+- [ ] **Step 1: Commit the gazetteer data file.** Create `names_gazetteer.rs`. The lists are **sorted, lowercase**, curated from US Census public-domain frequency data toward names whose name-frequency dominates their dictionary-word-frequency (keeps false positives down). Start with a representative curated subset; expanding the list is data curation, not code change. Lookup is `binary_search`.
+
+```rust
+//! Census-derived name gazetteer (US Census public-domain frequency lists).
+//! Sorted lowercase; looked up by binary search. Curated toward names whose
+//! name-frequency dominates their common-word-frequency to bound false
+//! positives. Data, not an ML model — no runtime dependency.
+
+/// Sorted, lowercase. Common given names.
+pub const FIRST_NAMES: &[&str] = &[
+    "alice", "bob", "carol", "david", "emma", "james", "john", "maria",
+    "michael", "robert", "sarah", "william",
+];
+
+/// Sorted, lowercase. Common surnames.
+pub const SURNAMES: &[&str] = &[
+    "brown", "davis", "garcia", "johnson", "jones", "miller", "smith",
+    "williams", "wilson",
+];
+
+/// True iff `token` (any case) is in `list` (which must be sorted lowercase).
+pub fn in_list(list: &[&str], token: &str) -> bool {
+    let lower = token.to_ascii_lowercase();
+    list.binary_search(&lower.as_str()).is_ok()
+}
+```
+
+- [ ] **Step 2: Write the failing test.** Create `name_scanner.rs` with the test module only:
+
+```rust
+//! `NameScanner` — redact personal names on egress, no ML.
+//!
+//! Names have no regex shape, so we catch the leaks that actually matter — the
+//! ones with context. Three signals: a name-like field label, a census
+//! gazetteer pair, or a capitalized pair adjacent to other PII. Freeform
+//! unlabeled names with no nearby PII are out of scope (would need NER).
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_a_labeled_name_field_json() {
+        let s = NameScanner::with_defaults();
+        let body = br#"{"first_name":"Jonathan","city":"Denver"}"#;
+        let (out, n) = s.redact(body, &[]);
+        let r = String::from_utf8_lossy(&out);
+        assert!(n >= 1);
+        assert!(!r.contains("Jonathan"), "labeled name not redacted: {r}");
+        assert!(r.contains("Denver"), "non-name value wrongly touched: {r}");
+    }
+
+    #[test]
+    fn redacts_a_gazetteer_name_pair() {
+        let s = NameScanner::with_defaults();
+        let body = b"contact John Smith about the order";
+        let (out, n) = s.redact(body, &[]);
+        let r = String::from_utf8_lossy(&out);
+        assert!(n >= 1, "gazetteer pair not redacted: {r}");
+        assert!(!r.contains("John Smith"), "name pair not masked: {r}");
+    }
+
+    #[test]
+    fn redacts_capitalized_pair_adjacent_to_pii_span() {
+        let s = NameScanner::with_defaults();
+        // "Zephyr Quibblesworth" is not in the gazetteer, but it abuts a PII
+        // span (passed in) → the co-occurrence signal fires.
+        let body = b"Zephyr Quibblesworth ssn 123-45-6789";
+        let pii_spans = [(21usize, 32usize)]; // the ssn span
+        let (out, n) = s.redact(body, &pii_spans);
+        let r = String::from_utf8_lossy(&out);
+        assert!(n >= 1, "co-occurrence name not redacted: {r}");
+        assert!(!r.contains("Zephyr Quibblesworth"), "name not masked: {r}");
+    }
+
+    #[test]
+    fn leaves_unanchored_non_gazetteer_capitalized_words() {
+        let s = NameScanner::with_defaults();
+        // Capitalized but not a known name, not labeled, no nearby PII.
+        let body = b"The Eiffel Tower is tall";
+        let (out, n) = s.redact(body, &[]);
+        assert_eq!(n, 0, "false positive on non-name capitalized words");
+        assert_eq!(out, body);
+    }
+}
+```
+
+- [ ] **Step 3: Run it; verify it fails to compile** (`NameScanner` undefined).
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd name_scanner 2>&1 | tail -5`
+Expected: compile error.
+
+- [ ] **Step 4: Implement `NameScanner`** above the test module. Three signals fold into a single set of spans, then mask right-to-left.
+
+```rust
+use crate::supervisor::names_gazetteer::{in_list, FIRST_NAMES, SURNAMES};
+use crate::supervisor::pii_redactor::REDACTION_MASK;
+use regex::bytes::Regex;
+use std::sync::OnceLock;
+
+/// JSON/form field keys whose value is a personal name.
+const NAME_LABELS: &[&str] = &[
+    "name", "first_name", "firstname", "last_name", "lastname", "full_name",
+    "fullname", "customer", "patient", "cardholder", "given_name", "surname",
+];
+
+fn label_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        // `"key":"value"` (JSON) or `key=value` (form) or `Key: value` (prose).
+        // The key alternation is built from NAME_LABELS; the value capture (1)
+        // is what we mask.
+        let keys = NAME_LABELS.join("|");
+        Regex::new(&format!(
+            r#"(?i)(?:"(?:{keys})"\s*:\s*"|(?:{keys})\s*[:=]\s*"?)([A-Za-z][A-Za-z .'\-]{{1,60}})"#
+        ))
+        .expect("name-label regex compiles")
+    })
+}
+
+/// A capitalized word run: `[A-Z][a-z]+`. Used for the gazetteer + co-occurrence
+/// signals. Each item is a (start, end, lowercased) tuple.
+fn cap_words() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"[A-Z][a-z]{1,}").expect("cap-word regex compiles"))
+}
+
+pub struct NameScanner {
+    /// Max byte gap between a capitalized pair and a PII span for the
+    /// co-occurrence signal to fire.
+    cooccur_window: usize,
+}
+
+impl NameScanner {
+    pub fn new(cooccur_window: usize) -> Self {
+        Self { cooccur_window }
+    }
+    pub fn with_defaults() -> Self {
+        Self::new(40)
+    }
+
+    /// Mask names in `body`. `pii_spans` are byte ranges of structured-PII hits
+    /// from a prior pass (empty if none). Returns the rewritten bytes + the
+    /// number of name spans masked.
+    pub fn redact(&self, body: &[u8], pii_spans: &[(usize, usize)]) -> (Vec<u8>, usize) {
+        let mut spans: Vec<(usize, usize)> = Vec::new();
+
+        // (a) labeled fields: mask capture group 1 (the value).
+        for caps in label_regex().captures_iter(body) {
+            if let Some(m) = caps.get(1) {
+                spans.push((m.start(), m.end()));
+            }
+        }
+
+        // Collect capitalized words once for (b) and (c).
+        let words: Vec<(usize, usize)> =
+            cap_words().find_iter(body).map(|m| (m.start(), m.end())).collect();
+
+        // (b) gazetteer pairs: adjacent capitalized words, first in FIRST_NAMES
+        //     OR surname list, second in SURNAMES OR first list.
+        for pair in words.windows(2) {
+            let (a, b) = (pair[0], pair[1]);
+            if !adjacent_words(body, a, b) {
+                continue;
+            }
+            let wa = std::str::from_utf8(&body[a.0..a.1]).unwrap_or("");
+            let wb = std::str::from_utf8(&body[b.0..b.1]).unwrap_or("");
+            if (in_list(FIRST_NAMES, wa) || in_list(SURNAMES, wa))
+                && (in_list(SURNAMES, wb) || in_list(FIRST_NAMES, wb))
+            {
+                spans.push((a.0, b.1));
+            }
+        }
+
+        // (c) co-occurrence: a capitalized pair within `cooccur_window` bytes of
+        //     any PII span (the "row" case — a name bound to other PII).
+        if !pii_spans.is_empty() {
+            for pair in words.windows(2) {
+                let (a, b) = (pair[0], pair[1]);
+                if !adjacent_words(body, a, b) {
+                    continue;
+                }
+                if pii_spans.iter().any(|&(ps, pe)| near(b.1, ps, pe, self.cooccur_window)) {
+                    spans.push((a.0, b.1));
+                }
+            }
+        }
+
+        if spans.is_empty() {
+            return (body.to_vec(), 0);
+        }
+        // Dedup + sort, mask right-to-left so offsets stay valid.
+        spans.sort_unstable();
+        spans.dedup();
+        let merged = merge_overlapping(spans);
+        let count = merged.len();
+        let mut out = body.to_vec();
+        for (s, e) in merged.into_iter().rev() {
+            out.splice(s..e, REDACTION_MASK.iter().copied());
+        }
+        (out, count)
+    }
+}
+
+/// Two capitalized words are a "pair" iff separated by exactly one space.
+fn adjacent_words(body: &[u8], a: (usize, usize), b: (usize, usize)) -> bool {
+    b.0 == a.1 + 1 && body.get(a.1) == Some(&b' ')
+}
+
+/// True iff byte offset `at` is within `window` of the [ps, pe) span.
+fn near(at: usize, ps: usize, pe: usize, window: usize) -> bool {
+    let lo = ps.saturating_sub(window);
+    at >= lo && at <= pe + window
+}
+
+/// Merge sorted, possibly-overlapping spans.
+fn merge_overlapping(sorted: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
+    let mut out: Vec<(usize, usize)> = Vec::with_capacity(sorted.len());
+    for (s, e) in sorted {
+        match out.last_mut() {
+            Some(last) if s <= last.1 => last.1 = last.1.max(e),
+            _ => out.push((s, e)),
+        }
+    }
+    out
+}
+```
+
+- [ ] **Step 5: Register the modules.** In `supervisor/mod.rs` add `pub mod name_scanner;` and `pub mod names_gazetteer;`.
+
+- [ ] **Step 6: Run; verify pass.**
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd "name_scanner|names_gazetteer" 2>&1 | tail -6`
+Expected: 4 passed.
+
+- [ ] **Step 7: Tick REFACTOR-STATUS slice-3 box + commit.**
+
+```bash
+git add crates/mvm-hostd/src/supervisor/name_scanner.rs crates/mvm-hostd/src/supervisor/names_gazetteer.rs crates/mvm-hostd/src/supervisor/mod.rs specs/REFACTOR-STATUS.md
+git commit -m "feat(secrets): anchored+gazetteer name detector for egress PII, no ML (plan 129 E1)"
+```
+
+---
+
+## Slice 4 — `RedactionAction` types (mvm-core) + `resolve()` (mvm-hostd)
+
+Types are pure serde data → `mvm-core`. The resolver needs
+`mvm_sdk::ir::host_matches` (mvm-sdk is **above** mvm-core), so it lives in
+`mvm-hostd`.
+
+**Files:**
+- Create: `crates/mvm-core/src/policy/redaction.rs`
+- Modify: `crates/mvm-core/src/policy/mod.rs` (add `pub mod redaction;` + re-export)
+- Create: `crates/mvm-hostd/src/supervisor/redaction_resolve.rs`
+- Modify: `crates/mvm-hostd/src/supervisor/mod.rs`
+
+- [ ] **Step 1: Write the failing serde + default test.** Create `crates/mvm-core/src/policy/redaction.rs` with the test module only:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redaction_policy_roundtrips_and_defaults_to_curated_only() {
+        let json = r#"{
+            "default": { "entropy": {"action":"off"}, "names": "off" },
+            "profiles": [
+              { "host": "*.untrusted.example",
+                "action": { "entropy": {"action":"redact","min_bits_per_char":4.0,"min_run_len":20},
+                            "names": "audit" } }
+            ]
+        }"#;
+        let p: RedactionPolicy = serde_json::from_str(json).unwrap();
+        assert_eq!(p.profiles.len(), 1);
+        assert_eq!(p.profiles[0].host, "*.untrusted.example");
+        // default action: entropy off, names off — today's curated-only baseline.
+        assert!(matches!(p.default.entropy, EntropyMode::Off));
+        assert!(matches!(p.default.names, NameMode::Off));
+        // round-trip
+        let s = serde_json::to_string(&p).unwrap();
+        let p2: RedactionPolicy = serde_json::from_str(&s).unwrap();
+        assert_eq!(p, p2);
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let json = r#"{ "default": {}, "bogus": 1 }"#;
+        assert!(serde_json::from_str::<RedactionPolicy>(json).is_err());
+    }
+
+    #[test]
+    fn empty_policy_default_is_all_off() {
+        let p = RedactionPolicy::default();
+        assert!(p.profiles.is_empty());
+        assert!(matches!(p.default.entropy, EntropyMode::Off));
+        assert!(matches!(p.default.names, NameMode::Off));
+    }
+}
+```
+
+- [ ] **Step 2: Run; verify fail** (types undefined).
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-core redaction 2>&1 | tail -5`
+Expected: compile error.
+
+- [ ] **Step 3: Implement the types** above the test module:
+
+```rust
+//! Per-destination egress redaction policy. Pure data; the destination
+//! resolver lives in mvm-hostd (it needs `mvm_sdk::ir::host_matches`, which
+//! sits above mvm-core). Default is today's curated-only baseline: structured
+//! PII per the workload `PiiPolicy`, curated secrets block, entropy + names off.
+
+use serde::{Deserialize, Serialize};
+
+use crate::policy::PiiPolicy;
+
+/// Entropy detection disposition for a destination.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EntropyMode {
+    /// No entropy scanning (default everywhere unless a profile opts in).
+    #[default]
+    Off,
+    /// Detect + audit, never mask (the safe first opt-in).
+    Audit { min_bits_per_char: f64, min_run_len: usize },
+    /// Detect + mask.
+    Redact { min_bits_per_char: f64, min_run_len: usize },
+}
+
+/// Name detection disposition. Names never block (false-positive risk).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum NameMode {
+    #[default]
+    Off,
+    Audit,
+    Redact,
+}
+
+/// Curated `SecretsScanner` disposition. Default Block — a known secret prefix
+/// on egress is always a fail.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SecretAction {
+    Audit,
+    Redact,
+    #[default]
+    Block,
+}
+
+/// What to do at one destination.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct RedactionAction {
+    pub entropy: EntropyMode,
+    /// Structured-regex PII (email/ssn/cc/phone/iban) — reuse the existing knob.
+    pub pii: PiiPolicy,
+    pub names: NameMode,
+    pub secrets: SecretAction,
+}
+
+/// One host-pattern → action mapping.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RedactionProfile {
+    /// Host or `*.`-wildcard, matched by `host_matches` at resolve time.
+    pub host: String,
+    pub action: RedactionAction,
+}
+
+/// A workload's per-destination redaction policy. Absent / default ⇒ the
+/// `default` curated-only action applies to every destination.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct RedactionPolicy {
+    pub default: RedactionAction,
+    pub profiles: Vec<RedactionProfile>,
+}
+```
+
+- [ ] **Step 4: Export it.** In `crates/mvm-core/src/policy/mod.rs` add `pub mod redaction;` and re-export the public types:
+`pub use redaction::{EntropyMode, NameMode, RedactionAction, RedactionPolicy, RedactionProfile, SecretAction};`
+
+- [ ] **Step 5: Run; verify the mvm-core tests pass.**
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-core redaction 2>&1 | tail -5`
+Expected: 3 passed.
+
+- [ ] **Step 6: Write the failing resolver test.** Create `crates/mvm-hostd/src/supervisor/redaction_resolve.rs` with the test module only:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::policy::{EntropyMode, NameMode, RedactionAction, RedactionPolicy, RedactionProfile};
+
+    fn entropy_redact() -> RedactionAction {
+        RedactionAction {
+            entropy: EntropyMode::Redact { min_bits_per_char: 4.0, min_run_len: 20 },
+            names: NameMode::Redact,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn first_matching_wildcard_wins_else_default() {
+        let pol = RedactionPolicy {
+            default: RedactionAction::default(),
+            profiles: vec![RedactionProfile { host: "*.openai.com".into(), action: entropy_redact() }],
+        };
+        // matches the wildcard
+        assert!(matches!(resolve(&pol, "api.openai.com").entropy, EntropyMode::Redact { .. }));
+        // no match → default (Off)
+        assert!(matches!(resolve(&pol, "example.com").entropy, EntropyMode::Off));
+    }
+
+    #[test]
+    fn earlier_profile_wins_on_overlap() {
+        let pol = RedactionPolicy {
+            default: RedactionAction::default(),
+            profiles: vec![
+                RedactionProfile { host: "api.openai.com".into(), action: entropy_redact() },
+                RedactionProfile { host: "*.openai.com".into(), action: RedactionAction::default() },
+            ],
+        };
+        assert!(matches!(resolve(&pol, "api.openai.com").entropy, EntropyMode::Redact { .. }));
+    }
+}
+```
+
+- [ ] **Step 7: Run; verify fail** (`resolve` undefined).
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd redaction_resolve 2>&1 | tail -5`
+Expected: compile error.
+
+- [ ] **Step 8: Implement the resolver:**
+
+```rust
+//! Resolve a destination host to its `RedactionAction`. Lives here, not in
+//! mvm-core, because host matching is `mvm_sdk::ir::host_matches` and mvm-sdk
+//! sits above mvm-core in the dependency graph.
+
+use mvm_core::policy::{RedactionAction, RedactionPolicy};
+use mvm_sdk::ir::host_matches;
+
+/// First profile whose `host` pattern matches `dest` wins; else the policy
+/// default. First-match-wins gives operators precedence control by ordering.
+pub fn resolve<'a>(policy: &'a RedactionPolicy, dest: &str) -> &'a RedactionAction {
+    policy
+        .profiles
+        .iter()
+        .find(|p| host_matches(&p.host, dest))
+        .map(|p| &p.action)
+        .unwrap_or(&policy.default)
+}
+```
+
+- [ ] **Step 9: Register + run.** Add `pub mod redaction_resolve;` to `supervisor/mod.rs`.
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd redaction_resolve 2>&1 | tail -5`
+Expected: 2 passed.
+
+- [ ] **Step 10: Tick REFACTOR-STATUS slice-4 box + commit.**
+
+```bash
+git add crates/mvm-core/src/policy/redaction.rs crates/mvm-core/src/policy/mod.rs crates/mvm-hostd/src/supervisor/redaction_resolve.rs crates/mvm-hostd/src/supervisor/mod.rs specs/REFACTOR-STATUS.md
+git commit -m "feat(policy): per-destination RedactionAction + resolver (plan 129 E1)"
+```
+
+---
+
+## Slice 5 — destination-aware wiring + fail-closed + audit categories
+
+Thread a `RedactionPolicy` into `SubstitutionService`, resolve the destination's
+action in `redact_outbound`, apply entropy/names per the action, fail closed on
+over-cap / compressed bodies, and carry the new categories into the
+`secret.redacted` audit.
+
+**Files:**
+- Modify: `crates/mvm-hostd/src/supervisor/network/stages.rs` (`RedactionHits` + a per-action redact entry)
+- Modify: `crates/mvm-hostd/src/supervisor/substitution_proxy.rs` (`SubstitutionService` field, `redact_outbound`, `process` fail-closed, `audit_redactions`)
+
+- [ ] **Step 1: Extend `RedactionHits`** in `network/stages.rs` with the two new category groups:
+
+```rust
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RedactionHits {
+    pub secrets: Vec<&'static str>,
+    pub pii: Vec<&'static str>,
+    pub entropy: usize,
+    pub names: usize,
+}
+```
+
+Update `is_empty` and `merge`:
+
+```rust
+    pub fn is_empty(&self) -> bool {
+        self.secrets.is_empty() && self.pii.is_empty() && self.entropy == 0 && self.names == 0
+    }
+    pub fn merge(&mut self, other: RedactionHits) {
+        self.secrets.extend(other.secrets);
+        self.pii.extend(other.pii);
+        self.entropy += other.entropy;
+        self.names += other.names;
+    }
+```
+
+- [ ] **Step 2: Write the failing per-action redact test** in `network/stages.rs`'s `mod tests` (add one if none):
+
+```rust
+    #[test]
+    fn redact_bytes_for_applies_entropy_when_action_opts_in() {
+        use mvm_core::policy::{EntropyMode, RedactionAction};
+        let r = RedactingSubstitution::with_default_rules();
+        let body = b"k=Xa9Kf2pQ7vL0mZ3rT8wB1nC4yH6dJ5sG2eU0iO9 e";
+        // default action: entropy off → no hit
+        let off = RedactionAction::default();
+        assert!(r.redact_bytes_for(body, &off).is_none());
+        // opt in → entropy redacts the run
+        let on = RedactionAction { entropy: EntropyMode::Redact { min_bits_per_char: 4.0, min_run_len: 20 }, ..Default::default() };
+        let (out, hits) = r.redact_bytes_for(body, &on).expect("entropy hit");
+        assert_eq!(hits.entropy, 1);
+        assert!(!String::from_utf8_lossy(&out).contains("Xa9Kf2pQ7vL0mZ3rT8wB1nC4yH6dJ5sG2eU0iO9"));
+    }
+```
+
+- [ ] **Step 3: Run; verify fail** (`redact_bytes_for` undefined).
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd redact_bytes_for 2>&1 | tail -5`
+Expected: compile error.
+
+- [ ] **Step 4: Add `redact_bytes_for`** to `impl RedactingSubstitution`. It always runs curated secrets, then PII, then entropy/names per the action. (Names co-occurrence reuses PII match spans; for this pass we approximate spans as "any pii fired" — pass an empty span list when none, the labeled+gazetteer signals still fire. Full span plumbing is a follow-up note in the design.)
+
+```rust
+    /// Per-destination redaction. Curated secrets always run; entropy and names
+    /// run only when the resolved action opts in. Returns `None` when nothing
+    /// fired. `secrets`/`pii` come from the existing curated rulesets; entropy
+    /// + names from the new detectors.
+    pub fn redact_bytes_for(
+        &self,
+        payload: &[u8],
+        action: &mvm_core::policy::RedactionAction,
+    ) -> Option<(Vec<u8>, RedactionHits)> {
+        use mvm_core::policy::{EntropyMode, NameMode};
+        use crate::supervisor::entropy_scanner::EntropyScanner;
+        use crate::supervisor::name_scanner::NameScanner;
+
+        let (after_secrets, secrets) = self.secrets.redact(payload, REDACTION_MASK);
+        let (after_pii, pii) = self.pii.redact(&after_secrets);
+        let mut buf = after_pii;
+        let mut hits = RedactionHits { secrets, pii, entropy: 0, names: 0 };
+
+        match &action.entropy {
+            EntropyMode::Off => {}
+            EntropyMode::Audit { min_bits_per_char, min_run_len } => {
+                let n = EntropyScanner::new(*min_run_len, *min_bits_per_char).scan(&buf).len();
+                hits.entropy += n; // audit: counted, not masked
+            }
+            EntropyMode::Redact { min_bits_per_char, min_run_len } => {
+                let (out, n) = EntropyScanner::new(*min_run_len, *min_bits_per_char).redact(&buf);
+                buf = out;
+                hits.entropy += n;
+            }
+        }
+
+        match action.names {
+            NameMode::Off => {}
+            NameMode::Audit => {
+                // scan-only: count without masking. NameScanner masks; reuse it
+                // on a copy and diff is overkill — count via a dry redact then drop.
+                let (_, n) = NameScanner::with_defaults().redact(&buf, &[]);
+                hits.names += n;
+            }
+            NameMode::Redact => {
+                let (out, n) = NameScanner::with_defaults().redact(&buf, &[]);
+                buf = out;
+                hits.names += n;
+            }
+        }
+
+        if hits.is_empty() { None } else { Some((buf, hits)) }
+    }
+```
+
+- [ ] **Step 5: Run; verify the stages test passes.**
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd redact_bytes_for 2>&1 | tail -5`
+Expected: pass.
+
+- [ ] **Step 6: Thread `RedactionPolicy` into `SubstitutionService`.** In `substitution_proxy.rs`, add the field + a builder, defaulting to all-off:
+
+```rust
+    /// Per-destination redaction policy (Plan 129 E1 Step 2). Default = curated
+    /// baseline (entropy + names off); a profile opts a destination in.
+    redaction_policy: mvm_core::policy::RedactionPolicy,
+```
+
+Initialize it to `RedactionPolicy::default()` in `SubstitutionService::new`, and add:
+
+```rust
+    /// Attach a per-destination redaction policy.
+    pub fn with_redaction_policy(mut self, policy: mvm_core::policy::RedactionPolicy) -> Self {
+        self.redaction_policy = policy;
+        self
+    }
+```
+
+- [ ] **Step 7: Write the failing fail-closed + audit test** in `substitution_proxy.rs`'s `mod tests` (model on `emits_secret_substituted_audit_on_success`). Assert a compressed body to an entropy-opted-in destination is refused:
+
+```rust
+    #[tokio::test]
+    async fn compressed_body_to_redaction_destination_is_refused() {
+        use mvm_core::policy::{EntropyMode, RedactionAction, RedactionPolicy, RedactionProfile};
+        let (service, ph, forwarder, dir) = service_with("sk-live-zzz", &["api.openai.com"]);
+        // rebuild service with a redaction policy opting api.openai.com into entropy
+        let policy = RedactionPolicy {
+            default: RedactionAction::default(),
+            profiles: vec![RedactionProfile {
+                host: "api.openai.com".into(),
+                action: RedactionAction { entropy: EntropyMode::Redact { min_bits_per_char: 4.0, min_run_len: 20 }, ..Default::default() },
+            }],
+        };
+        let service = Arc::new(Arc::try_unwrap(service).ok().unwrap().with_redaction_policy(policy));
+        let sock = dir.path().join("subst.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = tokio::spawn(Arc::clone(&service).serve(listener));
+        let mut client = UnixStream::connect(&sock).await.unwrap();
+        let wire = WireRequest {
+            method: "POST".into(),
+            url: "https://api.openai.com/v1".into(),
+            headers: vec![("content-encoding".into(), "gzip".into()), ("authorization".into(), format!("Bearer {ph}"))],
+            body_b64: base64encode(b"\x1f\x8b compressed bytes"),
+        };
+        write_json_frame(&mut client, &wire).await.unwrap();
+        let resp: WireResponse = read_json_frame(&mut client, MAX_FRAME_BYTES).await.unwrap();
+        assert!(matches!(resp, WireResponse::Refused { .. }), "compressed body must fail closed");
+        assert!(forwarder.seen.lock().unwrap().is_none());
+        server.abort();
+    }
+```
+
+> Implementer note: `service_with` returns `Arc<SubstitutionService>`; if
+> `Arc::try_unwrap` is awkward given internal Arcs, instead extend `service_with`
+> to accept an optional policy, or add a test-only constructor. Pick the path
+> that compiles cleanly; the assertion (refusal + no forward) is the contract.
+
+- [ ] **Step 8: Run; verify fail.**
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd compressed_body_to_redaction 2>&1 | tail -6`
+Expected: FAIL (compressed body currently forwarded).
+
+- [ ] **Step 9: Implement the fail-closed gate + per-destination redaction in `process`.** Resolve the action for the destination; if the destination opts into any redaction (entropy/names/pii non-default), refuse a `content-encoding`-bearing request and an over-cap body before forwarding; otherwise apply `redact_bytes_for` in `redact_outbound`.
+
+In `process`, after `let destination = destination_host(&req.url).ok();`:
+
+```rust
+        let action = destination
+            .as_deref()
+            .map(|d| crate::supervisor::redaction_resolve::resolve(&self.redaction_policy, d).clone())
+            .unwrap_or_default();
+        let redaction_active = !matches!(action.entropy, mvm_core::policy::EntropyMode::Off)
+            || !matches!(action.names, mvm_core::policy::NameMode::Off);
+        if redaction_active {
+            // Fail closed: a body we can't scan in cleartext is a silent bypass.
+            let compressed = req
+                .headers
+                .iter()
+                .any(|(k, _)| k.eq_ignore_ascii_case("content-encoding"));
+            if compressed || req.body.len() as u64 > mvm_core::policy::DEFAULT_BODY_CAP_BYTES {
+                return WireResponse::Refused {
+                    message: "egress redaction enabled for destination but body is \
+                              compressed or over the scan cap; refusing (fail-closed)"
+                        .into(),
+                };
+            }
+        }
+```
+
+Then change `redact_outbound` to take the action and call `redact_bytes_for`
+instead of `redact_bytes` (the body + each non-placeholder header value):
+replace the `self.redactor.redact_bytes(...)` calls in `redact_outbound` with
+`self.redactor.redact_bytes_for(..., action)`, threading `action` in as a
+parameter (`fn redact_outbound(&self, mut req: ProxyRequest, action: &RedactionAction)`).
+Update the `process` callsite to `self.redact_outbound(req, &action)`.
+
+- [ ] **Step 10: Extend the audit categories.** In `audit_redactions`, fold the new counts into the category list:
+
+```rust
+        let mut categories: Vec<String> = hits.secrets.iter().chain(hits.pii.iter())
+            .map(|s| s.to_string()).collect();
+        if hits.entropy > 0 { categories.push("entropy".into()); }
+        if hits.names > 0 { categories.push("name".into()); }
+        categories.sort_unstable();
+        categories.dedup();
+```
+
+(Adjust the existing `emit_secret_redacted(recorder, dest, &categories.join(","))`
+call to use this `Vec<String>`; the existing signature already takes a `&str`.)
+
+- [ ] **Step 11: Run the targeted tests, then the full package.**
+
+Run: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd substitution_proxy 2>&1 | tail -6`
+Then: `RUSTC="$(rustup which rustc)" cargo nextest run -p mvm-hostd 2>&1 | tail -4`
+Expected: all pass.
+
+- [ ] **Step 12: Lint + fmt.**
+
+Run: `export PATH="$(dirname "$(rustup which cargo)"):$PATH"; "$(rustup which cargo)" clippy -p mvm-hostd -p mvm-core --lib --tests -- -D warnings 2>&1 | tail -4`
+Run: `cargo fmt --all -- --check`
+Expected: clean.
+
+- [ ] **Step 13: Tick the final REFACTOR-STATUS box + commit.**
+
+```bash
+git add crates/mvm-hostd/src/supervisor/network/stages.rs crates/mvm-hostd/src/supervisor/substitution_proxy.rs specs/REFACTOR-STATUS.md
+git commit -m "feat(secrets): destination-aware egress redaction + fail-closed + audit categories (plan 129 E1)"
+```
+
+---
+
+## Per-slice PR flow
+
+Each slice is one PR off `origin/main`, squash-merged once green via the
+enforce_admins toggle (no `Co-Authored-By: Claude`). Slices land in order — 5
+depends on 1/3/4; 2 is independent. After each merge, the next slice rebases on
+the new main.
+
+## Self-review notes (coverage vs the design)
+
+- Entropy ✅ slice 1 (audit-first, no echo). IBAN ✅ slice 2. Names ✅ slice 3
+  (anchored + gazetteer + co-occurrence-via-spans). `RedactionAction` +
+  per-destination resolve ✅ slice 4 (types in mvm-core, resolver in mvm-hostd —
+  the host_matches dependency-direction fix). Wiring + fail-closed + audit ✅
+  slice 5. No `core::redact` move; no ML/heavy dep (gazetteer is static data).
+- **Deferred (note in the design's Out-of-scope, carry forward):** full PII
+  match-span plumbing into `NameScanner` co-occurrence on the live path (slice 5
+  passes `&[]` spans, so labeled + gazetteer name signals fire but live
+  co-occurrence is approximated); bounded in-window decompression instead of
+  refusing compressed bodies; the bound-host TLS terminator path
+  (`handle_terminator_connection`) wiring — same `redact_bytes_for` call, gated
+  on the terminator typed-error follow-up from the E2 work.

--- a/specs/notes/plan-129-e1-step2-pii-entropy-redaction-design.md
+++ b/specs/notes/plan-129-e1-step2-pii-entropy-redaction-design.md
@@ -1,0 +1,217 @@
+# Plan 129 E1 Step 2 — per-destination egress redaction + entropy detection
+
+**Status:** design, approved 2026-06-10. Implementation sequenced below.
+
+## Goal
+
+Catch **undeclared** secret-shaped tokens and PII on the egress the host can
+see, and redact (or block) them per destination — the "predicted" half of
+Plan 129, complementing declared-secret substitution (the "specified" half).
+No declaration required.
+
+## What already exists (do not rebuild)
+
+A detector ecosystem predating Plan 129 (Plan 37 Wave 2.x) already lives in
+`crates/mvm-hostd/src/supervisor/` and is wired live:
+
+- `secrets_scanner.rs` — `SecretsScanner`: curated, high-precision
+  gitleaks/trufflehog-style secret patterns compiled into one
+  `regex::bytes::RegexSet`; denies secret-bearing egress, names the rule that
+  fired, **never echoes the value**. Deliberately curated-only — its docs
+  reject generic entropy / "looks like base64" as too noisy.
+- `pii_redactor.rs` — `PiiRedactor`: `email`, `us_ssn`, `credit_card`
+  (Luhn-validated), `e164_phone`; `Mode { Allow, Redact, Block }`; built from
+  `mvm_core::policy::PiiPolicy { mode, categories }` via `from_policy`, which
+  fails admission loudly on a bad mode/category.
+- `RedactingSubstitution` (`network/stages.rs`) — byte-level redactor wrapping
+  the above rules; `redact_bytes(&[u8]) -> Option<(masked, RedactionHits{secrets,pii})>`.
+  Used by the gateway-bridge packet `SubstitutionStage` **and** the
+  substitution-endpoint request redactor (`substitution_proxy::redact_outbound`).
+- `injection_guard.rs` — `InjectionGuard`: prompt-injection patterns.
+
+The inspector chain (`aggregate.rs::build_inspector_chain_with_pii`) is built
+**once per workload** — detectors apply uniformly to every allowed
+destination. `DestinationPolicy` is an allow/deny host list, not a per-host
+detection action.
+
+So the spec-named items break down as: secret-shaped regex ✅, PII regex ✅,
+Luhn ✅, bounded `RegexSet` ✅. Genuinely missing: Shannon **entropy**,
+**per-destination** action, **names**, **IBAN**. The spec's "`core::redact`
+(new)" relocation and "named profile (125 E4)" coupling are both dropped — see
+Decisions.
+
+## Threat model & honest framing
+
+This is a **best-effort hygiene layer on inspectable egress**, not a
+containment boundary. The real containment is already shipped: claim-10
+default-deny egress + declared-secret substitution (the raw secret never
+enters the guest). Redaction **complements** those and must not weaken them or
+justify widening an allowlist.
+
+It addresses **accidental / sloppy leakage** — an LLM agent that dumps a
+`.env`, a customer row, or a DB result verbatim into an allowed request. It
+does **not** stop a determined exfiltrator: encoding, compression,
+reformatting ("j dot doe at gmail"), or chunking defeat byte-level detection.
+That scope is acceptable and is stated, not implied-away.
+
+### Why the vsock architecture makes this feasible
+
+All egress for these workloads funnels over **vsock** to the host endpoint —
+the guest has no NIC and no route to originate its own external connection. It
+hands the host a **cleartext request envelope** (method/url/headers/body); the
+host originates the real TLS. So the host sees cleartext and can redact.
+
+Coverage = **http + TLS-terminated (bound-host) https**. The one blind spot is
+**https spliced to an *unbound* host** (Stage 2 passes ciphertext through
+without terminating) — but that path does no substitution and is governed by
+the allowlist/default-deny anyway. There is no raw-packet egress path here, so
+the redactor is wired **only** into the cleartext endpoint path, never the
+gateway-bridge packet pipeline.
+
+## Detection design
+
+### Tier 1 — structured PII (reliable: format + checksum)
+
+`email`, `us_ssn`, `credit_card` (Luhn), `e164_phone` already exist. **Add
+IBAN** (mod-97 checksum). **Account numbers**: only via a checksum (IBAN) or a
+field-label anchor (Tier 3) — a bare digit run is indistinguishable from any
+number and is out of scope.
+
+### Tier 2 — entropy (secret-shaped unknowns)
+
+New `EntropyScanner` (`mvm-hostd`). Shannon entropy over candidate token runs
+— contiguous `[A-Za-z0-9+/=_\-]` of length ≥ `min_run_len` — flagged when
+bits/char ≥ `min_bits_per_char`. Single pass over `&[u8]`, allocates only the
+hit list, **never echoes** the matched bytes (audit carries rule + offset).
+Additive to `SecretsScanner` — catches unknown-shape tokens the curated rules
+miss. **Audit-only on first opt-in; redact is an explicit second step; never
+block** — high-entropy false positives (JWTs, UUIDs, base64 uploads, hashes,
+protobuf) must degrade, not break, and operators see hits before masking.
+
+### Tier 3 — names (anchored + gazetteer, no ML)
+
+NER (Presidio/spaCy) is **rejected**: an ML model in the host hot path breaks
+the deterministic/reproducible-build invariant, adds an adversarial-ML input
+surface, and is disproportionate for a non-boundary layer a determined
+exfiltrator evades anyway. Instead, target the name leaks that actually matter
+— structured dumps carry context:
+
+1. **Field-label anchor** — JSON keys / form fields / `Label:` prose matching
+   `name|first_name|last_name|full_name|customer|patient|cardholder|...` →
+   redact the value.
+2. **PII co-occurrence** — a capitalized 2–3 token run *near* a confirmed
+   email/SSN/phone/CC/IBAN hit → redact (the "row" case: a name bound to other
+   PII is the real leak).
+3. **Gazetteer validation** — a compile-time static census first/last-name set
+   (`phf` or a sorted slice baked into the binary — **data, not an ML dep**, no
+   runtime cost) gates unanchored candidates so not every capitalized word is
+   masked.
+
+Names run **redact-mode, audit-first**. Freeform unlabeled names with no
+nearby PII are **out of scope** (undetectable without NER, low-sensitivity) —
+documented, not pretended-away.
+
+## Per-destination action model
+
+New in `mvm_core::policy::policies`:
+
+```
+RedactionAction {
+    entropy: EntropyMode,   // Off | Audit{ min_bits_per_char, min_run_len } | Redact{ same }
+    pii: PiiPolicy,         // reuse existing: mode + structured categories (+ iban)
+    names: NameMode,        // Off | Audit | Redact — separate field: names use the
+                            //   anchored+gazetteer mechanism, not the structured-regex path
+    secrets: SecretAction,  // curated SecretsScanner action (existing default: Block)
+}
+```
+
+`names` is deliberately its own field, not a `pii` category: structured PII is
+regex+checksum, names are anchored+gazetteer with an audit-first default — two
+mechanisms with different failure modes. (The audit *category label* is still
+`name`; the config knob is `NameMode`.)
+
+A workload's egress policy gains an optional ordered
+`redaction_profiles: Vec<{ host: String /* `*.` wildcard */, action: RedactionAction }>`.
+A `resolve(dest) -> &RedactionAction` picks the first matching host (reusing
+the existing `host_matches` wildcard helper), else a `default` = today's
+curated-only baseline (entropy `Off`, names `Off`, structured PII per the
+workload `PiiPolicy`, curated secrets `Block`). `deny_unknown_fields` + a parse
+error on a bad enum value so a typo fails **admission**, not runtime — matching
+`PiiRedactor::from_policy`.
+
+**Self-contained** — independent of the unbuilt Plan 125 E4 `--profile`
+(whole-workload capability matrix). The two compose later: E4 sets workload
+posture, this sets per-destination redaction.
+
+## Where it plugs in
+
+Both live cleartext call sites already resolve a destination — the
+substitution endpoint (`substitution_proxy::process`, has `destination`) and
+the bound-host TLS terminator (`handle_terminator_connection`, has `orig_dst`).
+Each resolves `redaction_profiles.resolve(dest)` and applies that action's
+detectors. The shared rule definitions stay in `mvm-hostd` — **no `core::redact`
+relocation** (everything is host-side and already shares one definition; the
+move buys nothing).
+
+## Fail-closed posture
+
+- A `Block`-mode hit (curated secret, or an opted-in Block category) denies the
+  request — claim-10/13 lineage.
+- **Over-cap bodies** and **`Content-Encoding`-compressed bodies** to a
+  redaction-opted-in destination are **blocked + audited** — otherwise both are
+  silent bypasses (PII past the scan window / inside a gzip stream). Bounded
+  in-window decompression is a later refinement.
+- A malformed profile fails **admission**, not runtime.
+- Default for every unlisted destination is the unchanged curated-only
+  baseline, so the low-false-positive posture is preserved unless an operator
+  opts a destination in.
+
+## Audit
+
+Reuse `secret.redacted { destination, categories }` (the `audit_redactions`
+path already in `substitution_proxy`) — extend `categories` to carry `entropy`,
+`name`, `iban`. Metadata only; **never** the matched bytes. A `Block` keeps its
+existing deny-audit. `verify_audit_chain` stays green.
+
+## Out of scope / deferred
+
+- ML/NER name detection (rejected — see Tier 3).
+- Freeform unlabeled names with no co-occurring PII.
+- Bare account numbers without a checksum or label.
+- Decompressing bodies to scan inside (blocked + audited for now).
+- https spliced to unbound hosts (ciphertext; governed by the allowlist).
+- Raw gateway-bridge packet-pipeline redaction (no cleartext there; no raw path
+  over vsock).
+
+## Implementation slices (each a mergeable, TDD PR)
+
+1. **`EntropyScanner`** standalone — flags a high-entropy run, ignores
+   low-entropy prose, respects `min_run_len`/threshold, masks without echoing;
+   audit/redact modes. (No wiring yet.)
+2. **IBAN** rule (mod-97) added to the structured PII set + `PII_CATEGORY_NAMES`.
+3. **Name detector** — field-label anchor + PII co-occurrence + gazetteer
+   validation; redact/audit modes; static census name set baked in.
+4. **`RedactionAction` + `redaction_profiles` + `resolve`** in `mvm-core`
+   policy — serde, wildcard match, first-match-wins, default fallback, parse
+   error on bad enum.
+5. **Destination-aware wiring** — endpoint + terminator resolve the profile and
+   apply the action; over-cap / compressed bodies fail-closed; `secret.redacted`
+   carries the new categories.
+
+REFACTOR-STATUS Plan 129 boxes ticked with **each** landing, date bumped, in
+the same change.
+
+## Acceptance
+
+- Entropy detector catches an unknown high-entropy token a curated rule misses;
+  audit-first, never blocks; no value in the chain.
+- IBAN + structured PII redacted/blocked per the resolved per-destination action.
+- A labeled or PII-co-located name is redacted; an unlisted destination passes
+  it; a bare capitalized word with no anchor/gazetteer hit is not masked.
+- Over-cap and compressed bodies to an opted-in destination are blocked +
+  audited.
+- Default (no `redaction_profiles`) is byte-identical to today's behavior.
+- `secret.redacted` carries `entropy`/`name`/`iban` categories, never bytes;
+  `verify_audit_chain` green. `cargo nextest` + clippy + fmt green; **no ML/heavy
+  dependency** (a compile-time name set via `phf`/sorted-slice is data, not a
+  runtime dep).


### PR DESCRIPTION
## What

The **predicted** half of Plan 129 — detect *undeclared* secret-shaped tokens and PII on egress the host can see, complementing declared-secret substitution (the *specified* half). Five reviewed TDD slices building the detection + per-destination mechanism:

1. **EntropyScanner** — Shannon entropy over token runs; audit-first, never echoes the matched bytes, never blocks.
2. **IBAN** (mod-97) added to the structured PII redactor.
3. **Name detector** — field-label anchor + census gazetteer + PII co-occurrence; **no ML/NER** (gazetteer is committed static data, not a runtime dep).
4. **RedactionAction** policy types (mvm-core) + **resolve()** (mvm-hostd — `host_matches` lives in mvm-sdk, above mvm-core).
5. **Destination-aware wiring** into the cleartext substitution endpoint — `redact_bytes_for`, fail-closed on compressed/over-cap bodies (audited), `entropy`/`name`/`iban` audit categories.

Design + plan: `specs/notes/plan-129-e1-step2-pii-entropy-redaction-design.md`, `specs/notes/plan-129-e1-step2-implementation-plan.md`.

## Honest framing (in the design doc)

This is a **best-effort hygiene layer on inspectable egress, not a containment boundary.** It catches accidental/sloppy leakage (an LLM agent dumping a `.env` or a customer row) on the cleartext the vsock endpoint sees; a determined exfiltrator (encode/compress/reformat) evades it. The real containment remains claim-10 default-deny + declared-secret substitution. The vsock architecture is what makes redaction feasible: the guest has no NIC, so it hands the host a cleartext request envelope.

## Status: mechanism complete + tested + leak-free; NOT yet reachable in prod

Final cross-cutting review confirmed **no value-leak path** (counts/offsets/category-labels/destinations only — never matched bytes) and that **default-off is byte-identical** to prior behavior. Tracked follow-ups before it's end-to-end (see plan §"Deferred follow-ups" + REFACTOR-STATUS):

- **Admission wiring** — nothing yet reads a workload-authored `RedactionPolicy` and calls `with_redaction_policy`; only tests construct one. The feature is mechanism-only until this lands.
- `RedactionAction.pii` / `.secrets` are **doc-marked RESERVED** — parsed/resolved but not yet consumed (the redactor runs the always-on ruleset); wiring them is a tracked follow-up, so they're not presented as working knobs.
- Terminator (`:80`/`:443`) path redaction; live PII spans for name co-occurrence; bounded decompression.

## Tests

Every slice TDD red→green, each individually spec + code-quality reviewed. Full local gate: **2059/2059** pass across `mvm-core` + `mvm-hostd`; clippy `-D warnings` + `cargo fmt --all` clean. `mvm-backend` excluded locally (macOS codesign SIGKILL) — covered on CI.

## Note

The 5 slices are bundled into this one PR (clean commit-per-slice) rather than 5 stacked PRs. Each commit is independently reviewable; can split if preferred.