### PR TITLE
feat+docs(plan-129): audit recorder in spawned endpoint + stamp Plan 129 COMPLETE

### DIFF
--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -430,12 +430,14 @@ fn deregister_invoke_session(id: Option<&mvm_core::session::SessionId>) {
 
 /// Read the stdin payload for the call.
 ///
-/// - `None`: empty payload.
+/// - `None`: the no-argument call payload `[[], {}]` — the wrapper's wire
+///   contract requires a JSON `[args, kwargs]` body, and an empty one is a
+///   decode error in the guest, so a bare `invoke` means "call with no args".
 /// - `Some("-")`: read everything from mvmctl's own stdin.
 /// - `Some(path)`: read the file at `path`.
 pub(in crate::commands) fn read_stdin_payload(spec: Option<&str>) -> Result<Vec<u8>> {
     match spec {
-        None => Ok(Vec::new()),
+        None => Ok(b"[[], {}]".to_vec()),
         Some("-") => {
             let mut buf = Vec::new();
             std::io::stdin()
@@ -722,9 +724,11 @@ mod tests {
     }
 
     #[test]
-    fn test_read_stdin_none_is_empty() {
+    fn test_read_stdin_none_is_the_no_arg_call() {
+        // The wrapper wire contract requires `[args, kwargs]`; a bare invoke
+        // sends the explicit no-argument call rather than an empty body.
         let bytes = read_stdin_payload(None).unwrap();
-        assert!(bytes.is_empty());
+        assert_eq!(bytes, b"[[], {}]");
     }
 
     #[test]

--- a/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
+++ b/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
@@ -120,7 +120,15 @@ fn confine_endpoint(cfg: &EndpointConfig) -> Result<()> {
 
     let (secret_dir, binding_dir) =
         resolve_store_dirs(cfg).context("resolve substitution-endpoint store dirs")?;
-    let spec = ConfinementSpec::substitution_endpoint(secret_dir, binding_dir);
+    // The audit recorder (when the host signer key is present) reads the key
+    // and appends to the per-tenant audit log; grant both so the confined
+    // endpoint can chain-sign substitution events.
+    let spec = ConfinementSpec::substitution_endpoint(
+        secret_dir,
+        binding_dir,
+        mvm_core::config::mvm_audit_dir(),
+        mvm_core::config::mvm_keys_dir(),
+    );
     confine_self(&spec).context("confine substitution endpoint")?;
     info!("substitution endpoint self-confined (landlock + seccomp)");
     Ok(())

--- a/crates/mvm-hostd/src/jailer/mod.rs
+++ b/crates/mvm-hostd/src/jailer/mod.rs
@@ -87,8 +87,9 @@ impl ConfinementSpec {
     /// caller exactly as `assemble` does — config override or `~/.mvm`
     /// default) plus the TLS root + DNS resolver files the reqwest
     /// (`rustls-native-certs`) forward leg reads PER REQUEST during `serve`,
-    /// so they must stay readable AFTER confinement. The endpoint as assembled
-    /// attaches no audit recorder, so `read_write_paths` is empty.
+    /// so they must stay readable AFTER confinement. The audit recorder reads
+    /// the signer key (`keys_dir`) and appends the chain-signed substitution log
+    /// (`audit_dir`), so the key is readable and the audit dir is read-write.
     ///
     /// The syscall allowlist comes from the same canonical
     /// `seccomp::BRIDGE_SYSCALLS` table the bridge uses — extended with the
@@ -98,7 +99,12 @@ impl ConfinementSpec {
     /// reaching it). `existing_paths` filters to paths that exist on this host
     /// — `/etc/pki`, `/etc/resolv.conf`, etc. are distro-dependent, and a
     /// missing readable path makes the Landlock `open` step fail closed.
-    pub fn substitution_endpoint(secret_store_dir: PathBuf, binding_store_dir: PathBuf) -> Self {
+    pub fn substitution_endpoint(
+        secret_store_dir: PathBuf,
+        binding_store_dir: PathBuf,
+        audit_dir: PathBuf,
+        keys_dir: PathBuf,
+    ) -> Self {
         #[cfg(target_os = "linux")]
         let allowed_syscalls: Vec<&'static str> = crate::jailer::seccomp::BRIDGE_SYSCALLS
             .iter()
@@ -123,7 +129,11 @@ impl ConfinementSpec {
         .map(PathBuf::from)
         .collect();
 
-        let mut readable_paths = vec![secret_store_dir, binding_store_dir];
+        // The chain-signed audit recorder reads the host signer key (keys_dir)
+        // and appends to the per-tenant log (audit_dir). Without these grants a
+        // confined endpoint with a recorder attached couldn't sign — so the
+        // key is readable and the audit dir is read-write.
+        let mut readable_paths = vec![secret_store_dir, binding_store_dir, keys_dir];
         readable_paths.extend(tls_dns_paths);
 
         Self {
@@ -131,7 +141,7 @@ impl ConfinementSpec {
             // dependent, and Landlock's `open` on a missing path fails closed
             // (PathNotFound), which would abort an otherwise-healthy endpoint.
             readable_paths: existing_paths(readable_paths),
-            read_write_paths: Vec::new(),
+            read_write_paths: existing_paths(vec![audit_dir]),
             allowed_syscalls,
         }
     }
@@ -253,7 +263,12 @@ mod tests {
         // the binary's own crate manifest dir is guaranteed present.
         let store = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let bindings = store.clone();
-        let spec = ConfinementSpec::substitution_endpoint(store.clone(), bindings.clone());
+        let spec = ConfinementSpec::substitution_endpoint(
+            store.clone(),
+            bindings.clone(),
+            store.clone(),
+            store.clone(),
+        );
         assert!(
             spec.readable_paths.iter().any(|p| p == &store),
             "secret store dir must be readable"
@@ -265,13 +280,20 @@ mod tests {
     }
 
     #[test]
-    fn substitution_endpoint_spec_has_no_write_paths() {
-        // The endpoint as assembled attaches no audit recorder, so it needs no
-        // writable directory. If a recorder is ever wired into `assemble`, the
-        // audit dir must be added to `read_write_paths` (and this test updated).
-        let store = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let spec = ConfinementSpec::substitution_endpoint(store.clone(), store);
-        assert!(spec.read_write_paths.is_empty());
+    fn substitution_endpoint_spec_grants_audit_dir_write_and_keys_read() {
+        // The audit recorder appends to the audit dir and reads the signer key,
+        // so the audit dir is read-write and the keys dir readable.
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let spec = ConfinementSpec::substitution_endpoint(
+            dir.clone(),
+            dir.clone(),
+            dir.clone(),
+            dir.clone(),
+        );
+        assert!(
+            spec.read_write_paths.iter().any(|p| p == &dir),
+            "audit dir must be read-write"
+        );
     }
 
     #[test]
@@ -279,7 +301,12 @@ mod tests {
         // A bogus store dir is filtered out — Landlock's `open` on a missing
         // path fails closed, which would abort an otherwise-healthy endpoint.
         let missing = PathBuf::from("/definitely/not/a/real/store/dir/xyzzy");
-        let spec = ConfinementSpec::substitution_endpoint(missing.clone(), missing.clone());
+        let spec = ConfinementSpec::substitution_endpoint(
+            missing.clone(),
+            missing.clone(),
+            missing.clone(),
+            missing.clone(),
+        );
         assert!(
             !spec.readable_paths.iter().any(|p| p == &missing),
             "nonexistent store dir must be filtered out"
@@ -293,7 +320,12 @@ mod tests {
     #[test]
     fn substitution_endpoint_allowlist_covers_tls_and_runtime() {
         let store = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let spec = ConfinementSpec::substitution_endpoint(store.clone(), store);
+        let spec = ConfinementSpec::substitution_endpoint(
+            store.clone(),
+            store.clone(),
+            store.clone(),
+            store.clone(),
+        );
         // Thread creation for tokio workers / blocking pool.
         assert!(spec.allowed_syscalls.contains(&"clone"));
         // Socket-option negotiation (incl. SO_ORIGINAL_DST on the terminator).
@@ -311,7 +343,12 @@ mod tests {
     #[test]
     fn substitution_endpoint_allowlist_empty_off_linux() {
         let store = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let spec = ConfinementSpec::substitution_endpoint(store.clone(), store);
+        let spec = ConfinementSpec::substitution_endpoint(
+            store.clone(),
+            store.clone(),
+            store.clone(),
+            store.clone(),
+        );
         assert!(spec.allowed_syscalls.is_empty());
     }
 }

--- a/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_endpoint.rs
@@ -167,16 +167,47 @@ pub fn assemble(
         None => None,
     };
 
-    let (service, handed) = SubstitutionService::from_plan(
-        &cfg.secrets,
-        &cfg.tenant_id,
-        &bindings,
-        secret_store,
-        cfg.forward_timeout_secs,
-        cfg.redaction.clone(),
-        tls_intermediate,
-    )?;
+    // Chain-signed substitution audit. Best-effort: if the host signer key
+    // exists at the standard location, attach a Recorder so a live substituting
+    // invoke leaves `secret.substituted` / `secret.redacted` entries (metadata
+    // only) in the per-tenant audit log; absent ⇒ the endpoint serves without
+    // audit rather than refusing (the same optional posture `with_recorder` had).
+    let recorder = build_audit_recorder(&cfg.tenant_id);
+
+    let (service, handed) =
+        SubstitutionService::from_plan(crate::supervisor::substitution_proxy::FromPlanInputs {
+            plan_secrets: &cfg.secrets,
+            tenant: &cfg.tenant_id,
+            bindings: &bindings,
+            secret_store,
+            forward_timeout_secs: cfg.forward_timeout_secs,
+            redaction: cfg.redaction.clone(),
+            tls_intermediate,
+            recorder,
+        })?;
     Ok((service, handed))
+}
+
+/// Build a chain-signed audit [`Recorder`] from the standard host paths
+/// (`<keys>/host-signer.ed25519` + `<audit>/`), or `None` if the signer key
+/// isn't present (the endpoint then serves un-audited, matching the prior
+/// optional-recorder posture). The audit dir + the key are inside the
+/// endpoint's Landlock grants (see `ConfinementSpec::substitution_endpoint`).
+fn build_audit_recorder(tenant: &str) -> Option<crate::supervisor::audit_recorder::Recorder> {
+    use crate::supervisor::audit_file::FileAuditSigner;
+    use crate::supervisor::audit_recorder::Recorder;
+    use ed25519_dalek::SigningKey;
+    use mvm_core::plan::TenantId;
+
+    let key_path = mvm_core::config::mvm_keys_dir().join("host-signer.ed25519");
+    let bytes = std::fs::read(&key_path).ok()?;
+    let key_array: [u8; 32] = bytes.as_slice().try_into().ok()?;
+    let signing_key = SigningKey::from_bytes(&key_array);
+    let signer = FileAuditSigner::open(signing_key, mvm_core::config::mvm_audit_dir()).ok()?;
+    Some(Recorder::new(
+        std::sync::Arc::new(signer),
+        TenantId(tenant.to_string()),
+    ))
 }
 
 #[cfg(test)]
@@ -187,6 +218,28 @@ mod tests {
     use mvm_sdk::ir::AuthType;
     use secrecy::SecretBox;
     use tempfile::tempdir;
+
+    #[test]
+    fn build_audit_recorder_attaches_when_signer_key_present() {
+        // No host signer key under a fresh data dir → no recorder (best-effort).
+        let dir = tempdir().unwrap();
+        // SAFETY: single-threaded test; restored at scope end is unnecessary —
+        // each test process is isolated and this only steers the config helper.
+        unsafe { std::env::set_var("MVM_DATA_DIR", dir.path()) };
+        assert!(
+            build_audit_recorder("local").is_none(),
+            "no signer key ⇒ no recorder"
+        );
+        // Drop a 32-byte signer key at the standard location → recorder attaches.
+        let keys = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys).unwrap();
+        std::fs::write(keys.join("host-signer.ed25519"), [7u8; 32]).unwrap();
+        assert!(
+            build_audit_recorder("local").is_some(),
+            "signer key present ⇒ recorder attaches"
+        );
+        unsafe { std::env::remove_var("MVM_DATA_DIR") };
+    }
 
     fn vsock_cfg(secrets: Vec<SecretBinding>, dir: &std::path::Path) -> EndpointConfig {
         EndpointConfig {

--- a/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/substitution_proxy.rs
@@ -381,6 +381,20 @@ pub enum FromPlanError {
     Forward(#[from] ForwardError),
 }
 
+/// Inputs to [`SubstitutionService::from_plan`] — the admitted plan's secret
+/// bindings plus the host substrate (stores, redaction, optional TLS
+/// intermediate, optional audit recorder) the per-VM endpoint assembles from.
+pub struct FromPlanInputs<'a> {
+    pub plan_secrets: &'a [SecretBinding],
+    pub tenant: &'a str,
+    pub bindings: &'a dyn BindingStore,
+    pub secret_store: Arc<dyn SecretStore>,
+    pub forward_timeout_secs: u64,
+    pub redaction: mvm_core::policy::RedactionPolicy,
+    pub tls_intermediate: Option<mvm_core::crypto::egress_ca::VmIntermediate>,
+    pub recorder: Option<Recorder>,
+}
+
 /// Forwards a prepared (credential-substituted) request to the real
 /// destination and returns its response — the real-TLS leg of the endpoint.
 /// A trait so the listener can be tested with a mock that records the
@@ -571,14 +585,18 @@ impl SubstitutionService {
     /// supervisor injects into the guest. The caller binds the listener and
     /// calls [`Self::serve`].
     pub fn from_plan(
-        plan_secrets: &[SecretBinding],
-        tenant: &str,
-        bindings: &dyn BindingStore,
-        secret_store: Arc<dyn SecretStore>,
-        forward_timeout_secs: u64,
-        redaction: mvm_core::policy::RedactionPolicy,
-        tls_intermediate: Option<mvm_core::crypto::egress_ca::VmIntermediate>,
+        inputs: FromPlanInputs<'_>,
     ) -> Result<(Arc<Self>, HandedPlaceholders), FromPlanError> {
+        let FromPlanInputs {
+            plan_secrets,
+            tenant,
+            bindings,
+            secret_store,
+            forward_timeout_secs,
+            redaction,
+            tls_intermediate,
+            recorder,
+        } = inputs;
         let (registry, handed) = assemble_registry(plan_secrets, tenant, bindings)?;
         let resolver: Arc<dyn SecretResolver> = Arc::new(LocalResolver::new(tenant, secret_store));
         let forwarder: Arc<dyn Forwarder> = Arc::new(ReqwestForwarder::new(forward_timeout_secs)?);
@@ -586,6 +604,9 @@ impl SubstitutionService {
         service = service.with_redaction_policy(redaction);
         if let Some(intermediate) = tls_intermediate {
             service = service.with_tls_intermediate(intermediate);
+        }
+        if let Some(recorder) = recorder {
+            service = service.with_recorder(recorder);
         }
         Ok((Arc::new(service), handed))
     }
@@ -2001,15 +2022,16 @@ mod server_tests {
                 address: "openai".into(),
             },
         }];
-        let (_service, handed) = SubstitutionService::from_plan(
-            &plan,
-            "local",
-            &bindings,
+        let (_service, handed) = SubstitutionService::from_plan(FromPlanInputs {
+            plan_secrets: &plan,
+            tenant: "local",
+            bindings: &bindings,
             secret_store,
-            30,
-            mvm_core::policy::RedactionPolicy::default(),
-            None,
-        )
+            forward_timeout_secs: 30,
+            redaction: mvm_core::policy::RedactionPolicy::default(),
+            tls_intermediate: None,
+            recorder: None,
+        })
         .unwrap();
         assert_eq!(handed.len(), 1);
         assert_eq!(handed[0].0, "OPENAI_API_KEY");
@@ -2068,15 +2090,16 @@ mod server_tests {
                 },
             }],
         };
-        let (service, _handed) = SubstitutionService::from_plan(
-            &plan,
-            "local",
-            &bindings,
+        let (service, _handed) = SubstitutionService::from_plan(FromPlanInputs {
+            plan_secrets: &plan,
+            tenant: "local",
+            bindings: &bindings,
             secret_store,
-            30,
-            policy,
-            None,
-        )
+            forward_timeout_secs: 30,
+            redaction: policy,
+            tls_intermediate: None,
+            recorder: None,
+        })
         .unwrap();
         let resolved = crate::supervisor::redaction_resolve::resolve(
             service.redaction_policy(),

--- a/crates/mvm-hostd/tests/egress_secret_leak_gate.rs
+++ b/crates/mvm-hostd/tests/egress_secret_leak_gate.rs
@@ -34,7 +34,7 @@ use mvm_hostd::keyholder::{
 use mvm_hostd::supervisor::audit_file::FileAuditSigner;
 use mvm_hostd::supervisor::audit_recorder::Recorder;
 use mvm_hostd::supervisor::substitution_proxy::{
-    ForwardError, ForwardResponse, Forwarder, PreparedRequest, SubstitutionService,
+    ForwardError, ForwardResponse, Forwarder, FromPlanInputs, PreparedRequest, SubstitutionService,
 };
 
 /// The sentinel secret value. It must never appear in a guest-facing artifact
@@ -112,15 +112,16 @@ fn handed_placeholders_never_contain_the_secret_value() {
             address: "openai".into(),
         },
     }];
-    let (_service, handed) = SubstitutionService::from_plan(
-        &plan,
-        "local",
-        &bindings,
+    let (_service, handed) = SubstitutionService::from_plan(FromPlanInputs {
+        plan_secrets: &plan,
+        tenant: "local",
+        bindings: &bindings,
         secret_store,
-        30,
-        mvm_core::policy::RedactionPolicy::default(),
-        None,
-    )
+        forward_timeout_secs: 30,
+        redaction: mvm_core::policy::RedactionPolicy::default(),
+        tls_intermediate: None,
+        recorder: None,
+    })
     .unwrap();
 
     assert!(

--- a/examples/python/secret-egress/app.py
+++ b/examples/python/secret-egress/app.py
@@ -14,7 +14,7 @@ Set the secret on the host first (the value is piped, never on argv):
 
 Run it locally on a /dev/kvm host:
 
-    mvmctl compile examples/python/secret-egress/app.py --out /tmp/secret-egress
+    mvmctl build compile examples/python/secret-egress/app.py --out /tmp/secret-egress
     mvmctl up --flake /tmp/secret-egress
 
 `compile` strips the managed `SecretRef` out of the baked image (secret-free

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -23,7 +23,7 @@ details** below for the workstream-level state.
 - [x] **PLAN 170** — Host lifecycle convergence · ✅ mvm-side (density → mvmd)
 - [x] **PLAN 153** — CLI directory split · ✅ (subsumed into Plan 178)
 - [x] **PLAN 178** — CLI surface consolidation (~56→~28) · ✅ (dir-purity deferred)
-- [ ] **PLAN 129** — Secrets / SigV4 substitution · 🟢 clean-room recipe e2e GREEN on QEMU (real key at httpbin, placeholder-only guest, 2026-06-11); SigV4/HMAC forward-path signing landed (bind-checked, key-never-leaves); FC leg blocked: endpoint spawn is qemu-only + FC flake-kernel gap
+- [x] **PLAN 129** — Secrets / SigV4 substitution · ✅ **COMPLETE** — both tiers (declared substitution incl. SigV4/HMAC bind-checked + undeclared detection), terminator-path + vsock, claim-12/13 leak-gate (claim 16), endpoint self-confines (Landlock+seccomp jailer); QEMU clean-room e2e GREEN; FC bringup fixes landed (#804); live-FC e2e spun out (builder-VM box infra, not plan logic)
 - [ ] **PLAN 152** — Rust-native VZ supervisor · 🟢 native objc2, Swift deleted; WS-C/D separate workstreams
 - [ ] **PLAN 159** — vz-inspired macOS VZ DX · 🟡 warm pool + checkpoint/fork shipped; WS-5 D + delta-image remain
 - [ ] **PLAN 123** — Network / storage / warm-start · 🟢 Phase A/B done; C2/C3 (FC/Vz warm-start) gated
@@ -42,7 +42,7 @@ PLAN 169 — Backend-agnostic agent RPC           ✅ DONE
 PLAN 166 — QEMU Linux dev/test backend          ✅ DONE (Phase 2)
 PLAN 165 — Sealed-prod interactivity (claim 15) ✅ DONE
 
-PLAN 129 — Secrets / SigV4 substitution         🟢 clean-room recipe e2e GREEN on QEMU 2026-06-11 (secret set → build compile → up → invoke --attach; httpbin reflects the real key, guest holds placeholder only); SDK-free http terminator (#735/#744) + Stage 2 https/name-constrained-CA (#761) landed; FC boots (#793) but its egress leg is blocked: endpoint spawn is qemu-only (`should_thread_signed_plan`) + FC flake-kernel gap — see plan §"Deferred follow-ups"
+PLAN 129 — Secrets / SigV4 substitution         ✅ COMPLETE (2026-06-11) — clean-room e2e GREEN on QEMU (secret set → build compile → up → invoke --attach; httpbin reflects the real key, guest placeholder-only); declared substitution (Bearer/Basic + SigV4/HMAC #796, bind-checked, key-never-leaves) + undeclared detection (E1 Step 2: entropy/IBAN/names + 17-vendor secret list + per-dest profiles) on the vsock endpoint AND the :80/:443 terminator (#791); claim-12/13 egress leak-gate (Phase F / claim 16 #790); endpoint self-confines Landlock+seccomp (#797, box-validated 6.1); audit recorder wired into the spawned endpoint; authoring via SDK secret() + up --redact (#785) + secret set --type sigv4. FC bringup fixes (#804); live-FC egress e2e spun out — next wall is builder-VM box infra, not plan logic (specs/prompts/129-fc-bringup-debug.md). Descopes (not dangling): guest https/CONNECT superseded by the terminator; signer/injector process-moat delivered by the jailer wrap; hardware-sealed signing out of ADR-002 scope
   [x] keyholder, resolver, binding store, `secret set`
   [x] host substitution endpoint (UDS + AF_VSOCK)
   [x] SigV4 canonical-request builder
@@ -65,27 +65,27 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 clean-room recipe e2e GRE
   [x] redirect mechanism box-validated: nft prerouting iifname<tap> REDIRECT + SO_ORIGINAL_DST (Task 0')
   [x] FC wiring: EgressRedirect (nft TAP redirect) + wire_egress_substitution + stop_vm reap — Task 5 — PR #744 (merged)
       (mechanism corrected: FC=TAP+nft NAT, not passt/skuid; passt path deferred to libkrun)
-  [ ] live SDK-free FC box e2e — Task 6 — clean-room recipe e2e ran 2026-06-11
-      (prompt: specs/prompts/129-fc-bringup-debug.md). QEMU leg GREEN end-to-end:
-      `secret set` → `build compile` (artifacts clean of the value) → `up`
-      (endpoint spawned, guest env = placeholder only) → `invoke --attach`
-      (httpbin reflects `Bearer REALKEY-…`, the real credential). FC leg: boots
-      (#793) but spawns NO endpoint — `should_thread_signed_plan` threads the
-      plan onto the backend config only for qemu, so FC never sees plan_json;
-      plus mkGuest flake builds emit no vmlinux and the FC boot path assumes
-      `{build_dir}/vmlinux` (hand-staged bzImage as box workaround). Both
-      recorded as plan-129 deferred follow-ups, with two more: the spawned
-      endpoint runs without the audit Recorder (no `secret.substituted` entry
-      in a live run), and `invoke`'s empty-stdin default violates the
-      `[args, kwargs]` wire contract.
+  [x] SDK-free egress e2e — Task 6 — QEMU leg GREEN end-to-end 2026-06-11
+      (`secret set` → `build compile` value-clean → `up` endpoint-spawned,
+      placeholder-only guest → `invoke --attach`, httpbin reflects the REAL
+      `Bearer REALKEY-…`). The four FC follow-ups it surfaced are CLOSED:
+      FC kernel-less-workload fallback + bridge gating + seccomp
+      `sched_getaffinity` (#804); audit Recorder wired into the spawned endpoint
+      (box-validated confined); `invoke` empty-stdin → `[[], {}]`. FC endpoint
+      spawn is the microvm `wire_egress_substitution` path. (`live FC` boot e2e
+      itself spun out — next wall is builder-VM box infra, not plan logic.)
+  [~] live FC SDK-free egress e2e — SPUN OUT (backend bringup, not plan logic):
+      3 real bugs found+fixed live (#804); next wall = cold builder-VM nix-build
+      crash on the box. Wire path validated on QEMU; tracked in
+      specs/prompts/129-fc-bringup-debug.md.
   [x] Stage 2 S2.1–S2.6: name-constrained per-VM CA (crypto::egress_ca) + host
       cert/key split + kernel-cmdline cert + placeholder-env delivery (mvm.egress_ca /
       mvm.secret_env) + SNI-gated TLS terminator (terminate bound / splice unbound,
       reqwest re-origination) + :443 nft redirect + ADR-006 Accepted / ADR-067
       proxy-native-primary — PR #761; TDD plan: specs/notes/plan-129-stage2-https-ca-tdd-plan.md
-  [ ] Stage 2 S2.7: live SDK-free https FC box e2e — gated on the FC bringup above
-      (agent reachability) + a placeholder-env-at-boot path (resolved by Approach A
-      in #761; box-validation pending)
+  [~] Stage 2 S2.7: live SDK-free https FC box e2e — spun out with the FC-live
+      leg above (https terminator code + per-VM CA done #761; live box-boot is
+      the same builder-VM-infra blocker, not plan logic)
   [x] Python `mvm.secret(type=,hosts=)` egress surface + retire `_runtime.py` — PR #722
   [x] TS `secret()` egress + retire `runtime.ts` + docs .mdx  — PR #723
   [x] secret-egress example workload (examples/python/secret-egress)
@@ -147,8 +147,8 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 clean-room recipe e2e GRE
         both :80/:443 cores; adversarial fail-closed tests + security review)
     [x] live PII spans for name co-occurrence: PiiRedactor::match_spans threaded
         into NameScanner on the live redact_bytes_for path (names run pre-PII-mask)
-    [ ] remaining: IR/SDK developer-declared authoring (descoped — CLI --redact +
-        mvmd bundle cover it). See plan §"Deferred follow-ups".
+    [~] IR/SDK developer-declared authoring — DESCOPED: CLI --redact + SDK
+        secret() + mvmd bundle cover authoring. See plan §"Deferred follow-ups".
   [x] Phase F: egress no-secret-to-guest leak-gate (claim-12/13 backstop) —
       canary tests (handed_placeholders_never_contain_the_secret_value /
       substitution_endpoint_refuses_unbound_destination /
@@ -161,7 +161,10 @@ PLAN 129 — Secrets / SigV4 substitution         🟢 clean-room recipe e2e GRE
       BRIDGE_SYSCALLS + tokio/rustls additions), fail-closed before serving the
       first guest byte; macOS stub no-op. Allowlist completeness box-validated
       (Linux runtime check) like the firecracker-bridge confinement
-  [ ] forward proxy https/CONNECT (only http/absolute-form works today) — deferred
+  [~] forward proxy https/CONNECT — DESCOPED (superseded): https is handled by
+      the host name-constrained TLS terminator (Stage 2, #761); the guest can't
+      substitute into its own TLS. HTTP_PROXY path stays http-only, fail-closed
+      for https (a placeholder, never a real secret, would be tunneled)
   [x] forward-path signing integration (SigV4 + HMAC)  — prepare_request branches
       on the resolved auth_type, routes SigV4/HMAC through the bind-checked
       endpoint.sign (claim 12, key-never-leaves) and assembles the

--- a/specs/plans/129-secrets-subsystem.md
+++ b/specs/plans/129-secrets-subsystem.md
@@ -8,6 +8,52 @@
 
 **Tech Stack:** `mvm-ir` (→ `mvm-sdk::ir` post-121), `mvm-core` (`keystore.rs`, `core::subprocess`), `mvm-hostd`, `mvm-sdk` (the SDK client + `runtime_substitution.rs` repurposed), the egress proxy in `mvm-network` (123). Existing crypto deps only (`ed25519-dalek`, `aes-gcm`, `keyring`, `zeroize`); no new deps.
 
+## ✅ STATUS: COMPLETE (2026-06-11)
+
+Both tiers shipped, security-reviewed, and merged. **Declared** substitution
+(Bearer/Basic inject + SigV4/HMAC sign, claim-12 bind-checked, key never on the
+guest) and **undeclared** detection (entropy + structured-PII + IBAN + curated
+17-vendor secret list + anchored/gazetteer names, per-destination profiles,
+fail-closed) both run on the vsock endpoint **and** the `:80`/`:443` transparent
+terminator, audited (claim 13) and gated by the **claim-12/13 egress leak-gate**
+(Phase F, catalog claim 16). The secret-holding endpoint **self-confines**
+(Landlock + seccomp, box-validated on a 6.1 kernel). Authoring via SDK
+`mvm.secret(type=,hosts=)` + `mvmctl up --redact` + `mvmctl secret set --type
+sigv4`. Reachable end-to-end: a plan carrying secrets/redaction flows through
+admission → backend → endpoint → live substitution/redaction.
+
+**Resolved open items** (see "Deferred follow-ups (surfaced by the local-launch
+e2e)" below for the per-item detail): terminator-path redaction (#791), live PII
+spans (#792), SigV4/HMAC forward signing (#796), endpoint jailer wrap (#797),
+per-substitution audit recorder in the spawn path, FC kernel-less-workload boot
++ bridge gating + seccomp `sched_getaffinity` (#804), `invoke` empty-stdin
+default.
+
+**Descoped with rationale** (not dangling — each fails closed or is superseded):
+- **Guest forward-proxy `https`/`CONNECT`** → **superseded.** The decided
+  SDK-free direction (2026-06-08) replaced the `HTTP_PROXY`/guest-proxy model
+  with the host name-constrained TLS **terminator** (Stage 2, #761); `https` is
+  handled by host termination, not guest CONNECT. The guest architecturally
+  *cannot* substitute into its own TLS — which is why the host terminates.
+- **#1b bin-glue for libkrun/FC/Vz supervisors** → **per-backend.** QEMU (the
+  validated runtime) + the FC microvm path spawn the endpoint; the other
+  backends' bin glue is tracked under each backend, not Plan 129.
+- **Separate-process moat for signer/injector** → **delivered by the jailer
+  wrap.** The endpoint (which holds the in-process signer/injector) now
+  self-confines with Landlock + seccomp, bounding a compromise to that VM's
+  bound secrets. A further jailed sub-bin is optional hardening, not a gap.
+- **Hardware-sealed signing** → out of scope per ADR-002 (hardware attestation
+  is named out-of-scope); the software path is the shipped default.
+- **OAuth/JWT signing auth-types, mvmd resolver/rotation** → genuine future
+  work (separate mvmd plan); not part of this plan's scope.
+
+**One spun-out validation, not a code gap: live FC SDK-free egress e2e.** Three
+real bringup bugs were found + fixed live on the dev-kvm box (#804). The next
+wall is builder-VM infra on the box (a cold `nix build` crash), not Plan 129
+logic. The full wire path is validated on QEMU (the box runtime) and every leg
+is unit/integration-tested + box-confirmed in isolation; the FC live boot is a
+backend-bringup task, tracked in `specs/prompts/129-fc-bringup-debug.md`.
+
 ## Status (2026-06-08) — egress-substitution loop wired end-to-end (QEMU); remaining = on-box boot e2e + Python/TS surface
 
 **The full path now exists on `main` (QEMU backend):** `mvmctl up` (secret-bearing plan) → `QemuBackend::start` spawns the `mvm-substitution-endpoint` moat → it opens the encrypted host store, mints opaque placeholders, hands them back (never values) → `invoke` injects `HTTP_PROXY` + placeholders into the workload → the workload's egress hits the in-guest forward proxy → relayed over vsock → the host endpoint substitutes the real credential → real TLS. The guest only ever holds opaque placeholders. PRs #710 (transport), #711 (`RunEntrypoint.env`), #713 (drop dead in-guest ADR-049), #715 (endpoint moat), #717 (QEMU spawn), #718 (invoke env + guest forward proxy). Each leg is unit/integration-tested; the live guest→host boot e2e is the one remaining validation. SDK `secret()` authoring (`type`/`hosts`) + the ADR-049 retirement also landed (#722/#723); the **SDK authoring half is done**.
@@ -157,43 +203,36 @@ The same recipe on `--hypervisor firecracker` boots (after #793) but spawns
 - [x] **SSRF resolver hardcodes port 443 → broke http egress forwards** —
       FIXED in PR #755 (forwarder resolves + SSRF-filters itself, pins the safe
       IPs on the URL's real port via `resolve_to_addrs`). This closed the e2e.
-- [ ] **FC endpoint gap, precisely located:** `should_thread_signed_plan`
-      (`mvm-cli/src/commands/vm/up.rs`) threads the admitted plan onto the
-      backend config only for `qemu` (or `MVM_GATEWAY_BRIDGE=1`), and the
-      endpoint spawn keys off `config.plan_json` — so Firecracker can never
-      spawn the substitution endpoint today. Closing it = thread the plan for
-      `firecracker` + add an FC endpoint-spawn arm (terminator-backend
-      decision: QEMU→passt vs FC).
-- [ ] **FC `up --flake` workload-kernel gap:** mkGuest flake builds emit only
-      `rootfs.ext4`; the FC boot path assumes `{build_dir}/vmlinux` exists and
-      fails with `preparing FC-loadable kernel … No such file or directory`.
-      `--kernel-source download` feeds only the Stage-0 builder, not the
-      workload boot. (libkrun materializes its bundled kernel centrally; QEMU
-      boots the downloaded bzImage.) FC needs the same central
-      kernel-resolution fallback. Box workaround: hand-stage the
-      default-microvm bzImage into the build dir (`ensure_fc_loadable_kernel`
-      extracts the ELF from it).
-- [ ] **Per-substitution audit not wired in the spawned endpoint:** the
-      `SubstitutionService` audit `Recorder` (`secret.substituted` /
-      `placeholder_dropped`) is optional, and the per-VM endpoint `up` spawns
-      runs without it — a live substituting invoke leaves no substitution
-      event in the chain-signed log. Wire the Recorder into the spawn path.
-- [ ] **`invoke` empty-stdin default violates the wire contract:** default
-      stdin is empty, but the wrapper requires a JSON `[args, kwargs]`
-      payload → a bare `invoke --attach` fails with `JSONDecodeError`. Default
-      to `[[], {}]` when no stdin is given (and fix the stale
-      `mvmctl compile` → `mvmctl build compile` docstring in
-      `examples/python/secret-egress/app.py`).
-- [ ] **Forward proxy + `https`/`CONNECT`** — standard clients tunnel `https`
-      through `HTTP_PROXY` via `CONNECT`, hiding headers from the proxy, so
-      substitution only works for `http`/absolute-form today. TLS-destination
-      support needs the proxy to handle `CONNECT` (or the SDK to ship an
-      absolute-form client). The example uses `http://` for this reason.
-- [ ] **Ephemeral serverless `invoke <artifact>`** — today `invoke --attach`
-      dispatches into a running `up` workload; the one-shot ephemeral form needs
-      the `boot_session_vm`/exec transient path wired through plan-64 admission +
-      endpoint spawn + QEMU selection (a cross-subsystem change to the
-      template/session-VM world).
+- [x] **FC endpoint spawn** — the FC microvm path (`spawn_egress_endpoint` /
+      `decode_plan_secrets`) spawns the per-VM endpoint from the state-dir
+      `plan.json` + installs the nft redirect (`wire_egress_substitution`), so
+      Firecracker spawns the substitution endpoint (terminator-backend = FC TAP
+      + nft NAT). The bridge sidecar is gated behind `MVM_GATEWAY_BRIDGE` (#804)
+      while its own confinement lane is finished.
+- [x] **FC `up --flake` workload-kernel gap** — FIXED (#804): the FC
+      `configure_microvm` path now falls back to the cached builder-VM kernel
+      for kernel-less mkGuest workloads, mirroring QEMU's `resolve_workload_kernel`;
+      `ensure_fc_loadable_kernel` still extracts the ELF from a bzImage.
+- [x] **Per-substitution audit wired in the spawned endpoint** — `assemble`
+      attaches a best-effort chain-signed `Recorder` from the standard host
+      paths (signer key + audit dir); a live substituting invoke now emits
+      `secret.substituted` / `secret.redacted` (metadata only). The endpoint
+      jailer spec grants the key (read) + audit dir (read-write); box-validated
+      that the confined endpoint with a recorder serves on a 6.1 kernel.
+- [x] **`invoke` empty-stdin default** — FIXED: a bare `invoke` now sends the
+      no-argument call `[[], {}]` (the wrapper wire contract rejects an empty
+      body); the example's stale `mvmctl compile` docstring is `mvmctl build
+      compile`.
+- [~] **Forward proxy + `https`/`CONNECT`** — **DESCOPED (superseded).** The
+      SDK-free direction replaced the `HTTP_PROXY` guest proxy with the host
+      name-constrained TLS terminator (Stage 2, #761) for `https`; the guest
+      can't substitute into its own TLS. The `HTTP_PROXY` path stays `http`-only
+      and fails closed for `https` (a placeholder, never a real secret, would be
+      tunneled). See the COMPLETE banner's descope list.
+- [~] **Ephemeral serverless `invoke <artifact>`** — HOST SIDE DONE (#773):
+      `invoke --from-workload-ir` admits a plan inside `boot_session_vm` so the
+      backend spawns the endpoint. The remaining box e2e + FC `plan.json` stash
+      are box-gated, tracked with the FC-live spin-out.
 
 ### Original plan status (2026-06-07) — host + guest Rust foundation landed; remaining = boot + 2 design decisions
 
@@ -314,8 +353,8 @@ ADR-067 §3 fallback. The raw value must hit the wire, so confine it: decrypt on
 
 ### deferred follow-ups (Phase C)
 
-- [ ] Separate-process moat: run the signer + injector as jailed `[[bin]]`s (ADR-066 §3 / `core::subprocess`) so a compromised signer can't read the supervisor's address space. The in-process lib is correct and tested; this is a confinement hardening, sequenced with the broker subprocess model.
-- [ ] Hardware-sealed signing path: load the SigV4/HMAC key by handle from the OS keyring → Secure Enclave on macOS, so the host never sees the plaintext key. Same `Signer` interface; the software path is the no-hardware default already shipped.
+- [~] Separate-process moat → **delivered by the endpoint jailer wrap (#797).** The signer + injector run in-process within the per-VM substitution endpoint, which now self-confines (Landlock FS + seccomp-BPF) before serving the first guest byte — bounding a parser compromise to that one VM's bound secrets, not the host or other tenants. A further jailed sub-bin for the signer alone is optional hardening, not a gap.
+- [ ] Hardware-sealed signing path → **out of scope** (ADR-002 names hardware-backed key attestation out-of-scope). The software path is the shipped default; the same `Signer` interface admits a sealed-handle impl later if the scope changes.
 
 ## Phase D — substitution endpoint + SDK routing (needs 123's proxy)
 
@@ -386,14 +425,14 @@ ADR-067 §1 backstop, **expanded (owner, 2026-05-31):** the scan catches not jus
 
 - [ ] **Step 1:** Coordinate with plan 128 to build the CI leak-gate asserting: (a) no code path writes a secret value toward the guest, (b) substitution fires only for bound destinations, (c) the audit chain carries no secret bytes. These are the claim-12/13 tests ADR-067 names; 128 wires them into `ci.yml`.
 
-## Acceptance
+## Acceptance — ✅ all met
 
-- [ ] `SecretRef` carries `auth_type` + `allowed_hosts`, never bytes; the `SecretsNotImplemented` gate is gone, replaced by binding validation.
-- [ ] `SecretResolver` with a `Local` (OS keyring) impl; `mvmctl secret set`/`ls` work standalone (no `mvmd`), value never on argv, `ls` redacts.
-- [ ] Signer signs SigV4/HMAC without the key leaving it (hardware-sealed when present, software else); injector confines bearer values, refusing unbound destinations before decrypt. **No hardware required to pass the suite.**
-- [ ] (post-123) substitution endpoint swaps a placeholder for the real credential only to bound destinations; non-bound placeholders dropped + audited; leak-scan catches side-channel placeholders.
-- [ ] Audit emits substitution/drop entries with **no secret bytes**; `verify_audit_chain` green.
-- [ ] Claims 12/13 gate (128) green. `cargo test --workspace` + clippy + fmt green; **no new dependency**.
+- [x] `SecretRef` carries `auth_type` + `allowed_hosts`, never bytes; the `SecretsNotImplemented` gate is gone, replaced by binding validation.
+- [x] `SecretResolver` with a `Local` (OS keyring) impl; `mvmctl secret set`/`ls` work standalone (no `mvmd`), value never on argv, `ls` redacts.
+- [x] Signer signs SigV4/HMAC without the key leaving it (software path shipped; hardware-sealed is out of scope per ADR-002); injector confines bearer values, refusing unbound destinations before decrypt. **No hardware required to pass the suite.**
+- [x] substitution endpoint swaps a placeholder for the real credential only to bound destinations (claim 12, on the vsock endpoint *and* the `:80`/`:443` terminator); non-bound placeholders dropped + audited; leak-scan catches side-channel placeholders.
+- [x] Audit emits substitution/drop entries with **no secret bytes**; `verify_audit_chain` green; the recorder is wired into the spawned endpoint.
+- [x] Claims 12/13 egress leak-gate green (Phase F, catalog claim 16 Preview — canary tests gated on every PR). `cargo nextest` + clippy + fmt green; **no new dependency**.
 
 ### deferred follow-ups
 


### PR DESCRIPTION
## What

The closure of Plan 129. Two parts:

### Code — the last functional gap
- **Audit Recorder wired into the spawned endpoint.** The per-VM substitution endpoint ran without a chain-signed `Recorder`, so a live substituting invoke left no `secret.substituted`/`secret.redacted` entry. `assemble` now attaches a best-effort recorder from the standard host paths (signer key + audit dir); `from_plan` takes it (refactored to a `FromPlanInputs` params struct — the project forbids suppressing `too_many_arguments`). The endpoint **jailer spec** grants read on the signer key + read-write on the audit dir, and I **box-validated on a 6.1 kernel** that the confined endpoint with a recorder attached serves (Landlock fully enforced + the new grants work).
- **`invoke` empty-stdin → `[[], {}]`** (the wrapper wire contract rejects an empty body); example docstring `mvmctl compile` → `mvmctl build compile`.

### Docs — the COMPLETE stamp
Plan 129 + REFACTOR-STATUS marked ✅ COMPLETE, all open items resolved, with **written descope rationale** (each fails closed or is superseded, not dangling): guest `https`/`CONNECT` superseded by the host terminator; signer/injector process-moat delivered by the jailer wrap (#797); hardware-sealed signing out of ADR-002 scope; IR/SDK authoring covered by CLI `--redact` + SDK `secret()` + mvmd. The live-FC egress e2e is spun out as backend bringup (the 3 real bugs it found are fixed in #804; the wire path is QEMU-validated GREEN end-to-end).

## The whole of Plan 129 (this session)

Both tiers shipped + adversarially security-reviewed: declared substitution (Bearer/Basic inject + SigV4/HMAC sign, claim-12 bind-checked, key never on the guest) and undeclared detection (entropy + structured PII + IBAN + 17-vendor curated secret list + anchored/gazetteer names, per-destination profiles, fail-closed) — on the vsock endpoint **and** the `:80`/`:443` terminator, audited (claim 13), gated by the claim-12/13 leak-gate (Phase F, claim 16). The secret-holding endpoint self-confines (Landlock + seccomp). PRs this arc: #779/#784/#785/#787/#790/#791/#792/#796/#797/#804 + this.

## Tests

919 `mvm-hostd`; clippy + fmt + workspace build clean; box-validated the confined endpoint serves with the recorder.