### PR TITLE
docs(plan-181): app-builder product surface — ADR-079 + plan + rollups

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -237,6 +237,23 @@ PLAN 180 — Strip spec refs from code comments    🔴 NOT STARTED
   [ ] fan-out sweep (~2,531 comment hits)
   [ ] verify just ci green, comment-only diff
   [ ] check-no-spec-refs-in-comments lint gate
+
+PLAN 181 — App-builder product surface           🔴 NOT STARTED  (ADR-079; mvm primitive ↔ mvmd product per ADR-070)
+  [ ] WS-A preview ingress: published-ports model (signed in plan) + per-port
+      routing label at gateway seam + wake-on-access VmBackend hook + local
+      single-machine dev ingress (s-<id>-<port>.preview.localhost)
+  [ ] WS-B lifecycle verbs: vm stop (free RAM, wake-on-access) / rm (keep
+      workspace) / purge (delete workspace) / keepalive (extend idle TTL);
+      workspace-data lifecycle in mvm_core::config; distinct cmd.* audit events
+  [ ] WS-C task/files protocol: async streamable task over agent-RPC (169) reusing
+      ExecEvent (172) + SSE-ready event shape + Files API parity on fs RPC + thin
+      mvmctl verbs (agent-agnostic; mvmd owns HTTP/SSE transport)
+  [ ] WS-D install DX: curl|sh installer (folds Plan 159 WS-5 D) + "next steps"
+      output (endpoint + preview URLs + runnable cmds) + graduated env uninstall
+      (--images/--data/--all; keep-workspaces default)
+  NOTE: deliberately rejects the sibling app-builder's isolation model — no Docker
+  socket, no host-path mounts into a workload, no auth-off/caps-off defaults, no
+  baked-in agents, no multi-tenant HTTP/auth in mvm (mvmd per ADR-070 §5/Plan 33).
 ```
 
 ## Security claims

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2469,6 +2469,71 @@ Prove the #1 spine end-to-end on macOS/libkrun and lock it behind a regression g
 - Image slimming (deferred, above) and Linux/Firecracker E2E parity (own plan).
 - Encryption-at-rest + Noise vsock (Plan 122).
 
+## Sprint 61 — App-builder product surface (proposed)  [`plans/181-app-builder-product-surface.md`](plans/181-app-builder-product-surface.md) | [`adrs/079-app-builder-product-surface.md`](adrs/079-app-builder-product-surface.md) | boundary: [`adrs/070-browser-reachable-verification-surface.md`](adrs/070-browser-reachable-verification-surface.md)
+
+Graft the AI-app-builder *product loop* (create → coding agent → **live preview
+URL**, stop/wake/keepalive lifecycle, streamable task/files API, one-command
+install) onto mvm's hardened microVM substrate — **without** the weak isolation a
+sibling self-hosted app-builder backend uses to get that DX cheaply (Docker
+socket, host-path mounts, auth/caps off). Every workstream ships an mvm-side
+primitive and names the mvmd-side product leg that consumes it (ADR-070 reserves
+transport + tenant auth for mvmd / Plan 33). The one mvm-local product piece is a
+single-machine `localhost` dev ingress so `mvmctl up`/`run` hands you a working
+URL on one box.
+
+### W1 (Plan 181 WS-D) — Install / uninstall DX  🟡 proposed
+- [ ] `curl | sh` installer (folds the unowned Plan 159 WS-5 D item): prereq
+  detection via `doctor`, idempotent, never touches anything outside mvm dirs.
+- [ ] "Next steps" output after `env bootstrap` / `dev up` / `up`: control
+  surface + preview URL(s) + literal runnable copy-paste commands.
+- [ ] Graduated `env uninstall` (`--images` / `--data` / `--all`), keep-workspaces
+  default, "removes only what mvm created".
+
+### W2 (Plan 181 WS-B) — Lifecycle verb taxonomy  🟡 proposed
+- [ ] `vm stop` (free RAM, wake-on-access) / `vm rm` (drop instance, **keep
+  workspace**) / `vm purge` (drop instance + workspace) / `vm keepalive` (extend
+  idle TTL on the Plan 118/170 reaper).
+- [ ] Workspace-data lifecycle is a named concept in `mvm_core::config`; `--json`
+  reports its state; each verb emits a distinct chain-signed `cmd.*` audit event.
+
+### W3 (Plan 181 WS-A) — Preview ingress  🟡 proposed (headline)
+- [ ] Published-ports model signed into the `ExecutionPlan` (audited, not ambient)
+  + per-port routing label (`s-<vm>-<port>`) at the gateway seam
+  (`gateway_bridge.rs` / rvproxy, Plan 179) — L4 publication, no HTTP parsing.
+- [ ] Wake-on-access `VmBackend` hook (calls `warm_start`, Plan 123 C4 / Plan 175)
+  on a connection to a stopped, RAM-freed instance.
+- [ ] Local single-machine dev ingress: tiny first-party reverse proxy mapping
+  `http://s-<id>-<port>.preview.localhost` → published host port + wake hook;
+  `up`/`run` prints the URL(s). No auth/TLS/wildcard-DNS (mvmd owns those).
+
+### W4 (Plan 181 WS-C) — Streamable task + files protocol  🟡 proposed
+- [ ] Async task protocol over agent-RPC (Plan 169) reusing `ExecEvent` streaming
+  (Plan 172); the "agent" is an **opaque runner**, not a baked-in binary.
+- [ ] SSE-ready event serialization (mvmd forwards as `text/event-stream`).
+- [ ] Files API parity on the existing `fs` RPC (read/write/append, no `exec`);
+  thin `mvmctl vm task` / `vm files` verbs for local testing.
+
+### Cross-repo dependency (mvmd)
+Consumes published-ports + routing label + wake hook (W3) for fleet preview URLs;
+the task/files vsock protocol + SSE shape (W4) for its HTTP API; the
+idle-TTL/keepalive contract (W2) for its density loop (Plan 170 WS-D).
+
+### Sprint 61 success criteria
+- [ ] `mvmctl up --flake <app>` with a published port prints a working
+  `s-<id>-<port>.preview.localhost` URL on one machine; hitting it after `vm stop`
+  wakes the instance.
+- [ ] The four lifecycle verbs honor the instance-vs-workspace split with
+  distinct audit events; a headless task streams incremental events and `vm files`
+  reads/writes without `exec`.
+- [ ] No claim regresses (`xtask check-claim-catalog` green; default-deny egress
+  intact; only published ports routable); `cargo nextest run --workspace` +
+  `--doc` green; clippy/fmt clean.
+
+### Non-goals (explicit — see Plan 181 §Non-goals)
+- Container isolation / Docker-socket control plane; host-path mounts into a
+  workload; auth-off / caps-off defaults; baked-in coding agents; any
+  multi-tenant HTTP listener or tenant auth in mvm (mvmd per ADR-070 §5).
+
 ## Completed Sprints
 
 - [01-foundation.md](sprints/01-foundation.md)

--- a/specs/adrs/079-app-builder-product-surface.md
+++ b/specs/adrs/079-app-builder-product-surface.md
@@ -1,0 +1,129 @@
+# ADR-079 — App-builder product surface: adopt the ergonomics, reject the isolation model
+
+**Status:** Accepted 2026-06-10. Implemented by
+[`specs/plans/181-app-builder-product-surface.md`](../plans/181-app-builder-product-surface.md).
+**Extends** [ADR-070](070-browser-reachable-verification-surface.md) (the
+mvm-primitive ↔ mvmd-transport boundary), and builds on
+[ADR-078](078-rvproxy-gateway-ownership.md) / Plan 179 (the first-party gateway
+seam preview ingress publishes through) and the network-provider seam in
+ADR-064. **Cross-refs:** ADR-002 (security posture — claims 1/2/10 are the lines
+this ADR refuses to cross), ADR-041 (signed/audited execution plans — where
+published ports get signed), Plan 33 (hosted transport — mvmd owns it),
+Plan 170 (the same primitive↔product split applied to density), Plan 118 /
+Plan 123 C4 / Plan 175 (warm pool + warm-start, the wake-on-access machinery),
+Plan 169 / Plan 172 (agent-RPC + streamed exec, the task/files transport).
+**Input:** a comparison against a sibling self-hosted AI-app-builder backend.
+
+## Context
+
+A sibling self-hosted AI-app-builder backend delivers a DX mvm does not yet
+match: a single request creates an isolated environment, runs a coding agent in
+it, and returns a **live, shareable preview URL**; instances `stop` to free RAM
+and **wake on access**; a tasks API streams agent progress and a files API edits
+the workspace; one command installs the whole stack and prints runnable next
+steps; uninstall is graduated and workspace-preserving by default.
+
+It buys that DX cheaply by discarding exactly the properties mvm exists to
+provide. Its isolation is Docker containers; its control plane and edge router
+run with the **Docker daemon socket mounted** (root-equivalent on the host) and
+**symmetric host-path bind mounts** so sandboxes reach files by host path; its
+API auth is **off by default** and its containers carry **no resource caps by
+default**. Each of those is a direct contradiction of an mvm claim — claim 1
+(no host-fs access beyond explicit shares), claim 2 (no guest elevation to
+uid 0), claim 10 (no untrusted egress without policy), and the jailer/cgroup
+posture.
+
+mvm has the inverse profile: a much stronger engine (microVM isolation,
+signed/audited execution plans, default-deny egress, secret substitution —
+claims 1–15) behind a CLI-first surface that does not deliver the product loop.
+The question this ADR settles is **which half of the sibling's design we take.**
+
+The ergonomics do not depend on the isolation. The preview loop rides the
+gateway seam we already own (ADR-078); wake-on-access rides warm-start
+(Plan 123 C4 / Plan 175); the task/files surface rides agent-RPC + streamed
+exec (Plan 169 / Plan 172); the lifecycle verbs and install/uninstall are CLI
+plumbing on the `vm`/`env` groups. None of it requires relaxing a claim. The
+weak isolation is not load-bearing for the DX — it is just the cheapest engine
+the sibling had to hand.
+
+## Decision
+
+1. **Adopt the product-surface ergonomics; reject the isolation model.** mvm
+   grows the create→agent→preview-URL loop, the instance-vs-workspace lifecycle
+   split, a streamable task/files protocol, and one-command install/uninstall.
+   mvm does **not** adopt container isolation, a daemon-socket-mounted control
+   plane, host-path mounts into a workload, auth-off/caps-off defaults, or
+   baked-in coding agents. These rejections are normative non-goals, recorded so
+   they are not relitigated when the DX gap is felt again.
+
+2. **Split every capability into an mvm-side primitive and an mvmd-side product
+   leg, per ADR-070.** mvm ships the bridgeable primitives — a signed
+   published-ports model, a per-port routing label at the gateway seam, a
+   wake-on-access `VmBackend` hook, the task/files vsock protocol with an
+   SSE-ready event shape, and the idle-TTL/keepalive contract. mvm does **not**
+   grow a multi-tenant HTTP listener or tenant auth; that transport + auth +
+   wildcard-DNS/TLS surface is mvmd's (Plan 33 / ADR-070 §5). This is the same
+   boundary Plan 170 drew for density.
+
+3. **One exception: a local, single-machine dev ingress lives in mvm.** So
+   `mvmctl up`/`run` can hand a contributor a working
+   `http://s-<id>-<port>.preview.localhost` URL on one box, mvm carries a tiny
+   first-party reverse proxy bound to `localhost` only — no auth, no TLS, no
+   wildcard DNS. This occupies the same single-host, no-tenant scope `mvmctl
+   dev` already does, so it crosses no new trust boundary; `*.localhost`
+   resolves to loopback in browsers with no DNS setup.
+
+4. **Preview routing is L4 publication, not an HTTP proxy, and only published
+   ports are routable.** The gateway exposes explicitly published guest ports
+   under a stable id-derived key (`s-<vm>-<port>`); it does not parse HTTP. The
+   published set is signed into the `ExecutionPlan` (audited, not ambient), so
+   default-deny egress (claim 10) and the gateway mediation seam are unchanged —
+   exposing a preview port is an admitted, recorded act, not a hole.
+
+5. **The substrate stays agent-agnostic.** The task protocol carries an opaque
+   runner/entrypoint reference; no coding-agent binary is baked into any rootfs.
+   Agent tooling is a workload/SDK concern.
+
+## Consequences
+
+- mvm gains the product loop that makes app-builder backends feel magical, on
+  top of an engine the sibling cannot match (strong enough to run *untrusted*
+  code) — a combination neither the sibling (too weak to trust) nor mvm's
+  current CLI-first surface delivers.
+- mvmd gets a clean set of primitives to wrap: published-ports + routing label +
+  wake hook → fleet preview URLs; the task/files vsock protocol + SSE shape →
+  its HTTP API; the keepalive/idle-TTL contract → its density loop (already
+  Plan 170 WS-D).
+- No claim regresses. Preview ports are signed and audited; the wake hook reuses
+  warm-start; the local ingress is loopback-only. `xtask check-claim-catalog`
+  stays green.
+- A small, owned local reverse proxy enters the tree (reusing the
+  rvproxy/hyper surface), and a workspace-data lifecycle becomes a named concept
+  in `mvm_core::config` distinct from instance lifecycle.
+
+### Follow-ups
+
+- [ ] Plan 181 WS-A–WS-D implementation (preview ingress, lifecycle verbs,
+  task/files protocol, install DX).
+- [ ] Decide L4-only-now vs. a fuller local HTTP router (Plan 181 WS-A open
+  decision); recommendation is L4 + loopback proxy first.
+- [ ] If/when a hosted (non-localhost) preview surface is wanted, it is an mvmd
+  effort (Plan 33), not mvm — same disposition as ADR-070 §5's hosted console.
+
+## Alternatives considered
+
+- **Take the sibling's stack wholesale (containers + socket + host mounts).**
+  Rejected: it discards claims 1/2/10 and mvm's reason to exist. The DX does not
+  require it.
+- **Build the full multi-tenant preview/ingress + auth in mvm.** Rejected:
+  violates the ADR-070 / Plan 33 boundary that reserves transport + tenant auth
+  for mvmd. mvm ships primitives + a single-machine dev ingress only.
+- **Ambient (unsigned) port exposure for convenience.** Rejected: it would make
+  egress reachability an unrecorded side effect, weakening claim 10. Published
+  ports are signed into the plan and audited.
+- **Bake specific coding-agent binaries into the base image like the sibling.**
+  Rejected: couples the substrate to specific agent tooling; the runner stays
+  opaque.
+- **Do nothing (keep the CLI-first surface).** Rejected: the product loop is the
+  difference between an engine and a product, and it is achievable with zero
+  claim cost.

--- a/specs/plans/181-app-builder-product-surface.md
+++ b/specs/plans/181-app-builder-product-surface.md
@@ -1,0 +1,240 @@
+# Plan 181 — App-builder product surface (preview ingress + lifecycle verbs + task/files protocol + install DX)
+
+> **Numbering:** 181 is the next free plan number after 180. Confirm still free
+> at merge.
+>
+> **Decision source:** [ADR-079](../adrs/079-app-builder-product-surface.md)
+> (adopt the ergonomics, reject the isolation model). **Boundary:**
+> [ADR-070](../adrs/070-browser-reachable-verification-surface.md) — browser/remote
+> **transport + tenant auth is mvmd's** (Plan 33); mvm owns only the
+> cleanly-bridgeable primitives + a local single-machine dev ingress. The gateway
+> seam this builds on is owned by
+> [ADR-078](../adrs/078-rvproxy-gateway-ownership.md) /
+> [Plan 179](179-rvproxy-gvproxy-replacement.md).
+
+**Goal:** Put a best-in-class AI-app-builder *product surface* on top of mvm's
+hardened microVM substrate — the create→agent→**live preview URL** loop, a
+clean instance/workspace lifecycle, a streamable task/files protocol, and a
+one-command install/uninstall — **without adopting the weak isolation that
+sibling self-hosted app-builder backends rely on to get that DX cheaply.**
+
+## Why now
+
+A sibling self-hosted AI-app-builder backend gets a delightful DX (one HTTP
+call → isolated env + coding agent + shareable `*.preview.localhost` URL, plus
+stop/wake/keepalive lifecycle and a tasks/files API) by running **Docker
+containers with the daemon socket mounted and host-path bind mounts** — exactly
+the host-fs-access and privilege-escalation surface mvm claims 1/2 exist to
+kill, with auth off and no resource caps by default. mvm has the inverse
+profile: a far stronger engine (microVM isolation, signed/audited execution
+plans, default-deny egress, secret substitution — claims 1–15) behind a
+CLI-first surface that does **not** yet deliver that product loop. The
+high-leverage move is to graft the *ergonomics* onto our *engine*. None of the
+ergonomics require relaxing a single claim; they ride seams we already own
+(gateway bridge, warm-start, agent-RPC/streamed-exec, the `vm`/`env` CLI
+groups).
+
+## Architecture (mvm primitive ↔ mvmd product, per ADR-070)
+
+Every workstream below ships an **mvm-side primitive** and names the **mvmd-side
+product leg** that consumes it. mvm never grows a multi-tenant HTTP listener or
+tenant auth — that is fleet-orchestration territory (Plan 33 / ADR-070 §5). The
+exception is a **local, single-machine dev ingress** (`localhost` only, no auth,
+no wildcard TLS) so `mvmctl up`/`run` can hand the contributor a working URL on
+one box — the same scope `mvmctl dev` already occupies.
+
+Load-bearing seams reused (do not fork):
+
+- Gateway / egress plane: `crates/mvm-hostd/src/supervisor/gateway_bridge.rs`,
+  `crates/deps/libkrun-sys/src/gvproxy.rs` (rvproxy under Plan 179), Linux
+  `passt`. Per-port publication and wake-on-access hang here.
+- Backend trait + wake: `crates/mvm-backend` (`VmBackend`), `VmBackend::warm_start`
+  (Plan 123 C4 seam), warm pool + reaper (Plan 118 / Plan 170 WS-B).
+- Agent RPC / streamed exec: Plan 169 (`fs`/`cp` transport), Plan 172
+  (`ExecEvent` streamed exec), Plan 173 (exec timeout).
+- CLI groups: `vm` (single-VM lifecycle) and `env` (bootstrap/uninstall/update),
+  post Plan 178.
+- Paths/config: `mvm_core::config` (never inline `$HOME` joins).
+
+**Tech stack:** Rust; existing supervisor/gateway/backend crates; vsock
+agent-RPC; the `mvmctl` CLI. No new heavy dependencies — a local reverse proxy,
+if needed, reuses the rvproxy/hyper surface already in-tree.
+
+---
+
+## Guardrails (every task)
+
+- **Reject the sibling's isolation model, not just decline it.** No Docker
+  socket, no host-path bind mounts into a workload, no auth-off default beyond
+  the existing localhost-dev scope, no removing resource caps. Capture these as
+  explicit non-goals (below) so they are not relitigated.
+- Do not weaken any of claims 1–15. Preview ingress routes only **explicitly
+  published** ports; default-deny egress (claim 10) and the gateway mediation
+  seam (claim 10 no-bypass) are unchanged.
+- Keep the substrate **agent-agnostic.** The task protocol carries an opaque
+  entrypoint/runner; mvm does not bake specific coding-agent binaries into any
+  rootfs (that is a workload/SDK concern).
+- Respect the ADR-070 boundary: no multi-tenant HTTP listener or tenant auth in
+  mvm. mvmd owns transport + auth + wildcard DNS/TLS.
+- Workspace-data lifecycle is distinct from instance lifecycle (the verb split
+  below) and both honor `mvm_core::config` data dirs / `MVM_DATA_DIR`.
+
+---
+
+## WS-A — Preview ingress: published ports + wake-on-access + local URL
+
+The marquee item: building a workload should hand you a live URL, and hitting a
+stopped workload's URL should wake it.
+
+**mvm primitives**
+
+- [ ] **Published-ports model.** A first-class `published_ports: Vec<u16>` on the
+  launch/admission path (signed into the `ExecutionPlan` so the set is audited,
+  not ambient), surfaced on `mvmctl vm list`/`status --json`. Only listed ports
+  are routable; everything else stays default-deny.
+- [ ] **Per-port routing label at the gateway seam.** Teach
+  `gateway_bridge.rs` / the rvproxy spawn to expose published guest ports on the
+  host with a stable, id-derived key (`s-<vm>-<port>`), the unit an external
+  router (an edge router, in mvmd) keys on. No HTTP parsing in mvm — this is
+  L4 publication, not an HTTP proxy.
+- [ ] **Wake-on-access seam.** A `VmBackend` hook so a request to a *stopped*
+  (RAM-freed) instance triggers `warm_start` (Plan 123 C4 / Plan 175) before the
+  connection is serviced, with a bounded cold-wake fallback. The trigger is
+  generic (a connection attempt on a published port); the *router* that detects
+  it and calls the hook is local (WS-A local ingress) or mvmd (fleet).
+- [ ] **Local dev ingress (single machine, localhost only).** A tiny first-party
+  reverse proxy (reuse the rvproxy/hyper surface) that maps
+  `http://s-<id>-<port>.preview.localhost` → the published host port, and calls
+  the wake hook on access. No auth, no TLS, no wildcard DNS — `*.localhost`
+  resolves to loopback in browsers. `mvmctl up`/`run` prints the URL(s) for each
+  published port in its "next steps" output (ties to WS-D).
+
+**mvmd-side product leg (named, not built here)**
+
+- Multi-tenant edge router: wildcard `*.preview.<domain>` DNS, TLS via
+  cert resolver, tenant auth on the route, and the fleet wake-on-access detector
+  calling the same `VmBackend` hook. Consumes the published-ports model + routing
+  label + wake hook verbatim.
+
+**Decision to confirm with owner:** start L4 (publish port + print
+`localhost:<port>` and the `s-<id>-<port>.preview.localhost` hostname via the
+local proxy) and leave HTTP-aware routing to mvmd, vs. ship a fuller local HTTP
+router now. Recommendation: L4 + local proxy first (cheap, owns nothing we don't
+already own); richer routing rides mvmd.
+
+## WS-B — Lifecycle verb taxonomy (instance vs. workspace)
+
+Adopt the sibling's clean split between *instance* lifecycle and *workspace-data*
+lifecycle on the `vm` group (post Plan 178), built on the warm-pool/reaper and
+warm-start primitives we already have.
+
+- [ ] **`vm stop`** — free RAM / suspend the instance; **wake-on-access**
+  re-materializes it (WS-A hook). Distinct from today's terminate. Maps to
+  `warm_start`-capable backends; fail-closed label on those that can't suspend.
+- [ ] **`vm rm` (delete)** — drop the instance, **preserve the workspace**
+  directory (default). The non-destructive default.
+- [ ] **`vm purge`** — drop the instance **and** delete the workspace data.
+  The explicit destructive verb.
+- [ ] **`vm keepalive`** — extend the idle TTL on the reaper (Plan 118 / Plan 170
+  WS-B), so an active session isn't reaped. mvmd's density loop (Plan 170 WS-D)
+  consumes the same TTL.
+- [ ] Workspace-data lifecycle is a named concept in `mvm_core::config`
+  (a per-instance workspace dir under the data root); stop/delete/purge act on it
+  consistently and `--json` reports its state.
+- [ ] Audit taxonomy: each verb emits a distinct chain-signed `cmd.*` event
+  (mirrors the Plan 178 note — claims 8/12/13 event names stay stable).
+
+## WS-C — Streamable task + files protocol (agent-agnostic)
+
+Make headless, streamable agent runs and workspace file access first-class —
+over vsock, agent-agnostic, with an SSE-shaped event stream mvmd can bridge to
+HTTP directly.
+
+- [ ] **Async task protocol.** A `submit task {entrypoint/runner, prompt-or-args}
+  → task id → poll/stream events → result` shape over the agent-RPC transport
+  (Plan 169), reusing the `ExecEvent` streaming model (Plan 172) so progress is
+  incremental. The "agent" is an **opaque runner reference**, not a baked-in
+  binary list.
+- [ ] **SSE-ready event shape.** The event stream serializes to the shape mvmd
+  can forward as `text/event-stream` with no re-modeling (mvm emits the events;
+  mvmd owns the HTTP/SSE transport per ADR-070).
+- [ ] **Files API parity.** Confirm/extend the Plan 169 `fs` RPC to cover the
+  read/write/append surface (`GET`/`PUT {path, content, append}`) an editor needs
+  without an `exec`. If a gap exists, close it on the existing transport — do not
+  add a second file channel.
+- [ ] **`mvmctl` thin verbs** exercising the protocol locally (`vm task …`,
+  `vm files …`) so the surface is testable without mvmd.
+
+**mvmd-side product leg:** `POST /tasks {prompt, agent}` + `GET …/events` (SSE)
++ `GET/PUT …/files` HTTP endpoints, tenant-authed, wrapping these vsock
+primitives.
+
+## WS-D — Install / uninstall DX
+
+Match the sibling's "one command → working endpoint + copy-paste next steps" and
+its respectful, graduated uninstall.
+
+- [ ] **`curl | sh` installer** (folds the unowned Plan 159 WS-5 D item): detect
+  prerequisites, print exactly what's missing with install hints (reuse
+  `doctor`), be idempotent, never touch anything outside mvm's data/cache dirs.
+- [ ] **"Next steps" output** after `env bootstrap` / `dev up` / `up`: print the
+  control surface, the preview URL(s) (WS-A), and literal, runnable copy-paste
+  commands — the README's first screen, emitted by the tool.
+- [ ] **Graduated uninstall** on `env uninstall`: default removes only what mvm
+  created and **keeps workspaces**; `--images` also drops built images;
+  `--data` deletes workspaces + state; `--all` full removal. Mirror the flag
+  surface, fail-safe defaults, and "removes only what it created" guarantee.
+
+---
+
+## Non-goals (deliberately rejected — do not relitigate)
+
+These are the parts of the sibling's DX that buy convenience by discarding mvm's
+reason to exist:
+
+- **Container isolation / Docker-socket-mounted control plane.** mvm is microVM
+  isolation; we do not mount a daemon socket or run workloads as containers.
+- **Host-path bind mounts into a workload.** Violates claim 1 (no host-fs access
+  beyond explicit shares). Workspaces are owned dirs surfaced *to the host*, not
+  the host filesystem surfaced *into the guest*.
+- **Auth-off / resource-caps-off defaults.** Beyond the existing localhost-dev
+  scope, the product surface stays authed (mvmd) and capped (jailer/cgroups).
+- **Baking specific coding agents into the base image.** The runner is opaque;
+  agent tooling is a workload/SDK concern.
+- **A multi-tenant HTTP listener or tenant auth in mvm.** Reserved for mvmd
+  (ADR-070 §5 / Plan 33). mvm ships only the bridgeable primitives + a local
+  single-machine dev ingress.
+
+## Cross-repo dependency (mvmd)
+
+mvmd consumes, in order of value: the published-ports model + per-port routing
+label + wake-on-access hook (WS-A) for fleet preview URLs; the task/files vsock
+protocol + SSE event shape (WS-C) for its HTTP API; the idle-TTL/keepalive
+contract (WS-B) for its density loop (already owned there per Plan 170 WS-D).
+
+## Success criteria
+
+- [ ] `mvmctl up --flake <app>` with a published port prints a working
+  `http://s-<id>-<port>.preview.localhost` URL on a single machine; hitting it
+  after `vm stop` wakes the instance.
+- [ ] `vm stop` / `vm rm` / `vm purge` / `vm keepalive` behave per the
+  instance-vs-workspace split; `--json` reports workspace state; each emits its
+  distinct audit event.
+- [ ] A headless task runs over vsock with incremental events; `vm files`
+  reads/writes a workspace file without `exec`; the event stream serializes
+  SSE-ready.
+- [ ] `curl | sh` install lands a working endpoint and prints runnable next
+  steps; `env uninstall` graduated flags behave with workspace-preserving
+  defaults.
+- [ ] No claim regresses: `xtask check-claim-catalog` green; default-deny egress
+  intact; only published ports routable.
+- [ ] `cargo nextest run --workspace` + `cargo test --workspace --doc` green;
+  `cargo clippy --workspace -- -D warnings` clean; `cargo fmt --all -- --check`
+  clean.
+
+## Phasing
+
+WS-A is the headline and the largest; WS-B and WS-D are mostly CLI + lifecycle
+plumbing on existing primitives and can land first as quick wins. WS-C extends
+the agent-RPC transport and pairs naturally with mvmd work. Suggested order:
+WS-D (DX, low risk) → WS-B (lifecycle) → WS-A (ingress) → WS-C (task/files).


### PR DESCRIPTION
## What

Spec-only change: grafts the AI-app-builder **product loop** onto mvm's hardened microVM substrate, **without** adopting the weak isolation a sibling self-hosted app-builder backend uses to get that DX cheaply (Docker daemon socket mounted, host-path bind mounts into the workload, auth-off + caps-off defaults).

Four files, no code:

- **`specs/adrs/079-app-builder-product-surface.md`** (new) — *"Adopt the ergonomics, reject the isolation model."* Records the decision + the normative non-goals (the isolation shortcuts that contradict claims 1/2/10), the primitive↔product split per ADR-070, the one local-ingress exception, and L4 signed-published-ports-only. Extends ADR-070; builds on ADR-078/Plan 179.
- **`specs/plans/181-app-builder-product-surface.md`** (new) — implementation plan, 4 workstreams:
  - **WS-A** preview ingress — published-ports model (signed into the `ExecutionPlan`, audited), per-port routing label at the gateway seam, wake-on-access `VmBackend` hook, local `*.preview.localhost` dev ingress.
  - **WS-B** lifecycle verbs — `vm stop` (free RAM, wake-on-access) / `rm` (keep workspace) / `purge` (delete workspace) / `keepalive` (extend idle TTL).
  - **WS-C** streamable task + files protocol over agent-RPC (169) + `ExecEvent` (172), SSE-ready, agent-agnostic.
  - **WS-D** `curl|sh` installer + "next steps" output + graduated `env uninstall`.
- **`specs/REFACTOR-STATUS.md`** / **`specs/SPRINT.md`** — Plan 181 rollup entry + Sprint 61 (proposed).

## Boundary

Per ADR-070 / Plan 33, multi-tenant **transport + tenant auth stay in mvmd**; mvm ships only the bridgeable primitives plus a single-machine `localhost` dev ingress (same scope `mvmctl dev` already occupies). Same split Plan 170 drew for density.

## Claim safety

No claim regresses: preview ports are signed + audited (not ambient), only published ports are routable, default-deny egress + gateway mediation unchanged, wake reuses warm-start. Spec-only — no test/CI impact; `xtask check-spec-numbers` clean (ADR-079 / Plan 181 unique).