### PR TITLE
feat(cli): mvmctl up --redact authors per-destination egress redaction (plan 129 E1)

### DIFF
--- a/crates/mvm-cli/src/commands/ops/bench_probe.rs
+++ b/crates/mvm-cli/src/commands/ops/bench_probe.rs
@@ -77,6 +77,7 @@ pub fn admit_probe_plan(
         bundle_pin: None,
         deps_volume: None,
         shares: Vec::new(),
+        redaction: mvm_core::policy::RedactionPolicy::default(),
     };
     let ledger = InMemoryNonceLedger::new();
     admit_for_run(&input, &SystemClock, &ledger, keys_dir, None).context("admitting probe plan")

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -546,6 +546,25 @@ fn test_up_manifest_flag() {
 }
 
 #[test]
+fn test_up_redact_flag_parses_repeatably() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "up",
+        "--redact",
+        "api.openai.com",
+        "--redact",
+        "logs.example.com=audit",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Up(up::Args { redact, .. }) => {
+            assert_eq!(redact, vec!["api.openai.com", "logs.example.com=audit"]);
+        }
+        _ => panic!("Expected Up command"),
+    }
+}
+
+#[test]
 fn test_up_dev_flag_resolves_dev_mode() {
     let cli = Cli::try_parse_from(["mvmctl", "up", "--flake", ".", "--dev"]).unwrap();
     match cli.command {

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -548,6 +548,7 @@ fn emit_oci_run_admission(
         bundle_pin: None,
         deps_volume: None,
         shares: Vec::new(),
+        redaction: mvm_core::policy::RedactionPolicy::default(),
     };
     let ledger = InMemoryNonceLedger::new();
     let admitted = admit_for_run(&input, &SystemClock, &ledger, None, None)?;

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -292,6 +292,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
                             bundle_pin: None,
                             deps_volume: None,
                             shares: vec![],
+                            redaction: mvm_core::policy::RedactionPolicy::default(),
                         })?;
                         let Some(c) = ctx else { return Ok(None) };
                         let plan_json = serde_json::to_string(&c.admitted.signed)

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -24,6 +24,7 @@ pub(super) mod policy_resolver;
 pub(super) mod proc;
 pub(super) mod ps;
 pub(super) mod readiness;
+pub(super) mod redaction_flags;
 pub(super) mod run_plan;
 pub(super) mod sandbox;
 pub(super) mod session;

--- a/crates/mvm-cli/src/commands/vm/plan_admission.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_admission.rs
@@ -438,6 +438,7 @@ mod tests {
             bundle_pin: None,
             deps_volume: None,
             shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
         }
     }
 

--- a/crates/mvm-cli/src/commands/vm/plan_builder.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_builder.rs
@@ -145,6 +145,9 @@ pub struct SynthesisInput<'a> {
     /// into the signed plan + audit log (claim 1 / claim 8). Empty for
     /// the common no-volume case.
     pub shares: Vec<mvm_core::plan::HostShareGrant>,
+    /// Per-destination egress redaction authored by `--redact HOST[=audit]`.
+    /// Default (all-off) preserves the curated-only baseline.
+    pub redaction: mvm_core::policy::RedactionPolicy,
 }
 
 /// Build an unsigned `ExecutionPlan` from CLI-shaped input.
@@ -226,7 +229,7 @@ pub fn synthesize_plan(input: &SynthesisInput<'_>) -> Result<ExecutionPlan> {
         fs_policy,
         secrets: input.secrets.clone(),
         egress_policy,
-        redaction: Default::default(),
+        redaction: input.redaction.clone(),
         tool_policy,
         artifact_policy: ArtifactPolicy {
             capture_paths: Vec::new(),
@@ -354,6 +357,7 @@ mod tests {
             bundle_pin: None,
             deps_volume: None,
             shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
         }
     }
 
@@ -552,6 +556,31 @@ mod tests {
         }];
         let plan = synthesize_plan(&inp).unwrap();
         assert_eq!(plan.secrets, inp.secrets);
+    }
+
+    #[test]
+    fn synthesized_plan_carries_redaction_profiles() {
+        use mvm_core::policy::{
+            EntropyMode, NameMode, RedactionAction, RedactionPolicy, RedactionProfile,
+        };
+        let mut inp = input("myvm");
+        inp.redaction = RedactionPolicy {
+            default: RedactionAction::default(),
+            profiles: vec![RedactionProfile {
+                host: "api.openai.com".into(),
+                action: RedactionAction {
+                    entropy: EntropyMode::Redact {
+                        min_bits_per_char: 4.0,
+                        min_run_len: 20,
+                    },
+                    names: NameMode::Redact,
+                    ..Default::default()
+                },
+            }],
+        };
+        let plan = synthesize_plan(&inp).unwrap();
+        assert_eq!(plan.redaction.profiles.len(), 1);
+        assert_eq!(plan.redaction.profiles[0].host, "api.openai.com");
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/redaction_flags.rs
+++ b/crates/mvm-cli/src/commands/vm/redaction_flags.rs
@@ -1,0 +1,104 @@
+//! Parse `--redact HOST[=audit]` flags into a per-destination RedactionPolicy.
+
+use anyhow::{Result, bail};
+use mvm_core::policy::{EntropyMode, NameMode, RedactionAction, RedactionPolicy, RedactionProfile};
+
+/// Default entropy threshold + run length (mirror EntropyScanner::with_defaults).
+const ENTROPY_BITS: f64 = 4.0;
+const ENTROPY_RUN: usize = 20;
+
+/// Build a RedactionPolicy from repeatable `--redact HOST[=audit]` flags. A bare
+/// `HOST` opts that destination into masking undeclared secrets/PII (entropy +
+/// names redact); `HOST=audit` reports without masking. Empty input → all-off.
+pub fn parse_redaction_flags(flags: &[String]) -> Result<RedactionPolicy> {
+    let mut profiles = Vec::with_capacity(flags.len());
+    for raw in flags {
+        let (host, mode) = match raw.split_once('=') {
+            Some((h, m)) => (h.trim(), m.trim()),
+            None => (raw.trim(), "redact"),
+        };
+        if host.is_empty() {
+            bail!("--redact: empty host in {raw:?}");
+        }
+        let (entropy, names) = match mode {
+            "redact" => (
+                EntropyMode::Redact {
+                    min_bits_per_char: ENTROPY_BITS,
+                    min_run_len: ENTROPY_RUN,
+                },
+                NameMode::Redact,
+            ),
+            "audit" => (
+                EntropyMode::Audit {
+                    min_bits_per_char: ENTROPY_BITS,
+                    min_run_len: ENTROPY_RUN,
+                },
+                NameMode::Audit,
+            ),
+            other => bail!(
+                "--redact: unknown mode {other:?} for host {host:?}; use `=audit` or omit for masking"
+            ),
+        };
+        profiles.push(RedactionProfile {
+            host: host.to_string(),
+            action: RedactionAction {
+                entropy,
+                names,
+                ..Default::default()
+            },
+        });
+    }
+    Ok(RedactionPolicy {
+        default: RedactionAction::default(),
+        profiles,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_flags_yield_all_off_default() {
+        let p = parse_redaction_flags(&[]).unwrap();
+        assert!(p.profiles.is_empty());
+    }
+
+    #[test]
+    fn bare_host_opts_into_redact() {
+        let p = parse_redaction_flags(&["api.openai.com".to_string()]).unwrap();
+        assert_eq!(p.profiles.len(), 1);
+        assert_eq!(p.profiles[0].host, "api.openai.com");
+        assert!(matches!(
+            p.profiles[0].action.entropy,
+            EntropyMode::Redact { .. }
+        ));
+        assert!(matches!(p.profiles[0].action.names, NameMode::Redact));
+    }
+
+    #[test]
+    fn audit_suffix_downgrades_to_audit() {
+        let p = parse_redaction_flags(&["api.openai.com=audit".to_string()]).unwrap();
+        assert!(matches!(
+            p.profiles[0].action.entropy,
+            EntropyMode::Audit { .. }
+        ));
+        assert!(matches!(p.profiles[0].action.names, NameMode::Audit));
+    }
+
+    #[test]
+    fn unknown_mode_errors() {
+        assert!(parse_redaction_flags(&["h=bogus".to_string()]).is_err());
+    }
+
+    #[test]
+    fn empty_host_errors() {
+        assert!(parse_redaction_flags(&["=audit".to_string()]).is_err());
+    }
+
+    #[test]
+    fn multiple_hosts() {
+        let p = parse_redaction_flags(&["a.com".into(), "b.com=audit".into()]).unwrap();
+        assert_eq!(p.profiles.len(), 2);
+    }
+}

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -308,6 +308,7 @@ fn synthesis_input_for_app<'a>(workload: &'a Workload, app: &'a App) -> Result<S
         // the live `mvmctl up` path only.
         deps_volume: None,
         shares: Vec::new(),
+        redaction: mvm_core::policy::RedactionPolicy::default(),
     })
 }
 

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -148,6 +148,9 @@ pub(super) struct AdmitPlanForBootParams<'a> {
     /// into the signed plan + emitted to the chain-signed audit log
     /// (claim 1 / claim 8). Empty for the common no-volume case.
     pub shares: Vec<mvm_core::plan::HostShareGrant>,
+    /// Per-destination egress redaction authored by `--redact HOST[=audit]`.
+    /// Default (all-off) preserves the curated-only baseline.
+    pub redaction: mvm_core::policy::RedactionPolicy,
 }
 
 /// Build the signed-plan host-fs grant list from the resolved volume
@@ -304,6 +307,7 @@ pub(super) fn admit_plan_for_boot(
         bundle_pin: bundle_pin.clone(),
         deps_volume: p.deps_volume.clone(),
         shares: p.shares.clone(),
+        redaction: p.redaction.clone(),
     };
     let admission_ctx = match (&bundle_resolver, &bundle_trust) {
         (Some(r), Some(t)) => Some(BundleAdmissionContext {
@@ -1028,6 +1032,10 @@ pub(in crate::commands) struct Args {
     /// claim-4 dev-only `do_exec` rule client-side.
     #[arg(long = "up-json")]
     pub up_json: bool,
+    /// Scrub undeclared secrets/PII on egress to HOST (masks); `HOST=audit` only
+    /// reports. Repeatable. Per-destination egress redaction.
+    #[arg(long = "redact", value_name = "HOST[=audit]")]
+    pub redact: Vec<String>,
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Result<()> {
@@ -1201,6 +1209,10 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
     // value is only the string label that names the audit chain file.
     let resolved_tenant = super::tenant_resolution::resolve_tenant(args.tenant.as_deref());
 
+    // Plan 129 E1: author the per-destination egress redaction policy from
+    // `--redact HOST[=audit]`. Empty → all-off (curated-only baseline).
+    let redaction = super::redaction_flags::parse_redaction_flags(&args.redact)?;
+
     cmd_run(RunParams {
         flake_ref: args.flake.as_deref(),
         template_name: resolved_template_arg.as_deref(),
@@ -1225,6 +1237,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, cfg: &MvmConfig) -> Resul
         plan_seccomp_tier,
         plan_secret_release,
         plan_secrets: lowered_plan_secrets.secrets,
+        redaction,
         sandbox_tags,
         sandbox_ttl,
         auto_resume,
@@ -1312,6 +1325,9 @@ pub(in crate::commands) struct RunParams<'a> {
     pub(super) plan_seccomp_tier: mvm_core::plan::PlanSeccompTier,
     pub(super) plan_secret_release: mvm_core::plan::SecretReleasePolicy,
     pub(super) plan_secrets: Vec<mvm_core::plan::SecretBinding>,
+    /// Per-destination egress redaction authored by `--redact HOST[=audit]`.
+    /// All-off default preserves the curated-only baseline.
+    pub(super) redaction: mvm_core::policy::RedactionPolicy,
     /// Validated sandbox tags from `--tag k=v`.
     pub(super) sandbox_tags: std::collections::BTreeMap<String, String>,
     /// Parsed `--ttl` duration; reaper tears VM down after this elapses.
@@ -1379,6 +1395,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         plan_seccomp_tier,
         plan_secret_release,
         plan_secrets,
+        redaction,
         sandbox_tags,
         sandbox_ttl,
         auto_resume,
@@ -1528,6 +1545,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
             deps_volume: deps_volume_binding.clone(),
             // Re-exec path: user volumes aren't threaded here.
             shares: Vec::new(),
+            redaction: redaction.clone(),
         })?;
 
         let mut start_config = mvm_core::vm_backend::VmStartConfig {
@@ -1933,6 +1951,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         bundle_pin,
         deps_volume: deps_volume_binding.clone(),
         shares: shares_from_volume_cfg(&volume_cfg),
+        redaction: redaction.clone(),
     })?;
 
     // If a template snapshot exists AND the backend supports snapshots,
@@ -2447,6 +2466,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
                 bundle_pin,
                 deps_volume: deps_volume_binding.clone(),
                 shares: shares_from_volume_cfg(&w_volume_cfg),
+                redaction: redaction.clone(),
             }) {
                 Ok(ctx) => ctx,
                 Err(e) => {
@@ -2765,6 +2785,7 @@ mod admit_plan_tests {
             bundle_pin: None,
             deps_volume: None,
             shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
         })
         .expect("must succeed");
         assert!(result.is_none(), "no_supervisor must return None");
@@ -2795,6 +2816,7 @@ mod admit_plan_tests {
             bundle_pin: None,
             deps_volume: None,
             shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
         })
         .expect("admission")
         .expect("Some when admission ran");
@@ -2846,6 +2868,7 @@ mod admit_plan_tests {
             bundle_pin: None,
             deps_volume: None,
             shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
         })
         .expect_err("missing rootfs must fail");
         assert!(
@@ -2883,6 +2906,7 @@ mod admit_plan_tests {
             bundle_pin: None,
             deps_volume: None,
             shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
         })
         .unwrap()
         .unwrap();
@@ -2904,6 +2928,7 @@ mod admit_plan_tests {
             bundle_pin: None,
             deps_volume: None,
             shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
         })
         .unwrap()
         .unwrap();
@@ -2967,6 +2992,7 @@ mod admit_plan_tests {
             bundle_pin: None,
             deps_volume: None,
             shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
         })
         .expect("admission")
         .expect("Some when admission ran");
@@ -3054,6 +3080,7 @@ chain_signing = true
                 bundle_pin: None,
                 deps_volume: None,
                 shares: Vec::new(),
+                redaction: mvm_core::policy::RedactionPolicy::default(),
             },
             &SystemClock,
             &ledger,
@@ -3153,6 +3180,7 @@ stream_destinations = ["file://{}"]
                 bundle_pin: None,
                 deps_volume: None,
                 shares: Vec::new(),
+                redaction: mvm_core::policy::RedactionPolicy::default(),
             },
             &SystemClock,
             &ledger,
@@ -3251,6 +3279,7 @@ chain_signing = false
                 bundle_pin: None,
                 deps_volume: None,
                 shares: Vec::new(),
+                redaction: mvm_core::policy::RedactionPolicy::default(),
             },
             &SystemClock,
             &ledger,
@@ -3324,6 +3353,7 @@ chain_signing = false
                 bundle_pin: None,
                 deps_volume: None,
                 shares: Vec::new(),
+                redaction: mvm_core::policy::RedactionPolicy::default(),
             },
             &SystemClock,
             &ledger,
@@ -3417,6 +3447,7 @@ disabled_inspectors = ["ssrf_guarrd"]
                 bundle_pin: None,
                 deps_volume: None,
                 shares: Vec::new(),
+                redaction: mvm_core::policy::RedactionPolicy::default(),
             },
             &SystemClock,
             &ledger,
@@ -3516,6 +3547,7 @@ port_hi  = 443
                 bundle_pin: None,
                 deps_volume: None,
                 shares: Vec::new(),
+                redaction: mvm_core::policy::RedactionPolicy::default(),
             },
             &SystemClock,
             &ledger,

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -103,9 +103,11 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
         redaction_from_signed_json → backend EndpointConfig → from_plan →
         with_redaction_policy (a plan carrying redaction flows end-to-end);
         consume per-dest pii/secrets disposition (no longer RESERVED)
-    [ ] remaining: mvm-side AUTHORING surface (CLI/IR to set redaction_profiles —
-        plan_builder only has policy refs; mvmd can author via bundle),
-        terminator-path redaction, live PII spans. See plan §"Deferred follow-ups".
+    [x] CLI authoring: `mvmctl up --redact HOST[=audit]` parses a per-destination
+        RedactionPolicy → SynthesisInput → synthesize_plan sets ExecutionPlan.redaction
+    [ ] remaining: IR/SDK developer-declared authoring (the only open variant; mvmd
+        can author via bundle), terminator-path redaction, live PII spans.
+        See plan §"Deferred follow-ups".
   [ ] forward proxy https/CONNECT (only http/absolute-form works today) — deferred
   [ ] forward-path signing integration (SigV4)        — DEFERRED (user)
 


### PR DESCRIPTION
## What

Closes the last mvm-standalone reachability gap for the Plan 129 E1 egress-redaction feature: a `mvmctl up --redact` flag that lets a user author a per-destination `RedactionPolicy` into the synthesized plan. The carriage (#784) already threads it the rest of the way to the live endpoint, so this makes the whole feature usable end-to-end from the CLI.

## Flag

`--redact HOST[=audit]` (repeatable):
- `--redact api.openai.com` — mask undeclared secrets/PII on egress to that host (entropy + name redaction)
- `--redact api.openai.com=audit` — report without masking (the soak-period mode)

Builds a `RedactionPolicy { profiles: [per host] }`; no flag → all-off (unchanged behavior).

## How

`--redact` → `parse_redaction_flags` → `RunParams.redaction` → the 3 real `AdmitPlanForBootParams` admission sites → `SynthesisInput.redaction` → `synthesize_plan` sets `ExecutionPlan.redaction`. Adding the field rippled to ~17 `AdmitPlanForBootParams`/`SynthesisInput` construction sites (non-up admission paths + tests default to all-off).

## Choice

I chose a **CLI flag** over an SDK/IR field: redaction is an operator/launch-time posture (unlike secrets, which are an app capability the developer declares in code), and the flag is self-contained in mvm-cli (no cross-language Python/TS work). Developer-declared IR/SDK authoring remains a possible follow-up.

## Tests

TDD: 6 parser unit tests (bare host → redact, `=audit` → audit, unknown-mode/empty-host errors, multi-host), a `synthesize_plan` test that the policy carries into `ExecutionPlan.redaction`, and a clap-layer parse test. Local gate: **2108/2108** (mvm-cli + mvm-core), `cargo build --workspace --all-targets` + clippy + fmt + secret-display policy gate all clean. mvm-backend tests excluded locally (macOS SIGKILL) — covered on CI.

## Remaining

Developer-declared redaction in the SDK/IR (cross-language) is the only open authoring variant; `mvmctl run --image` / Sandbox-mode synthesis are separate surfaces if wanted. Terminator-path redaction + live PII spans still tracked in the plan.