### PR TITLE
chore: refresh folded-crate names in comments (Plan 121 tail)

### DIFF
--- a/crates/deps/libkrun-sys/Cargo.toml
+++ b/crates/deps/libkrun-sys/Cargo.toml
@@ -43,10 +43,9 @@ tracing = "0.1"
 serde = { workspace = true }
 # `SupervisorConfig` carries the per-VM ExecutionPlan + PolicyBundle as
 # `Option<serde_json::Value>` so the bin (`mvm-libkrun-supervisor`) can
-# feed them into the bridge factory without forcing mvm-libkrun to
-# depend on mvm-plan / mvm-policy (which would close the
-# `mvm-libkrun ← mvm-core ← mvm-plan`
-# cycle). The bin crate, being a leaf, deserializes the Values into
+# feed them into the bridge factory without typed coupling to the
+# `mvm_core::plan` / `mvm_core::policy` structs at this layer; the
+# bridge stays a serde boundary. The bin crate, being a leaf, deserializes the Values into
 # typed `ExecutionPlan` / `PolicyBundle` since it can depend on
 # both. Always-on (not feature-gated) because `SupervisorConfig` is
 # always-on per the comment above.

--- a/crates/deps/libkrun-sys/src/lib.rs
+++ b/crates/deps/libkrun-sys/src/lib.rs
@@ -1340,9 +1340,9 @@ pub struct SupervisorConfig {
     // needs `Arc<ExecutionPlan>` + `Option<Arc<PolicyBundle>>` to
     // construct chained `AuditEntry`s. Carrying them as
     // `Option<serde_json::Value>` (instead of the typed structs)
-    // avoids adding `mvm-plan` / `mvm-policy` to this crate's deps,
-    // which would close the `mvm-libkrun ← mvm-core ← mvm-plan`
-    // cycle. The leaf bin crate `mvm-libkrun-supervisor` can freely
+    // avoids a typed coupling to the `mvm_core::plan` /
+    // `mvm_core::policy` structs at this layer; the bridge stays a
+    // serde boundary. The leaf bin crate `mvm-libkrun-supervisor` can freely
     // depend on both and deserializes the Values on the bridge side.
     /// JSON-encoded [`mvm_core::plan::ExecutionPlan`] for this admission.
     /// The bin deserializes into the typed value when building

--- a/crates/mvm-backend/src/audit_substrate.rs
+++ b/crates/mvm-backend/src/audit_substrate.rs
@@ -33,7 +33,7 @@ pub struct AuditSubstrate {
 /// NUL, etc.) are fail-open by construction; allowlist is the correct
 /// shape.
 ///
-/// `mvm-plan`'s `TenantId` is an unchecked `String` newtype today
+/// `mvm-core::plan`'s `TenantId` is an unchecked `String` newtype today
 /// (only sha256_hex is validated); this is the defense-in-depth
 /// boundary.
 fn validate_dns_label(label: &str, kind: &str) -> Result<()> {

--- a/crates/mvm-backend/src/backend.rs
+++ b/crates/mvm-backend/src/backend.rs
@@ -7,7 +7,7 @@ use mvm_core::vm_backend::{
 
 // Every backend variant + the FC support modules live in this crate.
 // `microvm`, `image` are siblings under `crate::`; the substrate
-// (`config`, `shell`, `runtime_meta`) lives in `mvm-base`.
+// (`config`, `shell`, `runtime_meta`) lives in `crate::base`.
 use crate::base::config::{PortMapping, VMS_DIR};
 use crate::base::shell::run_in_vm_stdout;
 use crate::image::RuntimeVolume;

--- a/crates/mvm-backend/src/base/mod.rs
+++ b/crates/mvm-backend/src/base/mod.rs
@@ -1,4 +1,4 @@
-//! mvm-base — shared substrate for `mvm` + `mvm-backend`.
+//! base — shared substrate for `mvm` + `mvm-backend` (was `mvm-base`).
 //!
 //! Lifts the substrate that backend implementations need out of
 //! `mvm` so the concrete `VmBackend` impls can live in `mvm-backend`

--- a/crates/mvm-backend/src/lib.rs
+++ b/crates/mvm-backend/src/lib.rs
@@ -19,7 +19,7 @@
 //!   mvm-core              ← VmBackend trait + types
 //!   base (module)         ← config + shell + linux_env + ui +
 //!                           runtime_meta + cow (substrate, was mvm-base)
-//!   mvm-providers         ← libkrun/Apple-VZ FFI shims
+//!   providers (module)    ← libkrun/Apple-VZ FFI shims (was mvm-providers)
 //!     ↓                     ↓                     ↓
 //!     └─────── mvm-backend (this crate) ────────┘
 //!                          ↑

--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -274,8 +274,8 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
 
     // Parse the signed-plan + bundle envelopes from VmStartConfig.
     // libkrun_sys::SupervisorConfig carries them as Option<serde_json::Value>
-    // so the supervisor can re-verify the envelope without depending on
-    // mvm-plan at the parse boundary.
+    // so the supervisor can re-verify the envelope without typed coupling
+    // to `mvm_core::plan` at the parse boundary.
     let plan = match config.plan_json.as_deref() {
         Some(s) => Some(
             serde_json::from_str(s)

--- a/crates/mvm-cli/src/commands/vm/plan_admission.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_admission.rs
@@ -219,7 +219,8 @@ const BUNDLE_JSON_MAX_BYTES: usize = 4 * 1024 * 1024;
 /// gateway_events_socket, signing_key_path}` and activate the
 /// bridge-factory path.
 ///
-/// JSON-encoded so `mvm-core` carries no typed dep on `mvm-plan`. The
+/// JSON-encoded so the `VmStartConfig` wire type stays a serde seam
+/// with no typed coupling to `mvm_core::plan` at the backend boundary. The
 /// supervisor re-verifies the `SignedExecutionPlan` envelope before
 /// trusting any decoded field — see
 /// `mvm_hostd::supervisor::supervisor::SupervisorAdmission::admit`.

--- a/crates/mvm-cli/src/commands/vm/plan_builder.rs
+++ b/crates/mvm-cli/src/commands/vm/plan_builder.rs
@@ -83,8 +83,8 @@ pub struct SynthesisInput<'a> {
     /// Resolved runtime profile (`firecracker` / `libkrun` / `vz` / `qemu`).
     pub backend_name: &'a str,
     /// Image reference for `SignedImageRef`. `sha256` is the
-    /// lowercase-hex digest of the rootfs (computed by `mvm-security::
-    /// image_verify::hash_artifact` or upstream Nix).
+    /// lowercase-hex digest of the rootfs (computed by `mvm-core::crypto::
+    /// image_verify::sha256_file` or upstream Nix).
     pub image_name: &'a str,
     pub image_sha256: &'a str,
     pub image_cosign_bundle: Option<&'a str>,

--- a/crates/mvm-cli/src/commands/vm/policy_resolver.rs
+++ b/crates/mvm-cli/src/commands/vm/policy_resolver.rs
@@ -1,6 +1,6 @@
 //! `PolicyRef → concrete component slot` resolver.
 //!
-//! `mvm-plan::ExecutionPlan` carries four policy refs that name (but
+//! `mvm-core::plan::ExecutionPlan` carries four policy refs that name (but
 //! do not contain) the policy bundle a workload runs under:
 //!
 //! - `network_policy: PolicyRef`

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -861,7 +861,7 @@ pub struct SessionVm {
 /// backend spawns the substitution endpoint (the guest never holds a raw
 /// secret). The caller (`invoke --from-workload-ir`) admits the workload's
 /// lowered secrets and hands these JSON-serialized fields back; `boot_session_vm`
-/// threads them into the `VmStartConfig`. Strings (not typed `mvm-plan` values)
+/// threads them into the `VmStartConfig`. Strings (not typed `mvm-core::plan` values)
 /// so this module carries no admission-type dep. **Do not log `plan_json`** — the
 /// signed envelope carries secret bindings.
 pub struct SessionAuditSubstrate {

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -486,7 +486,7 @@ mod tests {
     /// `set_var` collided with another's `remove_var` mid-run; the
     /// resulting assertion failures surfaced as flaky CI on
     /// `cargo test --workspace`. Mirrors the
-    /// `mvm-base::runtime_meta::HOME_TEST_LOCK` pattern: every test
+    /// `mvm-backend::base::runtime_meta::HOME_TEST_LOCK` pattern: every test
     /// that reads or writes one of these env vars grabs the lock at
     /// entry. Pure-logic tests (`normalize_*`) skip the lock and
     /// continue to run in parallel.

--- a/crates/mvm-core/src/crypto/attestation/header.rs
+++ b/crates/mvm-core/src/crypto/attestation/header.rs
@@ -23,7 +23,7 @@
 //!
 //! The envelope reuses `crate::protocol::signing::SignedPayload`
 //! verbatim — same canonical-JSON-then-Ed25519 pattern that
-//! `mvm-plan` already uses for signed `ExecutionPlan`s.
+//! `mvm-core::plan` already uses for signed `ExecutionPlan`s.
 //!
 //! ## Signing pre-image
 //!
@@ -99,7 +99,7 @@ impl AttestationBody {
 }
 
 /// A signed attestation envelope. `serde(transparent)` matches the
-/// same pattern `SignedExecutionPlan` uses in `mvm-plan` — same wire
+/// same pattern `SignedExecutionPlan` uses in `mvm-core::plan` — same wire
 /// shape, distinct type for the type checker.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/crates/mvm-core/src/crypto/key_rotation.rs
+++ b/crates/mvm-core/src/crypto/key_rotation.rs
@@ -539,7 +539,7 @@ mod tests {
 
     #[test]
     fn rewrap_dek_rejects_aes_kwp_with_clear_error() {
-        // AES-KWP lives mvmd-side — mvm-security's rewrap path must
+        // AES-KWP lives mvmd-side — mvm-core::crypto's rewrap path must
         // refuse with a clear error rather than silently mis-handling
         // the envelope.
         let wrapped = WrappedKey {

--- a/crates/mvm-core/src/domain/template_tags.rs
+++ b/crates/mvm-core/src/domain/template_tags.rs
@@ -7,7 +7,7 @@
 //!
 //! - **tags** — set of free-form labels for filtering / discovery
 //!   (`mvmctl template ls --tag <tag>`). Tenant-controlled, so
-//!   they go through the same `mvm-security::policy::InputValidator`
+//!   they go through the same `mvm-core::crypto::policy::InputValidator`
 //!   discipline as sandbox tags.
 //! - **aliases** — name → revision_hash pointers (`latest`,
 //!   `stable`, etc.). Resolution happens at `mvmctl up` /

--- a/crates/mvm-core/src/domain/volume.rs
+++ b/crates/mvm-core/src/domain/volume.rs
@@ -230,7 +230,7 @@ impl std::fmt::Display for GuestPath {
     }
 }
 
-/// Reference to a secret stored elsewhere (mvm-security secret store on
+/// Reference to a secret stored elsewhere (mvm-core::crypto secret store on
 /// dev box; mvmd's sealed-creds infrastructure on the fleet side).
 /// Never carries the secret value itself.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/mvm-core/src/plan/execution_plan.rs
+++ b/crates/mvm-core/src/plan/execution_plan.rs
@@ -76,7 +76,7 @@ pub struct ExecutionPlan {
     pub runtime_profile: RuntimeProfileRef,
 
     /// Signed image to boot. SHA-256 + cosign bundle reference;
-    /// resolved by `mvm-security::image_verify`.
+    /// resolved by `mvm-core::crypto::image_verify`.
     pub image: SignedImageRef,
 
     pub resources: Resources,
@@ -87,7 +87,7 @@ pub struct ExecutionPlan {
     /// enforce for this boot.
     pub admission_profile: AdmissionProfile,
 
-    /// Network policy reference. Wired to `mvm-policy::EgressPolicy`
+    /// Network policy reference. Wired to `mvm-core::policy::EgressPolicy`
     /// (L7 + PII rules) via the supervisor's `EgressProxy`.
     pub network_policy: PolicyRef,
 

--- a/crates/mvm-core/src/plan/mod.rs
+++ b/crates/mvm-core/src/plan/mod.rs
@@ -1,4 +1,4 @@
-//! mvm-plan — typed, signed `ExecutionPlan` contract for mvm workloads.
+//! plan — typed, signed `ExecutionPlan` contract for mvm workloads (was `mvm-plan`).
 //!
 //! The `ExecutionPlan` is the runtime contract every workload boots
 //! from: image + resources + every policy reference, signed with

--- a/crates/mvm-core/src/plan/types.rs
+++ b/crates/mvm-core/src/plan/types.rs
@@ -34,7 +34,7 @@ pub struct RuntimeProfileRef(pub String);
 /// Reference to a signed image. SHA-256 of the rootfs + name. The
 /// `cosign_bundle` field
 /// is the path or URL to the cosign keyless bundle that
-/// `mvm-security::image_verify` validates against; in dev mode the
+/// `mvm-core::crypto::image_verify` validates against; in dev mode the
 /// resolver may stub this to `None` and accept the digest alone.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -89,7 +89,7 @@ pub struct TimeoutSpec {
 }
 
 /// Opaque pointer to a policy bundle. Until the real
-/// `mvm-policy::PolicyBundle` resolver lands, this is a name the
+/// `mvm-core::policy::PolicyBundle` resolver lands, this is a name the
 /// supervisor's `Noop` resolver maps to a default-deny / open stance
 /// per its bundle.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -113,10 +113,9 @@ pub struct WorkloadIntent(pub String);
 
 /// Seccomp tier name as it appears in a signed `ExecutionPlan`.
 ///
-/// The concrete filter lives in `mvm-security`; keeping this enum in
-/// `mvm-plan` avoids a dependency edge from the wire-contract crate
-/// into the enforcement crate while still making the selected tier a
-/// typed, auditable plan field.
+/// The concrete filter lives in `mvm-core::crypto`; keeping this enum
+/// in `mvm-core::plan` keeps the selected tier a typed, auditable plan
+/// field decoupled from the filter impl.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PlanSeccompTier {
@@ -293,7 +292,7 @@ pub enum SecretSource {
     /// resolves to a SecretId at the supervisor.
     Keystore { address: String },
     /// External provider (Vault, AWS SM, etc.). The provider URL +
-    /// path are opaque to mvm-plan; resolved by `KeystoreReleaser`.
+    /// path are opaque to mvm-core::plan; resolved by `KeystoreReleaser`.
     External { provider: String, path: String },
 }
 

--- a/crates/mvm-core/src/policy/bundle.rs
+++ b/crates/mvm-core/src/policy/bundle.rs
@@ -10,7 +10,7 @@ use crate::policy::policies::{
 };
 
 /// Wire-format version. Same fail-closed semantics as
-/// `mvm-plan::SCHEMA_VERSION` — older verifiers reject unknown
+/// `mvm-core::plan::SCHEMA_VERSION` — older verifiers reject unknown
 /// future bundle versions before any per-field deserialisation.
 pub const SCHEMA_VERSION: u32 = 1;
 

--- a/crates/mvm-core/src/policy/policies.rs
+++ b/crates/mvm-core/src/policy/policies.rs
@@ -188,7 +188,7 @@ pub struct ToolPolicy {
     pub allowed: Vec<String>,
 }
 
-/// Artifact policy. Distinct from `mvm-plan::ArtifactPolicy` —
+/// Artifact policy. Distinct from `mvm-core::plan::ArtifactPolicy` —
 /// the plan field is a per-run snapshot; this is the bundle-side
 /// source of truth that the supervisor's `ArtifactCollector`
 /// consults at workload exit.

--- a/crates/mvm-core/src/policy/signing.rs
+++ b/crates/mvm-core/src/policy/signing.rs
@@ -1,5 +1,5 @@
 //! `SignedPolicyBundle` — Ed25519-signed envelope around a
-//! `PolicyBundle`. Same shape `mvm-plan` uses for
+//! `PolicyBundle`. Same shape `mvm-core::plan` uses for
 //! `SignedExecutionPlan`.
 
 use crate::protocol::signing::SignedPayload;
@@ -38,7 +38,7 @@ pub fn sign_bundle(bundle: &PolicyBundle, key: &SigningKey, signer_id: &str) -> 
     })
 }
 
-/// Same verification order as `mvm-plan::verify_plan`: signature →
+/// Same verification order as `mvm-core::plan::verify_plan`: signature →
 /// schema version → JSON parse. Fail-closed on unknown signer
 /// before exposing the payload bytes.
 pub fn verify_bundle(

--- a/crates/mvm-core/src/policy/toml_loader.rs
+++ b/crates/mvm-core/src/policy/toml_loader.rs
@@ -54,7 +54,7 @@
 //!
 //! - **Sign / verify the bundle.** mvmd's signing key is the
 //!   eventual authoritative source; `verify_bundle` (in
-//!   `mvm-policy::signing`) takes a SignedPolicyBundle envelope.
+//!   `mvm-core::policy::signing`) takes a SignedPolicyBundle envelope.
 //!   This loader reads bare TOML for the single-host posture —
 //!   suitable for `local` tenant; mvmd-signed bundles layer on
 //!   later via the same parse + then verify-against-trusted-keys.

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -104,8 +104,8 @@ pub struct VmStartConfig {
     /// template restore).
     pub tenant_id: Option<String>,
     /// JSON-encoded `SignedExecutionPlan` envelope. Carried as a
-    /// `String` so `mvm-core` does not depend on `mvm-plan` (avoids the
-    /// `mvm-plan → mvm-libkrun → mvm-core` cycle). **The supervisor
+    /// `String` so this wire type stays a serde seam with no typed
+    /// coupling to `mvm_core::plan`. **The supervisor
     /// re-verifies the signature** before trusting any decoded field;
     /// the host is in the TCB but the supervisor still runs Ed25519
     /// verification. **Do not log this value** — the envelope may carry

--- a/crates/mvm-guest/src/runner/config.rs
+++ b/crates/mvm-guest/src/runner/config.rs
@@ -6,7 +6,7 @@
 //! invariant).
 //!
 //! Fields mirror the IR's `Entrypoint::Function` variant; the source
-//! of truth is `mvm-ir/src/workload.rs` and the JSON Schema regen
+//! of truth is `mvm-sdk/src/ir/workload.rs` and the JSON Schema regen
 //! lane keeps them in lockstep.
 
 use serde::{Deserialize, Serialize};

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -236,7 +236,7 @@ pub enum GuestRequest {
     //
     // Production-safe (unlike `Exec`): every verb is constrained by
     // the agent's uid 901 + read-only bind mounts + the
-    // `mvm-security::policy::path` deny-list. Extending the
+    // `mvm-core::crypto::policy::path` deny-list. Extending the
     // `prod-agent-runentry-contract` CI lane to assert handler
     // symbols PRESENT in prod builds is part of the per-verb landing.
     // ========================================================================

--- a/crates/mvm-guest/tests/seccomp_apply.rs
+++ b/crates/mvm-guest/tests/seccomp_apply.rs
@@ -1,6 +1,6 @@
 //! Functional integration test for `mvm-seccomp-apply`.
 //!
-//! The unit tests in `mvm-security::seccomp` cover tier *structure*
+//! The unit tests in `mvm-core::crypto::seccomp` cover tier *structure*
 //! (cumulative-subset, no duplicates, manifest roundtrip). They don't
 //! exercise the BPF program at runtime. This test does:
 //!

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -2,7 +2,7 @@
 //!
 //! The supervisor signs each audit entry into the previous entry's
 //! hash, producing a tamper-evident chain. Per
-//! `mvm-policy::AuditPolicy`, entries can also be replicated to
+//! `mvm-core::policy::AuditPolicy`, entries can also be replicated to
 //! per-tenant streams. This module ships the trait surface; the real
 //! chain-signing impl is wired separately.
 

--- a/crates/mvm-hostd/src/supervisor/policy_tool_gate.rs
+++ b/crates/mvm-hostd/src/supervisor/policy_tool_gate.rs
@@ -1,5 +1,5 @@
 //! `PolicyToolGate` — replaces `NoopToolGate` with a real
-//! allowlist check against `mvm-policy::ToolPolicy`.
+//! allowlist check against `mvm-core::policy::ToolPolicy`.
 //!
 //! ## Phase 1 scope (this module)
 //!

--- a/crates/mvm-hostd/src/supervisor/tool_gate.rs
+++ b/crates/mvm-hostd/src/supervisor/tool_gate.rs
@@ -2,7 +2,7 @@
 //!
 //! The supervisor mediates every tool the workload invokes via vsock
 //! RPC. The gate consults the plan's `tool_policy: PolicyRef`, looks
-//! the bundle up via `mvm-policy::ToolPolicy`, and allow/deny per
+//! the bundle up via `mvm-core::policy::ToolPolicy`, and allow/deny per
 //! call. Audit entries reference both the plan id and the tool name.
 
 use async_trait::async_trait;

--- a/crates/mvm-hostd/src/supervisor/tools/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/tools/mod.rs
@@ -45,7 +45,7 @@
 //!    parameter-free tools so the registry can build a default
 //!    bundle.
 //! 4. Add the tool name to the canonical allowlist in
-//!    `mvm-policy::ToolPolicy::DEFAULTS` (separate slice; this
+//!    `mvm-core::policy::ToolPolicy::DEFAULTS` (separate slice; this
 //!    substrate does not pre-allowlist anything).
 
 pub mod download;

--- a/crates/mvm-sdk/src/addon/manifest.rs
+++ b/crates/mvm-sdk/src/addon/manifest.rs
@@ -191,7 +191,7 @@ pub enum TrustTier {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SeccompProfile {
-    /// Strictest profile (default). Maps onto `mvm-security`'s
+    /// Strictest profile (default). Maps onto `mvm-core::crypto`'s
     /// existing `SecurityProfile::Strict` enum.
     #[default]
     Strict,

--- a/crates/mvm-sdk/src/addon/mod.rs
+++ b/crates/mvm-sdk/src/addon/mod.rs
@@ -24,7 +24,7 @@
 //! - [`verify`] — `mvm addon verify <ref>` reproducible-build check.
 //!
 //! The consumer-side IR shape (`AddonUse`, `AddonRef`, `AddonTier`,
-//! `ThreatTier`) lives in `mvm-ir` and is re-exported through
+//! `ThreatTier`) lives in `mvm-sdk::ir` and is re-exported through
 //! `mvm_sdk::addon` for convenience.
 
 pub mod archive;

--- a/crates/mvm-sdk/src/bin/emit_addon_schema.rs
+++ b/crates/mvm-sdk/src/bin/emit_addon_schema.rs
@@ -1,6 +1,6 @@
 //! Emit the canonical Addon Manifest JSON Schema to stdout.
 //!
-//! Mirrors `mvm-ir/src/bin/emit_schema.rs`. Output is canonicalized
+//! Mirrors `mvm-sdk/src/bin/emit_schema.rs`. Output is canonicalized
 //! via `mvm_sdk::ir::canonicalize` so that schema-freshness checks are
 //! deterministic across toolchain versions and platforms.
 

--- a/crates/mvm/src/lib.rs
+++ b/crates/mvm/src/lib.rs
@@ -1,7 +1,7 @@
-// mvm — VM lifecycle orchestration on top of `mvm-base`.
+// mvm — VM lifecycle orchestration on top of `mvm-backend::base`.
 //
-// Plan-60 W8 lifted the leaf substrate (`config`, `shell`, `linux_env`,
-// `ui`, `runtime_meta`, `cow`) into `mvm-base` so the FC backend
+// The leaf substrate (`config`, `shell`, `linux_env`,
+// `ui`, `runtime_meta`, `cow`) lives in `mvm-backend::base` so the FC backend
 // stack can move into `mvm-backend` without a back-edge. The
 // `pub use mvm_backend::base::*` re-exports below preserve the old
 // `mvm::{config, shell, linux_env, ui, shell_mock}` paths so

--- a/crates/mvm/src/security/mod.rs
+++ b/crates/mvm/src/security/mod.rs
@@ -5,7 +5,7 @@ pub mod metadata;
 pub mod seccomp;
 pub mod signing;
 
-// Re-export pure-logic modules from mvm-security for backward compatibility
+// Re-export pure-logic modules from mvm-core::crypto for backward compatibility
 pub use mvm_core::crypto::command_gate;
 pub use mvm_core::crypto::posture;
 pub use mvm_core::crypto::rate_limiter;

--- a/crates/mvm/src/vm/mod.rs
+++ b/crates/mvm/src/vm/mod.rs
@@ -4,7 +4,7 @@
 //     (firecracker, libkrun, vz, qemu, microvm,
 //     image, network, backend) live in `mvm-backend`.
 //   * The leaf substrate (`ui`, `runtime_meta`, `cow`,
-//     `snapshot_integrity`) lives in `mvm-base`.
+//     `snapshot_integrity`) lives in `mvm-backend::base`.
 //
 // What's left here is the orchestration layer — instance/pool/
 // template/tenant lifecycle, name + volume registries, the egress

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! | Module | Crate | Purpose |
 //! |--------|-------|---------|
 //! | [`core`] | mvm-core | Types, IDs, config, protocol, signing, routing |
-//! | [`security`] | mvm-security | Command gating, threat classification, rate limiting |
+//! | [`security`] | mvm-core::crypto | Command gating, threat classification, rate limiting |
 //! | [`runtime`] | mvm | Shell execution, VM lifecycle, template management |
 //! | [`build`] | mvm-build | Nix builder pipeline |
 //! | [`guest`] | mvm-guest | Vsock protocol, integration manifest, guest agent |


### PR DESCRIPTION
Updates stale references to the six crates that Plan 121 dissolved (32→15) and that no longer exist, so comments stop pointing readers at crates they can't find. **Comment-only — zero functional code changes** (verified: no non-comment lines in the diff).

## Mapping
| Old crate (gone) | Now |
|---|---|
| `mvm-security` | `mvm-core::crypto` |
| `mvm-plan` | `mvm-core::plan` |
| `mvm-policy` | `mvm-core::policy` |
| `mvm-ir` | `mvm-sdk::ir` |
| `mvm-base` | `mvm-backend::base` |
| `mvm-providers` | `mvm-backend` (Apple VZ objc2 interface) |

36 references updated to the post-121 paths (each new path verified to exist by grep — e.g. `KeyProvider` in `crypto/keystore.rs`, `verify_plan` in `plan/signing.rs`, and the distinct `crypto::policy::InputValidator` vs top-level `policy`). 12 accurate "folded in from the former X crate" retirement notes were deliberately **kept** as history.

## Also corrected (found en route)
- A couple of dependency-cycle comments that became self-contradictory once the folded crates moved *into* `mvm-core` (e.g. "`mvm-core` does not depend on `mvm-plan`" — now `mvm-plan` *is* inside `mvm-core`) → rewritten to the accurate present-day rationale (the JSON/String fields stay a serde seam with no typed coupling), keeping the live `mvm-libkrun-supervisor` binary name.
- Two pre-existing stale member names in comments: `image_verify::hash_artifact` (doesn't exist) → the real `sha256_file`; `ToolPolicy` prefix fixed.

Live binary names (`mvm-broker`, `mvm-host-signer`, `mvm-audit-signer`, `mvm-egress-proxy`, `mvm-libkrun-supervisor`, …) were left entirely untouched — only the six fully-folded crates were in scope.

## Verification
`cargo check --workspace --tests`, `clippy --all-targets -D warnings`, nightly fmt --check — all clean.