### PR TITLE
feat(secrets): admission carriage — redaction policy plan→backend→endpoint→service (plan 129 E1)

### DIFF
--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -2432,8 +2432,13 @@ fn resolve_fc_bridge_path() -> Result<std::path::PathBuf> {
 #[cfg(target_os = "linux")]
 fn decode_plan_secrets(
     state_dir: &std::path::Path,
-) -> Result<Option<(Vec<mvm_core::plan::SecretBinding>, mvm_core::policy::RedactionPolicy, String)>>
-{
+) -> Result<
+    Option<(
+        Vec<mvm_core::plan::SecretBinding>,
+        mvm_core::policy::RedactionPolicy,
+        String,
+    )>,
+> {
     let plan_path = state_dir.join("plan.json");
     let plan_json = match std::fs::read_to_string(&plan_path) {
         Ok(s) => s,

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -2432,7 +2432,8 @@ fn resolve_fc_bridge_path() -> Result<std::path::PathBuf> {
 #[cfg(target_os = "linux")]
 fn decode_plan_secrets(
     state_dir: &std::path::Path,
-) -> Result<Option<(Vec<mvm_core::plan::SecretBinding>, String)>> {
+) -> Result<Option<(Vec<mvm_core::plan::SecretBinding>, mvm_core::policy::RedactionPolicy, String)>>
+{
     let plan_path = state_dir.join("plan.json");
     let plan_json = match std::fs::read_to_string(&plan_path) {
         Ok(s) => s,
@@ -2454,9 +2455,12 @@ fn decode_plan_secrets(
     if secrets.is_empty() {
         return Ok(None);
     }
+    // Per-destination redaction rides the same signed plan; a parse hiccup
+    // defaults to all-off rather than failing the boot.
+    let redaction = mvm_core::plan::redaction_from_signed_json(&plan_json).unwrap_or_default();
     let tenant = mvm_core::plan::tenant_from_signed_json(&plan_json)
         .map_err(|e| anyhow::anyhow!("extract tenant from plan.json: {e}"))?;
-    Ok(Some((secrets, tenant)))
+    Ok(Some((secrets, redaction, tenant)))
 }
 
 /// Plan 129 Stage 2 (Approach A) — spawn the per-VM substitution endpoint
@@ -2475,7 +2479,7 @@ fn spawn_egress_endpoint(config: &FlakeRunConfig) -> Result<EndpointGuard> {
 
     let name = &config.slot.name;
     let state_dir = mvm_core::config::vm_state_dir(name);
-    let Some((secrets, tenant)) = decode_plan_secrets(&state_dir)? else {
+    let Some((secrets, redaction, tenant)) = decode_plan_secrets(&state_dir)? else {
         return Ok(EndpointGuard { vm_name: None });
     };
 
@@ -2493,6 +2497,7 @@ fn spawn_egress_endpoint(config: &FlakeRunConfig) -> Result<EndpointGuard> {
         &state_dir,
         &tenant,
         &secrets,
+        &redaction,
         Some(listen),
         tls_intermediate,
     )?;

--- a/crates/mvm-backend/src/qemu.rs
+++ b/crates/mvm-backend/src/qemu.rs
@@ -245,6 +245,11 @@ impl VmBackend for QemuBackend {
         {
             match mvm_core::plan::secrets_from_signed_json(plan_json) {
                 Ok(secrets) if !secrets.is_empty() => {
+                    // Per-destination redaction rides the same signed plan; a
+                    // parse hiccup defaults to all-off rather than failing the
+                    // boot (secrets already gate that).
+                    let redaction =
+                        mvm_core::plan::redaction_from_signed_json(plan_json).unwrap_or_default();
                     // QEMU is slirp (no host TAP) — no transparent terminator
                     // to install, so `terminator_listen: None`. The vsock
                     // substitution channel alone is unchanged from before 5B.
@@ -253,6 +258,7 @@ impl VmBackend for QemuBackend {
                         &state_dir,
                         tenant,
                         &secrets,
+                        &redaction,
                         None,
                         // No transparent terminator on slirp ⇒ no TLS leg, so no
                         // per-VM intermediate (https termination is FC-scoped).

--- a/crates/mvm-backend/src/substitution_spawn.rs
+++ b/crates/mvm-backend/src/substitution_spawn.rs
@@ -137,6 +137,7 @@ pub fn spawn_substitution_endpoint(
     state_dir: &Path,
     tenant: &str,
     secrets: &[SecretBinding],
+    redaction: &mvm_core::policy::RedactionPolicy,
     terminator_listen: Option<SocketAddr>,
     tls_intermediate: Option<(String, String)>,
 ) -> Result<()> {
@@ -146,6 +147,10 @@ pub fn spawn_substitution_endpoint(
     let mut cfg = serde_json::json!({
         "tenant_id": tenant,
         "secrets": secrets,
+        // Per-destination redaction policy from the signed plan; the endpoint
+        // applies it to the cleartext it forwards. Default (all-off) is harmless.
+        "redaction": serde_json::to_value(redaction)
+            .expect("RedactionPolicy serializes to JSON"),
         "transport": { "kind": "vsock", "port": mvm_guest::vsock::SUBSTITUTION_PORT },
     });
     if let Some(addr) = terminator_listen {

--- a/crates/mvm-cli/src/commands/vm/plan_builder.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_builder.rs
@@ -226,6 +226,7 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
         fs_policy,
         secrets: input.secrets.clone(),
         egress_policy,
+        redaction: Default::default(),
         tool_policy,
         artifact_policy: ArtifactPolicy {
             capture_paths: Vec::new(),

--- a/crates/mvm-cli/src/commands/vm/policy_resolver.rs
+++ b/crates/mvm-cli/src/commands/vm/policy_resolver.rs
@@ -638,6 +638,7 @@ mod tests {
             fs_policy: FsPolicyRef(LOCAL_DEFAULT.to_string()),
             secrets: Vec::new(),
             egress_policy: PolicyRef(LOCAL_DEFAULT.to_string()),
+            redaction: Default::default(),
             tool_policy: PolicyRef(LOCAL_DEFAULT.to_string()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: Vec::new(),

--- a/crates/mvm-core/src/plan/execution_plan.rs
+++ b/crates/mvm-core/src/plan/execution_plan.rs
@@ -55,7 +55,7 @@ pub const SCHEMA_VERSION: u32 = 5;
 /// in `mvm/src/enforce.rs` (Wave 1.5) walks the plan
 /// field-by-field and rejects any plan that doesn't satisfy
 /// the corresponding §5 row.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExecutionPlan {
     /// Wire-format version. See [`SCHEMA_VERSION`].
@@ -105,6 +105,13 @@ pub struct ExecutionPlan {
     /// but kept separate here so an audit entry can show "egress
     /// allowed, pii redacted" as orthogonal facts.
     pub egress_policy: PolicyRef,
+
+    /// Per-destination egress redaction policy. Rides inline in the signed plan
+    /// — like `secrets` — so the per-VM substitution endpoint gets it at spawn
+    /// without resolving the bundle. Default = the all-off curated baseline (no
+    /// per-destination entropy/name redaction).
+    #[serde(default)]
+    pub redaction: crate::policy::RedactionPolicy,
 
     /// Tool-call policy (which tools the model is allowed to invoke
     /// over the supervisor's vsock RPC). Wave 2.

--- a/crates/mvm-core/src/plan/mod.rs
+++ b/crates/mvm-core/src/plan/mod.rs
@@ -42,8 +42,8 @@ pub use bundle::{
 };
 pub use execution_plan::{ExecutionPlan, SCHEMA_VERSION};
 pub use signing::{
-    PlanVerifyError, SignedExecutionPlan, secrets_from_signed_json, sign_plan,
-    tenant_from_signed_json, verify_plan,
+    PlanVerifyError, SignedExecutionPlan, redaction_from_signed_json, secrets_from_signed_json,
+    sign_plan, tenant_from_signed_json, verify_plan,
 };
 pub use types::{
     AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, AuditTaxonomy,

--- a/crates/mvm-core/src/plan/signing.rs
+++ b/crates/mvm-core/src/plan/signing.rs
@@ -80,6 +80,17 @@ pub fn secrets_from_signed_json(plan_json: &str) -> Result<Vec<SecretBinding>, s
     Ok(plan.secrets)
 }
 
+/// Extract the per-destination redaction policy from a signed plan's payload,
+/// without verifying the signature — the caller (backend endpoint spawn) has
+/// already admitted the plan; this just reads the field the endpoint needs.
+pub fn redaction_from_signed_json(
+    plan_json: &str,
+) -> Result<crate::policy::RedactionPolicy, serde_json::Error> {
+    let signed: SignedExecutionPlan = serde_json::from_str(plan_json)?;
+    let plan: ExecutionPlan = serde_json::from_slice(&signed.0.payload)?;
+    Ok(plan.redaction)
+}
+
 /// Extract the `tenant` id from a serialised `SignedExecutionPlan` envelope.
 ///
 /// The Firecracker launch path (Plan 129 Task 5B) reads the admitted plan from
@@ -197,6 +208,7 @@ pub mod test_support {
             fs_policy: FsPolicyRef("default".to_string()),
             secrets: vec![],
             egress_policy: PolicyRef("agent-l7".to_string()),
+            redaction: crate::policy::RedactionPolicy::default(),
             tool_policy: PolicyRef("read-only-tools".to_string()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: vec!["/artifacts".to_string()],
@@ -273,6 +285,43 @@ mod tests {
             &secrets[0].source,
             SecretSource::Keystore { address } if address == "openai"
         ));
+    }
+
+    #[test]
+    fn redaction_extracted_from_signed_envelope() {
+        use crate::policy::{EntropyMode, RedactionAction, RedactionPolicy, RedactionProfile};
+        let mut plan = sample_plan();
+        plan.redaction = RedactionPolicy {
+            default: RedactionAction::default(),
+            profiles: vec![RedactionProfile {
+                host: "*.untrusted.example".to_string(),
+                action: RedactionAction {
+                    entropy: EntropyMode::Redact {
+                        min_bits_per_char: 4.0,
+                        min_run_len: 20,
+                    },
+                    ..Default::default()
+                },
+            }],
+        };
+        let (sk, _vk) = fresh_key();
+        let signed = sign_plan(&plan, &sk, "test-signer");
+        let json = serde_json::to_string(&signed).unwrap();
+        let recovered = redaction_from_signed_json(&json).unwrap();
+        assert_eq!(recovered, plan.redaction);
+        assert_eq!(recovered.profiles.len(), 1);
+        assert_eq!(recovered.profiles[0].host, "*.untrusted.example");
+    }
+
+    #[test]
+    fn plan_without_redaction_field_defaults_to_all_off() {
+        // A plan JSON missing `redaction` must deserialize via #[serde(default)].
+        let plan = sample_plan();
+        let mut value = serde_json::to_value(&plan).unwrap();
+        value.as_object_mut().unwrap().remove("redaction");
+        assert!(value.get("redaction").is_none());
+        let parsed: ExecutionPlan = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.redaction, crate::policy::RedactionPolicy::default());
     }
 
     #[test]

--- a/crates/mvm-core/src/policy/bundle.rs
+++ b/crates/mvm-core/src/policy/bundle.rs
@@ -24,7 +24,7 @@ pub struct PolicyId(pub String);
 
 /// A bundle of every policy a workload boots under. Resolved from a
 /// `PolicyRef` on `ExecutionPlan`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PolicyBundle {
     pub schema_version: u32,
@@ -49,7 +49,7 @@ pub struct PolicyBundle {
 
 /// Per-tenant overlay. Each field is optional — `None` means
 /// "inherit from the bundle base"; `Some(_)` overrides.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TenantOverlay {
     pub network: Option<NetworkPolicy>,

--- a/crates/mvm-core/src/policy/policies.rs
+++ b/crates/mvm-core/src/policy/policies.rs
@@ -135,7 +135,7 @@ pub struct L4RuleSpec {
 /// supervisor honours `mode = Some("open")` as a kill-switch that
 /// skips the proxy entirely. New fields are `#[serde(default)]` so
 /// older bundles continue to parse.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EgressPolicy {
     /// `open` — no proxy. Anything else routes through the L7 chain.
@@ -160,6 +160,10 @@ pub struct EgressPolicy {
     /// `pii_redactor`.
     #[serde(default)]
     pub disabled_inspectors: Vec<String>,
+    /// Per-destination egress redaction. Synthesized into the signed
+    /// `ExecutionPlan.redaction` at admission. Default = all-off.
+    #[serde(default)]
+    pub redaction: crate::policy::RedactionPolicy,
 }
 
 /// Default body cap when `EgressPolicy::body_cap_bytes` is 0.

--- a/crates/mvm-core/src/policy/redaction.rs
+++ b/crates/mvm-core/src/policy/redaction.rs
@@ -53,16 +53,12 @@ pub enum SecretAction {
 #[serde(deny_unknown_fields, default)]
 pub struct RedactionAction {
     pub entropy: EntropyMode,
-    /// RESERVED — parsed and resolved but not yet consumed by the redactor,
-    /// which currently applies the always-on structured-PII ruleset regardless
-    /// of this value. Per-destination PII mode/categories interact with that
-    /// always-on pass and need their own semantic pass before this knob takes
-    /// effect; until then a value here has no runtime effect.
+    /// Structured PII for this destination. Default (empty) runs the always-on
+    /// ruleset; `mode = "disabled"` skips PII here; a category list restricts it.
     pub pii: PiiPolicy,
     pub names: NameMode,
-    /// RESERVED — parsed and resolved but not yet consumed; curated secrets are
-    /// always masked (Block-equivalent) regardless of this value. Wiring it is a
-    /// tracked follow-up.
+    /// Curated-secret disposition for this destination. Default `Block` masks;
+    /// `Audit` observes a trusted sink without masking.
     pub secrets: SecretAction,
 }
 

--- a/crates/mvm-core/src/policy/resolver.rs
+++ b/crates/mvm-core/src/policy/resolver.rs
@@ -83,7 +83,7 @@ impl EmergencyDeny {
 ///
 /// The supervisor consumes this; `mvmctl plan inspect <plan>` can
 /// also print it for operator review.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EffectivePolicy {
     pub network: NetworkPolicy,
@@ -161,6 +161,7 @@ mod tests {
                 allow_plain_http: false,
                 body_cap_bytes: 0,
                 disabled_inspectors: vec![],
+                redaction: crate::policy::RedactionPolicy::default(),
             },
             pii: PiiPolicy {
                 mode: Some("detect".to_string()),

--- a/crates/mvm-core/tests/replay_protection.rs
+++ b/crates/mvm-core/tests/replay_protection.rs
@@ -42,6 +42,7 @@ fn fixture_plan(nonce: [u8; 16]) -> ExecutionPlan {
         fs_policy: FsPolicyRef("none".to_string()),
         secrets: vec![],
         egress_policy: PolicyRef("none".to_string()),
+        redaction: Default::default(),
         tool_policy: PolicyRef("none".to_string()),
         artifact_policy: ArtifactPolicy {
             capture_paths: vec![],

--- a/crates/mvm-hostd/src/audit/bind.rs
+++ b/crates/mvm-hostd/src/audit/bind.rs
@@ -103,6 +103,7 @@ mod tests {
             fs_policy: FsPolicyRef("local-default".to_string()),
             secrets: Vec::new(),
             egress_policy: PolicyRef("local-default".to_string()),
+            redaction: Default::default(),
             tool_policy: PolicyRef("local-default".to_string()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: Vec::new(),

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -363,6 +363,7 @@ mod tests {
             fs_policy: FsPolicyRef("local-default".to_string()),
             secrets: Vec::new(),
             egress_policy: PolicyRef("local-default".to_string()),
+            redaction: Default::default(),
             tool_policy: PolicyRef("local-default".to_string()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: Vec::new(),

--- a/crates/mvm-hostd/src/audit/host_keypair.rs
+++ b/crates/mvm-hostd/src/audit/host_keypair.rs
@@ -379,6 +379,7 @@ mod tests {
             fs_policy: FsPolicyRef("local-default".to_string()),
             secrets: Vec::new(),
             egress_policy: PolicyRef("local-default".to_string()),
+            redaction: Default::default(),
             tool_policy: PolicyRef("local-default".to_string()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: Vec::new(),

--- a/crates/mvm-hostd/src/audit/plan_persist.rs
+++ b/crates/mvm-hostd/src/audit/plan_persist.rs
@@ -153,6 +153,7 @@ mod tests {
             fs_policy: FsPolicyRef("local-default".to_string()),
             secrets: Vec::new(),
             egress_policy: PolicyRef("local-default".to_string()),
+            redaction: Default::default(),
             tool_policy: PolicyRef("local-default".to_string()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: Vec::new(),

--- a/crates/mvm-hostd/src/supervisor/aggregate.rs
+++ b/crates/mvm-hostd/src/supervisor/aggregate.rs
@@ -1200,6 +1200,7 @@ mod tests {
             fs_policy: FsPolicyRef("default".to_string()),
             secrets: vec![],
             egress_policy: PolicyRef("agent-l7".to_string()),
+            redaction: Default::default(),
             tool_policy: PolicyRef("read-only".to_string()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: vec!["/artifacts".to_string()],
@@ -1899,6 +1900,7 @@ mod tests {
             allow_plain_http,
             body_cap_bytes: 0,
             disabled_inspectors: vec![],
+            redaction: Default::default(),
         }
     }
 

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -342,6 +342,7 @@ mod tests {
             fs_policy: FsPolicyRef("f".to_string()),
             secrets: vec![],
             egress_policy: PolicyRef("e".to_string()),
+            redaction: Default::default(),
             tool_policy: PolicyRef("t".to_string()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: vec![],

--- a/crates/mvm-hostd/src/supervisor/audit_recorder.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_recorder.rs
@@ -375,6 +375,7 @@ mod tests {
             fs_policy: FsPolicyRef("local-default".to_string()),
             secrets: Vec::new(),
             egress_policy: PolicyRef("local-default".to_string()),
+            redaction: Default::default(),
             tool_policy: PolicyRef("local-default".to_string()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: Vec::new(),

--- a/crates/mvm-hostd/src/supervisor/backend.rs
+++ b/crates/mvm-hostd/src/supervisor/backend.rs
@@ -251,6 +251,7 @@ mod tests {
             fs_policy: mvm_core::plan::FsPolicyRef("default".to_string()),
             secrets: vec![],
             egress_policy: mvm_core::plan::PolicyRef("agent-l7".to_string()),
+            redaction: Default::default(),
             tool_policy: mvm_core::plan::PolicyRef("read-only".to_string()),
             artifact_policy: mvm_core::plan::ArtifactPolicy {
                 capture_paths: vec!["/artifacts".to_string()],

--- a/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
+++ b/crates/mvm-hostd/src/supervisor/gateway_bridge.rs
@@ -3177,6 +3177,7 @@ mod tests {
             fs_policy: FsPolicyRef("local-default".into()),
             secrets: Vec::new(),
             egress_policy: PolicyRef("local-default".into()),
+            redaction: Default::default(),
             tool_policy: PolicyRef("local-default".into()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: vec![],

--- a/crates/mvm-hostd/src/supervisor/lifecycle_hooks.rs
+++ b/crates/mvm-hostd/src/supervisor/lifecycle_hooks.rs
@@ -326,6 +326,7 @@ mod tests {
             fs_policy: FsPolicyRef("local-default".to_string()),
             secrets: Vec::new(),
             egress_policy: PolicyRef("local-default".to_string()),
+            redaction: Default::default(),
             tool_policy: PolicyRef("local-default".to_string()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: Vec::new(),

--- a/crates/mvm-hostd/src/supervisor/network/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/network/mod.rs
@@ -926,6 +926,7 @@ mod tests {
             fs_policy: FsPolicyRef("local-default".into()),
             secrets: Vec::new(),
             egress_policy: PolicyRef("local-default".into()),
+            redaction: Default::default(),
             tool_policy: PolicyRef("local-default".into()),
             artifact_policy: ArtifactPolicy {
                 capture_paths: vec![],

--- a/crates/mvm-hostd/src/supervisor/network/stages.rs
+++ b/crates/mvm-hostd/src/supervisor/network/stages.rs
@@ -155,11 +155,40 @@ impl RedactingSubstitution {
     ) -> Option<(Vec<u8>, RedactionHits)> {
         use crate::supervisor::entropy_scanner::EntropyScanner;
         use crate::supervisor::name_scanner::NameScanner;
-        use mvm_core::policy::{EntropyMode, NameMode};
+        use crate::supervisor::pii_redactor::PiiRedactor;
+        use mvm_core::policy::{EntropyMode, NameMode, SecretAction};
 
-        let (after_secrets, secrets) = self.secrets.redact(payload, REDACTION_MASK);
-        let (after_pii, pii) = self.pii.redact(&after_secrets);
-        let mut buf = after_pii;
+        // Curated secrets: default Block masks (today's behavior); a per-destination
+        // Audit downgrade observes a trusted sink without masking.
+        let (mut buf, secrets) = match action.secrets {
+            SecretAction::Block | SecretAction::Redact => self.secrets.redact(payload, REDACTION_MASK),
+            SecretAction::Audit => (payload.to_vec(), self.secrets.scan(payload)),
+        };
+
+        // Structured PII: a default (empty) action runs the always-on ruleset;
+        // an explicit per-destination policy overrides — `disabled` skips it, a
+        // category list restricts it. A malformed policy fails safe to always-on.
+        let pii_is_default = action.pii.mode.is_none() && action.pii.categories.is_empty();
+        let pii = if pii_is_default {
+            let (out, p) = self.pii.redact(&buf);
+            buf = out;
+            p
+        } else {
+            match PiiRedactor::from_policy(&action.pii) {
+                Ok(None) => Vec::new(),
+                Ok(Some(r)) => {
+                    let (out, p) = r.redact(&buf);
+                    buf = out;
+                    p
+                }
+                Err(_) => {
+                    let (out, p) = self.pii.redact(&buf);
+                    buf = out;
+                    p
+                }
+            }
+        };
+
         let mut hits = RedactionHits {
             secrets,
             pii,
@@ -655,6 +684,64 @@ mod tests {
         let (out, hits) = r.redact_bytes_for(body, &on).expect("entropy hit");
         assert_eq!(hits.entropy, 1);
         assert!(!String::from_utf8_lossy(&out).contains("Xa9Kf2pQ7vL0mZ3rT8wB1nC4yH6dJ5sG2eU0iO9"));
+    }
+
+    #[test]
+    fn default_action_still_masks_email_and_curated_secrets() {
+        // Regression guard: a default (no-profile) action preserves today's
+        // always-on behavior — structured PII + curated secrets are masked.
+        use mvm_core::policy::RedactionAction;
+        let r = RedactingSubstitution::with_default_rules();
+        let body = b"contact alice@example.com key AKIAIOSFODNN7EXAMPLE end";
+        let (out, hits) = r
+            .redact_bytes_for(body, &RedactionAction::default())
+            .expect("default masks pii+secrets");
+        let s = String::from_utf8_lossy(&out);
+        assert!(!s.contains("alice@example.com"), "email not masked: {s}");
+        assert!(!s.contains("AKIAIOSFODNN7EXAMPLE"), "secret not masked: {s}");
+        assert!(hits.pii.contains(&"email"));
+        assert!(!hits.secrets.is_empty());
+    }
+
+    #[test]
+    fn pii_disabled_for_destination_leaves_email() {
+        // A trusted sink can disable PII masking; the email survives while a
+        // default destination would mask it.
+        use mvm_core::policy::{PiiPolicy, RedactionAction};
+        let r = RedactingSubstitution::with_default_rules();
+        let body = b"contact alice@example.com end";
+        let action = RedactionAction {
+            pii: PiiPolicy {
+                mode: Some("disabled".into()),
+                categories: vec![],
+            },
+            ..Default::default()
+        };
+        // Nothing else opts in, so the whole pass is a no-op → None.
+        assert!(
+            r.redact_bytes_for(body, &action).is_none(),
+            "pii=disabled should leave the email and mask nothing"
+        );
+    }
+
+    #[test]
+    fn secrets_audit_counts_without_masking() {
+        // A per-destination secrets=audit downgrade observes but does not mask.
+        use mvm_core::policy::{RedactionAction, SecretAction};
+        let r = RedactingSubstitution::with_default_rules();
+        let body = b"key AKIAIOSFODNN7EXAMPLE end";
+        let action = RedactionAction {
+            secrets: SecretAction::Audit,
+            ..Default::default()
+        };
+        let (out, hits) = r
+            .redact_bytes_for(body, &action)
+            .expect("audit still reports the hit");
+        assert!(
+            String::from_utf8_lossy(&out).contains("AKIAIOSFODNN7EXAMPLE"),
+            "audit mode must not mask the secret"
+        );
+        assert!(!hits.secrets.is_empty(), "audit mode must still count the hit");
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/network/stages.rs
+++ b/crates/mvm-hostd/src/supervisor/network/stages.rs
@@ -161,7 +161,9 @@ impl RedactingSubstitution {
         // Curated secrets: default Block masks (today's behavior); a per-destination
         // Audit downgrade observes a trusted sink without masking.
         let (mut buf, secrets) = match action.secrets {
-            SecretAction::Block | SecretAction::Redact => self.secrets.redact(payload, REDACTION_MASK),
+            SecretAction::Block | SecretAction::Redact => {
+                self.secrets.redact(payload, REDACTION_MASK)
+            }
             SecretAction::Audit => (payload.to_vec(), self.secrets.scan(payload)),
         };
 
@@ -698,7 +700,10 @@ mod tests {
             .expect("default masks pii+secrets");
         let s = String::from_utf8_lossy(&out);
         assert!(!s.contains("alice@example.com"), "email not masked: {s}");
-        assert!(!s.contains("AKIAIOSFODNN7EXAMPLE"), "secret not masked: {s}");
+        assert!(
+            !s.contains("AKIAIOSFODNN7EXAMPLE"),
+            "secret not masked: {s}"
+        );
         assert!(hits.pii.contains(&"email"));
         assert!(!hits.secrets.is_empty());
     }
@@ -741,7 +746,10 @@ mod tests {
             String::from_utf8_lossy(&out).contains("AKIAIOSFODNN7EXAMPLE"),
             "audit mode must not mask the secret"
         );
-        assert!(!hits.secrets.is_empty(), "audit mode must still count the hit");
+        assert!(
+            !hits.secrets.is_empty(),
+            "audit mode must still count the hit"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
@@ -72,7 +72,7 @@ impl std::fmt::Debug for TlsIntermediate {
 /// Config the backend hands the `mvm-substitution-endpoint` subprocess on
 /// stdin at spawn. Carries the workload's secret bindings (NOT values — the
 /// endpoint resolves values itself from the host store) plus where to listen.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EndpointConfig {
     /// Tenant the workload belongs to — the store lookup key.
@@ -83,6 +83,11 @@ pub struct EndpointConfig {
     pub secrets: Vec<SecretBinding>,
     /// The guest→host transport to listen on.
     pub transport: EndpointTransport,
+    /// Per-destination egress redaction policy, carried from the signed
+    /// `ExecutionPlan.redaction`. Default (all-off) preserves the curated-only
+    /// baseline; a profile opts a destination into entropy/name redaction.
+    #[serde(default)]
+    pub redaction: mvm_core::policy::RedactionPolicy,
     /// Forward-leg (host → destination) timeout, seconds.
     #[serde(default = "default_forward_timeout_secs")]
     pub forward_timeout_secs: u64,
@@ -151,6 +156,7 @@ pub fn assemble(
         &bindings,
         secret_store,
         cfg.forward_timeout_secs,
+        cfg.redaction.clone(),
         tls_intermediate,
     )?;
     Ok((service, handed))
@@ -170,6 +176,7 @@ mod tests {
             tenant_id: "local".into(),
             secrets,
             transport: EndpointTransport::Vsock { port: 5253 },
+            redaction: mvm_core::policy::RedactionPolicy::default(),
             forward_timeout_secs: 30,
             secret_store_dir: Some(dir.join("secrets")),
             binding_store_dir: Some(dir.join("bindings")),
@@ -242,6 +249,97 @@ mod tests {
         });
         let cfg = parse(&serde_json::to_vec(&json).unwrap()).unwrap();
         assert!(cfg.tls_intermediate.is_none());
+    }
+
+    #[test]
+    fn config_defaults_redaction_to_all_off_when_omitted() {
+        // A config without a `redaction` block parses (field is
+        // `#[serde(default)]`) and defaults to the curated-only baseline.
+        let json = serde_json::json!({
+            "tenant_id": "local",
+            "secrets": [],
+            "transport": {"kind": "uds", "path": "/tmp/sub.sock"},
+        });
+        let cfg = parse(&serde_json::to_vec(&json).unwrap()).unwrap();
+        assert_eq!(cfg.redaction, mvm_core::policy::RedactionPolicy::default());
+    }
+
+    #[test]
+    fn config_redaction_block_roundtrips_and_reaches_the_service() {
+        use mvm_core::policy::{EntropyMode, RedactionAction, RedactionProfile};
+
+        let dir = tempdir().unwrap();
+        FileBindingStore::with_dir(dir.path().join("bindings"))
+            .put(
+                "local",
+                "openai",
+                &SecretBindingMeta {
+                    auth_type: AuthType::Bearer,
+                    allowed_hosts: vec!["api.openai.com".into()],
+                },
+            )
+            .unwrap();
+        FileSecretStore::with_dir(dir.path().join("secrets"))
+            .put(
+                "local",
+                "openai",
+                &SecretBox::new(Box::new("sk-live".to_string())),
+            )
+            .unwrap();
+
+        let mut cfg = vsock_cfg(
+            vec![SecretBinding {
+                name: "OPENAI_API_KEY".into(),
+                source: SecretSource::Keystore {
+                    address: "openai".into(),
+                },
+            }],
+            dir.path(),
+        );
+        cfg.redaction.profiles.push(RedactionProfile {
+            host: "api.openai.com".into(),
+            action: RedactionAction {
+                entropy: EntropyMode::Redact {
+                    min_bits_per_char: 4.0,
+                    min_run_len: 20,
+                },
+                ..Default::default()
+            },
+        });
+
+        // The block survives serde (the wire form the backend writes on stdin).
+        let bytes = serde_json::to_vec(&cfg).unwrap();
+        assert_eq!(parse(&bytes).unwrap(), cfg);
+
+        // And the assembled service carries it: the entropy opt-in for the bound
+        // host actually fires on an entropic token (the default would not).
+        let (service, _handed) = assemble(&cfg).unwrap();
+        let token = "Xa9Kf2pQ7vL0mZ3rT8wB1nC4yH6dJ5sG2eU0iO9";
+        let body = format!("k={token} e").into_bytes();
+        let action = crate::supervisor::redaction_resolve::resolve(
+            // SAFETY: assemble built the service from cfg.redaction; we re-resolve
+            // the same policy here to assert the opt-in took effect end-to-end.
+            &cfg.redaction,
+            "api.openai.com",
+        );
+        let out = service_redact(&service, &body, action);
+        assert!(
+            !String::from_utf8_lossy(&out).contains(token),
+            "entropy opt-in from EndpointConfig.redaction did not fire"
+        );
+    }
+
+    /// Drive the service's redactor for a destination action — small helper so the
+    /// roundtrip test asserts the policy *fires*, not just that it round-trips.
+    fn service_redact(
+        service: &SubstitutionService,
+        body: &[u8],
+        action: &mvm_core::policy::RedactionAction,
+    ) -> Vec<u8> {
+        service
+            .redactor_redact_bytes_for(body, action)
+            .map(|(out, _)| out)
+            .unwrap_or_else(|| body.to_vec())
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -312,6 +312,27 @@ impl SubstitutionService {
         self
     }
 
+    /// The attached redaction policy. Test-only: lets the threading tests prove
+    /// a policy carried through `from_plan` actually reached the service.
+    #[cfg(test)]
+    pub(crate) fn redaction_policy(&self) -> &mvm_core::policy::RedactionPolicy {
+        &self.redaction_policy
+    }
+
+    /// Run the service's redactor for a destination action. Test-only seam so the
+    /// endpoint-config tests can prove the threaded policy fires end-to-end.
+    #[cfg(test)]
+    pub(crate) fn redactor_redact_bytes_for(
+        &self,
+        payload: &[u8],
+        action: &mvm_core::policy::RedactionAction,
+    ) -> Option<(
+        Vec<u8>,
+        crate::supervisor::network::stages::RedactionHits,
+    )> {
+        self.redactor.redact_bytes_for(payload, action)
+    }
+
     /// Attach a chain-signed audit recorder; each substitution then emits a
     /// `secret.substituted` entry (metadata only — claim 13).
     pub fn with_recorder(mut self, recorder: Recorder) -> Self {
@@ -341,12 +362,14 @@ impl SubstitutionService {
         bindings: &dyn BindingStore,
         secret_store: Arc<dyn SecretStore>,
         forward_timeout_secs: u64,
+        redaction: mvm_core::policy::RedactionPolicy,
         tls_intermediate: Option<mvm_core::crypto::egress_ca::VmIntermediate>,
     ) -> Result<(Arc<Self>, HandedPlaceholders), FromPlanError> {
         let (registry, handed) = assemble_registry(plan_secrets, tenant, bindings)?;
         let resolver: Arc<dyn SecretResolver> = Arc::new(LocalResolver::new(tenant, secret_store));
         let forwarder: Arc<dyn Forwarder> = Arc::new(ReqwestForwarder::new(forward_timeout_secs)?);
         let mut service = Self::new(Arc::new(registry), resolver, forwarder);
+        service = service.with_redaction_policy(redaction);
         if let Some(intermediate) = tls_intermediate {
             service = service.with_tls_intermediate(intermediate);
         }
@@ -1405,12 +1428,87 @@ mod server_tests {
                 address: "openai".into(),
             },
         }];
-        let (_service, handed) =
-            SubstitutionService::from_plan(&plan, "local", &bindings, secret_store, 30, None)
-                .unwrap();
+        let (_service, handed) = SubstitutionService::from_plan(
+            &plan,
+            "local",
+            &bindings,
+            secret_store,
+            30,
+            mvm_core::policy::RedactionPolicy::default(),
+            None,
+        )
+        .unwrap();
         assert_eq!(handed.len(), 1);
         assert_eq!(handed[0].0, "OPENAI_API_KEY");
         assert!(handed[0].1.as_str().starts_with("mvm-secret-"));
+    }
+
+    #[test]
+    fn from_plan_threads_redaction_policy_onto_the_service() {
+        use crate::keyholder::{FileBindingStore, SecretBindingMeta};
+        use mvm_core::policy::{
+            EntropyMode, RedactionAction, RedactionPolicy, RedactionProfile,
+        };
+        use mvm_core::plan::{SecretBinding, SecretSource};
+
+        let dir = tempdir().unwrap();
+        let bindings = FileBindingStore::with_dir(dir.path().join("bindings"));
+        bindings
+            .put(
+                "local",
+                "openai",
+                &SecretBindingMeta {
+                    auth_type: AuthType::Bearer,
+                    allowed_hosts: vec!["api.openai.com".into()],
+                },
+            )
+            .unwrap();
+        let store = FileSecretStore::with_dir(dir.path().join("secrets"));
+        store
+            .put("local", "openai", &SecretBox::new(Box::new("sk".to_string())))
+            .unwrap();
+        let secret_store: Arc<dyn SecretStore> = Arc::new(store);
+
+        let plan = [SecretBinding {
+            name: "OPENAI_API_KEY".into(),
+            source: SecretSource::Keystore {
+                address: "openai".into(),
+            },
+        }];
+
+        // A policy that opts api.openai.com into entropy redaction. After
+        // from_plan, resolving that host must yield the opted-in action — proving
+        // the policy reached the live service (not just defaulted).
+        let policy = RedactionPolicy {
+            default: RedactionAction::default(),
+            profiles: vec![RedactionProfile {
+                host: "api.openai.com".into(),
+                action: RedactionAction {
+                    entropy: EntropyMode::Redact {
+                        min_bits_per_char: 4.0,
+                        min_run_len: 20,
+                    },
+                    ..Default::default()
+                },
+            }],
+        };
+        let (service, _handed) = SubstitutionService::from_plan(
+            &plan,
+            "local",
+            &bindings,
+            secret_store,
+            30,
+            policy,
+            None,
+        )
+        .unwrap();
+        let resolved =
+            crate::supervisor::redaction_resolve::resolve(service.redaction_policy(), "api.openai.com");
+        assert!(
+            matches!(resolved.entropy, EntropyMode::Redact { .. }),
+            "redaction policy did not reach the service: {:?}",
+            resolved.entropy
+        );
     }
 
     #[tokio::test]

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -326,10 +326,7 @@ impl SubstitutionService {
         &self,
         payload: &[u8],
         action: &mvm_core::policy::RedactionAction,
-    ) -> Option<(
-        Vec<u8>,
-        crate::supervisor::network::stages::RedactionHits,
-    )> {
+    ) -> Option<(Vec<u8>, crate::supervisor::network::stages::RedactionHits)> {
         self.redactor.redact_bytes_for(payload, action)
     }
 
@@ -1446,10 +1443,8 @@ mod server_tests {
     #[test]
     fn from_plan_threads_redaction_policy_onto_the_service() {
         use crate::keyholder::{FileBindingStore, SecretBindingMeta};
-        use mvm_core::policy::{
-            EntropyMode, RedactionAction, RedactionPolicy, RedactionProfile,
-        };
         use mvm_core::plan::{SecretBinding, SecretSource};
+        use mvm_core::policy::{EntropyMode, RedactionAction, RedactionPolicy, RedactionProfile};
 
         let dir = tempdir().unwrap();
         let bindings = FileBindingStore::with_dir(dir.path().join("bindings"));
@@ -1465,7 +1460,11 @@ mod server_tests {
             .unwrap();
         let store = FileSecretStore::with_dir(dir.path().join("secrets"));
         store
-            .put("local", "openai", &SecretBox::new(Box::new("sk".to_string())))
+            .put(
+                "local",
+                "openai",
+                &SecretBox::new(Box::new("sk".to_string())),
+            )
             .unwrap();
         let secret_store: Arc<dyn SecretStore> = Arc::new(store);
 
@@ -1502,8 +1501,10 @@ mod server_tests {
             None,
         )
         .unwrap();
-        let resolved =
-            crate::supervisor::redaction_resolve::resolve(service.redaction_policy(), "api.openai.com");
+        let resolved = crate::supervisor::redaction_resolve::resolve(
+            service.redaction_policy(),
+            "api.openai.com",
+        );
         assert!(
             matches!(resolved.entropy, EntropyMode::Redact { .. }),
             "redaction policy did not reach the service: {:?}",

--- a/crates/mvm-hostd/tests/substitution_endpoint_bin.rs
+++ b/crates/mvm-hostd/tests/substitution_endpoint_bin.rs
@@ -80,6 +80,7 @@ fn endpoint_bin_serves_substitution_and_refuses_unbound_destination() {
             },
         }],
         transport: EndpointTransport::Uds { path: sock.clone() },
+        redaction: mvm_core::policy::RedactionPolicy::default(),
         forward_timeout_secs: 30,
         secret_store_dir: Some(dir.path().join("secrets")),
         binding_store_dir: Some(dir.path().join("bindings")),

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -99,10 +99,13 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
     [x] slice 3: name detector (field-label + PII co-occurrence + gazetteer)
     [x] slice 4: RedactionAction + redaction_profiles + resolve (mvm-core)
     [x] slice 5: destination-aware wiring; fail-closed over-cap/compressed bodies
-    [ ] reachability: admission wiring (workload egress policy → with_redaction_policy)
-        — mechanism complete + tested; NOT yet reachable in prod. + consume
-        action.pii/action.secrets (RESERVED), terminator-path redaction. See plan
-        §"Deferred follow-ups".
+    [x] admission carriage: redaction rides inline in signed ExecutionPlan →
+        redaction_from_signed_json → backend EndpointConfig → from_plan →
+        with_redaction_policy (a plan carrying redaction flows end-to-end);
+        consume per-dest pii/secrets disposition (no longer RESERVED)
+    [ ] remaining: mvm-side AUTHORING surface (CLI/IR to set redaction_profiles —
+        plan_builder only has policy refs; mvmd can author via bundle),
+        terminator-path redaction, live PII spans. See plan §"Deferred follow-ups".
   [ ] forward proxy https/CONNECT (only http/absolute-form works today) — deferred
   [ ] forward-path signing integration (SigV4)        — DEFERRED (user)
 

--- a/specs/notes/plan-129-e1-step2-implementation-plan.md
+++ b/specs/notes/plan-129-e1-step2-implementation-plan.md
@@ -1121,22 +1121,23 @@ The five slices ship the complete detection + per-destination **mechanism**
 tested and leak-free. What remains to make it **reachable + complete** in
 production:
 
-- [ ] **Admission wiring (makes the feature reachable).** Nothing yet reads a
-  workload-authored redaction policy and calls
-  `SubstitutionService::with_redaction_policy`. Add a `redaction:
-  RedactionPolicy` field to the workload egress policy (mvm-core), thread it
-  through `from_plan` / the supervisor's endpoint-spawn site, and call the
-  builder. Until this lands the feature is mechanism-only — only tests
-  construct a policy; a real workload gets the default all-off action.
-- [ ] **Consume `RedactionAction.pii`.** `redact_bytes_for` currently runs the
-  always-on default PII ruleset and ignores the per-destination `pii`
-  mode/categories. Needs a semantic pass: how a per-destination PII disposition
-  composes with the always-on Phase E redaction (today's curated PII is masked
-  unconditionally). Fail-open risk: an operator setting `pii.mode=block` gets a
-  silent no-op until this lands (the field is doc-marked RESERVED meanwhile).
-- [ ] **Consume `RedactionAction.secrets`.** Curated secrets are always masked
-  (Block-equivalent) regardless of the action; wire the per-destination
-  disposition (field doc-marked RESERVED meanwhile).
+- [x] **Admission carriage (makes the feature reachable end-to-end).** DONE:
+  `redaction: RedactionPolicy` rides inline in the signed `ExecutionPlan` (and
+  `EgressPolicy`); `redaction_from_signed_json` extracts it; the backend
+  (`qemu.rs` + `microvm.rs` endpoint-spawn) extracts it and serializes it into
+  `EndpointConfig`; the endpoint bin's `from_plan` calls `with_redaction_policy`.
+  A plan carrying a redaction policy now flows through to the live service.
+- [ ] **mvm-side authoring surface (the remaining reachability gap).** The CLI
+  synth path (`plan_builder.rs`) only handles policy *refs* — it never resolves
+  a full `EgressPolicy`, so `ExecutionPlan.redaction` is always default on the
+  mvm path. There's no `mvmctl`/workload-IR way for a user to *set*
+  `redaction_profiles` yet. mvmd (fleet) can author it via the bundle; the
+  mvm-standalone authoring surface (a flag or IR field) is the open item.
+- [x] **Consume `RedactionAction.pii` / `.secrets`.** DONE: `redact_bytes_for`
+  honors the per-destination disposition — default preserves today's always-on
+  masking; `pii.mode="disabled"` skips PII for a destination, a category list
+  restricts it; `secrets=Audit` counts without masking. Fields no longer
+  RESERVED.
 - [ ] **Terminator-path redaction + fail-closed gate.** `handle_terminator_connection`
   (the `:80`/`:443` bound-host TLS terminator) does no redaction and no
   fail-closed gate — it never resolves the policy. A redaction-opted-in


### PR DESCRIPTION
## What

Makes the Plan 129 E1 Step 2 egress-redaction mechanism (#779) **reachable end-to-end**, and consumes the two RESERVED knobs.

- **Carriage:** `redaction: RedactionPolicy` now rides inline in the signed `ExecutionPlan` (and `EgressPolicy`) — exactly how `secrets` already reach the backend. `redaction_from_signed_json` extracts it; the backend (`qemu.rs` + `microvm.rs` endpoint-spawn) serializes it into `EndpointConfig`; the endpoint bin's `from_plan` calls `with_redaction_policy`. A plan carrying a redaction policy flows through to the live `SubstitutionService`.
- **Override semantics (the RESERVED knobs):** `redact_bytes_for` now honors the per-destination disposition — default preserves today's always-on masking (byte-identical); `pii.mode="disabled"` skips PII for a destination, a category list restricts it; `secrets=Audit` counts without masking (a trusted sink). Fields no longer doc-marked RESERVED.

## How

`ExecutionPlan.redaction` + `EgressPolicy.redaction` (`#[serde(default)]`) → `redaction_from_signed_json` → `spawn_substitution_endpoint(... &redaction ...)` → `EndpointConfig.redaction` → `from_plan(... redaction)` → `with_redaction_policy`. Adding the field rippled to ~15 `ExecutionPlan`/`EgressPolicy` construction sites and required dropping `Eq` from the 6 structs that transitively hold the f64-bearing `RedactionPolicy` (`PartialEq` preserved).

## Tests

TDD throughout. `from_plan` threads the policy onto the service; `EndpointConfig` redaction block round-trips + reaches the assembled service; default action still masks email+secrets (regression guard); `pii=disabled` leaves the email; `secrets=Audit` counts without masking. Local gate: **2067/2067** pass (mvm-core + mvm-hostd), clippy `-D warnings` (mvm-core/hostd/backend) + `cargo fmt --all` clean, workspace builds clean, secret-display policy gate clean. mvm-backend tests excluded locally (macOS SIGKILL) — covered on CI.

## Remaining (tracked, honest)

- **mvm-side authoring surface** — the CLI synth path (`plan_builder.rs`) only handles policy *refs*, so `ExecutionPlan.redaction` is always default on the mvm-standalone path; there's no `mvmctl`/IR way to *set* `redaction_profiles` yet (mvmd can author via the bundle). This is the last reachability gap on the mvm side.
- Terminator-path redaction; live PII spans for name co-occurrence. See plan §"Deferred follow-ups".
- Live QEMU endpoint-spawn validation is box-gated (dev-kvm), like the other Plan 129 box items.