### PR TITLE
chore: scrub stale references to deleted backends (apple_container/docker/cloud_hypervisor) + dead Vfkit variant

### DIFF
--- a/crates/mvm-backend/src/artifacts/config/mod.rs
+++ b/crates/mvm-backend/src/artifacts/config/mod.rs
@@ -1,7 +1,7 @@
 //! Backend-specific config writers.
 //!
 //! Each submodule implements `BackendConfigWriter` for one backend.
-//! Slice 1 ships Firecracker; QEMU and Vfkit are deferred.
+//! Slice 1 ships Firecracker; QEMU is deferred.
 
 pub mod firecracker;
 

--- a/crates/mvm-backend/src/compat.rs
+++ b/crates/mvm-backend/src/compat.rs
@@ -17,9 +17,6 @@
 //! - **Qemu**: no implementation yet; capabilities are conventional QEMU
 //!   defaults for the mvm workload shape (ELF/Image per arch, ext4 rootfs,
 //!   TAP networking, snapshots, no jailer). Flagged with `// assumption`.
-//! - **Vfkit**: no implementation yet; Apple Virtualization.framework thin
-//!   wrapper (same tier as Vz), aarch64/macOS only, gvproxy networking.
-//!   Flagged with `// assumption`.
 
 use mvm_core::arch::GuestArch;
 use mvm_core::kernel_format::KernelFormat;
@@ -34,7 +31,6 @@ pub enum MicrovmBackend {
     Libkrun,
     Vz,
     Qemu,
-    Vfkit,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -185,22 +181,6 @@ static QEMU: BackendCompat = BackendCompat {
     networking: NetworkingModel::Tap,       // assumption: QEMU standard TAP
 };
 
-// Vfkit: no implementation yet. Apple Virtualization.framework thin wrapper
-// (same tier as Vz), aarch64/macOS only. Capabilities modelled after Vz
-// since both use the same underlying Apple VZ API.                // assumption
-static VFKIT: BackendCompat = BackendCompat {
-    backend: MicrovmBackend::Vfkit,
-    guest_arches: &[Aarch64], // assumption: Apple Silicon / macOS only
-    kernel_formats: &[
-        (Aarch64, &[K::Elf, K::Image]), // assumption: same as Vz (Apple VZ accepts both)
-    ],
-    rootfs_formats: &[R::Ext4],            // assumption
-    required_boot_args: &["console=hvc0"], // assumption: matches Vz shape
-    supports_snapshots: false, // assumption: conservative; Vfkit snapshot API unverified
-    supports_jailer: false,    // assumption: no jailer (Apple VZ path)
-    networking: NetworkingModel::Gvproxy, // assumption: mirrors Vz gvproxy path
-};
-
 // ── lookup ────────────────────────────────────────────────────────────────────
 
 pub fn compat(b: MicrovmBackend) -> &'static BackendCompat {
@@ -209,7 +189,6 @@ pub fn compat(b: MicrovmBackend) -> &'static BackendCompat {
         MicrovmBackend::Libkrun => &LIBKRUN,
         MicrovmBackend::Vz => &VZ,
         MicrovmBackend::Qemu => &QEMU,
-        MicrovmBackend::Vfkit => &VFKIT,
     }
 }
 
@@ -243,7 +222,6 @@ mod tests {
             MicrovmBackend::Libkrun,
             MicrovmBackend::Vz,
             MicrovmBackend::Qemu,
-            MicrovmBackend::Vfkit,
         ] {
             assert_eq!(compat(b).backend, b);
         }
@@ -276,7 +254,6 @@ mod tests {
             MicrovmBackend::Libkrun,
             MicrovmBackend::Vz,
             MicrovmBackend::Qemu,
-            MicrovmBackend::Vfkit,
         ] {
             assert!(!compat(b).supports_jailer, "{b:?} should not have jailer");
         }

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -5,7 +5,7 @@
 //! the VM-lifecycle CLI verbs (`mvmctl up`, `down`, `pause`, `resume`,
 //! `set-ttl`, `fs`, `proc`, `volume mount`, `snapshot`) can be exercised
 //! end-to-end in hermetic tests — `cargo test` on a CI runner with no
-//! KVM, no Apple Container, no Nix builder VM, no Docker daemon.
+//! KVM, no VMM, and no Nix builder VM.
 //!
 //! Selected via `mvmctl up --hypervisor mock` (matches the
 //! [`AnyBackend::from_hypervisor`] selector). Production callers don't

--- a/crates/mvm-backend/src/qemu.rs
+++ b/crates/mvm-backend/src/qemu.rs
@@ -14,7 +14,7 @@
 //! the **best-case** Tier 2 (KVM-accelerated, comparable to the
 //! microvm.nix/qemu classification); when `/dev/kvm` is absent the boot
 //! runs under TCG software emulation and `start` emits a loud Tier-3
-//! banner (mirroring the Docker fallback). The static enum tier stays
+//! banner. The static enum tier stays
 //! Tier 2 because it's a compile-time classification consulted by the
 //! tier-sync test + `doctor`; the live KVM-vs-TCG mode is a *runtime*
 //! property surfaced through the banner and `doctor`, not the enum.
@@ -81,8 +81,8 @@ impl VmBackend for QemuBackend {
     fn capabilities(&self) -> VmCapabilities {
         VmCapabilities {
             // QEMU can pause/resume + snapshot via QMP, but mvm doesn't
-            // wire a QMP monitor today (parity with the microvm-nix
-            // backend). Declared false until the monitor lands.
+            // wire a QMP monitor today. Declared false until the
+            // monitor lands.
             pause_resume: false,
             snapshots: false,
             vsock: true,
@@ -117,7 +117,7 @@ impl VmBackend for QemuBackend {
 
         let kvm = kvm_available();
         if !kvm {
-            // Loud Tier-3 banner, mirroring the Docker fallback.
+            // Loud Tier-3 banner for the unaccelerated TCG fallback.
             ui::warn(&format!(
                 "QEMU workload '{}' is running UNACCELERATED (TCG — no /dev/kvm). \
                  This is a Tier-3 dev/test fallback: slow, and unaudited vs ADR-002. \
@@ -435,7 +435,7 @@ impl VmBackend for QemuBackend {
     }
 
     fn security_profile(&self) -> BackendSecurityProfile {
-        // Tier 2 best-case (KVM). Mirrors the microvm-nix/qemu profile:
+        // Tier 2 best-case (KVM), the microvm.nix-lineage QEMU profile:
         // QEMU's device model is much larger than Firecracker's (higher L2
         // audit cost), and claim 3 (verified boot) targets Firecracker.
         // The TCG (no-KVM) mode is a runtime Tier-3 degradation surfaced by

--- a/crates/mvm-build/src/bin/mvm-host-vm-init/workload.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init/workload.rs
@@ -8,7 +8,7 @@
 //! [`FirecrackerVmm`] is the only impl today and the only type that
 //! names Firecracker; the dispatch loop, the wire protocol, and the
 //! state-dir / process lifecycle are all VMM-agnostic. A second
-//! backend (cloud-hypervisor, qemu-microvm) is a pure addition: a
+//! backend (qemu) is a pure addition: a
 //! new `WorkloadVmm` impl, no other changes. Mirrors the host-side
 //! hypervisor-backend split in `mvm-backend/`.
 //!

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -169,9 +169,9 @@ pub struct DevBuildResult {
     pub revision_hash: String,
     /// Whether the build was a cache hit (artifacts already existed).
     pub cached: bool,
-    /// Path to the microvm.nix runner directory, if the build output
+    /// Path to the microvm.nix-lineage runner directory, if the build output
     /// contains runner scripts (e.g. `bin/microvm-run`). When present,
-    /// the microvm.nix backend can be used instead of manual Firecracker
+    /// the QEMU backend can use them instead of manual Firecracker
     /// API calls.
     pub runner_dir: Option<String>,
     /// Artifact file sizes (kernel, rootfs, initrd).

--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -1121,9 +1121,8 @@ impl VzPersistentBuilderVm {
 
         // Name-prefix isolation under the shared cache root.
         // libkrun uses `mvm-persistent-builder-vm-{session}`; Vz uses
-        // `mvm-persistent-builder-vz-{session}`. The Stage 0 reaper
-        // (`apple_container.rs`) is prefix-agnostic so both participate
-        // in cleanup without code changes.
+        // `mvm-persistent-builder-vz-{session}`. The Stage 0 reaper is
+        // prefix-agnostic so both participate in cleanup without code changes.
         let vm_name = format!("mvm-persistent-builder-vz-{session_id}");
         let vm_state_dir = builder_vm_cache_dir().join("vms").join(&vm_name);
         std::fs::create_dir_all(&vm_state_dir).map_err(|e| {

--- a/crates/mvm-cli/src/commands/env/artifact_verify.rs
+++ b/crates/mvm-cli/src/commands/env/artifact_verify.rs
@@ -4,7 +4,7 @@
 //! These are the generic "pull a file over curl and check it against the
 //! published checksum manifest" helpers that back hash-verified downloads;
 //! the dev-image and builder-VM download orchestration in
-//! `apple_container.rs` calls them.
+//! `dev_vz.rs` calls them.
 
 use anyhow::{Context, Result};
 

--- a/crates/mvm-cli/src/commands/env/linux_native.rs
+++ b/crates/mvm-cli/src/commands/env/linux_native.rs
@@ -15,7 +15,7 @@
 //! gone; the asset pipeline now runs directly on the host via the
 //! `mvm_backend::firecracker::*` functions.
 //!
-//! Apple Container hosts use `super::apple_container` instead; macOS
+//! macOS 26+ Apple Silicon hosts use `super::dev_vz` instead; macOS
 //! Intel / pre-26 / no-KVM-Linux hosts fall through to a "no dev
 //! backend" error in `super::dev::run` — those need the
 //! libkrun builder VM.

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -3,8 +3,8 @@
 //! lineage from one. Capture and fork are filesystem-only here; booting a
 //! forked child is a separate `mvmctl up` step.
 //!
-//! Only the macOS workload backends (Vz / apple_container) materialize a
-//! host-side rootfs image, so checkpointing is gated to a VM that has one.
+//! Only the macOS Vz workload backend materializes a host-side rootfs image,
+//! so checkpointing is gated to a VM that has one.
 
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -149,9 +149,9 @@ fn now_unix() -> u64 {
 /// queues quiesced). A live, unpaused VM is refused: an fs_quick checkpoint has
 /// no memory, so the rootfs must be in a clean, deterministic state.
 ///
-/// Rootfs location is backend-specific but both macOS workload backends keep
+/// Rootfs location is backend-specific but the macOS Vz workload backend keeps
 /// the image under `vm_state_dir(name)`:
-///   - apple_container clones a per-instance `rootfs.ext4` there;
+///   - a per-instance `rootfs.ext4` CoW clone lands there;
 ///   - Vz boots from a supplied path but persists the launch config, whose
 ///     `rootfs` disk records that path.
 fn resolve_quiesced_vm_rootfs(name: &str) -> Result<PathBuf> {
@@ -160,7 +160,7 @@ fn resolve_quiesced_vm_rootfs(name: &str) -> Result<PathBuf> {
     }
     let state_dir = vm_state_dir(name);
 
-    // apple_container per-instance clone — deterministic, present on disk.
+    // Per-instance CoW clone — deterministic, present on disk.
     let instance_rootfs = state_dir.join("rootfs.ext4");
     if instance_rootfs.is_file() {
         return Ok(instance_rootfs);

--- a/crates/mvm-cli/src/commands/vm/console.rs
+++ b/crates/mvm-cli/src/commands/vm/console.rs
@@ -461,8 +461,8 @@ mod accessible_gate_tests {
     fn pick_console_transport_selects_vz_when_only_vz_socket_present() {
         use std::os::unix::net::UnixListener;
         // Regression for the "console can't reach a Vz workload" gap: with a
-        // Vz workload's vsock socket present (and no apple-container / dev-proxy
-        // / libkrun / firecracker surface), the picker must select the Vz
+        // Vz workload's vsock socket present (and no dev-proxy / libkrun /
+        // firecracker surface), the picker must select the Vz
         // transport instead of erroring out on the firecracker fallback.
         let _g = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/mvm-cli/src/commands/vm/plan_builder.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_builder.rs
@@ -80,8 +80,7 @@ pub struct SynthesisInput<'a> {
     pub vm_name: &'a str,
     /// Optional tenant override. `None` → `DEFAULT_TENANT`.
     pub tenant: Option<&'a str>,
-    /// Resolved runtime profile (`firecracker` / `libkrun` /
-    /// `apple-container` / `cloud-hypervisor`).
+    /// Resolved runtime profile (`firecracker` / `libkrun` / `vz` / `qemu`).
     pub backend_name: &'a str,
     /// Image reference for `SignedImageRef`. `sha256` is the
     /// lowercase-hex digest of the rootfs (computed by `mvm-security::

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1786,7 +1786,7 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<()> {
 
     let backend_label = match effective_hypervisor {
         "vz" => "Apple Virtualization",
-        "qemu" => "QEMU (microvm.nix)",
+        "qemu" => "QEMU",
         _ => "Firecracker VM",
     };
     ui::step(2, 2, &format!("Booting {} '{}'", backend_label, vm_name));
@@ -2437,7 +2437,7 @@ fn resolve_vz_workload_kernel(vmlinux_path: &str, hypervisor: &str) -> anyhow::R
     // `virtualization` is the long-form alias the backend dispatcher
     // accepts for vz; missing it here would skip the fallback and hand
     // VZ a nonexistent kernel path.
-    if !matches!(hypervisor, "vz" | "virtualization" | "apple-container") {
+    if !matches!(hypervisor, "vz" | "virtualization") {
         return Ok(vmlinux_path.to_string());
     }
     let arch = if cfg!(target_arch = "aarch64") {

--- a/crates/mvm-cli/tests/core_demo_e2e.rs
+++ b/crates/mvm-cli/tests/core_demo_e2e.rs
@@ -8,9 +8,8 @@
 //! On macOS the workload microVM runs via libkrun (vsock-capable; the
 //! path the guest agent answers on). `--hypervisor libkrun` is passed
 //! explicitly so the test doesn't depend on `up`'s per-host auto-select
-//! preferring libkrun over apple-container on macOS 26+ (which is a
-//! deliberate apple-container priority for general use; the demo wants
-//! the vsock path).
+//! preferring libkrun over Vz on macOS 26+ (which is a deliberate Vz
+//! priority for general use; the demo wants the vsock path).
 //!
 //! `up` waits for the guest agent (`wait_for_guest_agent` → vsock Ping)
 //! and only prints `Guest agent not reachable.` on failure — so `up`

--- a/crates/mvm-core/src/crypto/image_verify.rs
+++ b/crates/mvm-core/src/crypto/image_verify.rs
@@ -1,6 +1,6 @@
 //! Signed-image verification primitive.
 //!
-//! Extends `apple_container.rs::verify_artifact_hash` by elevating the trust
+//! Extends the bare `verify_artifact` hash check below by elevating the trust
 //! anchor from "TLS-fetched checksum file" to "cosign-keyless-signed
 //! manifest." The `SignedManifest` schema records every artifact's SHA-256
 //! plus the input closure (Nix store hash, source git SHA, flake lockfile
@@ -353,9 +353,7 @@ pub fn check_revocation(
 }
 
 /// Stream `path` through SHA-256 and compare to `expected.sha256`. On
-/// mismatch, delete the file and return `DigestMismatch`. The
-/// delete-on-mismatch behaviour matches
-/// `apple_container.rs::verify_artifact_hash`.
+/// mismatch, delete the file and return `DigestMismatch`.
 ///
 /// Callers that want to keep the file for forensics should hash it
 /// directly with `sha256_file` and compare manually.

--- a/crates/mvm-core/src/plan/types.rs
+++ b/crates/mvm-core/src/plan/types.rs
@@ -25,9 +25,8 @@ pub struct TenantId(pub String);
 #[serde(transparent)]
 pub struct WorkloadId(pub String);
 
-/// Reference to a runtime profile (Firecracker / Apple Container /
-/// MicrovmNix / Lima / containerd). The open `BackendRegistry`
-/// resolves the name to a backend factory.
+/// Reference to a runtime profile (Firecracker / libkrun / Vz / QEMU).
+/// The open `BackendRegistry` resolves the name to a backend factory.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct RuntimeProfileRef(pub String);

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -93,7 +93,7 @@ pub struct VmStartConfig {
     pub config_files: Vec<VmFile>,
     /// Secret files (written with restricted permissions).
     pub secret_files: Vec<VmFile>,
-    /// Directory containing microvm.nix runner scripts (microvm.nix backend only).
+    /// Directory containing microvm.nix-lineage runner scripts (QEMU backend only).
     pub runner_dir: Option<String>,
     /// Tenant identifier from the admitted `ExecutionPlan`
     /// (`AdmittedPlan.plan.tenant.0`). When `Some`, the libkrun/Vz

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -35,10 +35,10 @@ pub const GUEST_CID: u32 = 3;
 /// keeps its disjoint-union shape. The "52" tail is a
 /// callback to the historical port for grep-ability.
 ///
-/// **Single source of truth.** `mvm-apple-container` and
-/// `mvm::vm::vminitd_client` re-declare this value because
-/// they cannot depend on `mvm-guest`. If you change this, update those
-/// duplicates in the same commit; the workspace tests catch drift.
+/// **Single source of truth.** `mvm::vm::vminitd_client` re-declares
+/// this value because it cannot depend on `mvm-guest`. If you change
+/// this, update that duplicate in the same commit; the workspace tests
+/// catch drift.
 pub const GUEST_AGENT_PORT: u32 = 5252;
 
 /// Control vsock port the guest's `/init` connects to (host side) to

--- a/crates/mvm-hostd/src/supervisor/backend.rs
+++ b/crates/mvm-hostd/src/supervisor/backend.rs
@@ -3,7 +3,7 @@
 //!
 //! For now this is just an abstraction so `Supervisor::launch(plan)` can
 //! be tested without a real Firecracker. An open `BackendRegistry` plus
-//! concrete `FirecrackerBackend` / `AppleContainerBackend` impls land in
+//! concrete `FirecrackerBackend` / `VzBackend` impls land in
 //! a follow-up that lifts today's `mvm/src/vm/backend.rs`
 //! `AnyBackend` enum behind this trait.
 

--- a/crates/mvm-hostd/src/supervisor/reaper.rs
+++ b/crates/mvm-hostd/src/supervisor/reaper.rs
@@ -74,7 +74,7 @@ pub type TeardownFn = Box<dyn Fn(&str, &VmRegistration) -> Result<(), String> + 
 /// reaper is about to put it to sleep (drain/pause — the *trigger*, not a
 /// new sleep mechanism). The implementation performs the
 /// backend-appropriate sleep (drain+snapshot for snapshot-capable backends,
-/// clean stop with data disk + TAP retained for libkrun/apple-container).
+/// clean stop with data disk + TAP retained for libkrun).
 /// Returning `Err` leaves the VM running so the next tick retries; the
 /// reaper itself flips `paused = true` in the registry on success.
 pub type SleepFn = Box<dyn Fn(&str, &VmRegistration) -> Result<(), String> + Send + Sync>;

--- a/crates/mvm-vm-host/src/bin/mvm-vz-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-vz-supervisor.rs
@@ -55,7 +55,7 @@ fn exe_has_virtualization_entitlement(exe: &std::path::Path) -> bool {
 
 /// Self-sign ad-hoc with the virtualization entitlement, then re-exec — we ship
 /// the bin unsigned, and VZ start is rejected without it. Mirrors
-/// `apple_container::ensure_signed` (virtualization-only). The `MVM_VZ_SIGNED`
+/// `mvm_backend::codesign::ensure_signed` (virtualization-only). The `MVM_VZ_SIGNED`
 /// guard prevents an exec loop; `exec()` preserves the pid and the stdin pipe
 /// the spawner writes the config to, so this is transparent to `mvm_backend::vz`.
 /// Best-effort: a signing failure logs and proceeds so the real entitlement

--- a/crates/mvm-vm-host/src/vz_objc.rs
+++ b/crates/mvm-vm-host/src/vz_objc.rs
@@ -1565,7 +1565,7 @@ fn dgram_socketpair() -> Result<(OwnedFd, OwnedFd)> {
 }
 
 /// Best-effort 1 MiB SO_SNDBUF/SO_RCVBUF so an MTU-sized datagram survives a
-/// backlog (matches cloud-hypervisor / Apple's sample).
+/// backlog (matches Apple's sample).
 fn bump_socket_buffers(fd: std::os::fd::RawFd) {
     let buf: libc::c_int = 1024 * 1024;
     let buf_ptr = std::ptr::addr_of!(buf).cast::<libc::c_void>();
@@ -1696,7 +1696,7 @@ fn sockaddr_un_from_path(path: &str) -> Result<libc::sockaddr_un> {
 
 /// Open and connect a SOCK_DGRAM AF_UNIX socket to gvproxy's vfkit listener,
 /// with 1 MiB send/recv buffers so an MTU-sized datagram survives a backlog
-/// (matches cloud-hypervisor / Apple's sample). Returns an owned fd that closes
+/// (matches Apple's sample). Returns an owned fd that closes
 /// on any early-return error path.
 ///
 /// An unbound unix-datagram socket has no return address, so gvproxy's

--- a/crates/mvm/src/vm/mod.rs
+++ b/crates/mvm/src/vm/mod.rs
@@ -1,7 +1,7 @@
 // Backend/substrate split:
 //
-//   * Every concrete `VmBackend` impl + the FC support modules
-//     (apple_container, libkrun, firecracker, microvm,
+//   * Every concrete `VmBackend` impl + the support modules
+//     (firecracker, libkrun, vz, qemu, microvm,
 //     image, network, backend) live in `mvm-backend`.
 //   * The leaf substrate (`ui`, `runtime_meta`, `cow`,
 //     `snapshot_integrity`) lives in `mvm-base`.

--- a/crates/mvm/src/vm/overlay.rs
+++ b/crates/mvm/src/vm/overlay.rs
@@ -47,9 +47,8 @@
 //! - Not encrypted. A LUKS-backed impl will wire
 //!   `mvm-security::keystore::KeyProvider` for per-overlay LUKS
 //!   keys.
-//! - Not mounted into VMs. The firecracker / cloud-hypervisor
-//!   backends will learn to attach the overlay as a virtio block
-//!   device.
+//! - Not mounted into VMs. The firecracker / qemu backends will
+//!   learn to attach the overlay as a virtio block device.
 //! - No destruction certificate yet. Signing the
 //!   [`DestructionReceipt`] under the host identity key and emitting
 //!   it to the audit chain is wired below.

--- a/crates/mvm/src/vsock_transport.rs
+++ b/crates/mvm/src/vsock_transport.rs
@@ -336,8 +336,8 @@ mod tests {
     #[test]
     fn for_vm_selects_vz_when_only_vz_socket_present() {
         use std::os::unix::net::UnixListener;
-        // With a Vz workload's socket present (and no apple-container/libkrun/
-        // firecracker surface), the picker must select the Vz transport rather
+        // With a Vz workload's socket present (and no libkrun/firecracker
+        // surface), the picker must select the Vz transport rather
         // than falling through to the firecracker error. Regression for the
         // "console can't reach a Vz workload" gap.
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Tail of the Plan 177 backend consolidation — removes now-stale/incorrect references to the deleted backends from code + comments. Pure cleanup, no behavior change.

## Changes
- **One functional fix:** `resolve_vz_workload_kernel` (up.rs) dropped a dead `"apple-container"` arm from its VZ-family guard — nothing resolves to that hypervisor string after #806/#814.
- **~23 comment corrections** across the deleted backends:
  - `apple_container` (9) — e.g. checkpoint.rs no longer lists it alongside Vz as a current backend; `super::apple_container` doc refs → `dev_vz`; `apple_container::ensure_signed` → `codesign::ensure_signed`.
  - `cloud_hypervisor` (4) and `docker` (2) — dropped from "second backend" examples / fallback prose.
  - `microvm_nix` (6) — corrected to "QEMU" where it named a current backend; the genuine microvm.nix *lineage/runner-script* heritage of the QEMU backend is kept (accurate).
- `image_verify.rs` doc repointed off the deleted `apple_container.rs` to the live `verify_artifact` helper in the same file.
- **Removed the dead `MicrovmBackend::Vfkit` variant** — a never-implemented capability-matrix entry marked `// assumption` throughout, with no constructor anywhere (mirrors the #814 `AppleContainer` removal). The `-listen-vfkit` gvproxy socket protocol + `NET_FLAG_VFKIT` FFI strings are load-bearing and untouched.

## Deliberately kept (load-bearing / accurate)
- gRPC proto package `com.apple.containerization.sandbox.v3` (wire identifier).
- `backend.rs` retirement notes ("microvm.nix folded into QEMU", "retired apple-container alias").
- QEMU's microvm.nix lineage/runner-script heritage; "Apple's sample" objc2 refs.

## Verification
`cargo check --workspace --tests`, `cargo build -p mvm-cli --no-default-features -D warnings`, `clippy --all-targets -D warnings`, `cargo test -p mvm-backend --no-run` (compiles; runs on CI's Linux lanes), nightly fmt — all clean. `rg` for the deleted-backend symbols is empty.