### PR TITLE
docs: ADR-081 wasm-component runner + Plan 192 (A1 capability projection fs/env)

### DIFF
--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2635,8 +2635,28 @@ each has a witness. The sprint lands those preconditions incrementally.
 - **P8** — single-session relay primitive (websocket session-token binding + wasmtime
   fuel/memory/wall-clock caps); multi-principal host execution must run wasmtime-in-microVM.
 - The **WASI-context mapping** (`WasiEgress` → `WasiCtxBuilder`) for the in-microVM
-  wasmtime runner.
+  wasmtime runner — now designed under ADR-081 (below).
 - Multi-tenant streaming service, sessions, auth, billing — **mvmd's**, per ADR-070.
+
+### Wasm-component runner (ADR-081) — design + A1 plan only; implementation NOT started
+
+[`adrs/081-wasm-component-runner.md`](adrs/081-wasm-component-runner.md) decides the
+prod-tier execution for ADR-080 §4's WASM-component regime: wasmtime as an in-guest
+binary (never a host dep); a `.wasm` admitted as a content-addressed artifact (claim
+8/9); fs/env capabilities clamp-authored by extending the Plan 188 projection seam
+from network to fs/env; AOT-compile at build for prod (no in-guest JIT → guest seccomp
+forbids `PROT_EXEC`), JIT for preview; WASI P1 v1 with a P2-ready seam. Decomposes into
+three plans:
+
+- **A1 — WASI capability projection (fs/env)** 📋 PLAN WRITTEN, not started
+  ([`plans/192-wasi-capability-projection-fs-env.md`](plans/192-wasi-capability-projection-fs-env.md)):
+  pure-logic `mvm-core` extension (`CanonicalFs`/`CanonicalEnv`, `clamp_fs`/`clamp_env`
+  intersection-only, WASI preopen/env-name generator, `WasiCapPolicy` bound,
+  clamp-never-widens witnesses). Foundation for A2/A3.
+- **A2 — `.wasm` artifact admission** 🔲 plan not yet written (queued as Plan 193).
+- **A3 — guest runner + Nix bake + AOT** 🔲 plan not yet written (queued as Plan 194).
+
+Owner-gated: docs land now; **no implementation is to begin** until explicitly directed.
 
 ### Sprint 62 success criteria
 

--- a/specs/adrs/081-wasm-component-runner.md
+++ b/specs/adrs/081-wasm-component-runner.md
@@ -1,0 +1,201 @@
+# ADR-081 — Production in-microVM wasm-component runner
+
+**Status:** Proposed 2026-06-12.
+**Extends** [ADR-080](080-wasm-preview-promotion-and-capability-policy.md) (§4 two
+fidelity regimes — this ADR builds the prod-tier execution for the WASM-component
+regime; §6 wasmtime as a new untrusted-input surface). **Builds on**
+[ADR-069](069-wasm-sandbox-backend.md) (the off-isolation-scale wasm-sandbox
+*preview* backend; this ADR is the *production microVM* path, not that backend).
+**Cross-refs:** ADR-002 (claims 1–3 isolation, 5 untrusted parsers, 8 signed
+plan, 10 egress, 11 sealed deps, 13 secrets), ADR-047 (app-deps audit — the
+builder already compiles untrusted inputs), ADR-057 (symmetric builder VM — the
+sandbox the AOT compile runs in), Plan 188 (the capability projection/clamp seam
+this extends from network to fs/env).
+
+## Context
+
+ADR-080 §4 names two fidelity regimes for the Tier-0→ship promotion. The
+**WASM-component** regime is the clean one: a workload that *is* a `.wasm`
+runs on the same engine in preview and prod (wasmtime ≈ wasmtime), so the
+microVM just wraps it. ADR-080 deferred building that prod runner to its own
+design. This ADR is that design — the **production, in-microVM wasm-component
+runner**: make "a `.wasm` is a workload" real, with the component executing on
+**wasmtime inside the guest**, the microVM providing isolation.
+
+The runtime mechanism is already scaffolded: `crates/mvm-guest/src/runner/`
+has a `Wasm` runner variant whose interpreter is `wasmtime` and whose entry is
+`wasmtime run dispatch.wasm`, using the stdin→stdout function-invoke contract —
+handled exactly like the `python3`/`node` runners. So **wasmtime is a guest
+binary** (Nix-baked into the rootfs), invoked as a subprocess. **mvm's host
+code never links wasmtime.** The work is to wire the surrounding pieces:
+admit the `.wasm` as an artifact, project policy into the guest's WASI config,
+and bake the engine.
+
+The browser / host-streamed *preview* execution of components (ADR-080's P8
+relay) is a **separate** subsystem that consumes the same component artifact;
+it is out of scope here.
+
+## Decision
+
+### 1. v1 targets WASI Preview 1 modules, with a P2-ready seam
+
+v1 runs WASI Preview 1 modules via the existing `wasmtime run` + stdin→stdout
+invoke contract — the most-scaffolded path. The artifact-admission, capability
+projection, and IR shapes are kept **WASI-version-agnostic** so swapping to
+WASI Preview 2 / the Component Model (WIT worlds, `wasi:sockets`,
+`wasi:http`) is a runner-internal change, not a re-architecture. P1 has no
+socket API, which is *why* network stays a microVM-layer concern in v1
+(below).
+
+### 2. The `.wasm` is an admitted, content-addressed artifact
+
+v1 source is a **local `.wasm` file**: `mvmctl run ./component.wasm`
+(auto-detected, or `--wasm`). The file is SHA-256'd and admitted through the
+**existing claim-8/9 path** — a signed `ExecutionPlan` whose content-addressed
+artifact is the `.wasm`, with provenance (digest, wasmtime version) recorded in
+the chain-signed audit log. No parallel admission path.
+
+- **Fast-follow (this ADR's P6 leg):** a registry reference
+  (`--wasm <registry>@sha256:…`), reusing the OCI claim-14 path — mutable refs
+  refused under `--prod`, cosign verification, provenance recorded.
+- **Deferred:** SDK-compiled-from-user-code (author in any language → `.wasm`)
+  — the byte-identical-preview dream lives there, but it needs per-language
+  compile-to-wasm toolchains and is its own program.
+
+### 3. WASI capabilities are clamp-authored — the Plan 188 seam extended network→fs/env
+
+In WASI P1 the *fine* layer the component sees is **filesystem preopens + env
+vars** (P1 has no sockets). These grants are governed by the **clamp model
+from Plan 188**, now extended from network to fs/env: the workload **requests**
+fs/env capabilities in its IR; the authoritative **tenant policy bounds** them;
+the granted set is the **intersection** (a request can attenuate, never widen).
+**Default-deny** on both sides — a component is denied every dir/var not
+granted. This makes ADR-080 §3's "one capability policy, two enforcement
+fidelities" literal:
+
+- **fine:** the resolved capability policy → wasmtime fs preopens + env grants,
+  in-guest (extends `mvm-core::policy::projection`).
+- **coarse:** the microVM layer — nftables/passt egress (Plan 188/190, already
+  built). In P1 this is the *only* network enforcement; the `WasiEgress`
+  *network* grant shape (Plan 188) becomes live only at P2 sockets.
+
+Env grants carry `SecretRef` placeholders, substituted host-side, never raw
+(claim 13) — same as every other workload.
+
+### 4. AOT-compile at build for prod; JIT only for preview
+
+The dangerous step is turning attacker `.wasm` bytes into native code. For the
+**production in-microVM path**, the component is **AOT-compiled in the builder
+VM** (`wasmtime compile` → a `.cwasm`); the guest runs the **precompiled**
+artifact. Consequences:
+
+- **No JIT in the live guest** → the guest seccomp profile can **forbid**
+  `mmap(PROT_EXEC)` / exec-`mprotect`, materially tightening the
+  workload-bearing tier (the whole point of running in a locked-down microVM).
+- The compiler runs on attacker bytes in the **builder**, which already
+  executes attacker-influenced build logic (`nix build`, `uv pip install`) in
+  its own sandbox (ADR-047/057) — no *new* privileged trust boundary, one more
+  build step in a place designed for it.
+- **Deterministic** (claim 7 double-build) given a pinned wasmtime version,
+  which is recorded in provenance; the `.cwasm` is same-arch as the guest by
+  construction; precompiling removes cold-start JIT latency.
+
+The **preview tier keeps JIT** (`wasmtime run` the `.wasm`) — there the
+browser / host sandbox contains the JIT and the fast author-loop matters.
+
+**Fidelity note (honest):** prod runs the AOT `.cwasm`, preview JITs the same
+source `.wasm` — *same source component, two compilations*, identical wasm
+semantics but not literally the same machine code. A far tighter gap than the
+source-language regime's Pyodide-vs-CPython; recorded, not hidden.
+
+### 5. wasmtime is a guest binary, never a host dependency
+
+wasmtime enters the rootfs via Nix for `Wasm`-kind workloads (like `python3`/
+`node`), pinned and recorded in the build closure. The host crates do **not**
+take a `wasmtime` Cargo dependency — keeping the host TCB unchanged and the new
+untrusted-input surface *inside* the guest, behind the microVM.
+
+## Security considerations (the threat-model delta)
+
+The new surfaces beyond the existing claim set:
+
+1. **wasmtime as a new untrusted-`.wasm` parser/compiler (claim 5 family).** A
+   wasmtime validation/codegen bug → arbitrary code where it runs. Mitigated by
+   defense-in-depth (Decision 4 puts the *compile* in the sandboxed builder and
+   the *execution* of precompiled code in the sealed guest with no JIT), version
+   pinning + `cargo deny`/audit, and confining the in-guest wasmtime as the
+   uid-901 setpriv service (claims 1–2). **We do not fuzz wasmtime ourselves —
+   we rely on its upstream OSS-Fuzz coverage** (the ADR-055 precedent for the
+   virtio parsers) and record that as the posture.
+2. **The WASI config generator is new security-critical code**, peer to the
+   Plan 188 projection seam: it turns the resolved policy into the actual
+   preopen/env grant set; a bug = over-grant. It carries the same discipline —
+   **deny-by-default, the clamp invariant (a request never widens tenant
+   policy), and negative tests** ("a denied dir is not preopened").
+3. **Resource exhaustion.** The microVM cgroup/jailer caps bound the blast
+   radius, with wasmtime **fuel/epoch + a wall-clock timeout** as the inner
+   bound so one component cannot wedge its VM.
+4. **WASI preopen enforcement is wasmtime's to get right** (path-traversal /
+   symlink escape out of a preopen) — an explicit **trust assumption**, the way
+   nftables is trusted for egress. Bounded by: the rootfs is verity/read-only
+   except granted writable dirs, and an escape is still inside the sealed guest.
+5. **Secrets-in-env are exfil-safe in v1, with a P2 caveat.** A substituted
+   credential in env (claim 13) has no exfil path in P1 (no sockets; network
+   blocked at the microVM). When P2 `wasi:sockets` lands, the Plan 129
+   egress-substitution / host proxy MUST mediate the component's outbound or a
+   network-granted component could leak it. Flagged now, enforced at P2.
+6. **P2 imports/worlds are capabilities to clamp** (forward-looking): a
+   component's imports (`wasi:http`, custom host functions) are ambient
+   authority if auto-satisfied. The capability/clamp model must govern which
+   imports are granted; the v1 seam anticipates this so P2 is not a
+   re-architecture.
+
+## Claim mapping
+
+A wasm-component workload runs in a microVM, so it inherits claims 1–3
+(isolation), 8 (signed plan), 10 (default-deny egress), 11 (sealed deps, if it
+has any), 13 (secrets), 15 (no interactive sealed access). The new fine-grained
+fs/env enforcement (Decision 3) is a *strengthening* within claims 1–2, not a
+new numbered claim — promotion to the ADR-002 table can follow the OCI-provenance
+precedent once witnesses exist. The AOT-no-JIT-in-guest posture (Decision 4)
+strengthens the claim-1/2 seccomp story.
+
+## Decomposition (an ADR + ~3 plans — for `writing-plans`)
+
+| Piece | What | Reuses |
+|---|---|---|
+| **A1** | Capability-policy extension: the resolved policy + `mvm-core::policy::projection` carry fs/env capabilities (not just network); `clamp` from Plan 188 applies; the WASI-config generator (deny-by-default, clamp invariant, negative tests). **Foundation — A2/A3 consume it.** | Plan 188 projection/clamp |
+| **A2** | `.wasm` artifact admission: `mvmctl run ./x.wasm` → SHA-256 → signed `ExecutionPlan` with the `.wasm` as the content-addressed artifact → provenance (digest + wasmtime version) in the audit chain. | claim 8/9 admission |
+| **A3** | Guest runner + Nix bake + AOT: bake wasmtime into the rootfs for `Wasm` workloads; AOT-compile the `.wasm`→`.cwasm` in the builder; generate the `wasmtime run` invocation + WASI config (preopens/env, as data) from A1; tighten guest seccomp to forbid `PROT_EXEC`; run under the existing invoke contract. | the `Wasm` runner scaffold + the factory bake (Plan 191-style) |
+
+**Sequencing:** A1 (foundation) → A2 + A3 (largely parallel; both consume A1).
+v1 "done": `mvmctl run ./hello.wasm` boots a microVM, the AOT-compiled
+component runs on wasmtime under clamped fs/env grants with a no-`PROT_EXEC`
+guest seccomp, output returns, provenance recorded.
+
+## Alternatives considered
+
+- **JIT-in-guest** (compile at load): rejected for prod — forces the guest
+  seccomp to permit executable-memory syscalls, loosening the workload-bearing
+  tier. Kept for the preview tier where a sandbox already contains it.
+- **Linking the `wasmtime` crate into the host** (e.g. a host-side WASI runner):
+  rejected — grows the host TCB for no benefit; the component runs in the guest,
+  so wasmtime belongs in the guest (subprocess), like python/node.
+- **A new parallel admission path for `.wasm`**: rejected — reuse claim-8/9;
+  a `.wasm` is just another content-addressed artifact.
+- **WASI P2 / Component Model for v1**: deferred — the scaffold is P1 and P1
+  modules cover the v1 target; Decision 1's seam keeps P2 a later swap.
+
+## Consequences
+
+- A `.wasm` becomes a first-class, claim-bearing workload with no new host
+  dependency and no new host trust surface; the new untrusted-input surface is
+  in-guest, behind the microVM, and (for prod) is precompiled in the sandboxed
+  builder rather than JIT'd in the live workload.
+- The capability model graduates from network-only to network+fs/env, all
+  through the one Plan 188 projection/clamp seam.
+- New code/gates owned by plans A1–A3: the fs/env projection + WASI-config
+  generator (with the clamp/deny-by-default witnesses), the `.wasm` admission,
+  the AOT build step + the tightened guest seccomp, the Nix wasmtime bake.
+- Out of scope: the preview/relay tier (ADR-080 P8), SDK-compile-to-wasm
+  (Decision 2 deferred), and WASI P2 (Decision 1 seam).

--- a/specs/plans/192-wasi-capability-projection-fs-env.md
+++ b/specs/plans/192-wasi-capability-projection-fs-env.md
@@ -1,0 +1,881 @@
+# Plan 192 — WASI capability projection (fs/env) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the capability-projection seam from network (Plan 188) to the WASI filesystem-preopen and env-var domains, so a wasm-component workload's fs/env grants are deny-by-default, clamp-authored (a request attenuates, never widens the tenant bound), and projected into a backend-agnostic WASI-config shape the in-guest runner will consume.
+
+**Architecture:** A new pure-logic module `crates/mvm-core/src/policy/projection_fs_env.rs`, sibling to `projection.rs`, mirroring its resolve→canonicalize→clamp→wasi-shape walk for two new capability domains. `CanonicalFs`/`CanonicalEnv` are the authoritative resolved grant sets; `clamp_fs`/`clamp_env` are intersection-only merges; `to_wasi_preopens`/`to_wasi_env_names` emit the data the A3 guest runner turns into wasmtime preopens/env. A new `WasiCapPolicy` sub-policy on `EffectivePolicy` carries the tenant bound. Decision logic only — no I/O, no wasmtime, no enforcement. This is **A1** of ADR-081; A2 (`.wasm` admission) and A3 (guest runner + Nix bake + AOT) are follow-on plans that consume this.
+
+**Tech Stack:** Rust, `mvm-core` (no async/runtime deps — the `xtask check-core-runtime-free` gate must stay green), `serde` (already a dep), no new crates.
+
+**Source of truth:** `specs/adrs/081-wasm-component-runner.md` §Decision 3 + §Decomposition (A1). The network analogue this mirrors line-for-line is `crates/mvm-core/src/policy/projection.rs` (Plan 188).
+
+---
+
+## Design decisions locked by ADR-081 (read before starting)
+
+- **Deny-by-default, both domains.** An empty resolved set grants nothing. There is **no `Unrestricted`/`open` mode for fs/env** (unlike egress) — a component sees only the preopens/env-names explicitly granted. This is simpler than `CanonicalEgress` and deliberate.
+- **Clamp = intersection-only.** A *requested* grant (from the workload IR, wired in A3) survives only if a *resolved* grant (the tenant bound) covers it. Partial coverage drops the whole grant, fail-closed. This is the Plan 188 `clamp` invariant, re-expressed for fs paths and env names.
+- **fs covering rule:** resolved grant `R` covers requested grant `Q` iff `R.guest_path` is `Q.guest_path` or an ancestor directory of it, **and** `R.access >= Q.access` (an RW request under an RO bound drops; an RO request under an RW bound survives as RO).
+- **env grant is name-level.** A1 decides *which env var names* a component may see. The *values* are filled later by the existing env/secret-substitution path (claim 13) — out of scope here. `clamp_env` survival = the requested name is in the resolved allowed-name set.
+- **No path normalization cleverness.** Refuse anything that isn't a clean absolute path: must start with `/`, must not contain a `..` segment, must not be empty. A traversal-shaped path is a loud refusal at projection (mirrors `refuse_inverted_ports`), never a silently-sanitized grant.
+
+---
+
+## File Structure
+
+- **Create:** `crates/mvm-core/src/policy/projection_fs_env.rs` — the entire fs/env projection seam (types, canonicalize, clamp, wasi-shape, decision fns, tests, property witnesses). One responsibility: the fs/env analogue of `projection.rs`.
+- **Modify:** `crates/mvm-core/src/policy/policies.rs` — add the `WasiCapPolicy` sub-policy + its specs (`FsGrantSpec`).
+- **Modify:** `crates/mvm-core/src/policy/resolver.rs` — add the `wasi` field to `EffectivePolicy` and resolve it via `pick`.
+- **Modify:** `crates/mvm-core/src/policy/mod.rs` — `pub mod projection_fs_env;` + re-export the public surface alongside `projection`.
+- **Modify:** `specs/REFACTOR-STATUS.md`, `specs/SPRINT.md` — bookkeeping (Task 6).
+
+---
+
+### Task 1: Fs grant types + decision function
+
+**Files:**
+- Create: `crates/mvm-core/src/policy/projection_fs_env.rs`
+- Modify: `crates/mvm-core/src/policy/mod.rs`
+
+- [ ] **Step 1: Register the module**
+
+In `crates/mvm-core/src/policy/mod.rs`, find the line `pub mod projection;` and add directly below it:
+
+```rust
+pub mod projection_fs_env;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `crates/mvm-core/src/policy/projection_fs_env.rs` with the types and a test. Start the file with this content:
+
+```rust
+//! WASI capability projection seam (filesystem preopens + env vars).
+//!
+//! The fs/env analogue of [`crate::policy::projection`]. One resolved
+//! [`EffectivePolicy`] bound projects to the deny-by-default grant sets
+//! a wasm-component runner enforces: a set of filesystem preopens (a
+//! guest path + an access mode) and a set of permitted env-var names.
+//! A *requested* grant (the workload IR, wired in the runner plan) is
+//! clamped against the resolved bound — intersection only, a request
+//! attenuates and never widens. Decision logic only: no I/O, no
+//! wasmtime, no enforcement.
+//!
+//! Unlike egress there is no `Unrestricted` mode here — fs/env are
+//! always explicit. An empty resolved set grants nothing.
+//!
+//! [`EffectivePolicy`]: crate::policy::resolver::EffectivePolicy
+
+/// Access mode of a filesystem preopen. `ReadOnly < ReadWrite` so a
+/// resolved RW bound covers an RO request but not vice versa.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FsAccess {
+    ReadOnly,
+    ReadWrite,
+}
+
+/// One canonical filesystem preopen: an absolute guest path and the
+/// access the component is granted under it. `guest_path` is a clean
+/// absolute path (validated at canonicalization — no `..`, non-empty,
+/// leading `/`).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FsGrant {
+    pub guest_path: String,
+    pub access: FsAccess,
+}
+
+/// The canonical filesystem projection of a resolved policy bound.
+/// Deny-by-default: an empty rule set admits nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalFs {
+    pub grants: Vec<FsGrant>,
+}
+
+impl CanonicalFs {
+    /// Pure membership decision: is `path` admitted at `access`?
+    /// True when some grant's `guest_path` is `path` or an ancestor of
+    /// it AND the grant's access is at least `access`.
+    pub fn permits(&self, path: &str, access: FsAccess) -> bool {
+        self.grants
+            .iter()
+            .any(|g| g.access >= access && path_under(&g.guest_path, path))
+    }
+}
+
+/// True when `prefix` is `path` or an ancestor directory of it,
+/// compared by whole path segments (so `/a/bc` is NOT under `/a/b`).
+fn path_under(prefix: &str, path: &str) -> bool {
+    if prefix == path {
+        return true;
+    }
+    let prefix_trimmed = prefix.strip_suffix('/').unwrap_or(prefix);
+    path.strip_prefix(prefix_trimmed)
+        .is_some_and(|rest| rest.starts_with('/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fs_permits_path_under_granted_preopen() {
+        let fs = CanonicalFs {
+            grants: vec![FsGrant {
+                guest_path: "/data".to_string(),
+                access: FsAccess::ReadOnly,
+            }],
+        };
+        assert!(fs.permits("/data", FsAccess::ReadOnly));
+        assert!(fs.permits("/data/in.txt", FsAccess::ReadOnly));
+        assert!(fs.permits("/data/sub/deep.txt", FsAccess::ReadOnly));
+    }
+
+    #[test]
+    fn fs_denies_outside_sibling_and_insufficient_access() {
+        let fs = CanonicalFs {
+            grants: vec![FsGrant {
+                guest_path: "/data".to_string(),
+                access: FsAccess::ReadOnly,
+            }],
+        };
+        assert!(!fs.permits("/etc/passwd", FsAccess::ReadOnly), "outside");
+        assert!(!fs.permits("/database", FsAccess::ReadOnly), "sibling prefix-collision");
+        assert!(!fs.permits("/data/in.txt", FsAccess::ReadWrite), "RW under RO bound");
+    }
+
+    #[test]
+    fn fs_empty_is_deny_all() {
+        let fs = CanonicalFs { grants: vec![] };
+        assert!(!fs.permits("/data", FsAccess::ReadOnly));
+    }
+
+    #[test]
+    fn fs_rw_grant_covers_ro_and_rw_reads() {
+        let fs = CanonicalFs {
+            grants: vec![FsGrant {
+                guest_path: "/work".to_string(),
+                access: FsAccess::ReadWrite,
+            }],
+        };
+        assert!(fs.permits("/work/out.txt", FsAccess::ReadOnly));
+        assert!(fs.permits("/work/out.txt", FsAccess::ReadWrite));
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails, then passes**
+
+Run: `cargo test -p mvm-core policy::projection_fs_env::tests::fs_ -- --nocapture`
+Expected: the module compiles and all four `fs_*` tests PASS (the implementation is included in Step 2 — this task ships type + decision logic together because the decision fn is trivial and the tests are the spec for `path_under`'s segment-boundary rule).
+
+- [ ] **Step 4: Verify the segment-boundary guard specifically**
+
+Confirm `fs_denies_outside_sibling_and_insufficient_access` passes — it is the witness that `/database` is not treated as under `/data`. If it fails, `path_under` is doing a raw `starts_with` and must compare on the `/`-boundary as written.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-core/src/policy/projection_fs_env.rs crates/mvm-core/src/policy/mod.rs
+git commit -m "feat(core): CanonicalFs preopen grants + segment-boundary permits"
+```
+
+---
+
+### Task 2: canonicalize_fs — lower the resolved bound, refuse malformed paths
+
+**Files:**
+- Modify: `crates/mvm-core/src/policy/projection_fs_env.rs`
+- Modify: `crates/mvm-core/src/policy/policies.rs`
+
+- [ ] **Step 1: Add the bound spec type**
+
+In `crates/mvm-core/src/policy/policies.rs`, after the `EgressPolicy` definition, add the fs grant spec (mirror the derive set on `L4RuleSpec`):
+
+```rust
+/// One filesystem-preopen grant in a policy bound. `access` is the
+/// wire string `"ro"` / `"rw"`; anything else refuses at projection.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FsGrantSpec {
+    pub guest_path: String,
+    pub access: String,
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+In `projection_fs_env.rs`, add to the `tests` module:
+
+```rust
+use crate::policy::policies::FsGrantSpec;
+
+fn fs_spec(path: &str, access: &str) -> FsGrantSpec {
+    FsGrantSpec {
+        guest_path: path.to_string(),
+        access: access.to_string(),
+    }
+}
+
+#[test]
+fn canonicalize_fs_lowers_and_dedups() {
+    let specs = vec![fs_spec("/data", "ro"), fs_spec("/work", "rw")];
+    let fs = canonicalize_fs(&specs).unwrap();
+    assert!(fs.permits("/data/x", FsAccess::ReadOnly));
+    assert!(fs.permits("/work/y", FsAccess::ReadWrite));
+}
+
+#[test]
+fn canonicalize_fs_rw_supersedes_ro_for_same_path() {
+    // Same path granted ro and rw collapses to the wider rw.
+    let specs = vec![fs_spec("/work", "ro"), fs_spec("/work", "rw")];
+    let fs = canonicalize_fs(&specs).unwrap();
+    assert_eq!(fs.grants.len(), 1, "merged: {:?}", fs.grants);
+    assert!(fs.permits("/work/y", FsAccess::ReadWrite));
+}
+
+#[test]
+fn canonicalize_fs_refuses_relative_traversal_and_bad_access() {
+    assert!(matches!(
+        canonicalize_fs(&[fs_spec("data", "ro")]).unwrap_err(),
+        FsEnvError::NonAbsolutePath { .. }
+    ));
+    assert!(matches!(
+        canonicalize_fs(&[fs_spec("/data/../etc", "ro")]).unwrap_err(),
+        FsEnvError::PathTraversal { .. }
+    ));
+    assert!(matches!(
+        canonicalize_fs(&[fs_spec("", "ro")]).unwrap_err(),
+        FsEnvError::NonAbsolutePath { .. }
+    ));
+    assert!(matches!(
+        canonicalize_fs(&[fs_spec("/data", "exec")]).unwrap_err(),
+        FsEnvError::UnknownAccess { .. }
+    ));
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test -p mvm-core policy::projection_fs_env::tests::canonicalize_fs`
+Expected: FAIL to compile — `canonicalize_fs`, `FsEnvError` not defined.
+
+- [ ] **Step 4: Write the implementation**
+
+In `projection_fs_env.rs`, above the `tests` module, add the error enum, the access parser, and `canonicalize_fs`:
+
+```rust
+use thiserror::Error;
+
+use crate::policy::policies::FsGrantSpec;
+
+/// Projection-time refusals for the fs/env domains. Every variant is
+/// a fail-closed admission error.
+#[derive(Debug, Error)]
+pub enum FsEnvError {
+    #[error("fs grant path {path:?} is not absolute (must start with '/')")]
+    NonAbsolutePath { path: String },
+    #[error("fs grant path {path:?} contains a '..' traversal segment")]
+    PathTraversal { path: String },
+    #[error("unknown fs access {access:?} for {path:?} (expected \"ro\" or \"rw\")")]
+    UnknownAccess { path: String, access: String },
+    #[error("env var name {name:?} is empty or contains '=' or NUL")]
+    BadEnvName { name: String },
+}
+
+impl FsAccess {
+    /// Parse the `"ro"` / `"rw"` wire form. Loud refusal otherwise.
+    fn parse(path: &str, s: &str) -> Result<Self, FsEnvError> {
+        match s {
+            "ro" => Ok(Self::ReadOnly),
+            "rw" => Ok(Self::ReadWrite),
+            other => Err(FsEnvError::UnknownAccess {
+                path: path.to_string(),
+                access: other.to_string(),
+            }),
+        }
+    }
+}
+
+/// Reject anything that is not a clean absolute path. Traversal is a
+/// loud refusal, never silently sanitized.
+fn validate_abs_path(path: &str) -> Result<(), FsEnvError> {
+    if !path.starts_with('/') {
+        return Err(FsEnvError::NonAbsolutePath {
+            path: path.to_string(),
+        });
+    }
+    if path.split('/').any(|seg| seg == "..") {
+        return Err(FsEnvError::PathTraversal {
+            path: path.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Lower a resolved policy's fs grant specs into the canonical set.
+/// Refuses malformed paths/access; collapses duplicate paths so the
+/// widest access (rw) wins. Deny-by-default: empty specs → empty set.
+pub fn canonicalize_fs(specs: &[FsGrantSpec]) -> Result<CanonicalFs, FsEnvError> {
+    let mut grants: Vec<FsGrant> = Vec::new();
+    for spec in specs {
+        validate_abs_path(&spec.guest_path)?;
+        let access = FsAccess::parse(&spec.guest_path, &spec.access)?;
+        let path = spec.guest_path.strip_suffix('/').unwrap_or(&spec.guest_path);
+        match grants.iter_mut().find(|g| g.guest_path == path) {
+            Some(existing) => existing.access = existing.access.max(access),
+            None => grants.push(FsGrant {
+                guest_path: path.to_string(),
+                access,
+            }),
+        }
+    }
+    grants.sort();
+    Ok(CanonicalFs { grants })
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p mvm-core policy::projection_fs_env::tests::canonicalize_fs`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mvm-core/src/policy/projection_fs_env.rs crates/mvm-core/src/policy/policies.rs
+git commit -m "feat(core): canonicalize_fs lowering with traversal refusal + rw-supersedes merge"
+```
+
+---
+
+### Task 3: Env grant types + canonicalize_env
+
+**Files:**
+- Modify: `crates/mvm-core/src/policy/projection_fs_env.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `projection_fs_env.rs` `tests` module:
+
+```rust
+#[test]
+fn canonicalize_env_dedups_and_sorts() {
+    let env = canonicalize_env(&["PATH".to_string(), "HOME".to_string(), "PATH".to_string()])
+        .unwrap();
+    assert_eq!(env.allowed, vec!["HOME".to_string(), "PATH".to_string()]);
+    assert!(env.permits("PATH"));
+    assert!(!env.permits("SECRET_KEY"));
+}
+
+#[test]
+fn canonicalize_env_empty_is_deny_all() {
+    let env = canonicalize_env(&[]).unwrap();
+    assert!(!env.permits("PATH"));
+}
+
+#[test]
+fn canonicalize_env_refuses_malformed_names() {
+    assert!(matches!(
+        canonicalize_env(&["".to_string()]).unwrap_err(),
+        FsEnvError::BadEnvName { .. }
+    ));
+    assert!(matches!(
+        canonicalize_env(&["A=B".to_string()]).unwrap_err(),
+        FsEnvError::BadEnvName { .. }
+    ));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mvm-core policy::projection_fs_env::tests::canonicalize_env`
+Expected: FAIL to compile — `CanonicalEnv`, `canonicalize_env` not defined.
+
+- [ ] **Step 3: Write the implementation**
+
+In `projection_fs_env.rs`, after `canonicalize_fs`:
+
+```rust
+/// The canonical env-name projection: the set of env-var names a
+/// component may see. Values are filled by the env/secret-substitution
+/// path elsewhere — this is name-level only. Deny-by-default.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalEnv {
+    pub allowed: Vec<String>,
+}
+
+impl CanonicalEnv {
+    /// Pure membership decision: is `name` a permitted env var?
+    pub fn permits(&self, name: &str) -> bool {
+        self.allowed.iter().any(|n| n == name)
+    }
+}
+
+/// Lower a resolved policy's permitted env names into the canonical
+/// set. Refuses empty names or names containing `=` / NUL (which can
+/// never be a valid env key). Sorted + deduped.
+pub fn canonicalize_env(names: &[String]) -> Result<CanonicalEnv, FsEnvError> {
+    let mut allowed: Vec<String> = Vec::new();
+    for name in names {
+        if name.is_empty() || name.contains('=') || name.contains('\0') {
+            return Err(FsEnvError::BadEnvName { name: name.clone() });
+        }
+        if !allowed.iter().any(|n| n == name) {
+            allowed.push(name.clone());
+        }
+    }
+    allowed.sort();
+    Ok(CanonicalEnv { allowed })
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mvm-core policy::projection_fs_env::tests::canonicalize_env`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-core/src/policy/projection_fs_env.rs
+git commit -m "feat(core): CanonicalEnv name-level projection + canonicalize_env"
+```
+
+---
+
+### Task 4: clamp_fs + clamp_env — intersection-only merge
+
+**Files:**
+- Modify: `crates/mvm-core/src/policy/projection_fs_env.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In the `tests` module:
+
+```rust
+fn fs(grants: &[(&str, FsAccess)]) -> CanonicalFs {
+    CanonicalFs {
+        grants: grants
+            .iter()
+            .map(|(p, a)| FsGrant { guest_path: p.to_string(), access: *a })
+            .collect(),
+    }
+}
+
+#[test]
+fn clamp_fs_keeps_only_covered_requests() {
+    let requested = fs(&[
+        ("/data/sub", FsAccess::ReadOnly), // under resolved /data → kept
+        ("/etc", FsAccess::ReadOnly),      // not granted → dropped
+    ]);
+    let resolved = fs(&[("/data", FsAccess::ReadOnly)]);
+    let granted = clamp_fs(&requested, &resolved);
+    assert!(granted.permits("/data/sub/x", FsAccess::ReadOnly));
+    assert!(!granted.permits("/etc/passwd", FsAccess::ReadOnly));
+}
+
+#[test]
+fn clamp_fs_rw_request_under_ro_bound_drops() {
+    let requested = fs(&[("/data", FsAccess::ReadWrite)]);
+    let resolved = fs(&[("/data", FsAccess::ReadOnly)]);
+    let granted = clamp_fs(&requested, &resolved);
+    assert_eq!(granted.grants, vec![], "RW not covered by RO bound");
+}
+
+#[test]
+fn clamp_fs_ro_request_under_rw_bound_survives_as_ro() {
+    let requested = fs(&[("/work/out", FsAccess::ReadOnly)]);
+    let resolved = fs(&[("/work", FsAccess::ReadWrite)]);
+    let granted = clamp_fs(&requested, &resolved);
+    assert!(granted.permits("/work/out/x", FsAccess::ReadOnly));
+    assert!(!granted.permits("/work/out/x", FsAccess::ReadWrite), "request asked ro");
+}
+
+#[test]
+fn clamp_env_keeps_only_resolved_names() {
+    let requested = CanonicalEnv { allowed: vec!["PATH".into(), "SECRET".into()] };
+    let resolved = CanonicalEnv { allowed: vec!["PATH".into(), "HOME".into()] };
+    let granted = clamp_env(&requested, &resolved);
+    assert!(granted.permits("PATH"));
+    assert!(!granted.permits("SECRET"), "not in resolved bound");
+    assert!(!granted.permits("HOME"), "not requested");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mvm-core policy::projection_fs_env::tests::clamp_`
+Expected: FAIL to compile — `clamp_fs`, `clamp_env` not defined.
+
+- [ ] **Step 3: Write the implementation**
+
+In `projection_fs_env.rs`, after `canonicalize_env`:
+
+```rust
+/// True when resolved grant `r` covers requested grant `q`: `r`'s path
+/// is `q`'s path or an ancestor, AND `r` grants at least `q`'s access.
+fn fs_covers(r: &FsGrant, q: &FsGrant) -> bool {
+    r.access >= q.access && path_under(&r.guest_path, &q.guest_path)
+}
+
+/// Intersection-only merge of a *requested* fs grant set against the
+/// *resolved* (authoritative) bound. A requested grant survives only
+/// when some resolved grant fully covers it (path + access); partial
+/// coverage drops it whole, fail-closed. The request attenuates, never
+/// widens — the Plan 188 `clamp` invariant for the fs domain.
+pub fn clamp_fs(requested: &CanonicalFs, resolved: &CanonicalFs) -> CanonicalFs {
+    let grants = requested
+        .grants
+        .iter()
+        .filter(|q| resolved.grants.iter().any(|r| fs_covers(r, q)))
+        .cloned()
+        .collect();
+    CanonicalFs { grants }
+}
+
+/// Intersection-only merge of requested env names against the resolved
+/// allowed-name bound. A requested name survives only if the bound
+/// permits it.
+pub fn clamp_env(requested: &CanonicalEnv, resolved: &CanonicalEnv) -> CanonicalEnv {
+    let allowed = requested
+        .allowed
+        .iter()
+        .filter(|n| resolved.permits(n))
+        .cloned()
+        .collect();
+    CanonicalEnv { allowed }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mvm-core policy::projection_fs_env::tests::clamp_`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-core/src/policy/projection_fs_env.rs
+git commit -m "feat(core): clamp_fs/clamp_env intersection-only merges (request attenuates)"
+```
+
+---
+
+### Task 5: WASI-shape generator + the "denied is not preopened" negative witness
+
+**Files:**
+- Modify: `crates/mvm-core/src/policy/projection_fs_env.rs`
+
+This is the data the A3 guest runner turns into wasmtime preopens/env. Keeping it backend-agnostic (plain `String`/`bool`) keeps wasmtime out of `mvm-core`.
+
+- [ ] **Step 1: Write the failing test**
+
+In the `tests` module:
+
+```rust
+#[test]
+fn to_wasi_preopens_emits_one_entry_per_grant_with_writable_flag() {
+    let granted = fs(&[
+        ("/data", FsAccess::ReadOnly),
+        ("/work", FsAccess::ReadWrite),
+    ]);
+    let pre = to_wasi_preopens(&granted);
+    assert_eq!(
+        pre,
+        vec![
+            WasiPreopen { guest_path: "/data".into(), writable: false },
+            WasiPreopen { guest_path: "/work".into(), writable: true },
+        ]
+    );
+}
+
+#[test]
+fn denied_dir_is_not_preopened() {
+    // The security-critical negative: a path the bound does not grant
+    // never appears in the preopen list the runner will hand wasmtime.
+    let requested = fs(&[("/etc", FsAccess::ReadOnly)]);
+    let resolved = fs(&[("/data", FsAccess::ReadOnly)]);
+    let granted = clamp_fs(&requested, &resolved);
+    let pre = to_wasi_preopens(&granted);
+    assert!(
+        !pre.iter().any(|p| p.guest_path == "/etc"),
+        "denied /etc must not be preopened: {pre:?}"
+    );
+    assert!(pre.is_empty());
+}
+
+#[test]
+fn to_wasi_env_names_passes_through_allowed_names() {
+    let granted = CanonicalEnv { allowed: vec!["HOME".into(), "PATH".into()] };
+    assert_eq!(to_wasi_env_names(&granted), vec!["HOME".to_string(), "PATH".to_string()]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mvm-core policy::projection_fs_env::tests::to_wasi`
+Expected: FAIL to compile — `WasiPreopen`, `to_wasi_preopens`, `to_wasi_env_names` not defined.
+
+- [ ] **Step 3: Write the implementation**
+
+In `projection_fs_env.rs`, after `clamp_env`:
+
+```rust
+/// One filesystem preopen in the WASI-facing shape — the data the
+/// guest runner maps onto a `wasmtime`/`WasiCtxBuilder` preopen.
+/// Backend-agnostic by design: no wasmtime types reach `mvm-core`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasiPreopen {
+    pub guest_path: String,
+    pub writable: bool,
+}
+
+/// Project the granted fs set into the runner-facing preopen list.
+/// One entry per grant; `writable` is true exactly for `ReadWrite`.
+pub fn to_wasi_preopens(granted: &CanonicalFs) -> Vec<WasiPreopen> {
+    granted
+        .grants
+        .iter()
+        .map(|g| WasiPreopen {
+            guest_path: g.guest_path.clone(),
+            writable: g.access == FsAccess::ReadWrite,
+        })
+        .collect()
+}
+
+/// Project the granted env set into the runner-facing name list.
+pub fn to_wasi_env_names(granted: &CanonicalEnv) -> Vec<String> {
+    granted.allowed.clone()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mvm-core policy::projection_fs_env::tests::to_wasi && cargo test -p mvm-core policy::projection_fs_env::tests::denied_dir`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mvm-core/src/policy/projection_fs_env.rs
+git commit -m "feat(core): WASI preopen/env-name generator + denied-not-preopened witness"
+```
+
+---
+
+### Task 6: Property witness, EffectivePolicy wiring, exports, bookkeeping
+
+**Files:**
+- Modify: `crates/mvm-core/src/policy/projection_fs_env.rs`
+- Modify: `crates/mvm-core/src/policy/policies.rs`
+- Modify: `crates/mvm-core/src/policy/resolver.rs`
+- Modify: `crates/mvm-core/src/policy/mod.rs`
+- Modify: `specs/REFACTOR-STATUS.md`, `specs/SPRINT.md`
+
+- [ ] **Step 1: Write the clamp-never-widens property witness (failing)**
+
+In `projection_fs_env.rs`, add a `property` module at the end of the file (sibling to `tests`), mirroring `projection.rs`'s xorshift generator:
+
+```rust
+#[cfg(test)]
+mod property {
+    use super::*;
+
+    /// Deterministic xorshift64 — no rand dep at this layer.
+    struct Xs(u64);
+    impl Xs {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+        fn below(&mut self, n: u64) -> u64 {
+            self.next() % n
+        }
+    }
+
+    fn gen_fs(rng: &mut Xs) -> CanonicalFs {
+        let dirs = ["/a", "/a/b", "/a/b/c", "/data", "/data/sub", "/work", "/etc"];
+        let mut grants = Vec::new();
+        for _ in 0..rng.below(5) {
+            let path = dirs[rng.below(dirs.len() as u64) as usize];
+            let access = if rng.below(2) == 0 { FsAccess::ReadOnly } else { FsAccess::ReadWrite };
+            grants.push(FsGrant { guest_path: path.to_string(), access });
+        }
+        CanonicalFs { grants }
+    }
+
+    /// Probe paths biased to grant edges plus a few siblings.
+    fn fs_probes() -> Vec<(&'static str, FsAccess)> {
+        vec![
+            ("/a/b/c/file", FsAccess::ReadOnly),
+            ("/a/b/c/file", FsAccess::ReadWrite),
+            ("/data/sub/x", FsAccess::ReadOnly),
+            ("/data/sub/x", FsAccess::ReadWrite),
+            ("/work/o", FsAccess::ReadWrite),
+            ("/etc/passwd", FsAccess::ReadOnly),
+            ("/database", FsAccess::ReadOnly),
+            ("/", FsAccess::ReadOnly),
+        ]
+    }
+
+    /// clamp_fs soundness: the granted set never admits a probe the
+    /// resolved bound denies. The fs-domain analogue of
+    /// projection.rs::clamp_never_widens_property.
+    #[test]
+    fn clamp_fs_never_widens_property() {
+        let mut rng = Xs(0x192_f5_e0a1);
+        for _ in 0..512 {
+            let requested = gen_fs(&mut rng);
+            let resolved = gen_fs(&mut rng);
+            let granted = clamp_fs(&requested, &resolved);
+            for (path, access) in fs_probes() {
+                if granted.permits(path, access) {
+                    assert!(
+                        resolved.permits(path, access),
+                        "clamp_fs widened: {path} {access:?}\n req={requested:?}\n res={resolved:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// clamp_env soundness: same invariant for env names.
+    #[test]
+    fn clamp_env_never_widens_property() {
+        let mut rng = Xs(0x192_e0_b2c3);
+        let names = ["PATH", "HOME", "SECRET", "TOKEN", "LANG", "TZ"];
+        for _ in 0..512 {
+            let pick = |rng: &mut Xs| CanonicalEnv {
+                allowed: names
+                    .iter()
+                    .filter(|_| rng.below(2) == 0)
+                    .map(|s| s.to_string())
+                    .collect(),
+            };
+            let requested = pick(&mut rng);
+            let resolved = pick(&mut rng);
+            let granted = clamp_env(&requested, &resolved);
+            for n in names {
+                if granted.permits(n) {
+                    assert!(resolved.permits(n), "clamp_env widened: {n}");
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the property witnesses**
+
+Run: `cargo test -p mvm-core policy::projection_fs_env::property`
+Expected: PASS (2 tests). If `clamp_fs_never_widens_property` fails, `fs_covers`/`path_under` have a widening bug — fix there, not in the test.
+
+- [ ] **Step 3: Add the WasiCapPolicy sub-policy**
+
+In `crates/mvm-core/src/policy/policies.rs`, after `FsGrantSpec`, add:
+
+```rust
+/// The tenant bound on a wasm-component's WASI capabilities: which
+/// filesystem preopens and env-var names it may receive. Deny-by-
+/// default — an empty policy grants nothing.
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WasiCapPolicy {
+    #[serde(default)]
+    pub fs: Vec<FsGrantSpec>,
+    #[serde(default)]
+    pub env: Vec<String>,
+}
+```
+
+- [ ] **Step 4: Wire it into EffectivePolicy**
+
+In `crates/mvm-core/src/policy/resolver.rs`:
+
+1. Add the field to the `EffectivePolicy` struct (after `audit`):
+
+```rust
+    #[serde(default)]
+    pub wasi: WasiCapPolicy,
+```
+
+2. Import it — add `WasiCapPolicy` to the `use crate::policy::policies::{...}` list (or add a `use` if absent).
+
+3. Resolve it in `resolve()` alongside the others (after the `audit:` line):
+
+```rust
+        wasi: pick(overlay.and_then(|o| o.wasi.clone()), &bundle.wasi),
+```
+
+> **Note for the implementer:** step 3 requires `PolicyBundle` and `TenantOverlay` (in `crates/mvm-core/src/policy/bundle.rs`) to carry a `wasi` field too. Add `#[serde(default)] pub wasi: WasiCapPolicy` to `PolicyBundle` and `#[serde(default)] pub wasi: Option<WasiCapPolicy>` to `TenantOverlay`, mirroring how `network`/`egress` appear in each. Build will tell you exactly which structs need the field; the `#[serde(default)]` keeps existing bundle JSON deserializing.
+
+- [ ] **Step 5: Verify the resolver still builds and resolves**
+
+Run: `cargo test -p mvm-core policy::resolver`
+Expected: PASS — existing resolver tests still green; `EffectivePolicy::default().wasi` is the empty (deny-all) `WasiCapPolicy`.
+
+- [ ] **Step 6: Re-export the public surface**
+
+In `crates/mvm-core/src/policy/mod.rs`, find where `projection`'s public items are re-exported (e.g. `pub use projection::{...}`). Add a sibling re-export:
+
+```rust
+pub use projection_fs_env::{
+    canonicalize_env, canonicalize_fs, clamp_env, clamp_fs, to_wasi_env_names,
+    to_wasi_preopens, CanonicalEnv, CanonicalFs, FsAccess, FsEnvError, FsGrant, WasiPreopen,
+};
+```
+
+> If `mod.rs` does not re-export `projection`'s items (callers use the `projection::` path), skip the `pub use` and leave the module path-qualified to match the existing convention.
+
+- [ ] **Step 7: Full gate run**
+
+Run, in order:
+
+```bash
+cargo fmt --all -- --check
+cargo nextest run -p mvm-core
+cargo clippy -p mvm-core -- -D warnings
+cargo run -p xtask -- check-core-runtime-free
+```
+
+Expected: fmt clean; all `mvm-core` tests pass (including the new `projection_fs_env` module + property witnesses); zero clippy warnings; `check-core-runtime-free` green (no `tokio` pulled — this plan adds none).
+
+- [ ] **Step 8: Spec bookkeeping**
+
+- In `specs/REFACTOR-STATUS.md`: add a glance line and a detail entry recording "Plan 192 (ADR-081 A1) — WASI fs/env capability projection LANDED", and bump the "Last updated" date.
+- In `specs/SPRINT.md`: record Plan 192 under the active sprint with the A1 deliverable + the two clamp-never-widens witnesses; note A2 (`.wasm` admission) and A3 (guest runner/Nix/AOT) as the remaining ADR-081 legs (their own plans).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/mvm-core/src/policy/projection_fs_env.rs crates/mvm-core/src/policy/policies.rs crates/mvm-core/src/policy/resolver.rs crates/mvm-core/src/policy/bundle.rs crates/mvm-core/src/policy/mod.rs specs/REFACTOR-STATUS.md specs/SPRINT.md
+git commit -m "feat(core): WasiCapPolicy bound + clamp-never-widens property witnesses (ADR-081 A1)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (against ADR-081 §Decision 3 + A1):**
+- "fs/env capabilities, not just network" → Tasks 1–3 (`CanonicalFs`, `CanonicalEnv`, canonicalizers). ✓
+- "clamp from Plan 188 applies" → Task 4 (`clamp_fs`/`clamp_env`, intersection-only) + Task 6 property witnesses. ✓
+- "deny-by-default" → no `Unrestricted` for fs/env; empty-is-deny-all tests in Tasks 1 & 3. ✓
+- "clamp invariant (request never widens tenant policy)" → `clamp_fs_never_widens_property` + `clamp_env_never_widens_property`. ✓
+- "WASI-config generator … turns resolved policy into the actual preopen/env grant set" → Task 5 (`to_wasi_preopens`/`to_wasi_env_names`). ✓
+- "negative tests (a denied dir is not preopened)" → Task 5 `denied_dir_is_not_preopened`. ✓
+- "extends `mvm-core::policy::projection`" → sibling module + `WasiCapPolicy` on `EffectivePolicy`. ✓
+- Out of scope here (correctly deferred to A2/A3): `.wasm` admission, the IR request-side source of requested grants, the guest runner, Nix bake, AOT, seccomp. The clamp consumers in A1 take `CanonicalFs`/`CanonicalEnv` directly; A3 supplies the requested side from the IR.
+
+**Placeholder scan:** none — every code step carries complete code; every run step carries the exact command + expected result.
+
+**Type consistency:** `FsAccess`/`FsGrant`/`CanonicalFs`/`CanonicalEnv`/`FsEnvError`/`WasiPreopen` and the fns `canonicalize_fs`/`canonicalize_env`/`clamp_fs`/`clamp_env`/`to_wasi_preopens`/`to_wasi_env_names`/`path_under`/`fs_covers` are named identically across all tasks. `FsAccess: Ord` (derived in Task 1) is what makes `>=` in `fs_covers`/`permits` and `.max()` in `canonicalize_fs` compile. `FsGrantSpec`/`WasiCapPolicy` live in `policies.rs`; `EffectivePolicy.wasi` is wired in `resolver.rs`.
+
+## Follow-on (separate plans — do NOT implement here)
+
+- **Plan 193 = ADR-081 A2:** `.wasm` artifact admission — `mvmctl run ./x.wasm` → SHA-256 → signed `ExecutionPlan` (claim 8/9) → provenance (digest + wasmtime version) in the audit chain.
+- **Plan 194 = ADR-081 A3:** guest runner + Nix bake + AOT — bake wasmtime for `Wasm` workloads; AOT-compile `.wasm`→`.cwasm` in the builder; map this plan's `WasiPreopen`/env-name output onto the `wasmtime run` invocation + WASI config; tighten guest seccomp to forbid `PROT_EXEC`.


### PR DESCRIPTION
Lands the **design and the first implementation plan** for the production in-microVM wasm-component runner. **Docs only — no implementation, and none is to begin until explicitly directed** (owner-gated; noted in SPRINT.md).

## What's here

- **`specs/adrs/081-wasm-component-runner.md`** — extends ADR-080 §4's WASM-component regime into a prod-tier design:
  - wasmtime runs as an **in-guest binary** (Nix-baked, like python3/node) — **never a host Cargo dep**; the host TCB is unchanged.
  - a `.wasm` is admitted as a **content-addressed artifact** through the existing claim-8/9 path (local file v1 → registry/digest fast-follow → SDK-compile deferred).
  - WASI fs/env capabilities are **clamp-authored** by extending the Plan 188 projection seam from network to fs/env (deny-by-default, request-never-widens).
  - **AOT-compile at build for prod** (no in-guest JIT → guest seccomp can forbid `PROT_EXEC`); JIT only for the preview tier.
  - WASI P1 v1 with a P2-ready seam; full §Security-considerations threat-model delta.
  - decomposes into A1/A2/A3.

- **`specs/plans/192-wasi-capability-projection-fs-env.md`** — the **A1** implementation plan (foundation A2/A3 consume): six bite-sized TDD tasks, all pure logic in `mvm-core`, zero new deps — the exact shape of Plan 188. `CanonicalFs`/`CanonicalEnv`, `canonicalize_*`, `clamp_*` (intersection-only), the WASI preopen/env-name generator, the `denied-not-preopened` witness, `clamp-never-widens` property witnesses, and the `WasiCapPolicy` bound on `EffectivePolicy`.

- **`specs/SPRINT.md`** — Sprint 62 notes ADR-081 + the A1/A2/A3 decomposition, marked design/plan-only, not started.

A2 (`.wasm` admission) and A3 (guest runner / Nix bake / AOT) are queued as Plans 193/194 — **plans not yet written**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)