### PR TITLE
docs(plan-177): record Phase 2 landing (#806) + prune ADR-002 tier matrix

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status — rollup checklist
 
-**Last updated: 2026-06-11**
+**Last updated: 2026-06-12**
 
 > MAINTENANCE: keep this file current. Whenever you land, merge, or descope a
 > workstream in any plan below, tick/strike the matching box here in the SAME
@@ -29,7 +29,7 @@ details** below for the workstream-level state.
 - [ ] **PLAN 123** — Network / storage / warm-start · 🟢 Phase A/B done; C2/C3 (FC/Vz warm-start) gated
 - [ ] **PLAN 124** — Lean guest agent · 🟡 ~65%; SDK codegen + signed on-device config remain
 - [ ] **PLAN 126** — Dependency reduction · 🟡 ~25%; sigstore/aws-lc/lock-gate remain
-- [ ] **PLAN 177** — Backend consolidation (8→4) · 🟡 Phase 1 done; Phase 2 (AVF convergence) in progress
+- [ ] **PLAN 177** — Backend consolidation (8→4) · 🟡 Phase 1 done; Phase 2 convergence landed (#806) — remaining: hardware smoke (host-gated) + cosmetic rename slice
 - [ ] **PLAN 175** — Firecracker live-memory warm-start · 🔴 not started (live-KVM-gated)
 - [ ] **PLAN 183** — Builder-VM egress posture + network bootstrap · 🟡 WS-A/B/C landed; WS-D (E2E proof) remains
 - [x] **PLAN 180** — Strip spec refs from code comments · ✅ (lint-gated, #786)
@@ -300,29 +300,28 @@ PLAN 126 — Dependency reduction                 🟡 ~25%
 PLAN 153 — CLI directory split                  ✅ DONE (subsumed into Plan 178)
   [x] image.rs → image/ ; catalog.rs → catalog/ (last two flat files)
 
-PLAN 177 — Backend consolidation (8→4)           🟡 Phase 1 DONE; Phase 2 in progress (gate cleared: Plan 152 WS-B + save/pause landed)  (ADR-076)
+PLAN 177 — Backend consolidation (8→4)           🟡 Phase 1 DONE; Phase 2 convergence LANDED (#806) — 4 backends + mock; one vz AVF path. Remaining to tick DONE: hardware smoke (host-gated) + cosmetic rename slice  (ADR-076)
   [x] Phase 1 delete docker (+ dead Tier-3 banner subsystem)
   [x] Phase 1 delete cloud_hypervisor (+ ch_runtime, ch-bootcheck)
   [x] Phase 1 fold microvm_nix → qemu
   [x] Phase 1 prune dead CI lane + Justfile setup recipe
   [x] Phase 1 verify: doctor lists {firecracker,libkrun,vz,qemu,apple-container,mock};
       4837/4837 workspace tests (excl mvm-backend SIGKILL bin); clippy/fmt clean
-  [ ] Phase 2 — AVF convergence onto supervisor vz + shared console transport
-      + drop apple-container. Code COMPLETE on feat/plan-177-phase2-avf (PR open):
+  [x] Phase 2 — AVF convergence onto supervisor vz — MERGED #806:
       apple_container backend + providers/ deleted; AnyBackend converted; macOS-26
       default→vz; CoW per-instance rootfs ported (#789); console/transport/codesign/
       port-proxy relocated; `mvmctl dev` + `up -d` converged onto VzPersistentBuilderVm
       (detached supervisor outlives CLI, `dev down` reaps by PID file — no launchd);
       `has_apple_containers`→`is_vz_default_tier`; all `"apple-container"` selectors
-      collapsed to vz; backend.rs tests repointed. Workspace check + clippy + fmt
-      clean; mvm-cli/mvm-build nextest green (mvm-backend tests are CI-only — local
-      codesign SIGKILL). Remaining before tick: (a) live macOS-26 vz `dev up`/`up`
-      hardware smoke (deferred — a parallel session is mid-vz-debug on this host, and
-      known in-flight dev-boot bugs would confound attribution); (b) cosmetic rename
-      slice — the env module file `apple_container.rs`, `AppleContainerEnv`,
-      `MicrovmBackend::AppleContainer`, and the objc2 `mvm_apple_container_*` cdecl
-      symbols still carry the old name (functional path is already vz); (c) ADR-002
-      tier-matrix row prune.
+      collapsed to vz; backend.rs tests repointed; ADR-002 tier matrix pruned
+      (docker/CH/apple-container rows dropped, microvm.nix→QEMU); CLAUDE.md updated.
+  [ ] Remaining before Phase 2 ticks fully DONE: (a) live macOS-26 vz `dev up`/`up`
+      hardware smoke (host-gated — deferred while a parallel session is mid-vz-debug
+      on this host + known in-flight dev-boot bugs would confound attribution);
+      (b) cosmetic rename slice — the env module file `apple_container.rs`,
+      `AppleContainerEnv`, `MicrovmBackend::AppleContainer`, and the objc2
+      `mvm_apple_container_*` cdecl symbols still carry the old name (functional
+      path is already vz).
 
 PLAN 178 — CLI surface consolidation (~56→~28)   ✅ DONE (dir-purity deferred)  (ADR-077)
   [x] lock tree (D1–D6) + hide internal subprocess commands

--- a/specs/adrs/002-microvm-security-posture.md
+++ b/specs/adrs/002-microvm-security-posture.md
@@ -329,38 +329,36 @@ The following are decided and committed for v1 of this hardening:
 
 ## Per-backend tier matrix
 
-Plan 53 (cross-platform roadmap) introduces multiple backends —
-Firecracker, Apple Container, libkrun, Docker, microvm.nix — each
-with different layer coverage. A given user run carries the tier of
-its active backend, not the strongest tier the project supports. The
-following matrix is what `mvmctl doctor` reports and what the
-mvm-cli startup banner surfaces (loudly, when the active backend
-falls below Tier 1).
+mvm ships four VM backends (+ a test-only mock) — Firecracker, libkrun,
+vz, and QEMU — each with different layer coverage. A given user run
+carries the tier of its active backend, not the strongest tier the
+project supports. The following matrix is what `mvmctl doctor` reports
+and what the mvm-cli startup banner surfaces (loudly, when the active
+backend falls below Tier 1). Plan 177 consolidated the former
+8-backend set: Docker and Cloud Hypervisor were deleted in Phase 1,
+microvm.nix folded into the QEMU backend, and the in-process
+Apple-Container backend folded into the supervisor-model `vz` backend
+in Phase 2.
 
 | Backend | L1 | L2 | L3 | L4 | L5 | Notes |
 |---|---|---|---|---|---|---|
 | Firecracker (Linux + KVM) | ✅ | ✅ | ✅ | ✅ | ✅ | **Tier 1** — full ADR-002. All seven claims hold. |
-| Cloud Hypervisor (Linux + KVM) | ✅ | ✅ | ⚠️ in flight | ✅ | ✅ | **Tier 1 peer** of Firecracker — same VMM-TCB shape (rust-vmm), wider device model (VFIO, virtio-fs, larger guests). Claim 3 (verified boot) lands alongside Firecracker via the shared `mvm-verity-init` initramfs path; the CH JSON-API spawn dance is the only delta. Selected over Firecracker when a workload needs VFIO/GPU passthrough or virtio-fs. |
-| Apple Container (macOS 26+ Apple Silicon) | ✅ VZ | ✅ Containerization | ⚠️ no verified boot yet | ✅ | ✅ | Tier 2 — claim 3 partial; claims 1, 2, 4, 5, 6, 7 hold. |
-| Vz / Virtualization.framework (macOS 13+) | ✅ HVF | ✅ Vz (Apple-controlled API surface on top of HVF) | ⚠️ no verified boot yet | ✅ | ✅ | Tier 2 — same `Hypervisor.framework` primitive as libkrun, smaller Apple-controlled API surface, balloon + (macOS 14+) snapshots. Claim 3 partial — dm-verity pipeline targets Firecracker today; claims 1, 2, 4, 5, 6, 7 hold. Opt-in via `--backend vz` / `MVM_BACKEND=vz`; `auto_select` keeps libkrun as the macOS default (ADR-056). |
-| libkrun / libkrun (Linux KVM, macOS HVF) | ✅ | ✅ | ⚠️ no verified boot yet | ✅ | ✅ | Tier 2 — claim 3 partial; comparable VMM TCB to Firecracker; shipped as the cross-platform default per ADR-013. macOS arm64/x86_64 + Linux-without-KVM hosts land here. |
-| Docker | ❌ shared host kernel | ❌ container runtime is L2=host kernel | ❌ shared with host | ✅ | ✅ | **Tier 3** — claims 1, 2, 3 do *not* hold; 4, 6, 7 hold; 5 N/A (unix socket). |
-| microvm.nix (QEMU) | ✅ KVM | ⚠️ QEMU TCB much larger | ⚠️ partial verified boot | ✅ | ✅ | Tier 2 — claims 3 partial; QEMU's larger device model raises L2 audit cost. **Dev/test only** (Plan 166): selected by `mvm` for a Linux dev/test loop, never by `mvmd` — it carries no untrusted multi-tenant workload, so claim-10 egress enforcement is deliberately *not* wired into its start path (see the egress-enforcement note below). |
+| Vz / Virtualization.framework (macOS 13+) | ✅ HVF | ✅ Vz (Apple-controlled API surface on top of HVF) | ⚠️ no verified boot yet | ✅ | ✅ | Tier 2 — the single AVF backend (the former in-process Apple-Container path folded in here, Plan 177 Phase 2). Same `Hypervisor.framework` primitive as libkrun, smaller Apple-controlled API surface, balloon + snapshots. Claim 3 partial — dm-verity pipeline targets Firecracker today; claims 1, 2, 4, 5, 6, 7 hold. Auto-selected default on macOS 26+ Apple Silicon; opt-in elsewhere on macOS via `--builder vz` / `--hypervisor vz`. |
+| libkrun / libkrun (Linux KVM, macOS HVF) | ✅ | ✅ | ⚠️ no verified boot yet | ✅ | ✅ | Tier 2 — claim 3 partial; comparable VMM TCB to Firecracker; the macOS 13-25 default and the Linux-without-KVM fallback per ADR-013. |
+| QEMU (Linux KVM/TCG) | ✅ KVM | ⚠️ QEMU TCB much larger | ⚠️ partial verified boot | ✅ | ✅ | Tier 2 — claim 3 partial; QEMU's larger device model raises L2 audit cost. **Dev/test only** (Plan 166, was microvm.nix): selected by `mvm` for a Linux dev/test loop, never by `mvmd` — it carries no untrusted multi-tenant workload, so claim-10 egress enforcement is deliberately *not* wired into its start path (see the egress-enforcement note below). |
 
 **Tier discipline**: Tier 1 is the production default and the only
 tier that carries the *full* ADR-002 promise. Tier 2 carries six of
 the seven claims with claim 3 (verified boot) tracked as a follow-up
-once verified-boot lands for VZ/HVF. Tier 3 (Docker) carries only the
-supply-chain and guest-agent claims; the L1–L3 isolation collapses to
-the host kernel. Plan 53 §"Security posture decision" documents *why*
-we keep Docker available but unpromoted — the convenience is real,
-but we refuse to launder a container as a microVM in marketing or in
-auto-selected defaults.
+once verified-boot lands for VZ/HVF. There is no Tier 3 anymore — the
+only Tier-3 backend was Docker (a shared-kernel container that held
+none of the L1–L3 isolation claims), and it was deleted in Plan 177
+Phase 1 along with its auto-select warning banner. mvm refuses to
+launder a container as a microVM, so no shared-kernel runtime ships.
 
 `mvmctl doctor` (plan 40 folded the standalone `security` verb into
 doctor) renders this matrix per-host with the active backend
-highlighted and prints a loud `MVM_ACK_DOCKER_TIER`-suppressible
-warning banner whenever Tier 3 is auto-selected.
+highlighted.
 
 **Claim-10 egress enforcement coverage (Plan 123 Phase A).** Claim 10's
 default-deny egress is enforced at the host-side network chokepoint of the
@@ -371,7 +369,7 @@ the TAP, with the per-tenant allow-list layered on by the L4 gate), and
 flow-open gate derived from the admitted plan's resolved policy) composed with
 the always-on `MandatoryDenyEgressScan` + per-tenant `L4PolicyScan` /
 `DnsSinkholeScan` packet scans. Both derive the same posture from the same
-`NetworkPolicy` through their respective seams. **microvm.nix (QEMU) is
+`NetworkPolicy` through their respective seams. **QEMU is
 intentionally excluded**: it is a `mvm`-only dev/test backend (Plan 166), never
 reached by `mvmd`, so it carries no untrusted multi-tenant workload and there
 is no admission flow to source a policy from — forcing `deny_all()` onto its

--- a/specs/plans/177-backend-consolidation.md
+++ b/specs/plans/177-backend-consolidation.md
@@ -112,6 +112,18 @@ Modified:
 
 ## Phase 2 — AVF convergence (GATED — do not start until both land on `main`)
 
+> **STATUS (2026-06-12): the convergence LANDED in #806.** Tasks 6-9 plus
+> Task 10's docs are done: the `apple_container` backend + `providers/` are
+> deleted, `AnyBackend` resolves macOS-26 to `Vz`, CoW per-instance rootfs is
+> ported (#789), `mvmctl dev` + `up -d` run on the detached vz supervisor
+> (`VzPersistentBuilderVm`, no launchd), `has_apple_containers`→
+> `is_vz_default_tier`, every `"apple-container"` selector collapsed to vz,
+> CLAUDE.md + ADR-002 tier matrix updated. **Not yet ticked DONE:** the live
+> macOS-26 vz `dev up`/`up` hardware smoke (host-gated) and the cosmetic
+> rename slice (the env module file `apple_container.rs`, `AppleContainerEnv`,
+> `MicrovmBackend::AppleContainer`, and the objc2 `mvm_apple_container_*` cdecl
+> symbols still carry the old name — functional path is already vz).
+
 > **GATE:** `feat/plan-152-wsb-rust-vz-supervisor` (Plan 152 WS-B, native
 > objc2 VZ supervisor) **and** `feat/plan-152-fix-vz-save-pause` must be
 > merged to `main` first. They rewrite the VZ supervisor surface this phase


### PR DESCRIPTION
Docs-only follow-up to #806 (Plan 177 Phase 2 AVF convergence).

- **ADR-002 per-backend tier matrix:** drop the rows for the deleted backends (Docker, Cloud Hypervisor, in-process Apple Container), rename `microvm.nix`→`QEMU`, mark `vz` the single AVF backend + macOS-26 default, and remove the now-empty Tier-3 (Docker) discussion and its deleted `MVM_ACK_DOCKER_TIER` warning banner. The matrix is now the 4 shipped backends (Firecracker Tier 1; vz/libkrun/QEMU Tier 2) + mock.
- **REFACTOR-STATUS:** flip Plan 177 Phase 2 to "convergence landed (#806)"; record the two items still open before it ticks fully done.
- **Plan 177 doc:** status banner under the Phase 2 header.

**Still open (not in this PR, both tracked):** the live macOS-26 vz `dev up`/`up` hardware smoke (host-gated) and the cosmetic rename slice (`apple_container.rs` module + `AppleContainerEnv`/`MicrovmBackend::AppleContainer`/objc2 `mvm_apple_container_*` symbols still carry the old name; functional path is already vz).