### PR TITLE
fix(supply-chain): duplicate-major lock-gate + restore red cargo-deny/cargo-audit (Plan 126 D2)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,7 +70,7 @@ jobs:
         # Ignored advisories must mirror deny.toml's `[advisories].ignore`.
         # cargo-audit doesn't read deny.toml; CLI flags are the
         # discoverable way to keep the two tools in sync.
-        run: cargo audit --ignore RUSTSEC-2025-0057 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0009 --ignore RUSTSEC-2025-0052 --ignore RUSTSEC-2024-0436
+        run: cargo audit --ignore RUSTSEC-2025-0057 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0009 --ignore RUSTSEC-2025-0052 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2026-0173 --ignore RUSTSEC-2025-0134
 
   # ── Lane 2: Production-agent symbol contract ─────────────────────
   # ADR-002 §W4.3 + ADR-007 §W5 — combined contract on the production

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -929,6 +939,24 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1409,18 +1437,6 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "enumflags2"
@@ -1929,23 +1945,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.4"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.8.6",
- "thiserror 1.0.69",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1963,6 +1979,7 @@ dependencies = [
  "ipnet",
  "jni",
  "once_cell",
+ "prefix-trie",
  "rand 0.10.1",
  "ring",
  "thiserror 2.0.18",
@@ -1973,21 +1990,26 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto 0.24.4",
+ "hickory-net",
+ "hickory-proto",
  "ipconfig",
- "lru-cache",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.8.6",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "system-configuration",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2889,12 +2911,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,15 +2962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -3052,6 +3059,23 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -3268,7 +3292,7 @@ name = "mvm-guest-helpers"
 version = "0.16.1"
 dependencies = [
  "anyhow",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "libc",
  "mvm-core",
  "serde",
@@ -4320,6 +4344,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4973,7 +5008,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -5157,7 +5192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5731,6 +5766,33 @@ dependencies = [
  "once_cell",
  "windows",
 ]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"
@@ -6557,7 +6619,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ rtnetlink = "0.14"
 async-trait = "0.1"
 
 # Pure-Rust DNS resolver, used only by the opt-in custom-dns feature.
-hickory-resolver = "0.24"
+hickory-resolver = "0.26"
 # DNS server/protocol stack for the in-guest addon DNS resolver.
 hickory-server = "0.26"
 hickory-proto = "0.26"

--- a/crates/mvm-hostd/Cargo.toml
+++ b/crates/mvm-hostd/Cargo.toml
@@ -62,7 +62,9 @@ ed25519-dalek = { workspace = true, features = ["rand_core"] }
 etherparse = { workspace = true }
 sysinfo = { version = "0.30", default-features = false }
 ipnet.workspace = true
-hickory-resolver = { workspace = true, features = ["tokio-runtime"], optional = true }
+# custom-dns pulls hickory 0.26 (needs Rust 1.88); the default build
+# carries no hickory and stays on the workspace 1.85 floor.
+hickory-resolver = { workspace = true, features = ["tokio"], optional = true }
 rand.workspace = true
 regex.workspace = true
 secrecy.workspace = true

--- a/crates/mvm-hostd/src/supervisor/hickory_dns.rs
+++ b/crates/mvm-hostd/src/supervisor/hickory_dns.rs
@@ -16,7 +16,7 @@
 //!
 //! The resolver is `Arc<HickoryDnsResolver>` so multiple proxy
 //! tasks can share one cache. Construction is sync — the actual
-//! `hickory_resolver::TokioAsyncResolver` is built lazily on first
+//! `hickory_resolver::TokioResolver` is built lazily on first
 //! `resolve` call so callers can construct in non-tokio contexts.
 //!
 //! ## What this module does NOT do
@@ -32,8 +32,9 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use hickory_resolver::TokioAsyncResolver;
+use hickory_resolver::TokioResolver;
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use tokio::sync::OnceCell;
 
 use crate::supervisor::egress::EgressError;
@@ -45,7 +46,7 @@ use crate::supervisor::l7_proxy::DnsResolver;
 pub struct HickoryDnsResolver {
     config: ResolverConfig,
     opts: ResolverOpts,
-    inner: OnceCell<TokioAsyncResolver>,
+    inner: OnceCell<TokioResolver>,
 }
 
 impl HickoryDnsResolver {
@@ -68,10 +69,18 @@ impl HickoryDnsResolver {
         }
     }
 
-    async fn ensure_resolver(&self) -> &TokioAsyncResolver {
+    async fn ensure_resolver(&self) -> Result<&TokioResolver, EgressError> {
         self.inner
-            .get_or_init(|| async {
-                TokioAsyncResolver::tokio(self.config.clone(), self.opts.clone())
+            .get_or_try_init(|| async {
+                TokioResolver::builder_with_config(
+                    self.config.clone(),
+                    TokioRuntimeProvider::default(),
+                )
+                .with_options(self.opts.clone())
+                .build()
+                .map_err(|e| {
+                    EgressError::UpstreamUnreachable(format!("hickory build resolver: {e}"))
+                })
             })
             .await
     }
@@ -86,11 +95,11 @@ impl Default for HickoryDnsResolver {
 #[async_trait]
 impl DnsResolver for HickoryDnsResolver {
     async fn resolve_one(&self, host: &str, _port: u16) -> Result<IpAddr, EgressError> {
-        let resolver = self.ensure_resolver().await;
+        let resolver = self.ensure_resolver().await?;
         let lookup = resolver.lookup_ip(host).await.map_err(|e| {
             EgressError::UpstreamUnreachable(format!("hickory lookup_ip({host}): {e}"))
         })?;
-        lookup.into_iter().next().ok_or_else(|| {
+        lookup.iter().next().ok_or_else(|| {
             EgressError::UpstreamUnreachable(format!("hickory resolved {host} to zero IPs"))
         })
     }

--- a/crates/mvm-verify/Cargo.toml
+++ b/crates/mvm-verify/Cargo.toml
@@ -3,6 +3,7 @@ name = "mvm-verify"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 publish = false
 description = "Dependency-light, wasm-clean verifier for mvm's chain-signed audit log. No filesystem, no mvm-* deps — feed it bytes and an Ed25519 public key."
 

--- a/deny.toml
+++ b/deny.toml
@@ -81,6 +81,21 @@ ignore = [
     # runtime code in the shipped binary, same class as proc-macro-error
     # above. No runtime/IO surface.
     { id = "RUSTSEC-2024-0436", reason = "paste unmaintained; build-time proc-macro, no runtime surface; audited 2026-06-03" },
+    # `proc-macro-error2` — the maintained fork of `proc-macro-error`
+    # (RUSTSEC-2024-0370) is now itself unmaintained. Transitive via
+    # `oci-client → oci-spec → getset` (a derive-macro crate). Build-time
+    # proc-macro only: produces no runtime code in any shipped artifact,
+    # same class as the proc-macro-error v1 / paste entries above. Will
+    # resolve when oci-spec's getset dep drops it.
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; build-time-only via oci-client→oci-spec→getset; no runtime surface; audited 2026-06-12" },
+    # `rustls-pemfile` unmaintained — its PEM parsing was folded into
+    # `rustls-pki-types` upstream. Direct dep of mvm-hostd, used only to
+    # parse CA/cert/key PEM the host itself mints for the Plan 129 TLS
+    # termination path (operator-controlled material, never
+    # attacker-influenced bytes). Unmaintained, not vulnerable; the
+    # crate is a small, functionally-complete parser. Follow-up: migrate
+    # to `rustls_pki_types::pem` to drop it (tracked in plan 126).
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained; parses host-minted CA/cert PEM only, no untrusted input; migrate to rustls-pki-types; audited 2026-06-12" },
 ]
 
 # ── Licenses ──────────────────────────────────────────────────────
@@ -127,14 +142,76 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 # fragment audit attention, and frequently mask transitive
 # duplication of cryptographic primitives. We deny by default and
 # add a `skip` only with a reason.
-multiple-versions = "warn"
+multiple-versions = "deny"
 wildcards = "deny"
+# A versionless `{ path = "../x" }` dep reads as a wildcard to
+# cargo-deny, but a local path dep is first-party source, not an
+# unvetted registry `*` — it carries none of the supply-chain risk
+# the wildcard ban exists to catch. Exempt path/git deps so the ban
+# stays strict for registry crates (the real risk) without flagging
+# intra-workspace links.
+allow-wildcard-paths = true
 highlight = "all"
 
 # A "skip" allows multiple versions of a single crate; a "skip-tree"
 # allows them under a specific subtree. Use sparingly; each entry
 # is a place auditors must reason about by hand.
-skip = []
+#
+# This list is the audited *baseline* of duplicate-major crates the
+# current transitive graph already carries. Freezing it turns the
+# previously-advisory `multiple-versions` check into a ratchet: a
+# brand-new duplicated crate (the usual regression — a fresh dep that
+# drags a second major of something) now fails CI and forces a
+# conscious decision, while none of the cuts already landed (tokio
+# drop, opendal→object_store, Alpine seed removal) can silently
+# regress. Entries are grouped by why they duplicate; shrink the list
+# as upstream majors converge or a dep is replaced — never grow it
+# without a recorded reason.
+skip = [
+    # Windows host-target shim families. The windows-sys / -core /
+    # -targets umbrellas and their per-arch link shims legitimately
+    # coexist at several majors across the graph; they are host/build
+    # only and carry no runtime surface on the Linux guest path.
+    "windows-core",
+    "windows-sys",
+    "windows-targets",
+    "windows_aarch64_gnullvm",
+    "windows_aarch64_msvc",
+    "windows_i686_gnu",
+    "windows_i686_gnullvm",
+    "windows_i686_msvc",
+    "windows_x86_64_gnu",
+    "windows_x86_64_gnullvm",
+    "windows_x86_64_msvc",
+
+    # Host syscall layer mid-migration. rustix's move to linux-raw-sys
+    # 0.12, the nix 0.29→0.31 churn, and mio/redox_syscall sit at two
+    # majors because different deps track different releases. mvm pins
+    # a single major where it depends directly; the rest is transitive.
+    "linux-raw-sys",
+    "mio",
+    "nix",
+    "redox_syscall",
+    "rustix",
+
+    # Foundational crates mid v1→v2 ecosystem migration. mvm pins one
+    # major for each it uses directly (e.g. which = 7); the other major
+    # is dragged in by deps that have not finished migrating. Not
+    # collapsible without forking those deps.
+    "bitflags",
+    "getrandom",
+    "thiserror",
+    "thiserror-impl",
+    "unicode-width",
+    "which",
+
+    # reqwest 0.12 (mvm) vs 0.13 (oci-client). Unifying was evaluated
+    # and rejected: oci-client hard-pins 0.13 (and forces aws-lc-rs —
+    # see the B4 block), a transitive 0.12 holdout remains regardless,
+    # and the bump collapses no transitive duplicates. Revisit when
+    # oci-client is forked.
+    "reqwest",
+]
 skip-tree = []
 
 deny = []

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -28,7 +28,7 @@ details** below for the workstream-level state.
 - [ ] **PLAN 159** — vz-inspired macOS VZ DX · 🟡 warm pool + checkpoint/fork shipped; WS-5 D + delta-image remain
 - [ ] **PLAN 123** — Network / storage / warm-start · 🟢 Phase A/B done; C2/C3 (FC/Vz warm-start) gated
 - [ ] **PLAN 124** — Lean guest agent · 🟡 ~65%; SDK codegen + signed on-device config remain
-- [ ] **PLAN 126** — Dependency reduction · 🟡 ~25%; sigstore/aws-lc/lock-gate remain
+- [ ] **PLAN 126** — Dependency reduction · 🟡 ~30%; duplicate-major lock-gate landed (+ supply-chain CI restored); sigstore/aws-lc/forbidden-dep-gate remain
 - [ ] **PLAN 177** — Backend consolidation (8→4) · 🟡 Phase 1 done; Phase 2 convergence landed (#806) — remaining: hardware smoke (host-gated) + cosmetic rename slice
 - [ ] **PLAN 175** — Firecracker live-memory warm-start · 🔴 not started (live-KVM-gated)
 - [x] **PLAN 183** — Builder-VM egress posture + network bootstrap · ✅ (E2E-proven 2026-06-12; Vz checkpoint-integration follow-ups tracked in the plan)
@@ -307,7 +307,11 @@ PLAN 126 — Dependency reduction                 🟡 ~25%
   [ ] B1 sigstore — already off default; needs cross-repo mvmd decision (relocate cosign-verify)
   [ ] B3 pgp (168) — SUPERSEDED by plan 160 (drop Alpine seed); security decision
   [ ] B4 aws-lc-rs → ring — BLOCKED upstream (oci-client hardcodes aws-lc; needs a fork)
-  [ ] C1/D1 unify reqwest majors + lock gate
+  [~] C1 reqwest unify — REJECTED/blocked on B4 (0.13 forces aws-lc + transitive 0.12 holdout; no tree collapse)
+  [x] D2 duplicate-major lock-gate — cargo-deny multiple-versions=deny + 23-crate baseline (ratchet); also
+      un-broke the red cargo-deny/cargo-audit jobs: wildcard-paths, mvm-verify license, 2 unmaintained ignores,
+      and FIXED RUSTSEC-2026-0119 (hickory-proto DoS) by bumping hickory-resolver 0.24→0.26 (collapsed its dup)
+  [ ] D1 forbidden-dep gate (check-forbidden-deps extension) — still open
 
 PLAN 153 — CLI directory split                  ✅ DONE (subsumed into Plan 178)
   [x] image.rs → image/ ; catalog.rs → catalog/ (last two flat files)

--- a/specs/plans/126-dependency-reduction.md
+++ b/specs/plans/126-dependency-reduction.md
@@ -110,8 +110,8 @@ The mvm-repo's apparent third consumer — a local `mvm-hostd` daemon at `crates
 
 Two major versions of the same crate inflate the lock + compile time.
 
-- [ ] **Step 1:** `cargo tree -d` (duplicates) — identify the two `reqwest` (and/or `oci-client`) majors + who pulls each.
-- [ ] **Step 2:** Align on one major (bump the lagging consumer, or feature-match). Failing test — `cargo tree -d | grep -E 'reqwest|oci-client'` shows one major each; the OCI + HTTP paths still pass their tests. Commit.
+- [x] **Step 1:** `cargo tree -d` — `reqwest 0.12` is mvm's (mvm-cli/-hostd/-build, on `ring`); `reqwest 0.13` is pulled **only** by `oci-client`. `oci-client` itself splits 0.15/0.16.
+- [~] **Step 2:** **REJECTED — blocked on B4.** Bumping mvm to `reqwest 0.13` to match oci-client does **not** collapse the tree: a transitive `0.12` holdout remains, the duplicate-major count is unchanged, and 0.13's `rustls` feature forces aws-lc-rs (the B4 block). The unify only lands once `oci-client` is forked (B4 Step 0). Until then, `reqwest` is a recorded entry in the duplicate-major baseline (D2), not a free cut.
 
 ## Phase D — lock it
 
@@ -119,6 +119,20 @@ Two major versions of the same crate inflate the lock + compile time.
 
 - [ ] **Step 1:** Extend `xtask check-forbidden-deps` (exists) to fail if `sigstore`, `opendal`, `pgp`, or `aws-lc-rs` re-enter the default `mvmctl` closure (an allow-list of off-by-default features for the deliberately-gated ones), **and** if `tokio` re-enters `mvm-core`'s default closure (the B5 runtime-free-core assertion). Failing test — adding any one back trips the gate.
 - [ ] **Step 2:** Final measure — total before/after in `dep-baseline.md`; the sum of B1–B4 + C1 is the headline reduction (alongside 124's ~25–35 agent crates). Commit. Wire the gate into `ci.yml` (with 128), alongside 156's sibling `check-binary-size` gate.
+
+### Task D2: duplicate-major lock-gate (cargo-deny ratchet) — DONE
+
+The forbidden-dep gate (D1) stops the four named heavy deps re-entering;
+this complements it by freezing the *whole* duplicate-major set so no
+new second-major creeps in silently. Reuses the existing cargo-deny job
+rather than a new xtask.
+
+- [x] **Step 1:** `deny.toml` `[bans] multiple-versions` flipped `warn`→`deny` with an audited `skip` baseline (the 23 crates cargo-deny's default-feature graph already carries, grouped by why). A brand-new duplicated crate now fails CI; the existing cuts (tokio drop, opendal→object_store, Alpine seed) can't silently regress. Verified: dropping any baseline entry trips `error[duplicate]`.
+- [x] **Step 2 (restore the gate to green):** the cargo-deny + cargo-audit jobs had been red on main since ~2026-06-07 from drift unrelated to duplicates — fixed in the same change so the ratchet means something:
+  - `allow-wildcard-paths = true` — a versionless `{ path = "../mvm-verify" }` read as a wildcard; path deps are first-party source, not a registry `*`.
+  - `mvm-verify` was `unlicensed` — added `license.workspace = true`.
+  - Two new `unmaintained` advisories accepted with rationale (`RUSTSEC-2026-0173` proc-macro-error2, `RUSTSEC-2025-0134` rustls-pemfile); cargo-audit `--ignore` flags kept in sync.
+  - `RUSTSEC-2026-0119` (hickory-proto 0.24 O(n²) name-compression DoS): **fixed, not ignored** — bumped `hickory-resolver 0.24→0.26` (migrated the `custom-dns` resolver to the 0.26 `TokioResolver` builder). Also collapsed the `hickory-proto` 0.24/0.26 duplicate.
 
 ## Acceptance
 
@@ -132,6 +146,8 @@ Two major versions of the same crate inflate the lock + compile time.
 
 - [ ] The mvmd cosign-verify relocation is an **mvmd plan** (this plan only removes it from `mvmctl`).
 - [ ] Periodic `cargo tree -d` sweep as the dashboard (127) surfaces new duplicates.
+- [ ] Migrate off the unmaintained `rustls-pemfile` (RUSTSEC-2025-0134) to `rustls_pki_types::pem` and drop the advisory ignore. Direct dep of mvm-hostd (`certs.rs`, `terminator/tls.rs`).
+- [ ] Shrink the D2 baseline as upstream majors converge (e.g. the windows-* families, the rustix/linux-raw-sys split) or `oci-client` is forked (drops `reqwest`).
 
 ## Self-review
 


### PR DESCRIPTION
## What

Lands the **duplicate-major lock-gate** (Plan 126 D2) and restores the **Security workflow's supply-chain jobs**, which had been red on `main` since ~2026-06-07 from drift unrelated to duplicates.

### The ratchet (the actual D2 deliverable)
`deny.toml` `[bans] multiple-versions` flips `warn` → `deny` with an audited 23-crate baseline `skip` list (the duplicates cargo-deny's default-feature graph already carries, grouped by *why*). A **new** duplicated crate now fails CI; none of the cuts already landed (tokio drop, opendal→object_store, Alpine seed) can silently regress.
*Verified:* dropping any baseline entry trips `error[duplicate]` + `bans FAILED`.

### Un-breaking the gate (so the ratchet means something)
Three independent failures were making `cargo deny check` / `cargo audit` red on main:
- **wildcard** — a versionless `{ path = "../mvm-verify" }` reads as a `*`. Path deps are first-party source, not a registry wildcard → `allow-wildcard-paths = true` (registry `*` stays denied).
- **unlicensed** — `mvm-verify` missed `license.workspace = true` (workspace license is Apache-2.0).
- **advisories** — two new `unmaintained` advisories accepted with audited rationale (`RUSTSEC-2026-0173` proc-macro-error2 — build-time only via oci-client; `RUSTSEC-2025-0134` rustls-pemfile — parses host-minted CA PEM only). cargo-audit `--ignore` flags kept in sync per the workflow's own mandate.

### Real DoS fixed, not ignored
`RUSTSEC-2026-0119` — hickory-proto 0.24 O(n²) name-compression DoS. Rather than ignore it, **bumped `hickory-resolver` 0.24 → 0.26** (the patched line, already used by the sibling hickory crates) and migrated the off-default `custom-dns` resolver to the 0.26 `TokioResolver` builder. This also **collapses the `hickory-proto` 0.24/0.26 duplicate**.

## Scope / tradeoff
- The hickory 0.26 closure (moka, system-configuration, …) is confined to the opt-in `custom-dns` feature — **absent from every shipped artifact**; the default binary's dep surface is unchanged. custom-dns now needs Rust 1.88 (noted at the dep); the default build stays on the 1.85 floor.
- **reqwest unify (C1) stays rejected/blocked on B4**: oci-client hard-pins reqwest 0.13 (forcing aws-lc) and a transitive 0.12 holdout remains, so the bump collapses nothing. reqwest is a recorded baseline entry, not a free cut.

## Not in this PR
The third red Security job — **`Flake locks — committed + in sync`** — is a separate nix-domain concern (lock drift), untouched here.

## Verification (local)
- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`
- `cargo audit` (synced ignores) → exit 0
- nightly `cargo fmt --all -- --check` clean; `clippy -p mvm-hostd --features custom-dns` clean
- `mvm-hostd` builds default **and** `--features custom-dns`; the 3 resolver module tests pass
- ratchet adversarially confirmed (drop a baseline entry → fails)