### PR TITLE
feat(secrets): SigV4/HMAC forward-path signing, bind-checked (plan 129)

### DIFF
--- a/crates/mvm-cli/src/commands/ops/secret.rs
+++ b/crates/mvm-cli/src/commands/ops/secret.rs
@@ -261,6 +261,7 @@ fn cmd_set(
             &SecretBindingMeta {
                 auth_type,
                 allowed_hosts: hosts,
+                sigv4: None,
             },
         )
     })();
@@ -799,6 +800,7 @@ mod tests {
         let b = SecretBindingMeta {
             auth_type: AuthType::Bearer,
             allowed_hosts: vec!["api.openai.com".into(), "*.openai.com".into()],
+            sigv4: None,
         };
         let line = ls_line("openai", Some(&b));
         assert!(line.starts_with("openai"));

--- a/crates/mvm-cli/src/commands/ops/secret.rs
+++ b/crates/mvm-cli/src/commands/ops/secret.rs
@@ -845,30 +845,34 @@ mod tests {
         )
     }
 
+    /// The injected stores + audit log a `set` test threads through — grouped
+    /// so the SigV4 helper stays under the argument-count lint.
+    struct SetCtx<'a> {
+        store: &'a dyn SecretStore,
+        bindings: &'a dyn BindingStore,
+        audit: &'a AuditLog,
+    }
+
     /// Like [`set`] but for a SigV4 secret: passes the scope params through.
     fn set_sigv4(
-        store: &dyn SecretStore,
-        bindings: &dyn BindingStore,
-        audit: &AuditLog,
+        ctx: SetCtx<'_>,
         name: &str,
         hosts: &[&str],
-        access_key_id: &str,
-        region: &str,
-        service: &str,
+        params: Sigv4Params,
         value: &str,
     ) -> Result<()> {
         cmd_set(
-            store,
-            bindings,
-            audit,
+            ctx.store,
+            ctx.bindings,
+            ctx.audit,
             SetArgs {
                 tenant: "local".into(),
                 name: name.into(),
                 hosts: hosts.iter().map(|h| h.to_string()).collect(),
                 auth_type: AuthType::Sigv4,
-                aws_access_key_id: Some(access_key_id.into()),
-                region: Some(region.into()),
-                service: Some(service.into()),
+                aws_access_key_id: Some(params.access_key_id),
+                region: Some(params.region),
+                service: Some(params.service),
                 value: Some(value.into()),
                 value_file: None,
             },
@@ -916,14 +920,18 @@ mod tests {
         let (_audit_dir, audit) = temp_audit();
 
         set_sigv4(
-            &store,
-            &bindings,
-            &audit,
+            SetCtx {
+                store: &store,
+                bindings: &bindings,
+                audit: &audit,
+            },
             "aws",
             &["s3.us-east-1.amazonaws.com"],
-            "AKIAIOSFODNN7EXAMPLE",
-            "us-east-1",
-            "s3",
+            Sigv4Params {
+                access_key_id: "AKIAIOSFODNN7EXAMPLE".into(),
+                region: "us-east-1".into(),
+                service: "s3".into(),
+            },
             "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", // the secret-access-key
         )
         .unwrap();

--- a/crates/mvm-cli/src/commands/ops/secret.rs
+++ b/crates/mvm-cli/src/commands/ops/secret.rs
@@ -43,7 +43,7 @@ use mvm_core::crypto::secret_store::{self, SecretStore};
 use mvm_core::plan::TenantId;
 use mvm_hostd::keyholder::{BindingStore, FileBindingStore, SecretBindingMeta};
 use mvm_hostd::supervisor::{EventCategory, FileAuditSigner, Recorder};
-use mvm_sdk::ir::AuthType;
+use mvm_sdk::ir::{AuthType, Sigv4Params};
 use secrecy::SecretBox;
 
 use mvm_core::user_config::MvmConfig;
@@ -108,6 +108,19 @@ pub(in crate::commands) enum SecretAction {
         /// How the credential authenticates outbound requests.
         #[arg(long = "type", value_enum)]
         auth_type: AuthTypeArg,
+        /// AWS access-key id (e.g. `AKIA…`). Required with `--type sigv4`,
+        /// rejected otherwise. Public (it pairs with the secret-access-key
+        /// value, which is the stored secret) — not the signing key.
+        #[arg(long = "aws-access-key-id")]
+        aws_access_key_id: Option<String>,
+        /// AWS credential-scope region (e.g. `us-east-1`). Required with
+        /// `--type sigv4`, rejected otherwise.
+        #[arg(long)]
+        region: Option<String>,
+        /// AWS credential-scope service (e.g. `s3`, `execute-api`). Required
+        /// with `--type sigv4`, rejected otherwise.
+        #[arg(long)]
+        service: Option<String>,
         /// Inline value. Pass `-` to read from stdin (preferred when
         /// scripting; avoids shell-history exposure).
         #[arg(long, conflicts_with = "value_file")]
@@ -180,6 +193,9 @@ pub(in crate::commands) fn run_with_stores(
             tenant,
             hosts,
             auth_type,
+            aws_access_key_id,
+            region,
+            service,
             value,
             value_file,
         } => cmd_set(
@@ -191,6 +207,9 @@ pub(in crate::commands) fn run_with_stores(
                 name,
                 hosts,
                 auth_type: auth_type.into(),
+                aws_access_key_id,
+                region,
+                service,
                 value,
                 value_file,
             },
@@ -231,6 +250,9 @@ struct SetArgs {
     name: String,
     hosts: Vec<String>,
     auth_type: AuthType,
+    aws_access_key_id: Option<String>,
+    region: Option<String>,
+    service: Option<String>,
     value: Option<String>,
     value_file: Option<PathBuf>,
 }
@@ -246,10 +268,17 @@ fn cmd_set(
         name,
         hosts,
         auth_type,
+        aws_access_key_id,
+        region,
+        service,
         value,
         value_file,
     } = set;
     let result = (|| -> Result<()> {
+        // Validate the SigV4 scope params against the auth-type BEFORE touching
+        // the store: `--type sigv4` requires all three; any of them is rejected
+        // for a non-sigv4 type (they'd be silently dropped otherwise).
+        let sigv4 = resolve_sigv4_params(auth_type, aws_access_key_id, region, service)?;
         let raw = resolve_value(value, value_file, &name)?;
         let secret = SecretBox::new(Box::new(raw));
         store.put(&tenant, &name, &secret)?;
@@ -261,7 +290,7 @@ fn cmd_set(
             &SecretBindingMeta {
                 auth_type,
                 allowed_hosts: hosts,
-                sigv4: None,
+                sigv4,
             },
         )
     })();
@@ -269,6 +298,45 @@ fn cmd_set(
     result?;
     eprintln!("Defined secret '{name}' for tenant '{tenant}'.");
     Ok(())
+}
+
+/// Validate + assemble the SigV4 scope params against the auth-type. Pure so it
+/// is unit-testable without a store. `Sigv4` demands all three (`access_key_id`,
+/// `region`, `service`); any other auth-type rejects all three (a passed param
+/// would otherwise be silently ignored, masking an operator mistake). The secret
+/// value (the secret-access-key) is resolved separately and never lands here.
+fn resolve_sigv4_params(
+    auth_type: AuthType,
+    access_key_id: Option<String>,
+    region: Option<String>,
+    service: Option<String>,
+) -> Result<Option<Sigv4Params>> {
+    match auth_type {
+        AuthType::Sigv4 => {
+            let access_key_id = access_key_id
+                .filter(|s| !s.is_empty())
+                .context("--type sigv4 requires --aws-access-key-id")?;
+            let region = region
+                .filter(|s| !s.is_empty())
+                .context("--type sigv4 requires --region")?;
+            let service = service
+                .filter(|s| !s.is_empty())
+                .context("--type sigv4 requires --service")?;
+            Ok(Some(Sigv4Params {
+                access_key_id,
+                region,
+                service,
+            }))
+        }
+        AuthType::Hmac | AuthType::Bearer | AuthType::Basic => {
+            if access_key_id.is_some() || region.is_some() || service.is_some() {
+                anyhow::bail!(
+                    "--aws-access-key-id/--region/--service are only valid with --type sigv4"
+                );
+            }
+            Ok(None)
+        }
+    }
 }
 
 fn cmd_get(store: &dyn SecretStore, audit: &AuditLog, tenant: String, name: String) -> Result<()> {
@@ -307,11 +375,23 @@ fn cmd_ls(
 /// which is never an input.
 fn ls_line(name: &str, binding: Option<&SecretBindingMeta>) -> String {
     match binding {
-        Some(b) => format!(
-            "{name}\ttype={}\thosts={}",
-            auth_type_label(b.auth_type),
-            b.allowed_hosts.join(",")
-        ),
+        Some(b) => {
+            let mut line = format!(
+                "{name}\ttype={}\thosts={}",
+                auth_type_label(b.auth_type),
+                b.allowed_hosts.join(",")
+            );
+            // SigV4 scope is non-secret operator metadata. access_key_id is
+            // identifying but public (it pairs with the secret-access-key, which
+            // is never shown); region/service name the credential scope.
+            if let Some(s) = &b.sigv4 {
+                line.push_str(&format!(
+                    "\taccess_key_id={}\tregion={}\tservice={}",
+                    s.access_key_id, s.region, s.service
+                ));
+            }
+            line
+        }
         None => name.to_string(),
     }
 }
@@ -756,6 +836,39 @@ mod tests {
                 name: name.into(),
                 hosts: hosts.iter().map(|h| h.to_string()).collect(),
                 auth_type,
+                aws_access_key_id: None,
+                region: None,
+                service: None,
+                value: Some(value.into()),
+                value_file: None,
+            },
+        )
+    }
+
+    /// Like [`set`] but for a SigV4 secret: passes the scope params through.
+    fn set_sigv4(
+        store: &dyn SecretStore,
+        bindings: &dyn BindingStore,
+        audit: &AuditLog,
+        name: &str,
+        hosts: &[&str],
+        access_key_id: &str,
+        region: &str,
+        service: &str,
+        value: &str,
+    ) -> Result<()> {
+        cmd_set(
+            store,
+            bindings,
+            audit,
+            SetArgs {
+                tenant: "local".into(),
+                name: name.into(),
+                hosts: hosts.iter().map(|h| h.to_string()).collect(),
+                auth_type: AuthType::Sigv4,
+                aws_access_key_id: Some(access_key_id.into()),
+                region: Some(region.into()),
+                service: Some(service.into()),
                 value: Some(value.into()),
                 value_file: None,
             },
@@ -793,6 +906,108 @@ mod tests {
             !sidecar.contains("sk-live-zzz"),
             "binding sidecar must not contain the secret value: {sidecar}"
         );
+    }
+
+    #[test]
+    fn cmd_set_sigv4_stores_params_in_binding_not_value_in_sidecar() {
+        let tmp_store = tempfile::tempdir().unwrap();
+        let store = FileSecretStore::with_dir(tmp_store.path());
+        let (bind_dir, bindings) = temp_bindings();
+        let (_audit_dir, audit) = temp_audit();
+
+        set_sigv4(
+            &store,
+            &bindings,
+            &audit,
+            "aws",
+            &["s3.us-east-1.amazonaws.com"],
+            "AKIAIOSFODNN7EXAMPLE",
+            "us-east-1",
+            "s3",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", // the secret-access-key
+        )
+        .unwrap();
+
+        // The value (secret-access-key) landed in the value store.
+        assert_eq!(store.list("local").unwrap(), vec!["aws"]);
+        // The binding carries the non-secret scope params.
+        let b = bindings.get("local", "aws").unwrap().unwrap();
+        assert_eq!(b.auth_type, AuthType::Sigv4);
+        let params = b.sigv4.expect("sigv4 params stored");
+        assert_eq!(params.access_key_id, "AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(params.region, "us-east-1");
+        assert_eq!(params.service, "s3");
+        // The secret-access-key (the signing key) never lands in the sidecar.
+        let sidecar =
+            std::fs::read_to_string(bind_dir.path().join("local").join("aws.json")).unwrap();
+        assert!(
+            !sidecar.contains("wJalrXUtnFEMI"),
+            "binding sidecar must not carry the secret-access-key: {sidecar}"
+        );
+    }
+
+    #[test]
+    fn resolve_sigv4_params_requires_all_three_for_sigv4() {
+        // Missing any of the three is an error.
+        assert!(
+            resolve_sigv4_params(AuthType::Sigv4, Some("AKIA".into()), Some("r".into()), None)
+                .is_err()
+        );
+        assert!(
+            resolve_sigv4_params(AuthType::Sigv4, Some("AKIA".into()), None, Some("s".into()))
+                .is_err()
+        );
+        assert!(
+            resolve_sigv4_params(AuthType::Sigv4, None, Some("r".into()), Some("s".into()))
+                .is_err()
+        );
+        // All three present → params.
+        let p = resolve_sigv4_params(
+            AuthType::Sigv4,
+            Some("AKIA".into()),
+            Some("us-east-1".into()),
+            Some("s3".into()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(p.access_key_id, "AKIA");
+        assert_eq!(p.region, "us-east-1");
+        assert_eq!(p.service, "s3");
+    }
+
+    #[test]
+    fn resolve_sigv4_params_rejects_params_for_non_sigv4_types() {
+        // Passing a sigv4 param to a bearer secret is an operator error, not
+        // a silent no-op.
+        for t in [AuthType::Bearer, AuthType::Basic, AuthType::Hmac] {
+            assert!(
+                resolve_sigv4_params(t, Some("AKIA".into()), None, None).is_err(),
+                "{t:?} must reject --aws-access-key-id"
+            );
+            // No params → None, fine.
+            assert_eq!(resolve_sigv4_params(t, None, None, None).unwrap(), None);
+        }
+    }
+
+    #[test]
+    fn ls_line_shows_sigv4_scope_for_a_sigv4_secret() {
+        let b = SecretBindingMeta {
+            auth_type: AuthType::Sigv4,
+            allowed_hosts: vec!["s3.us-east-1.amazonaws.com".into()],
+            sigv4: Some(Sigv4Params {
+                access_key_id: "AKIAIOSFODNN7EXAMPLE".into(),
+                region: "us-east-1".into(),
+                service: "s3".into(),
+            }),
+        };
+        let line = ls_line("aws", Some(&b));
+        assert!(line.contains("type=sigv4"), "got: {line}");
+        assert!(
+            line.contains("access_key_id=AKIAIOSFODNN7EXAMPLE"),
+            "got: {line}"
+        );
+        assert!(line.contains("region=us-east-1"), "got: {line}");
+        assert!(line.contains("service=s3"), "got: {line}");
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/managed_secrets.rs
+++ b/crates/mvm-cli/src/commands/vm/managed_secrets.rs
@@ -118,6 +118,7 @@ mod tests {
                 mount: SecretMount::Env { var: var.into() },
                 auth_type: mvm_sdk::ir::AuthType::Bearer,
                 allowed_hosts: vec!["api.example.com".into()],
+                sigv4: None,
             },
         }
     }

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -4047,6 +4047,7 @@ mod resolve_deps_volume_tests {
                 &SecretBindingMeta {
                     auth_type: mvm_sdk::ir::AuthType::Bearer,
                     allowed_hosts: vec!["api.openai.com".into()],
+                    sigv4: None,
                 },
             )
             .unwrap();

--- a/crates/mvm-hostd/src/keyholder/admission.rs
+++ b/crates/mvm-hostd/src/keyholder/admission.rs
@@ -80,6 +80,10 @@ pub fn assemble_registry(
             },
             auth_type: meta.auth_type,
             allowed_hosts: meta.allowed_hosts,
+            // Non-secret SigV4 scope from the operator-set binding; the
+            // forward-path signer reads it to name the credential. None for
+            // every non-SigV4 secret.
+            sigv4: meta.sigv4,
         };
         let placeholder = registry.mint(secret_ref);
         handed.push((b.name.clone(), placeholder));
@@ -114,6 +118,7 @@ mod tests {
                 &SecretBindingMeta {
                     auth_type: AuthType::Bearer,
                     allowed_hosts: vec!["api.openai.com".into()],
+                    sigv4: None,
                 },
             )
             .unwrap();
@@ -139,6 +144,40 @@ mod tests {
         assert_eq!(env[0].0, "OPENAI_API_KEY");
         assert_eq!(env[0].1, placeholder.as_str());
         assert!(env[0].1.starts_with("mvm-secret-"));
+    }
+
+    #[test]
+    fn reconstructs_sigv4_params_onto_the_secret_ref() {
+        use mvm_sdk::ir::Sigv4Params;
+        let dir = tempdir().unwrap();
+        let store = FileBindingStore::with_dir(dir.path());
+        store
+            .put(
+                "local",
+                "aws",
+                &SecretBindingMeta {
+                    auth_type: AuthType::Sigv4,
+                    allowed_hosts: vec!["s3.us-east-1.amazonaws.com".into()],
+                    sigv4: Some(Sigv4Params {
+                        access_key_id: "AKIAIOSFODNN7EXAMPLE".into(),
+                        region: "us-east-1".into(),
+                        service: "s3".into(),
+                    }),
+                },
+            )
+            .unwrap();
+
+        let plan = [keystore_binding("AWS_SIG", "aws")];
+        let (registry, handed) = assemble_registry(&plan, "local", &store).unwrap();
+        let secret_ref = registry.resolve(handed[0].1.as_str()).unwrap();
+        assert_eq!(secret_ref.auth_type, AuthType::Sigv4);
+        let params = secret_ref
+            .sigv4
+            .as_ref()
+            .expect("sigv4 params reconstructed");
+        assert_eq!(params.access_key_id, "AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(params.region, "us-east-1");
+        assert_eq!(params.service, "s3");
     }
 
     #[test]

--- a/crates/mvm-hostd/src/keyholder/binding.rs
+++ b/crates/mvm-hostd/src/keyholder/binding.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use mvm_core::config::mvm_data_dir_strict;
 use mvm_core::crypto::keystore::validate_shell_id;
-use mvm_sdk::ir::AuthType;
+use mvm_sdk::ir::{AuthType, Sigv4Params};
 use serde::{Deserialize, Serialize};
 
 /// Per-(tenant, name) binding metadata. No secret bytes — safe to print.
@@ -30,6 +30,12 @@ pub struct SecretBindingMeta {
     /// Destinations the substituted credential may reach (claim 12).
     /// `*.` subdomain wildcards per [`mvm_sdk::ir::host_matches`].
     pub allowed_hosts: Vec<String>,
+    /// Non-secret SigV4 params (access-key id + credential scope), set only for
+    /// `auth_type = Sigv4`. The secret-access-key (the signing key) stays in the
+    /// value store; these are reconstructed onto the `SecretRef` at admission so
+    /// the forward-path signer can name the credential scope. `None` otherwise.
+    #[serde(default)]
+    pub sigv4: Option<Sigv4Params>,
 }
 
 /// Storage for [`SecretBindingMeta`], keyed by (tenant, name). Parallel
@@ -128,7 +134,25 @@ mod tests {
         SecretBindingMeta {
             auth_type: AuthType::Bearer,
             allowed_hosts: vec!["api.openai.com".into()],
+            sigv4: None,
         }
+    }
+
+    #[test]
+    fn sigv4_binding_roundtrips_with_params() {
+        let dir = tempdir().unwrap();
+        let store = FileBindingStore::with_dir(dir.path());
+        let m = SecretBindingMeta {
+            auth_type: AuthType::Sigv4,
+            allowed_hosts: vec!["s3.us-east-1.amazonaws.com".into()],
+            sigv4: Some(Sigv4Params {
+                access_key_id: "AKIAIOSFODNN7EXAMPLE".into(),
+                region: "us-east-1".into(),
+                service: "s3".into(),
+            }),
+        };
+        store.put("local", "aws", &m).unwrap();
+        assert_eq!(store.get("local", "aws").unwrap(), Some(m));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/keyholder/injector.rs
+++ b/crates/mvm-hostd/src/keyholder/injector.rs
@@ -121,6 +121,7 @@ mod tests {
             mount: SecretMount::Env { var: "K".into() },
             auth_type,
             allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
         }
     }
 

--- a/crates/mvm-hostd/src/keyholder/resolver.rs
+++ b/crates/mvm-hostd/src/keyholder/resolver.rs
@@ -97,6 +97,7 @@ mod tests {
             },
             auth_type: AuthType::Bearer,
             allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
         }
     }
 

--- a/crates/mvm-hostd/src/keyholder/signer.rs
+++ b/crates/mvm-hostd/src/keyholder/signer.rs
@@ -175,6 +175,7 @@ mod tests {
             mount: SecretMount::Env { var: "K".into() },
             auth_type,
             allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
         }
     }
 

--- a/crates/mvm-hostd/src/keyholder/signer.rs
+++ b/crates/mvm-hostd/src/keyholder/signer.rs
@@ -59,6 +59,10 @@ pub struct SigV4Input {
     pub date_stamp: String,
     pub region: String,
     pub service: String,
+    /// The `;`-joined, lowercased, sorted header names that were signed —
+    /// the `SignedHeaders=` field of the `Authorization` header. Request
+    /// metadata, not key material, so Debug can't leak a secret.
+    pub signed_headers: String,
 }
 
 impl SigV4Input {
@@ -211,6 +215,7 @@ mod tests {
             date_stamp: "20150830".into(),
             region: "us-east-1".into(),
             service: "service".into(),
+            signed_headers: "host;x-amz-date".into(),
         };
         let sig = signer
             .sign_sigv4(
@@ -247,6 +252,7 @@ mod tests {
             date_stamp: "20150830".into(),
             region: "us-east-1".into(),
             service: "service".into(),
+            signed_headers: String::new(),
         };
         let err = signer
             .sign_sigv4(

--- a/crates/mvm-hostd/src/keyholder/sigv4.rs
+++ b/crates/mvm-hostd/src/keyholder/sigv4.rs
@@ -189,6 +189,7 @@ mod tests {
             mount: SecretMount::Env { var: "K".into() },
             auth_type: AuthType::Sigv4,
             allowed_hosts: vec!["example.amazonaws.com".into()],
+            sigv4: None,
         };
         let sig = Signer::new(&resolver as &dyn SecretResolver)
             .sign_sigv4(&secret, &get_vanilla())

--- a/crates/mvm-hostd/src/keyholder/sigv4.rs
+++ b/crates/mvm-hostd/src/keyholder/sigv4.rs
@@ -87,6 +87,7 @@ pub fn build_sigv4_input(
         date_stamp,
         region: region.to_string(),
         service: service.to_string(),
+        signed_headers,
     })
 }
 
@@ -164,6 +165,26 @@ mod tests {
              x-amz-date:20150830T123600Z\n\nhost;x-amz-date\n\
              e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
         assert_eq!(get_vanilla().canonical_request, expected);
+    }
+
+    #[test]
+    fn signed_headers_is_returned_sorted_and_lowercased() {
+        // The forward path needs SignedHeaders for the Authorization header;
+        // it's the sorted, lowercased, `;`-joined set of header names.
+        let input = build_sigv4_input(
+            "POST",
+            "https://h/p",
+            &[
+                ("X-Amz-Date".into(), "20150830T123600Z".into()),
+                ("Host".into(), "h".into()),
+                ("Content-Type".into(), "application/json".into()),
+            ],
+            b"{}",
+            "us-east-1",
+            "s3",
+        )
+        .unwrap();
+        assert_eq!(input.signed_headers, "content-type;host;x-amz-date");
     }
 
     #[test]

--- a/crates/mvm-hostd/src/keyholder/substitution.rs
+++ b/crates/mvm-hostd/src/keyholder/substitution.rs
@@ -145,6 +145,14 @@ impl<'a> SubstitutionEndpoint<'a> {
             .map(|r| (r.name.clone(), r.auth_type))
     }
 
+    /// The full [`SecretRef`] a placeholder resolves to (binding metadata only —
+    /// name, auth-type, allowed_hosts, sigv4 scope; never the value). The
+    /// forward path reads it to branch inject-vs-sign and to name the SigV4
+    /// credential scope. `None` for an unknown placeholder.
+    pub fn resolve_ref(&self, placeholder: &str) -> Option<&SecretRef> {
+        self.registry.resolve(placeholder)
+    }
+
     /// Substitute `placeholder` in `request_text` with the real credential
     /// for `destination`. Returns the rewritten request `Zeroizing` (it now
     /// carries the raw credential). Refuses — without decrypting — when the
@@ -305,6 +313,7 @@ mod tests {
             date_stamp: "20150830".into(),
             region: "us-east-1".into(),
             service: "service".into(),
+            signed_headers: "host;x-amz-date".into(),
         });
         let sig = endpoint
             .sign(ph.as_str(), "example.amazonaws.com", &input)

--- a/crates/mvm-hostd/src/keyholder/substitution.rs
+++ b/crates/mvm-hostd/src/keyholder/substitution.rs
@@ -256,6 +256,7 @@ mod tests {
             mount: SecretMount::Env { var: "K".into() },
             auth_type: AuthType::Bearer,
             allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
         }
     }
 
@@ -279,6 +280,7 @@ mod tests {
             mount: SecretMount::Env { var: "K".into() },
             auth_type: auth,
             allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
         }
     }
 

--- a/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
@@ -276,6 +276,7 @@ mod tests {
                 &SecretBindingMeta {
                     auth_type: AuthType::Bearer,
                     allowed_hosts: vec!["api.openai.com".into()],
+                    sigv4: None,
                 },
             )
             .unwrap();
@@ -378,6 +379,7 @@ mod tests {
                 &SecretBindingMeta {
                     auth_type: AuthType::Bearer,
                     allowed_hosts: vec!["api.openai.com".into()],
+                    sigv4: None,
                 },
             )
             .unwrap();

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -1112,6 +1112,7 @@ mod tests {
             mount: SecretMount::Env { var: "K".into() },
             auth_type: AuthType::Bearer,
             allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
         }
     }
 
@@ -1225,6 +1226,7 @@ mod server_tests {
             mount: SecretMount::Env { var: "K".into() },
             auth_type: AuthType::Bearer,
             allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
         }
     }
 
@@ -1515,6 +1517,7 @@ mod server_tests {
                 &SecretBindingMeta {
                     auth_type: AuthType::Bearer,
                     allowed_hosts: vec!["api.openai.com".into()],
+                    sigv4: None,
                 },
             )
             .unwrap();
@@ -1564,6 +1567,7 @@ mod server_tests {
                 &SecretBindingMeta {
                     auth_type: AuthType::Bearer,
                     allowed_hosts: vec!["api.openai.com".into()],
+                    sigv4: None,
                 },
             )
             .unwrap();

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -29,8 +29,8 @@ use mvm_sdk::ir::AuthType;
 use crate::framing::{FrameError, read_json_frame, write_json_frame};
 use crate::keyholder::{
     AssembleError, BindingStore, HandedPlaceholders, LocalResolver, SecretResolver,
-    SubstituteError, SubstitutionEndpoint, SubstitutionRegistry, assemble_registry,
-    find_placeholder,
+    SignDispatchError, SigningInput, SubstituteError, SubstitutionEndpoint, SubstitutionRegistry,
+    assemble_registry, build_sigv4_input, find_placeholder,
 };
 use crate::supervisor::audit_recorder::Recorder;
 use crate::supervisor::network::stages::{RedactingSubstitution, RedactionHits};
@@ -72,6 +72,18 @@ pub enum ProxyError {
     BadUrl(String),
     #[error(transparent)]
     Substitute(#[from] SubstituteError),
+    /// The signing path (SigV4/HMAC) refused or failed. Carries the
+    /// bind-check refusal (`DestinationNotBound`), an unknown placeholder, the
+    /// signer error, or a malformed/over-restricted request — every variant is
+    /// fail-closed: `prepare_request` returns `Err` and nothing is forwarded.
+    #[error(transparent)]
+    Sign(#[from] SignDispatchError),
+    /// A signing secret reached the forward path without the data the
+    /// signature needs (e.g. a SigV4 secret with no `access_key_id`/`region`/
+    /// `service` binding, or a request the canonical form can't be built from).
+    /// Fail-closed: refuse rather than forward an unsigned request.
+    #[error("refusing to forward: {0}")]
+    Refused(String),
 }
 
 /// Substitute every placeholder in `req`'s headers against `endpoint`,
@@ -88,25 +100,165 @@ pub fn prepare_request(
     req: ProxyRequest,
 ) -> Result<PreparedRequest, ProxyError> {
     let dest = destination_host(&req.url)?;
+    // Inject pass (Bearer/Basic): the credential is substituted *into* the
+    // header value in place. A signing placeholder (SigV4/HMAC) is left as-is
+    // here and handled in the sign pass below — it never carries the value.
     let mut headers = Vec::with_capacity(req.headers.len());
+    let mut signing: Option<(String, AuthType)> = None;
     for (name, value) in req.headers {
         let new_value = match find_placeholder(&value) {
             Some(ph) => {
                 let ph = ph.to_string();
-                // `substitute` carries the claim-12 bind-check: an unbound
-                // destination or unknown token errors here, before forwarding.
-                endpoint.substitute(&ph, &dest, &value)?.to_string()
+                match endpoint.resolve_ref(&ph).map(|r| r.auth_type) {
+                    Some(AuthType::Bearer) | Some(AuthType::Basic) => {
+                        // `substitute` carries the claim-12 bind-check: an
+                        // unbound destination or unknown token errors here,
+                        // before forwarding.
+                        endpoint.substitute(&ph, &dest, &value)?.to_string()
+                    }
+                    Some(sign_auth @ (AuthType::Sigv4 | AuthType::Hmac)) => {
+                        // A signing secret: remember the placeholder and DROP its
+                        // header value (it only ever held the opaque token). The
+                        // real signature header is assembled in the sign pass.
+                        if signing.is_some() {
+                            return Err(ProxyError::Refused(
+                                "more than one signing placeholder in one request".into(),
+                            ));
+                        }
+                        signing = Some((ph, sign_auth));
+                        continue; // drop this header entirely
+                    }
+                    None => {
+                        // Unknown token: route through `substitute` so the
+                        // existing claim-12 `UnknownPlaceholder` refusal fires.
+                        endpoint.substitute(&ph, &dest, &value)?.to_string()
+                    }
+                }
             }
             None => value,
         };
         headers.push((name, new_value));
     }
+
+    // Sign pass: a SigV4/HMAC secret signs the whole request and adds its own
+    // header. The signing key never leaves the signer; the bind-check is
+    // enforced inside `endpoint.sign` (claim 12). Any failure is fail-closed.
+    if let Some((ph, auth_type)) = signing {
+        sign_into_headers(
+            endpoint,
+            &ph,
+            auth_type,
+            &dest,
+            &req.method,
+            &req.url,
+            &req.body,
+            &mut headers,
+        )?;
+    }
+
     Ok(PreparedRequest {
         method: req.method,
         url: req.url,
         headers,
         body: req.body,
     })
+}
+
+/// `yyyymmddThhmmssZ` UTC, the SigV4 `x-amz-date` format.
+fn amz_date_now() -> String {
+    chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string()
+}
+
+/// Sign the request for a SigV4/HMAC secret and append the signature header,
+/// routing through the bind-checked `endpoint.sign` (claim 12, key-never-leaves).
+/// Fail-closed: a missing SigV4 binding, a bad request, or a refused/failed sign
+/// returns `Err` and the caller forwards nothing.
+#[allow(clippy::too_many_arguments)]
+fn sign_into_headers(
+    endpoint: &SubstitutionEndpoint<'_>,
+    placeholder: &str,
+    auth_type: AuthType,
+    dest: &str,
+    method: &str,
+    url: &str,
+    body: &[u8],
+    headers: &mut Vec<(String, String)>,
+) -> Result<(), ProxyError> {
+    match auth_type {
+        AuthType::Sigv4 => {
+            // The non-secret scope (access_key_id/region/service) is operator-set
+            // in the binding and reconstructed onto the ref at admission. Absent
+            // ⇒ fail closed: we can't name a credential to sign under.
+            let params = endpoint
+                .resolve_ref(placeholder)
+                .and_then(|r| r.sigv4.clone())
+                .ok_or_else(|| {
+                    ProxyError::Refused(
+                        "sigv4 secret missing access_key_id/region/service binding".into(),
+                    )
+                })?;
+            // SigV4 signs `x-amz-date`. Use the guest's if present, else
+            // synthesize one now (UTC) — and make sure it is on the outgoing
+            // request so the signature matches what the destination verifies.
+            let amz_date = headers
+                .iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case("x-amz-date"))
+                .map(|(_, v)| v.clone())
+                .unwrap_or_else(|| {
+                    let d = amz_date_now();
+                    headers.push(("x-amz-date".to_string(), d.clone()));
+                    d
+                });
+            // Build the canonical request over the headers we will actually send
+            // (the placeholder header is already dropped; x-amz-date is present).
+            // `build_sigv4_input` reads x-amz-date from this set.
+            let _ = &amz_date;
+            let input =
+                build_sigv4_input(method, url, headers, body, &params.region, &params.service)
+                    .map_err(|e| {
+                        ProxyError::Refused(format!("building sigv4 canonical request: {e}"))
+                    })?;
+            let sig = endpoint.sign(placeholder, dest, &SigningInput::SigV4(input.clone()))?;
+            let scope = input.credential_scope();
+            let authorization = format!(
+                "AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
+                params.access_key_id, scope, input.signed_headers, sig.hex
+            );
+            // Replace any existing Authorization, else add it. The secret-access-
+            // key never appears here — only the derived signature hex.
+            if let Some(slot) = headers
+                .iter_mut()
+                .find(|(k, _)| k.eq_ignore_ascii_case("authorization"))
+            {
+                slot.1 = authorization;
+            } else {
+                headers.push(("Authorization".to_string(), authorization));
+            }
+            Ok(())
+        }
+        AuthType::Hmac => {
+            // HMAC webhook: sign the body, emit the signature in a documented
+            // default header. The key never leaves the signer.
+            let sig = endpoint.sign(
+                placeholder,
+                dest,
+                &SigningInput::Hmac {
+                    payload: body.to_vec(),
+                },
+            )?;
+            if let Some(slot) = headers
+                .iter_mut()
+                .find(|(k, _)| k.eq_ignore_ascii_case("x-mvm-signature"))
+            {
+                slot.1 = sig.hex;
+            } else {
+                headers.push(("x-mvm-signature".to_string(), sig.hex));
+            }
+            Ok(())
+        }
+        // Inject types never reach the sign pass.
+        AuthType::Bearer | AuthType::Basic => Ok(()),
+    }
 }
 
 /// The destination host (no port) from an absolute URL.
@@ -1114,6 +1266,318 @@ mod tests {
             allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
             sigv4: None,
         }
+    }
+
+    fn sigv4_ref(name: &str, hosts: &[&str], service: &str, region: &str) -> SecretRef {
+        use mvm_sdk::ir::Sigv4Params;
+        SecretRef {
+            name: name.into(),
+            mount: SecretMount::Env { var: "K".into() },
+            auth_type: AuthType::Sigv4,
+            allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: Some(Sigv4Params {
+                access_key_id: "AKIAIOSFODNN7EXAMPLE".into(),
+                region: region.into(),
+                service: service.into(),
+            }),
+        }
+    }
+
+    fn sigv4_ref_no_params(name: &str, hosts: &[&str]) -> SecretRef {
+        SecretRef {
+            name: name.into(),
+            mount: SecretMount::Env { var: "K".into() },
+            auth_type: AuthType::Sigv4,
+            allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
+        }
+    }
+
+    fn hmac_ref(name: &str, hosts: &[&str]) -> SecretRef {
+        SecretRef {
+            name: name.into(),
+            mount: SecretMount::Env { var: "K".into() },
+            auth_type: AuthType::Hmac,
+            allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
+        }
+    }
+
+    /// Parse the structured fields of an `AWS4-HMAC-SHA256` Authorization value.
+    fn parse_sigv4_authorization(v: &str) -> (String, String, String) {
+        let rest = v.strip_prefix("AWS4-HMAC-SHA256 ").expect("scheme prefix");
+        let mut credential = String::new();
+        let mut signed_headers = String::new();
+        let mut signature = String::new();
+        for part in rest.split(", ") {
+            if let Some(c) = part.strip_prefix("Credential=") {
+                credential = c.to_string();
+            } else if let Some(s) = part.strip_prefix("SignedHeaders=") {
+                signed_headers = s.to_string();
+            } else if let Some(s) = part.strip_prefix("Signature=") {
+                signature = s.to_string();
+            }
+        }
+        (credential, signed_headers, signature)
+    }
+
+    // The canonical AWS example secret-access-key — used as our seeded signing
+    // key so the no-leak assertions have a distinctive string to grep for.
+    const AWS_SECRET_ACCESS_KEY: &str = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+
+    #[test]
+    fn sigv4_request_gets_a_valid_authorization_header() {
+        let (_dir, resolver) = resolver_with("aws", AWS_SECRET_ACCESS_KEY);
+        let mut reg = SubstitutionRegistry::new();
+        let ph = reg.mint(sigv4_ref(
+            "aws",
+            &["s3.us-east-1.amazonaws.com"],
+            "s3",
+            "us-east-1",
+        ));
+        let endpoint = SubstitutionEndpoint::new(&reg, &resolver);
+
+        // The guest puts the opaque placeholder in the Authorization header,
+        // exactly like Bearer; the endpoint branches on the resolved auth_type.
+        let req = ProxyRequest {
+            method: "GET".into(),
+            url: "https://s3.us-east-1.amazonaws.com/bucket/key".into(),
+            headers: vec![
+                ("authorization".into(), ph.as_str().to_string()),
+                ("host".into(), "s3.us-east-1.amazonaws.com".into()),
+                ("x-amz-date".into(), "20150830T123600Z".into()),
+            ],
+            body: vec![],
+        };
+        let prepared = prepare_request(&endpoint, req).unwrap();
+
+        let auth = prepared
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("authorization"))
+            .map(|(_, v)| v.clone())
+            .expect("Authorization header produced");
+        let (credential, signed_headers, signature) = parse_sigv4_authorization(&auth);
+        assert!(
+            credential.starts_with("AKIAIOSFODNN7EXAMPLE/20150830/us-east-1/s3/aws4_request"),
+            "credential scope: {credential}"
+        );
+        assert!(
+            signed_headers.contains("host"),
+            "signed headers: {signed_headers}"
+        );
+        assert!(
+            signed_headers.contains("x-amz-date"),
+            "signed headers: {signed_headers}"
+        );
+        // 64 hex chars of HMAC-SHA256.
+        assert_eq!(signature.len(), 64, "signature: {signature}");
+        assert!(signature.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // No-leak: the secret-access-key (signing key) appears NOWHERE in the
+        // prepared request — not the Authorization header, not any other header,
+        // not the body, and the opaque placeholder is gone too.
+        for (k, v) in &prepared.headers {
+            assert!(
+                !v.contains(AWS_SECRET_ACCESS_KEY),
+                "key leaked in header {k}: {v}"
+            );
+            assert!(
+                !v.contains(ph.as_str()),
+                "placeholder leaked in header {k}: {v}"
+            );
+        }
+        assert!(
+            !prepared
+                .body
+                .windows(AWS_SECRET_ACCESS_KEY.len())
+                .any(|w| w == AWS_SECRET_ACCESS_KEY.as_bytes())
+        );
+    }
+
+    #[test]
+    fn sigv4_forward_path_matches_the_aws_get_vanilla_signature() {
+        // End-to-end oracle: drive the published aws-sig-v4-test-suite
+        // get-vanilla request through prepare_request and assert the assembled
+        // Authorization carries the published signature — proves the forward
+        // path's canonicalization + signing is byte-correct, not just well-shaped.
+        let (_dir, resolver) = resolver_with("aws", AWS_SECRET_ACCESS_KEY);
+        let mut reg = SubstitutionRegistry::new();
+        // get-vanilla scope: region=us-east-1, service="service".
+        let ph = reg.mint(sigv4_ref(
+            "aws",
+            &["example.amazonaws.com"],
+            "service",
+            "us-east-1",
+        ));
+        let endpoint = SubstitutionEndpoint::new(&reg, &resolver);
+        let req = ProxyRequest {
+            method: "GET".into(),
+            url: "https://example.amazonaws.com/".into(),
+            headers: vec![
+                ("authorization".into(), ph.as_str().to_string()),
+                ("host".into(), "example.amazonaws.com".into()),
+                ("x-amz-date".into(), "20150830T123600Z".into()),
+            ],
+            body: vec![],
+        };
+        let prepared = prepare_request(&endpoint, req).unwrap();
+        let auth = prepared
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("authorization"))
+            .map(|(_, v)| v.clone())
+            .unwrap();
+        let (_, _, signature) = parse_sigv4_authorization(&auth);
+        assert_eq!(
+            signature,
+            "5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"
+        );
+    }
+
+    #[test]
+    fn sigv4_unbound_destination_is_refused_before_signing() {
+        // The key security test: a sigv4 placeholder bound to host A, sent to
+        // host B (not in allowed_hosts), is refused by the bind-check inside
+        // `endpoint.sign` BEFORE any signature is produced. No Authorization.
+        let (_dir, resolver) = resolver_with("aws", AWS_SECRET_ACCESS_KEY);
+        let mut reg = SubstitutionRegistry::new();
+        let ph = reg.mint(sigv4_ref(
+            "aws",
+            &["s3.us-east-1.amazonaws.com"], // bound to host A only
+            "s3",
+            "us-east-1",
+        ));
+        let endpoint = SubstitutionEndpoint::new(&reg, &resolver);
+
+        let req = ProxyRequest {
+            method: "GET".into(),
+            url: "https://evil.example.com/bucket/key".into(), // host B — unbound
+            headers: vec![
+                ("authorization".into(), ph.as_str().to_string()),
+                ("host".into(), "evil.example.com".into()),
+                ("x-amz-date".into(), "20150830T123600Z".into()),
+            ],
+            body: vec![],
+        };
+        let err = prepare_request(&endpoint, req).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ProxyError::Sign(crate::keyholder::SignDispatchError::DestinationNotBound(_))
+            ),
+            "expected a bind-check refusal, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn sigv4_without_params_is_refused() {
+        // A sigv4 secret with no access_key_id/region/service binding can't be
+        // signed — fail closed rather than forward an unsigned request.
+        let (_dir, resolver) = resolver_with("aws", AWS_SECRET_ACCESS_KEY);
+        let mut reg = SubstitutionRegistry::new();
+        let ph = reg.mint(sigv4_ref_no_params("aws", &["s3.us-east-1.amazonaws.com"]));
+        let endpoint = SubstitutionEndpoint::new(&reg, &resolver);
+
+        let req = ProxyRequest {
+            method: "GET".into(),
+            url: "https://s3.us-east-1.amazonaws.com/bucket/key".into(),
+            headers: vec![
+                ("authorization".into(), ph.as_str().to_string()),
+                ("host".into(), "s3.us-east-1.amazonaws.com".into()),
+                ("x-amz-date".into(), "20150830T123600Z".into()),
+            ],
+            body: vec![],
+        };
+        let err = prepare_request(&endpoint, req).unwrap_err();
+        assert!(matches!(err, ProxyError::Refused(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn sigv4_synthesizes_x_amz_date_when_absent() {
+        // When the guest omits x-amz-date, the endpoint synthesizes one and adds
+        // it to the outgoing request so the signature it computes matches.
+        let (_dir, resolver) = resolver_with("aws", AWS_SECRET_ACCESS_KEY);
+        let mut reg = SubstitutionRegistry::new();
+        let ph = reg.mint(sigv4_ref(
+            "aws",
+            &["s3.us-east-1.amazonaws.com"],
+            "s3",
+            "us-east-1",
+        ));
+        let endpoint = SubstitutionEndpoint::new(&reg, &resolver);
+        let req = ProxyRequest {
+            method: "GET".into(),
+            url: "https://s3.us-east-1.amazonaws.com/x".into(),
+            headers: vec![
+                ("authorization".into(), ph.as_str().to_string()),
+                ("host".into(), "s3.us-east-1.amazonaws.com".into()),
+            ],
+            body: vec![],
+        };
+        let prepared = prepare_request(&endpoint, req).unwrap();
+        let amz = prepared
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("x-amz-date"))
+            .map(|(_, v)| v.clone())
+            .expect("x-amz-date synthesized");
+        // yyyymmddThhmmssZ — 16 chars.
+        assert_eq!(amz.len(), 16, "amz date: {amz}");
+        assert!(amz.contains('T') && amz.ends_with('Z'));
+    }
+
+    #[test]
+    fn hmac_request_gets_a_signature_header() {
+        // RFC 4231 case 2: key="Jefe", body="what do ya want for nothing?".
+        let (_dir, resolver) = resolver_with("hook", "Jefe");
+        let mut reg = SubstitutionRegistry::new();
+        let ph = reg.mint(hmac_ref("hook", &["hooks.example.com"]));
+        let endpoint = SubstitutionEndpoint::new(&reg, &resolver);
+        let req = ProxyRequest {
+            method: "POST".into(),
+            url: "https://hooks.example.com/event".into(),
+            headers: vec![("x-sig".into(), ph.as_str().to_string())],
+            body: b"what do ya want for nothing?".to_vec(),
+        };
+        let prepared = prepare_request(&endpoint, req).unwrap();
+        let sig = prepared
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("x-mvm-signature"))
+            .map(|(_, v)| v.clone())
+            .expect("x-mvm-signature produced");
+        assert_eq!(
+            sig,
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+        // No-leak: the signing key ("Jefe") and the placeholder are both gone.
+        for (k, v) in &prepared.headers {
+            assert!(!v.contains("Jefe"), "key leaked in header {k}");
+            assert!(!v.contains(ph.as_str()), "placeholder leaked in header {k}");
+        }
+    }
+
+    #[test]
+    fn hmac_unbound_destination_is_refused_before_signing() {
+        let (_dir, resolver) = resolver_with("hook", "Jefe");
+        let mut reg = SubstitutionRegistry::new();
+        let ph = reg.mint(hmac_ref("hook", &["hooks.example.com"]));
+        let endpoint = SubstitutionEndpoint::new(&reg, &resolver);
+        let req = ProxyRequest {
+            method: "POST".into(),
+            url: "https://evil.example.com/event".into(), // unbound
+            headers: vec![("x-sig".into(), ph.as_str().to_string())],
+            body: b"x".to_vec(),
+        };
+        let err = prepare_request(&endpoint, req).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ProxyError::Sign(crate::keyholder::SignDispatchError::DestinationNotBound(_))
+            ),
+            "expected a bind-check refusal, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/terminator/handler.rs
+++ b/crates/mvm-hostd/src/supervisor/terminator/handler.rs
@@ -73,6 +73,7 @@ mod tests {
             mount: SecretMount::Env { var: "K".into() },
             auth_type: AuthType::Bearer,
             allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
         }
     }
 

--- a/crates/mvm-hostd/src/supervisor/terminator/tls.rs
+++ b/crates/mvm-hostd/src/supervisor/terminator/tls.rs
@@ -473,6 +473,7 @@ mod tests {
             mount: SecretMount::Env { var: "K".into() },
             auth_type: AuthType::Bearer,
             allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+            sigv4: None,
         }
     }
 

--- a/crates/mvm-hostd/tests/egress_secret_leak_gate.rs
+++ b/crates/mvm-hostd/tests/egress_secret_leak_gate.rs
@@ -70,6 +70,7 @@ fn bearer_ref(name: &str, hosts: &[&str]) -> SecretRef {
         },
         auth_type: AuthType::Bearer,
         allowed_hosts: hosts.iter().map(|h| h.to_string()).collect(),
+        sigv4: None,
     }
 }
 
@@ -91,6 +92,7 @@ fn handed_placeholders_never_contain_the_secret_value() {
             &SecretBindingMeta {
                 auth_type: AuthType::Bearer,
                 allowed_hosts: vec!["api.openai.com".into()],
+                sigv4: None,
             },
         )
         .unwrap();

--- a/crates/mvm-hostd/tests/substitution_endpoint_bin.rs
+++ b/crates/mvm-hostd/tests/substitution_endpoint_bin.rs
@@ -60,6 +60,7 @@ fn endpoint_bin_serves_substitution_and_refuses_unbound_destination() {
             &SecretBindingMeta {
                 auth_type: AuthType::Bearer,
                 allowed_hosts: vec!["api.openai.com".into()],
+                sigv4: None,
             },
         )
         .unwrap();

--- a/crates/mvm-sdk/src/compile/orchestrator.rs
+++ b/crates/mvm-sdk/src/compile/orchestrator.rs
@@ -661,6 +661,7 @@ mod tests {
                     },
                     auth_type: crate::ir::AuthType::Bearer,
                     allowed_hosts: vec!["api.openai.com".into()],
+                    sigv4: None,
                 },
             },
         );
@@ -713,6 +714,7 @@ mod tests {
                     },
                     auth_type: crate::ir::AuthType::Bearer,
                     allowed_hosts: vec!["api.openai.com".into()],
+                    sigv4: None,
                 },
             },
         );
@@ -751,6 +753,7 @@ mod tests {
                         },
                         auth_type: crate::ir::AuthType::Bearer,
                         allowed_hosts: vec!["api.openai.com".into()],
+                        sigv4: None,
                     },
                 },
             );

--- a/crates/mvm-sdk/src/decorator/value.rs
+++ b/crates/mvm-sdk/src/decorator/value.rs
@@ -651,6 +651,9 @@ fn helper_to_env_value(v: Value, path: &Path, line: usize) -> Result<EnvValue, P
                     },
                     auth_type,
                     allowed_hosts,
+                    // SigV4 scope params are operator-set in the local binding,
+                    // not authored in source — the keyholder reconstructs them.
+                    sigv4: None,
                 },
             })
         }

--- a/crates/mvm-sdk/src/ir/mod.rs
+++ b/crates/mvm-sdk/src/ir/mod.rs
@@ -30,5 +30,5 @@ pub use workload::{
     App, AuthType, Concurrency, Dependencies, Entrypoint, EnvValue, Format, HostPort, Image,
     InProcessMode, JsonSchemaShape, Mount, MountMode, MountSource, Network, NetworkDns,
     NetworkEgress, NetworkMode, NodeTool, PortForward, PortProto, PythonTool, Resources,
-    SecretMount, SecretRef, Source, Volume, WarmProcessConfig, Workload, host_matches,
+    SecretMount, SecretRef, Sigv4Params, Source, Volume, WarmProcessConfig, Workload, host_matches,
 };

--- a/crates/mvm-sdk/src/ir/workload.rs
+++ b/crates/mvm-sdk/src/ir/workload.rs
@@ -410,6 +410,28 @@ pub struct SecretRef {
     /// Supports `*.` subdomain wildcards (see [`host_matches`]). An empty list
     /// is an unbound secret, rejected at validation (`SecretWithoutBinding`).
     pub allowed_hosts: Vec<String>,
+    /// Non-secret SigV4 parameters, present only for `auth_type = Sigv4`. The
+    /// secret value is the secret-access-key; these name the credential scope
+    /// (operator-set in the binding, reconstructed onto the ref at admission).
+    /// `None` for every other auth type.
+    #[serde(default)]
+    pub sigv4: Option<Sigv4Params>,
+}
+
+/// The non-secret half of a SigV4 credential: the public access-key id and the
+/// credential scope (`region`/`service`). The signing key (the AWS
+/// secret-access-key) is **not** here — it lives in the secret store and never
+/// leaves the signer. Identifying but not secret, so Debug is safe.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Sigv4Params {
+    /// The AWS access-key id (e.g. `AKIA…`). Public; pairs with the
+    /// secret-access-key the signer holds.
+    pub access_key_id: String,
+    /// Credential-scope region (e.g. `us-east-1`).
+    pub region: String,
+    /// Credential-scope service (e.g. `s3`, `execute-api`).
+    pub service: String,
 }
 
 /// How a secret authenticates an outbound request, so the keyholder picks the

--- a/crates/mvm-sdk/tests/validate.rs
+++ b/crates/mvm-sdk/tests/validate.rs
@@ -127,6 +127,7 @@ fn admits_secret_ref_with_a_binding() {
                 },
                 auth_type: AuthType::Bearer,
                 allowed_hosts: vec!["api.example.com".to_string()],
+                sigv4: None,
             },
         },
     );
@@ -151,6 +152,7 @@ fn rejects_unbound_secret_ref() {
                 },
                 auth_type: AuthType::Bearer,
                 allowed_hosts: vec![],
+                sigv4: None,
             },
         },
     );

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -23,7 +23,7 @@ details** below for the workstream-level state.
 - [x] **PLAN 170** — Host lifecycle convergence · ✅ mvm-side (density → mvmd)
 - [x] **PLAN 153** — CLI directory split · ✅ (subsumed into Plan 178)
 - [x] **PLAN 178** — CLI surface consolidation (~56→~28) · ✅ (dir-purity deferred)
-- [ ] **PLAN 129** — Secrets / SigV4 substitution · 🟢 declared + undeclared landed; live FC https e2e gated on agent bringup
+- [ ] **PLAN 129** — Secrets / SigV4 substitution · 🟢 declared + undeclared landed; SigV4/HMAC forward-path signing landed (bind-checked, key-never-leaves); live FC https e2e gated on agent bringup
 - [ ] **PLAN 152** — Rust-native VZ supervisor · 🟢 native objc2, Swift deleted; WS-C/D separate workstreams
 - [ ] **PLAN 159** — vz-inspired macOS VZ DX · 🟡 warm pool + checkpoint/fork shipped; WS-5 D + delta-image remain
 - [ ] **PLAN 123** — Network / storage / warm-start · 🟢 Phase A/B done; C2/C3 (FC/Vz warm-start) gated
@@ -148,7 +148,19 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 declared + undeclared (bo
       catalog.md row 16 witnesses (Preview), gated on every PR (Test lane +
       check-claim-catalog)
   [ ] forward proxy https/CONNECT (only http/absolute-form works today) — deferred
-  [ ] forward-path signing integration (SigV4)        — DEFERRED (user)
+  [x] forward-path signing integration (SigV4 + HMAC)  — prepare_request branches
+      on the resolved auth_type, routes SigV4/HMAC through the bind-checked
+      endpoint.sign (claim 12, key-never-leaves) and assembles the
+      Authorization (AWS4-HMAC-SHA256) / x-mvm-signature header. Credential
+      model: the secret value IS the secret-access-key (in the encrypted store,
+      the signing key); access_key_id/region/service are non-secret operator
+      metadata on the binding (mvmctl secret set --type sigv4
+      --aws-access-key-id/--region/--service) reconstructed onto the SecretRef
+      at admission. Security tests: sigv4_request_gets_a_valid_authorization_header,
+      sigv4_forward_path_matches_the_aws_get_vanilla_signature,
+      sigv4_unbound_destination_is_refused_before_signing,
+      sigv4_without_params_is_refused, hmac_request_gets_a_signature_header +
+      hmac_unbound_destination_is_refused_before_signing.
 
 PLAN 152 — Rust-native VZ supervisor            🟢 native objc2; no Swift
   [x] WS-A exit channel (vsock + PID-1 helper) — PR #698 (merged)


### PR DESCRIPTION
## What

Completes the 4th auth-type on the egress forward leg. The signer + canonicalizer + the bind-checked `endpoint.sign` dispatch were already built/tested; this wires them in. Previously a SigV4/HMAC secret on the forward path was **refused** (`WrongAuthType`) — fail-closed; now it produces a real signature.

- **SigV4** → the host builds the canonical request, signs, and assembles `Authorization: AWS4-HMAC-SHA256 Credential=<access_key_id>/<scope>, SignedHeaders=…, Signature=…`.
- **HMAC** → HMAC-SHA256 over the body → `x-mvm-signature: <hex>`.
- **Bearer/Basic** → unchanged (inject).

The guest references the secret via the placeholder in the `Authorization` header exactly like Bearer; `prepare_request` branches on the resolved `auth_type`.

## Credential model

The **secret value stays the AWS secret-access-key** (encrypted store; used only inside the zeroizing `Signer`). The **non-secret** `access_key_id`/`region`/`service` are operator-set on the binding via `mvmctl secret set --type sigv4 --aws-access-key-id … --region … --service …` (never the secret-key on argv). Clean security separation; the signer is untouched.

## Security (this is a new untrusted-input signing surface)

All signing routes through the existing **claim-12 bind-checked `endpoint.sign`** — a guest cannot get the host to sign for an unbound destination, and the bind-check uses the **dialed request URL**, not a spoofable `Host` header. The secret-access-key **never leaves the `Signer`** (no `expose_secret` in the forward path; only the derived `sig.hex` + non-secret params are handled). Every error fails closed (`prepare_request` → `Err` → `process`/terminator close, never forward). Audit stays metadata-only.

## Tests

Security tests: `sigv4_unbound_destination_is_refused_before_signing` (the bind-check fires, 0 key resolves), `sigv4_request_gets_a_valid_authorization_header` (the secret-key + placeholder absent from **every** byte), `sigv4_without_params_is_refused`, HMAC twins, and an **AWS get-vanilla oracle** (byte-exact published signature). Plus an **independent adversarial security review** found no key-leak / no bind-bypass / no fail-open. **2152 tests** across mvm-hostd/mvm-sdk/mvm-cli (incl. Phase F leak-gate); clippy + fmt + workspace build + secret-display gate clean.

Pre-existing tracked limitation inherited unchanged: the SigV4 canonical-URI builder passes the path as-is (clean API paths + S3 single-encode; non-S3 double-encode is a tracked follow-up in sigv4.rs).