### PR TITLE
feat(secrets): live PII spans into name co-occurrence on the redact path (plan 129 E1)

### DIFF
--- a/crates/mvm-hostd/src/supervisor/network/stages.rs
+++ b/crates/mvm-hostd/src/supervisor/network/stages.rs
@@ -166,11 +166,46 @@ impl RedactingSubstitution {
             SecretAction::Audit => (payload.to_vec(), self.secrets.scan(payload)),
         };
 
+        // The name detector's co-occurrence signal needs the positions of other
+        // PII. Compute them on the current (pre-PII-mask) buffer, then run the name
+        // pass BEFORE masking PII so the offsets line up. Always the curated
+        // ruleset — co-occurrence is a detection signal, independent of the
+        // per-destination PII masking policy.
+        let names_active = !matches!(action.names, NameMode::Off);
+        let pii_spans = if names_active {
+            self.pii.match_spans(&buf)
+        } else {
+            Vec::new()
+        };
+
+        let mut hits = RedactionHits {
+            secrets,
+            pii: Vec::new(),
+            entropy: 0,
+            names: 0,
+        };
+
+        // Names first, on the pre-PII-mask buffer with real PII spans. Names and
+        // structured PII never overlap, so masking names here doesn't disturb the
+        // PII re-scan below.
+        match action.names {
+            NameMode::Off => {}
+            NameMode::Audit => {
+                let (_, n) = NameScanner::with_defaults().redact(&buf, &pii_spans);
+                hits.names += n;
+            }
+            NameMode::Redact => {
+                let (out, n) = NameScanner::with_defaults().redact(&buf, &pii_spans);
+                buf = out;
+                hits.names += n;
+            }
+        }
+
         // Structured PII: a default (empty) action runs the always-on ruleset;
         // an explicit per-destination policy overrides — `disabled` skips it, a
         // category list restricts it. A malformed policy fails safe to always-on.
         let pii_is_default = action.pii.mode.is_none() && action.pii.categories.is_empty();
-        let pii = if pii_is_default {
+        hits.pii = if pii_is_default {
             let (out, p) = self.pii.redact(&buf);
             buf = out;
             p
@@ -188,13 +223,6 @@ impl RedactingSubstitution {
                     p
                 }
             }
-        };
-
-        let mut hits = RedactionHits {
-            secrets,
-            pii,
-            entropy: 0,
-            names: 0,
         };
 
         match &action.entropy {
@@ -215,23 +243,6 @@ impl RedactingSubstitution {
                 let (out, n) = EntropyScanner::new(*min_run_len, *min_bits_per_char).redact(&buf);
                 buf = out;
                 hits.entropy += n;
-            }
-        }
-
-        match action.names {
-            NameMode::Off => {}
-            NameMode::Audit => {
-                // Count without masking: the scanner masks, so dry-redact a copy
-                // for the count and drop the buffer. Live PII match-span plumbing
-                // into co-occurrence is a follow-up — pass empty spans, so the
-                // labeled + gazetteer name signals still fire.
-                let (_, n) = NameScanner::with_defaults().redact(&buf, &[]);
-                hits.names += n;
-            }
-            NameMode::Redact => {
-                let (out, n) = NameScanner::with_defaults().redact(&buf, &[]);
-                buf = out;
-                hits.names += n;
             }
         }
 
@@ -726,6 +737,32 @@ mod tests {
             r.redact_bytes_for(body, &action).is_none(),
             "pii=disabled should leave the email and mask nothing"
         );
+    }
+
+    #[test]
+    fn name_co_occurrence_fires_on_the_live_path() {
+        // "Zephyr Quibblesworth" is neither labeled nor in the gazetteer, so it
+        // only gets masked via the co-occurrence signal — a capitalized pair next
+        // to other PII (the SSN). This proves the live path now threads real PII
+        // spans into the name detector (it would survive with empty spans).
+        use mvm_core::policy::{NameMode, RedactionAction};
+        let r = RedactingSubstitution::with_default_rules();
+        let body = b"Zephyr Quibblesworth ssn 123-45-6789 end";
+        let action = RedactionAction {
+            names: NameMode::Redact,
+            ..Default::default()
+        };
+        let (out, hits) = r
+            .redact_bytes_for(body, &action)
+            .expect("name + ssn should fire");
+        let s = String::from_utf8_lossy(&out);
+        assert!(
+            !s.contains("Zephyr Quibblesworth"),
+            "co-occurrence name not masked: {s}"
+        );
+        assert!(hits.names >= 1, "expected a name hit, got {hits:?}");
+        // The SSN is still masked by the PII pass.
+        assert!(!s.contains("123-45-6789"), "ssn not masked: {s}");
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/pii_redactor.rs
+++ b/crates/mvm-hostd/src/supervisor/pii_redactor.rs
@@ -305,6 +305,24 @@ impl PiiRedactor {
         hits
     }
 
+    /// Validated match byte ranges (`[start, end)`) across all rules. Same
+    /// precision as `scan`/`redact` (a match failing its validator is excluded).
+    /// For callers that need positions, not just category names — e.g. the name
+    /// detector's co-occurrence signal ("a name adjacent to other PII").
+    pub fn match_spans(&self, body: &[u8]) -> Vec<(usize, usize)> {
+        let candidate_indices: Vec<usize> = self.set.matches(body).into_iter().collect();
+        let mut spans = Vec::new();
+        for idx in candidate_indices {
+            let rule = &self.rules[idx];
+            for m in self.regexes[idx].find_iter(body) {
+                if match_passes_validator(rule, m.as_bytes()) {
+                    spans.push((m.start(), m.end()));
+                }
+            }
+        }
+        spans
+    }
+
     /// Replace every *validated* rule match in `body` with
     /// [`REDACTION_MASK`], returning the redacted bytes + the rule names
     /// that fired (stable order, no dups). The mask-and-continue path:

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -134,9 +134,12 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
         square/shopify/digitalocean/vault/postman/linear/figma/google-oauth/
         slack-webhook) in SecretsScanner DEFAULT_RULES — anchored prefixes, low-FP,
         masked on ALL egress by default (no flag). JWT deliberately excluded (legit bearer).
-    [ ] remaining: IR/SDK developer-declared authoring (the only open variant; mvmd
-        can author via bundle), terminator-path redaction, live PII spans.
-        See plan §"Deferred follow-ups".
+    [x] terminator-path redaction + fail-closed + audit (typed TerminatorError;
+        both :80/:443 cores; adversarial fail-closed tests + security review)
+    [x] live PII spans for name co-occurrence: PiiRedactor::match_spans threaded
+        into NameScanner on the live redact_bytes_for path (names run pre-PII-mask)
+    [ ] remaining: IR/SDK developer-declared authoring (descoped — CLI --redact +
+        mvmd bundle cover it). See plan §"Deferred follow-ups".
   [x] Phase F: egress no-secret-to-guest leak-gate (claim-12/13 backstop) —
       canary tests (handed_placeholders_never_contain_the_secret_value /
       substitution_endpoint_refuses_unbound_destination /


### PR DESCRIPTION
## What

Closes the name-detector precision gap: the live `redact_bytes_for` path passed empty PII spans to `NameScanner`, so the **co-occurrence** signal (a capitalized name next to other PII — the "row" case, a name bound to an SSN/email/phone) was dormant. Now the real structured-PII match offsets are threaded in.

## How

- New `PiiRedactor::match_spans(&[u8]) -> Vec<(usize,usize)>` surfaces the validated PII match byte ranges (same precision as `scan`/`redact`).
- `redact_bytes_for` is reordered so the **name pass runs on the pre-PII-mask buffer** with those spans (offsets must line up; PII is masked to `XXX` after). Names and structured PII never overlap, so masking names first doesn't disturb the PII re-scan. Co-occurrence spans always use the curated ruleset — it's a detection signal, independent of the per-destination PII masking policy.

## Test

`name_co_occurrence_fires_on_the_live_path`: "Zephyr Quibblesworth" (neither labeled nor in the gazetteer) is masked **only** because it abuts an SSN — which would survive with empty spans. Regressions hold (default still masks email+secrets, `pii=disabled`, `secrets=audit`, entropy). Full `mvm-hostd` **902 passed**; clippy + fmt clean.