### PR TITLE
feat(secrets): egress no-secret-to-guest leak-gate (claim 16, Preview) — plan 129 Phase F

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,11 @@ The `RuntimeBuildEnv` in mvm implements only `ShellEnvironment`. The full `Build
 ## Security model
 
 mvm makes fifteen CI-enforced security claims (numbered 1–15 in
-`specs/claims/catalog.md`, the contiguous ledger). Each one is backed by
-a test or a workflow gate. **ADR-002
+`specs/claims/catalog.md`, the contiguous ledger), plus a `Preview`
+claim 16 (egress-substitution leak-gate, ADR-067 — witnesses are
+machine-checked but promotion into ADR-002's numbered prose is a
+pending maintainer decision, mirroring claim 14's path). Each one is
+backed by a test or a workflow gate. **ADR-002
 (`specs/adrs/002-microvm-security-posture.md`) is the source of truth**
 for the claim numbering, threat model, and per-backend tier matrix;
 this section is the summary. Implementation is sequenced in

--- a/crates/mvm-hostd/tests/egress_secret_leak_gate.rs
+++ b/crates/mvm-hostd/tests/egress_secret_leak_gate.rs
@@ -1,0 +1,288 @@
+//! Egress no-secret-to-guest leak-gate.
+//!
+//! A standing, canary-based backstop for the egress substitution model: the
+//! raw secret stays on the host, the guest only ever holds an opaque
+//! placeholder, and the audit chain carries metadata only. The three tests
+//! below pin those invariants so a future refactor of the substitution path
+//! can't silently regress them. Each asserts existing behaviour — a failure
+//! here is a real leak, not a stale test.
+//!
+//! The canary is a distinctive sentinel: if it shows up in a guest-facing
+//! artifact or the audit chain, the assertion names exactly which surface
+//! leaked.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as B64;
+use ed25519_dalek::SigningKey;
+use secrecy::SecretBox;
+use tempfile::tempdir;
+use tokio::net::{UnixListener, UnixStream};
+
+use mvm_core::crypto::secret_store::{FileSecretStore, SecretStore};
+use mvm_core::plan::{SecretBinding, SecretSource, TenantId};
+use mvm_core::substitution_wire::{WireRequest, WireResponse};
+use mvm_sdk::ir::{AuthType, SecretMount, SecretRef};
+
+use mvm_hostd::framing::{read_json_frame, write_json_frame};
+use mvm_hostd::keyholder::{
+    BindingStore, FileBindingStore, LocalResolver, SecretBindingMeta, SecretResolver,
+    SubstitutionRegistry, secret_placeholder_env,
+};
+use mvm_hostd::supervisor::audit_file::FileAuditSigner;
+use mvm_hostd::supervisor::audit_recorder::Recorder;
+use mvm_hostd::supervisor::substitution_proxy::{
+    ForwardError, ForwardResponse, Forwarder, PreparedRequest, SubstitutionService,
+};
+
+/// The sentinel secret value. It must never appear in a guest-facing artifact
+/// (the handed placeholder env) or in the audit chain.
+const CANARY: &str = "CANARY-SECRET-VALUE-MUST-NOT-LEAK";
+
+/// 16 MiB — matches the endpoint's framing cap.
+const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
+
+/// Records the request it was handed so a test can prove the destination — not
+/// the guest — received the substituted credential, without a network call.
+struct RecordingForwarder {
+    seen: Mutex<Option<PreparedRequest>>,
+}
+
+#[async_trait]
+impl Forwarder for RecordingForwarder {
+    async fn forward(&self, req: PreparedRequest) -> Result<ForwardResponse, ForwardError> {
+        *self.seen.lock().unwrap() = Some(req);
+        Ok(ForwardResponse {
+            status: 200,
+            headers: vec![("x-mock".into(), "1".into())],
+            body: b"pong".to_vec(),
+        })
+    }
+}
+
+fn bearer_ref(name: &str, hosts: &[&str]) -> SecretRef {
+    SecretRef {
+        name: name.into(),
+        mount: SecretMount::Env {
+            var: "OPENAI_API_KEY".into(),
+        },
+        auth_type: AuthType::Bearer,
+        allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+    }
+}
+
+/// (a) The handed `(var, placeholder)` pairs — the artifact injected into the
+/// guest's environment — carry only opaque placeholders, never the value. The
+/// canary lives in the host secret store; `from_plan` mints placeholders; the
+/// canary must appear in NONE of them, and `secret_placeholder_env` (the guest
+/// env) must carry the canary in no value.
+#[test]
+fn handed_placeholders_never_contain_the_secret_value() {
+    let dir = tempdir().unwrap();
+
+    // Binding metadata (the `mvmctl secret set` side) + the value store.
+    let bindings = FileBindingStore::with_dir(dir.path().join("bindings"));
+    bindings
+        .put(
+            "local",
+            "openai",
+            &SecretBindingMeta {
+                auth_type: AuthType::Bearer,
+                allowed_hosts: vec!["api.openai.com".into()],
+            },
+        )
+        .unwrap();
+    let store = FileSecretStore::with_dir(dir.path().join("secrets"));
+    store
+        .put(
+            "local",
+            "openai",
+            &SecretBox::new(Box::new(CANARY.to_string())),
+        )
+        .unwrap();
+    let secret_store: Arc<dyn SecretStore> = Arc::new(store);
+
+    let plan = [SecretBinding {
+        name: "OPENAI_API_KEY".into(),
+        source: SecretSource::Keystore {
+            address: "openai".into(),
+        },
+    }];
+    let (_service, handed) = SubstitutionService::from_plan(
+        &plan,
+        "local",
+        &bindings,
+        secret_store,
+        30,
+        mvm_core::policy::RedactionPolicy::default(),
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        !handed.is_empty(),
+        "expected at least one handed placeholder"
+    );
+    for (var, placeholder) in &handed {
+        assert!(
+            placeholder.as_str().starts_with("mvm-secret-"),
+            "handed placeholder for `{var}` is not an opaque token: {}",
+            placeholder.as_str()
+        );
+        assert!(
+            !placeholder.as_str().contains(CANARY),
+            "LEAK: handed placeholder for `{var}` carries the secret value"
+        );
+    }
+
+    // The guest env (the actual artifact injected at launch) carries only
+    // placeholders — the canary appears in no value.
+    let env = secret_placeholder_env(&handed);
+    assert!(!env.is_empty(), "expected at least one guest env entry");
+    for (var, value) in &env {
+        assert!(
+            value.starts_with("mvm-secret-"),
+            "guest env `{var}` is not an opaque placeholder: {value}"
+        );
+        assert!(
+            !value.contains(CANARY),
+            "LEAK: guest env value for `{var}` carries the secret value"
+        );
+    }
+}
+
+/// (b) claim 12 — substitution fires only for bound destinations. A placeholder
+/// bound to host A, routed to host B, is refused before the forward leg, and
+/// the forwarder never sees the request. Mirrors the in-module
+/// `endpoint_refuses_unbound_destination_and_never_forwards` over the public
+/// service surface, as the standing leak-gate witness.
+#[tokio::test]
+async fn substitution_endpoint_refuses_unbound_destination() {
+    let dir = tempdir().unwrap();
+    let store = FileSecretStore::with_dir(dir.path().join("secrets"));
+    store
+        .put(
+            "local",
+            "openai",
+            &SecretBox::new(Box::new(CANARY.to_string())),
+        )
+        .unwrap();
+    let resolver: Arc<dyn SecretResolver> = Arc::new(LocalResolver::new("local", Arc::new(store)));
+
+    let mut reg = SubstitutionRegistry::new();
+    // Bound to host A only.
+    let ph = reg
+        .mint(bearer_ref("openai", &["api.openai.com"]))
+        .as_str()
+        .to_string();
+    let forwarder = Arc::new(RecordingForwarder {
+        seen: Mutex::new(None),
+    });
+    let service = Arc::new(SubstitutionService::new(
+        Arc::new(reg),
+        resolver,
+        Arc::clone(&forwarder) as _,
+    ));
+
+    let sock = dir.path().join("subst.sock");
+    let listener = UnixListener::bind(&sock).unwrap();
+    let server = tokio::spawn(Arc::clone(&service).serve(listener));
+
+    let mut client = UnixStream::connect(&sock).await.unwrap();
+    // Bound placeholder, but pointed at host B (unbound for this secret).
+    let wire = WireRequest {
+        method: "POST".into(),
+        url: "https://evil.example.com/x".into(),
+        headers: vec![("authorization".into(), format!("Bearer {ph}"))],
+        body_b64: String::new(),
+    };
+    write_json_frame(&mut client, &wire).await.unwrap();
+    let resp: WireResponse = read_json_frame(&mut client, MAX_FRAME_BYTES).await.unwrap();
+
+    assert!(
+        matches!(resp, WireResponse::Refused { .. }),
+        "unbound destination must be refused: {resp:?}"
+    );
+    // claim 12: the unbound destination never reached the forward leg, so the
+    // real credential was never substituted toward it.
+    assert!(
+        forwarder.seen.lock().unwrap().is_none(),
+        "LEAK: an unbound destination reached the forward leg"
+    );
+    server.abort();
+}
+
+/// (c) claim 13 — the audit chain carries no secret bytes. Drive a successful
+/// substitution with a recorder + the canary secret; the chain must record the
+/// `secret.substituted` event (metadata) but never the canary value.
+#[tokio::test]
+async fn audit_chain_carries_no_secret_value() {
+    let dir = tempdir().unwrap();
+    let store = FileSecretStore::with_dir(dir.path().join("secrets"));
+    store
+        .put(
+            "local",
+            "openai",
+            &SecretBox::new(Box::new(CANARY.to_string())),
+        )
+        .unwrap();
+    let resolver: Arc<dyn SecretResolver> = Arc::new(LocalResolver::new("local", Arc::new(store)));
+
+    let mut reg = SubstitutionRegistry::new();
+    let ph = reg
+        .mint(bearer_ref("openai", &["api.openai.com"]))
+        .as_str()
+        .to_string();
+    let forwarder = Arc::new(RecordingForwarder {
+        seen: Mutex::new(None),
+    });
+
+    let chain = dir.path().join("audit.jsonl");
+    let signer = FileAuditSigner::open_file(SigningKey::from_bytes(&[9u8; 32]), &chain).unwrap();
+    let recorder = Recorder::new(Arc::new(signer), TenantId("local".into()));
+
+    let service = Arc::new(
+        SubstitutionService::new(Arc::new(reg), resolver, Arc::clone(&forwarder) as _)
+            .with_recorder(recorder),
+    );
+    let sock = dir.path().join("subst.sock");
+    let listener = UnixListener::bind(&sock).unwrap();
+    let server = tokio::spawn(Arc::clone(&service).serve(listener));
+
+    let mut client = UnixStream::connect(&sock).await.unwrap();
+    let wire = WireRequest {
+        method: "POST".into(),
+        url: "https://api.openai.com/v1".into(),
+        headers: vec![("authorization".into(), format!("Bearer {ph}"))],
+        body_b64: B64.encode(b"{}"),
+    };
+    write_json_frame(&mut client, &wire).await.unwrap();
+    // The audit emit completes before the Ok response is written, so the chain
+    // entry is on disk by the time the reply lands.
+    let resp: WireResponse = read_json_frame(&mut client, MAX_FRAME_BYTES).await.unwrap();
+    assert!(
+        matches!(resp, WireResponse::Ok { .. }),
+        "bound substitution must succeed: {resp:?}"
+    );
+
+    // The destination (forwarder) — not the guest — saw the real credential.
+    let seen = forwarder.seen.lock().unwrap().clone().unwrap();
+    assert_eq!(
+        seen.headers[0],
+        ("authorization".into(), format!("Bearer {CANARY}"))
+    );
+
+    let logged = std::fs::read_to_string(&chain).unwrap();
+    assert!(
+        logged.contains("secret.substituted"),
+        "expected a secret.substituted audit entry: {logged}"
+    );
+    // claim 13: the value never reaches the audit chain.
+    assert!(
+        !logged.contains(CANARY),
+        "LEAK: audit chain carries the secret value: {logged}"
+    );
+    server.abort();
+}

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -279,5 +279,6 @@ PLAN 181 — App-builder product surface           🔴 NOT STARTED  (ADR-079; m
 
 ## Security claims
 
-15/15 shipped, none regressed (`specs/claims/catalog.md`, gated by
-`xtask check-claim-catalog`).
+15/15 shipped, none regressed, + 1 `Preview` (claim 16, egress-substitution
+leak-gate — witnesses machine-checked, ADR-002 promotion pending) (`specs/claims/catalog.md`,
+gated by `xtask check-claim-catalog`).

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -113,6 +113,13 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
     [ ] remaining: IR/SDK developer-declared authoring (the only open variant; mvmd
         can author via bundle), terminator-path redaction, live PII spans.
         See plan §"Deferred follow-ups".
+  [x] Phase F: egress no-secret-to-guest leak-gate (claim-12/13 backstop) —
+      canary tests (handed_placeholders_never_contain_the_secret_value /
+      substitution_endpoint_refuses_unbound_destination /
+      audit_chain_carries_no_secret_value) in crates/mvm-hostd/tests/
+      egress_secret_leak_gate.rs + claim doc claim-egress-no-secret-to-guest.md +
+      catalog.md row 16 witnesses (Preview), gated on every PR (Test lane +
+      check-claim-catalog)
   [ ] forward proxy https/CONNECT (only http/absolute-form works today) — deferred
   [ ] forward-path signing integration (SigV4)        — DEFERRED (user)
 

--- a/specs/claims/catalog.md
+++ b/specs/claims/catalog.md
@@ -42,6 +42,15 @@ tracked separately as a follow-up audit (see "deferred follow-ups").
 | 13 | No raw secret value crosses the broker channel | fn:resolved_secrets_placeholders, fn:substitute | destination-bound signed credentials (ADR-049) | Shipped |
 | 14 | OCI image provenance is recorded in the chain-signed audit log | fn:prod_pull_requires_digest_pin_before_network, fn:prod_run_image_requires_digest_pin_before_network | cosign + OCI digest (specs/claims/claim-10-oci-image-provenance.md) | Shipped |
 | 15 | No interactive access to a sealed production microVM | fn:console_refused_on_sealed_image, ci:prod-agent-no-console, fn:prod_console_attachment_has_no_input | dev-image-only console + dm-verity + host accessible-gate + dev-shell-gated agent (Plan 165 WS-C, ADR-002 §W4.3 extension) | Shipped |
+| 16 | Egress substitution keeps a raw secret off the guest, bound-only, no value in audit | fn:handed_placeholders_never_contain_the_secret_value, fn:substitution_endpoint_refuses_unbound_destination, fn:audit_chain_carries_no_secret_value | egress substitution leak-gate; reinforces claims 12+13 on the egress delivery (ADR-067, specs/claims/claim-egress-no-secret-to-guest.md) | Preview |
+
+Row 16 is the egress-substitution leak-gate. Like claim 14 (OCI provenance),
+it is registered here for witness machine-checking and tracked by its own doc
+(`claim-egress-no-secret-to-guest.md`) at status `Preview`; promotion to a
+numbered claim in ADR-002's source-of-truth table is a separate maintainer
+decision. It does not restate or replace the broker rows 12/13 — those are the
+shipped broker delivery; row 16 backs the same two invariants on the egress
+substitution path.
 
 ## Maintaining this catalog
 

--- a/specs/claims/claim-egress-no-secret-to-guest.md
+++ b/specs/claims/claim-egress-no-secret-to-guest.md
@@ -1,0 +1,103 @@
+---
+claim: egress-no-secret-to-guest
+status: Preview
+gated_phrases:
+  - "egress secret substitution"
+  - "raw secret never reaches the guest"
+  - "no secret value reaches the guest"
+exempt_paths:
+  - "specs/**"
+  - "CHANGELOG.md"
+  - ".github/**"
+  - "memory/**"
+  - "crates/mvm-hostd/**"
+  - "public/src/content/docs/contributing/adr/**"
+---
+
+# Egress substitution — a raw secret never reaches the guest
+
+## Assertion
+
+The egress substitution model (ADR-067) keeps raw secret values off the
+untrusted guest. The guest receives an opaque placeholder
+(`mvm-secret-<hex>`) where its credential would go; the host substitution
+endpoint holds the real value and substitutes it on the outbound forward
+leg, after binding-checking the request's destination. Three invariants
+back this:
+
+- **(a) No secret value reaches a guest-facing artifact.** The
+  `(var, placeholder)` pairs handed to the guest, and the guest
+  environment derived from them, carry only opaque placeholders — never
+  the value.
+- **(b) Substitution fires only for bound destinations (claim 12).** A
+  placeholder bound to host A and routed to host B is refused before the
+  forward leg runs; the real credential is never substituted toward an
+  unbound destination.
+- **(c) The audit chain carries no secret bytes (claim 13).** A
+  successful substitution records a `secret.substituted` metadata event —
+  name, destination, auth-type — but never the secret value.
+
+`mvmctl audit verify` continues to detect drift on the audit chain;
+tampering with any field of a `secret.substituted` entry breaks the chain
+signature.
+
+## Threat
+
+The guest is the untrusted workload. A raw secret reaching guest RAM can
+be exfiltrated, logged, baked into a snapshot, or sent to an
+attacker-controlled host. A future refactor of the substitution path
+could silently regress any of the three invariants — handing the value
+into the guest env, substituting toward an unbound host, or writing the
+value into the audit chain — with no test noticing. This leak-gate is the
+standing backstop: a distinctive canary value
+(`CANARY-SECRET-VALUE-MUST-NOT-LEAK`) is driven through the path, and the
+assertions name exactly which surface leaked if it ever appears where it
+must not.
+
+## CI gate that ratifies the claim
+
+The canary leak-gate runs on every PR via the normal Test lane
+(`crates/mvm-hostd/tests/egress_secret_leak_gate.rs`), with three
+witnesses:
+
+- `fn:handed_placeholders_never_contain_the_secret_value` — puts the
+  canary in a `FileSecretStore`, binds it to a host, calls
+  `SubstitutionService::from_plan`, and asserts every handed placeholder
+  is `mvm-secret-`-prefixed and carries the canary in none of them; also
+  that `secret_placeholder_env` (the guest env) contains the canary in no
+  value. (invariant a)
+- `fn:substitution_endpoint_refuses_unbound_destination` — a placeholder
+  bound to host A, a request routed to host B, asserting the endpoint
+  refuses and the forwarder never saw the request. (invariant b /
+  claim 12)
+- `fn:audit_chain_carries_no_secret_value` — drives a successful
+  substitution with a recorder + the canary secret, reads the chain file,
+  and asserts it contains `secret.substituted` but never the canary value.
+  (invariant c / claim 13)
+
+`xtask check-claim-catalog` resolves these three `fn:` witnesses against
+the tree on every PR, so renaming or deleting one trips the gate.
+
+## Status
+
+- **2026-06-11**: leak-gate filed at status `Preview`. The egress
+  substitution model is delivered (plan 129) and these invariants are
+  enforced; the claim's guarded phrases stay blocked in user-facing
+  surface until a maintainer promotes it.
+
+Promotion to a numbered claim in the ADR-002 source-of-truth table is the
+maintainer's call — exactly like the OCI image provenance claim
+(`claim-10-oci-image-provenance.md`), which is tracked via its own doc
+and only later folded into the numbered set. This doc + the catalog row
+register the witnesses for machine-checking without asserting the claim
+in ADR-002's prose.
+
+## Cross-refs
+
+- ADR-067 §"Decision" — egress substitution, never in the guest; the
+  per-VM name-constrained terminator and the placeholder model.
+- ADR-002 §"Security model" — claims 12 + 13, which these invariants
+  reinforce on the egress (vs. broker) delivery.
+- `specs/claims/catalog.md` — the witness ledger row for this leak-gate.
+- `specs/claims/claim-10-oci-image-provenance.md` — the precedent for a
+  not-yet-numbered claim tracked via its own doc.


### PR DESCRIPTION
## What

The Plan 129 security backstop: a standing, canary-based **leak-gate** that fails CI if the egress-substitution invariants ever regress. Three integration tests (run on every PR via the Test lane) assert, with a distinctive canary secret value:

1. **No secret value reaches guest-facing artifacts** — `from_plan` handed placeholders + `secret_placeholder_env` (the guest env) contain only `mvm-secret-` placeholders, never the value.
2. **Substitution fires only for bound destinations** — a placeholder bound to host A, routed to host B → `Refused`, forwarder never saw it (claim 12).
3. **The audit chain carries no secret bytes** — a successful substitution emits `secret.substituted` but the chain never contains the canary value (claim 13).

No canary surfaced a real leak — all three pass on current behavior.

## Claim registration (your call — option A)

Registered as **claim 16, status `Preview`** in `specs/claims/catalog.md` + its own doc `claim-egress-no-secret-to-guest.md`, mirroring how claim 14 (OCI provenance) is handled — a numbered row so `xtask check-claim-catalog` **machine-checks the three witnesses** (a rename is caught), explicitly marked not-yet-promoted to ADR-002's numbered prose (a maintainer decision). The broker's shipped claims 12/13 are untouched. CLAUDE.md + REFACTOR-STATUS prose reconciled to "15 shipped + 1 preview."

## Gates

`cargo nextest -p mvm-hostd` **892 passed**; `check-claim-catalog` clean (16 claims, 39 witnesses); `check-no-overclaim` clean; clippy + fmt clean. No spec/PR/ADR refs in Rust code (only in the claim doc + catalog, which are spec files).