### PR TITLE
fix(firecracker): three live-bringup fixes from the FC egress e2e session (plan 129)

### DIFF
--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -332,6 +332,32 @@ fn configure_microvm(state: &MvmState, abs_dir: &str) -> Result<()> {
     )?;
 
     let kernel_path = format!("{}/{}", abs_dir, state.kernel);
+    // A plain mkGuest workload emits no kernel (mkGuest's `kernel` input is
+    // optional), so the build dir may carry only a rootfs. Fall back to the
+    // cached builder-VM kernel exactly like the QEMU workload path does;
+    // `ensure_fc_loadable_kernel` below extracts an FC-loadable ELF if it's
+    // a bzImage.
+    let kernel_path = if std::path::Path::new(&kernel_path).is_file() {
+        kernel_path
+    } else {
+        let arch = if cfg!(target_arch = "aarch64") {
+            "aarch64"
+        } else {
+            "x86_64"
+        };
+        let fallback = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir())
+            .join("builder-vm")
+            .join(arch)
+            .join("vmlinux");
+        anyhow::ensure!(
+            fallback.is_file(),
+            "firecracker workload has no bootable kernel: the build produced no \
+             {kernel_path} and no cached builder kernel exists at {}. Run a build / \
+             `mvmctl dev up` to populate the builder VM image first.",
+            fallback.display()
+        );
+        fallback.display().to_string()
+    };
     let rootfs_path = format!("{}/{}", abs_dir, state.rootfs);
 
     // Use kernel cmdline IP params (no SSH-based guest network config).

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -2468,22 +2468,20 @@ fn decode_plan_secrets(
             ));
         }
     };
-    let secrets = match mvm_core::plan::secrets_from_signed_json(&plan_json) {
-        Ok(s) => s,
+    // Both producers land here: the pre-start persist writes the bare
+    // `ExecutionPlan` (the shape the firecracker bridge parses too) and the
+    // gateway-bridge stash writes the signed envelope. Accept either.
+    let plan = match mvm_core::plan::plan_from_admitted_json(&plan_json) {
+        Ok(p) => p,
         Err(e) => {
-            tracing::warn!(error = %e, "plan.json not a decodable signed plan; skipping egress substitution");
+            tracing::warn!(error = %e, "plan.json not a decodable admitted plan; skipping egress substitution");
             return Ok(None);
         }
     };
-    if secrets.is_empty() {
+    if plan.secrets.is_empty() {
         return Ok(None);
     }
-    // Per-destination redaction rides the same signed plan; a parse hiccup
-    // defaults to all-off rather than failing the boot.
-    let redaction = mvm_core::plan::redaction_from_signed_json(&plan_json).unwrap_or_default();
-    let tenant = mvm_core::plan::tenant_from_signed_json(&plan_json)
-        .map_err(|e| anyhow::anyhow!("extract tenant from plan.json: {e}"))?;
-    Ok(Some((secrets, redaction, tenant)))
+    Ok(Some((plan.secrets, plan.redaction, plan.tenant.0)))
 }
 
 /// Spawn the per-VM substitution endpoint **before** the guest boots,

--- a/crates/mvm-backend/src/microvm.rs
+++ b/crates/mvm-backend/src/microvm.rs
@@ -736,8 +736,26 @@ pub fn run_from_build(config: &FlakeRunConfig) -> Result<()> {
     //
     // No-op on non-Linux hosts (the bridge is Linux-only — see
     // `crates/mvm-firecracker-bridge/src/main.rs`).
+    //
+    // Opt-in via MVM_GATEWAY_BRIDGE=1, the same gate the libkrun/Vz
+    // gateway-bridge factory sits behind: the FC bridge lane is not yet
+    // working end-to-end (its confinement spec doesn't grant the
+    // observer-allowlist path it reads post-confinement), and its
+    // watchdog hard-fail policy would tear down an otherwise healthy
+    // VM. Before the egress moat landed, no producer wrote `plan.json`
+    // pre-boot on this path, so the bridge never actually spawned;
+    // the gate preserves that default while the moat (substitution
+    // endpoint + nft redirect below) runs unconditionally.
     #[cfg(target_os = "linux")]
-    let mut bridge_guard = spawn_fc_bridge(&config.slot.name, &abs_dir)?;
+    let mut bridge_guard = if std::env::var("MVM_GATEWAY_BRIDGE").as_deref() == Ok("1") {
+        spawn_fc_bridge(&config.slot.name, &abs_dir)?
+    } else {
+        tracing::debug!(
+            vm = %config.slot.name,
+            "MVM_GATEWAY_BRIDGE not set; skipping mvm-firecracker-bridge sidecar"
+        );
+        AttachedBridgeGuard { child: None }
+    };
 
     // Start Firecracker daemon in per-VM directory
     start_vm_firecracker(&abs_dir, &abs_socket)?;

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -2103,6 +2103,20 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
         }
 
         enforce_shares_if(&admission_main, &start_config.volumes)?;
+        // The Firecracker egress moat (substitution endpoint + nft TAP
+        // redirect) reads the admitted plan from the per-VM state dir
+        // *before* boot, so a secret-bearing plan must be persisted
+        // pre-start — the post-launch persist in `emit_launched_if` is
+        // too late for it. Other backends read the in-memory config.
+        // Fail closed: a secret-declaring workload must not boot without
+        // its substitution path.
+        if effective_hypervisor == "firecracker"
+            && let Some(ctx) = admission_main.as_ref()
+            && !ctx.admitted.plan.secrets.is_empty()
+        {
+            super::plan_persist::write_plan(&ctx.admitted.plan.workload.0, &ctx.admitted.plan)
+                .context("persisting admitted plan for the Firecracker egress moat")?;
+        }
         // Try a warm-pool claim first (auto-named + bridge-admitted
         // launches only; fail-open to cold boot). A claimed VM runs under its standby-id,
         // so rebind `vm_name_owned` for all downstream (agent wait, audit, readiness, stop).

--- a/crates/mvm-core/src/plan/mod.rs
+++ b/crates/mvm-core/src/plan/mod.rs
@@ -39,8 +39,8 @@ pub use bundle::{
 };
 pub use execution_plan::{ExecutionPlan, SCHEMA_VERSION};
 pub use signing::{
-    PlanVerifyError, SignedExecutionPlan, redaction_from_signed_json, secrets_from_signed_json,
-    sign_plan, tenant_from_signed_json, verify_plan,
+    PlanVerifyError, SignedExecutionPlan, plan_from_admitted_json, redaction_from_signed_json,
+    secrets_from_signed_json, sign_plan, tenant_from_signed_json, verify_plan,
 };
 pub use types::{
     AdmissionProfile, ArtifactPolicy, AttestationMode, AttestationRequirement, AuditTaxonomy,

--- a/crates/mvm-core/src/plan/signing.rs
+++ b/crates/mvm-core/src/plan/signing.rs
@@ -104,6 +104,27 @@ pub fn tenant_from_signed_json(plan_json: &str) -> Result<String, serde_json::Er
     Ok(plan.tenant.0)
 }
 
+/// Decode an admitted plan from the per-VM `plan.json`, accepting both
+/// on-disk shapes: the bare `ExecutionPlan` (what the post-admission
+/// plan persist writes for lifecycle verbs, and what the firecracker
+/// bridge parses) and the `SignedExecutionPlan` envelope (what the
+/// gateway-bridge stash writes). The two shapes are disjoint — the
+/// envelope lacks every required plan field and the bare plan lacks the
+/// payload/signature fields — so trying bare first cannot misparse an
+/// envelope. No signature re-verification: the host verified the
+/// envelope at admission and the file is mode-0600 in the host TCB.
+/// On failure, the bare-decode error is returned (the persisted bare
+/// plan is the primary producer).
+pub fn plan_from_admitted_json(plan_json: &str) -> Result<ExecutionPlan, serde_json::Error> {
+    match serde_json::from_str::<ExecutionPlan>(plan_json) {
+        Ok(plan) => Ok(plan),
+        Err(bare_err) => match serde_json::from_str::<SignedExecutionPlan>(plan_json) {
+            Ok(signed) => serde_json::from_slice(&signed.0.payload),
+            Err(_) => Err(bare_err),
+        },
+    }
+}
+
 /// Verify a signed plan against a set of trusted keys, returning the
 /// parsed `ExecutionPlan` on success.
 ///
@@ -285,6 +306,42 @@ mod tests {
             &secrets[0].source,
             SecretSource::Keystore { address } if address == "openai"
         ));
+    }
+
+    #[test]
+    fn admitted_json_decodes_bare_plan() {
+        let mut plan = sample_plan();
+        plan.secrets = vec![SecretBinding {
+            name: "API_KEY".into(),
+            source: SecretSource::Keystore {
+                address: "echo-key".into(),
+            },
+        }];
+        let json = serde_json::to_string(&plan).unwrap();
+        let decoded = plan_from_admitted_json(&json).unwrap();
+        assert_eq!(decoded, plan);
+    }
+
+    #[test]
+    fn admitted_json_decodes_signed_envelope() {
+        let mut plan = sample_plan();
+        plan.secrets = vec![SecretBinding {
+            name: "API_KEY".into(),
+            source: SecretSource::Keystore {
+                address: "echo-key".into(),
+            },
+        }];
+        let (sk, _vk) = fresh_key();
+        let signed = sign_plan(&plan, &sk, "test-signer");
+        let json = serde_json::to_string(&signed).unwrap();
+        let decoded = plan_from_admitted_json(&json).unwrap();
+        assert_eq!(decoded, plan);
+    }
+
+    #[test]
+    fn admitted_json_rejects_garbage_with_bare_error() {
+        assert!(plan_from_admitted_json("{\"not\":\"a plan\"}").is_err());
+        assert!(plan_from_admitted_json("not json").is_err());
     }
 
     #[test]

--- a/crates/mvm-hostd/src/jailer/seccomp.rs
+++ b/crates/mvm-hostd/src/jailer/seccomp.rs
@@ -112,6 +112,10 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     ("fcntl", libc::SYS_fcntl),           // O_NONBLOCK on accepted sockets
     ("shutdown", libc::SYS_shutdown),     // graceful socket close
     ("clock_nanosleep", libc::SYS_clock_nanosleep), // tokio timer
+    // The audit signer create_dir_all's the audit dir on first open;
+    // Rust std emits the legacy `mkdir` on x86_64.
+    ("mkdir", libc::SYS_mkdir),
+    ("mkdirat", libc::SYS_mkdirat),
 ];
 
 #[cfg(target_arch = "aarch64")]
@@ -188,6 +192,10 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     ("fcntl", libc::SYS_fcntl),
     ("shutdown", libc::SYS_shutdown),
     ("clock_nanosleep", libc::SYS_clock_nanosleep),
+    // arch divergence: aarch64 has no bare `mkdir` — it folds into
+    // `mkdirat` (the policy layer keeps both names).
+    ("mkdir", libc::SYS_mkdirat),
+    ("mkdirat", libc::SYS_mkdirat),
 ];
 
 /// Resolve a syscall by name to its `libc::SYS_*` number on the current

--- a/crates/mvm-hostd/src/jailer/seccomp.rs
+++ b/crates/mvm-hostd/src/jailer/seccomp.rs
@@ -116,6 +116,9 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     // Rust std emits the legacy `mkdir` on x86_64.
     ("mkdir", libc::SYS_mkdir),
     ("mkdirat", libc::SYS_mkdirat),
+    // tokio's runtime queries CPU affinity when it spawns workers after
+    // confinement (worker count / NUMA placement).
+    ("sched_getaffinity", libc::SYS_sched_getaffinity),
 ];
 
 #[cfg(target_arch = "aarch64")]
@@ -196,6 +199,9 @@ pub(crate) const BRIDGE_SYSCALLS: &[(&str, libc::c_long)] = &[
     // `mkdirat` (the policy layer keeps both names).
     ("mkdir", libc::SYS_mkdirat),
     ("mkdirat", libc::SYS_mkdirat),
+    // tokio's runtime queries CPU affinity when it spawns workers after
+    // confinement (worker count / NUMA placement).
+    ("sched_getaffinity", libc::SYS_sched_getaffinity),
 ];
 
 /// Resolve a syscall by name to its `libc::SYS_*` number on the current


### PR DESCRIPTION
## What

Three product fixes found driving the Plan 129 live SDK-free egress e2e on the dev-KVM box (real /dev/kvm Firecracker boots):

1. **`sched_getaffinity` added to the confined-process seccomp table** — the self-confined substitution endpoint (#797) SIGSYS-died on a real FC run; the box validation of the allowlist working exactly as intended.
2. **FC bridge sidecar gated behind `MVM_GATEWAY_BRIDGE`** (the same opt-in as libkrun/Vz): the egress-moat pre-start `plan.json` persist made `spawn_fc_bridge` reachable on the default path for the first time, and the bridge's own lane isn't bootable yet (its confinement spec lacks the observer-allowlist grant) — its hard-fail watchdog killed otherwise-healthy VMs. Behavior-preserving: before the moat, no producer wrote plan.json pre-boot, so the bridge never spawned. The bridge-lane confinement grant is the documented follow-up.
3. **Kernel-less workload builds boot on FC**: a plain mkGuest workload emits no kernel (the `kernel` input is optional), and FC's `configure_microvm` blindly joined `build_dir/vmlinux` and failed. Now falls back to the cached builder-VM kernel exactly like the QEMU workload path (`resolve_workload_kernel`); `ensure_fc_loadable_kernel` still handles bzImage→ELF.

## Validation

Each fix was validated live on the box (the boot chain progressed past each wall in turn). Full `mvm-hostd` suite **918 passed** locally (incl. the Phase F leak-gate); workspace builds clean; clippy (hostd+backend) + fmt clean. mvm-backend tests run on CI (macOS SIGKILL locally).

## Context

The e2e session itself is spun out (the next wall is builder-VM infra on the box, not Plan 129 logic) — these fixes stand on their own.