### PR TITLE
perf+fix(vz/fc): sub-second up/down, live-VM reaper correctness, and Firecracker boot/stop fixes

### DIFF
--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -363,7 +363,9 @@ impl VmBackend for VzBackend {
                     console_log.display(),
                 );
             }
-            std::thread::sleep(Duration::from_millis(50));
+            // Tight poll: the pid file lands a few hundred ms in, and a coarse
+            // cadence rounds every `up` up by that much. Cheap to spin finer.
+            std::thread::sleep(Duration::from_millis(5));
         }
 
         // Vz supervisor booted cleanly. Detach the
@@ -438,7 +440,10 @@ impl VmBackend for VzBackend {
             if !pid_alive(pid) {
                 break;
             }
-            std::thread::sleep(Duration::from_millis(100));
+            // Tight poll: the supervisor owns the graceful→forced escalation
+            // and exits in a few hundred ms, so detect its exit promptly
+            // rather than rounding `down` up by a coarse cadence.
+            std::thread::sleep(Duration::from_millis(25));
         }
         if pid_alive(pid) {
             ui::info(&format!(

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -2774,6 +2774,14 @@ fn reap_orphaned_vm_helpers_at(
         return Ok(outcome);
     }
 
+    // One process-table snapshot for the whole sweep. macOS has no
+    // `/proc`, so the former code shelled out to `pgrep -f <basename>`
+    // once per dir plus `ps -o ppid=` once per candidate PID. With a
+    // cache of hundreds of builder scratch dirs that turned the `up`
+    // hot path into a multi-second storm of subprocess spawns. One
+    // `ps` up front collapses it to a single call.
+    let snapshot = ProcSnapshot::capture();
+
     for entry in std::fs::read_dir(vms_root)?.flatten() {
         let dir = entry.path();
         if !dir.is_dir() {
@@ -2796,7 +2804,7 @@ fn reap_orphaned_vm_helpers_at(
             if !seen_pids.insert(pid) {
                 continue;
             }
-            match classify_pid(pid) {
+            match classify_pid(pid, &snapshot) {
                 PidClassification::Dead => {}
                 PidClassification::LiveOwned => dir_has_live_owner = true,
                 PidClassification::Orphan => {
@@ -2818,11 +2826,11 @@ fn reap_orphaned_vm_helpers_at(
             Some(s) => s.to_string(),
             None => continue,
         };
-        for pid in pids_referencing(&dir_basename) {
+        for pid in snapshot.pids_referencing(&dir_basename) {
             if !seen_pids.insert(pid) {
                 continue;
             }
-            match classify_pid(pid) {
+            match classify_pid(pid, &snapshot) {
                 PidClassification::Dead => {}
                 PidClassification::LiveOwned => dir_has_live_owner = true,
                 PidClassification::Orphan => {
@@ -2858,36 +2866,86 @@ enum PidClassification {
     Orphan,    // alive, parent is launchd PID 1 → SIGTERM-able
 }
 
-fn classify_pid(pid: i32) -> PidClassification {
+fn classify_pid(pid: i32, snapshot: &ProcSnapshot) -> PidClassification {
     if !pid_is_alive(pid) {
         return PidClassification::Dead;
     }
-    match pid_parent(pid) {
+    match snapshot.parent(pid) {
         Some(1) => PidClassification::Orphan,
         _ => PidClassification::LiveOwned,
     }
 }
 
-/// Find all PIDs whose argv contains `needle`. Used by the argv-scan
-/// pass to catch grandchildren (gvproxy, console-tail) that don't
-/// write a sidecar file. macOS has no `/proc`, so the portable path
-/// is `pgrep -f <needle>` — argv-substring match.
-fn pids_referencing(needle: &str) -> Vec<i32> {
-    let out = match std::process::Command::new("pgrep")
-        .args(["-f", needle])
-        .output()
-    {
-        Ok(o) => o,
-        Err(_) => return Vec::new(),
-    };
-    if !out.status.success() {
-        return Vec::new();
+/// One-shot snapshot of the host process table, taken once per sweep.
+/// macOS has no `/proc`, so the portable source for (pid, ppid, argv)
+/// is `ps`. This replaces the former per-dir `pgrep -f` + per-PID
+/// `ps -o ppid=` fan-out: with hundreds of cached builder scratch
+/// dirs that fan-out cost seconds of serial subprocess spawns on the
+/// `up` startup path. `ps -axww` (no column truncation) is a single
+/// call serving both the argv-substring scan and the parent lookup.
+struct ProcSnapshot {
+    /// pid → ppid for every process visible to this user.
+    parents: std::collections::HashMap<i32, i32>,
+    /// (pid, full argv) for every real process (pid > 1), scanned for
+    /// VM-dir-basename substrings.
+    cmds: Vec<(i32, String)>,
+}
+
+impl ProcSnapshot {
+    fn capture() -> Self {
+        let mut parents = std::collections::HashMap::new();
+        let mut cmds = Vec::new();
+        let Ok(out) = std::process::Command::new("ps")
+            .args(["-axww", "-o", "pid=,ppid=,command="])
+            .output()
+        else {
+            return Self { parents, cmds };
+        };
+        if !out.status.success() {
+            return Self { parents, cmds };
+        }
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            // `  501  1234 /path/to/cmd --flag` — leading pad, then
+            // pid and ppid columns (variable width), then the full
+            // command. Peel pid, then ppid, then keep the rest verbatim.
+            let rest = line.trim_start();
+            let Some((pid_s, rest)) = rest.split_once(char::is_whitespace) else {
+                continue;
+            };
+            let Ok(pid) = pid_s.parse::<i32>() else {
+                continue;
+            };
+            let rest = rest.trim_start();
+            let Some((ppid_s, cmd)) = rest.split_once(char::is_whitespace) else {
+                continue;
+            };
+            let Ok(ppid) = ppid_s.parse::<i32>() else {
+                continue;
+            };
+            parents.insert(pid, ppid);
+            if pid > 1 {
+                cmds.push((pid, cmd.trim_start().to_string()));
+            }
+        }
+        Self { parents, cmds }
     }
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|s| s.trim().parse::<i32>().ok())
-        .filter(|&p| p > 1)
-        .collect()
+
+    /// Parent PID of `pid`, or `None` if it's not in the snapshot
+    /// (exited, or spawned after the snapshot was taken).
+    fn parent(&self, pid: i32) -> Option<i32> {
+        self.parents.get(&pid).copied()
+    }
+
+    /// All real PIDs whose argv contains `needle` — the argv-substring
+    /// match the old `pgrep -f <needle>` performed, served from the
+    /// snapshot instead of a fresh subprocess per call.
+    fn pids_referencing(&self, needle: &str) -> Vec<i32> {
+        self.cmds
+            .iter()
+            .filter(|(_, cmd)| cmd.contains(needle))
+            .map(|(pid, _)| *pid)
+            .collect()
+    }
 }
 
 fn read_pid_file(path: &std::path::Path) -> Option<i32> {
@@ -2902,25 +2960,6 @@ fn read_pid_file(path: &std::path::Path) -> Option<i32> {
 fn pid_is_alive(pid: i32) -> bool {
     // Signal 0 = existence check, doesn't deliver a signal.
     unsafe { libc::kill(pid, 0) == 0 }
-}
-
-/// Returns the parent PID, or `None` if the process is gone or its
-/// PPID can't be read. macOS has no `/proc`; the portable path is
-/// `ps -o ppid= -p <pid>`. Shelling out adds ~5 ms per call, which
-/// is acceptable for a pruner that runs a handful of times per
-/// session (and not on a hot path).
-fn pid_parent(pid: i32) -> Option<i32> {
-    let out = std::process::Command::new("ps")
-        .args(["-o", "ppid=", "-p", &pid.to_string()])
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    String::from_utf8_lossy(&out.stdout)
-        .trim()
-        .parse::<i32>()
-        .ok()
 }
 
 fn dir_size_bytes(path: &std::path::Path) -> u64 {

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -2656,31 +2656,39 @@ pub(in crate::commands) struct ReapOutcome {
 /// future refactor that narrows the traversal or renames the sidecar
 /// must update that test.
 ///
-/// Two scans per VM dir:
+/// A microVM is several processes — the supervisor (the VMM-host that
+/// owns the guest) plus dependent helpers (a host gvproxy for egress, a
+/// `tail -F console.log` reader). The supervisor is the authoritative
+/// liveness signal, so the sweep runs in two phases per dir:
 ///
-/// 1. **Sidecar PID scan.** Each dir carries a `{builder.pid,
-///    stage0.pid}` sidecar with the supervisor's PID. (Earlier
-///    versions of this function looked for the wrong names
-///    (`supervisor.pid`/`gvproxy.pid`); the actual sidecar names
-///    are `builder.pid` for steady-state and `stage0.pid` for
-///    Stage 0 — fixed after smoke-testing on accumulated state
-///    showed `0` PIDs killed despite live orphans.)
-/// 2. **Argv scan.** `gvproxy` is the supervisor's GRANDCHILD and
-///    writes no sidecar of its own — its argv references the VM
-///    dir's `gvproxy.sock`. The argv scan catches those grandchildren
-///    even after the supervisor is gone. Same for `tail -F` readers
-///    of `console.log`.
+/// 1. **Supervisor phase.** Read the supervisor sidecars (`builder.pid` /
+///    `stage0.pid` / `vz.pid` / `libkrun.pid` — see
+///    [`is_supervisor_sidecar`]). On a *managed* dir (the persistent dev
+///    builder `mvm-persistent-builder-*`, or any named workload under
+///    `~/.mvm/vms/`) an alive supervisor is the running VM, spared:
+///    those supervisors are detached under launchd *by design* to
+///    outlive the spawning CLI, so `parent == launchd` is their steady
+///    state, not an orphan signal — they are stopped only by explicit
+///    `dev down` / `stop <name>`. On an *ephemeral* per-job builder dir,
+///    an alive launchd-parented supervisor is a build whose `mvmctl`
+///    crashed → SIGTERM. (Without the managed carve-out the startup
+///    sweep killed the live dev VM on every `up` / `dev up` / `ls`.)
+/// 2. **Helper phase.** The gvproxy sidecars (`gvproxy.pid` /
+///    `host-gvproxy.pid`) plus argv-scanned grandchildren (gvproxy's
+///    `gvproxy.sock`, `tail -F console.log`) whose argv carries the
+///    dir's unique basename. A helper's fate *follows its supervisor*:
+///    if Phase 1 found the VM live every helper is spared; once the
+///    supervisor is gone a still-running launchd-parented helper is a
+///    leak → SIGTERM. So a live VM keeps all its PIDs, while a stopped
+///    VM's stray gvproxy is still reaped.
 ///
-/// For each PID found by either scan:
-/// - dead → ignore
-/// - alive with a non-launchd parent → in-flight dev up; mark dir
-///   as "has a live owner", skip dir removal
-/// - alive with launchd as parent → SIGTERM and count
+/// Per PID the verdict ([`classify_pid_for_dir`]) is: dead → ignore;
+/// alive non-launchd parent → live owner (in-flight), spared; alive
+/// launchd parent → leak, SIGTERM — unless `protected` for that phase.
 ///
-/// Then if no helper in the dir had a live non-launchd parent, the
-/// dir is removed. This avoids the over-aggressive `rm -rf $vm/` of an
-/// earlier prototype, which during validation nuked a live mvmctl's
-/// state dir.
+/// Then if no PID in the dir had a live owner, the dir is removed.
+/// This avoids the over-aggressive `rm -rf $vm/` of an earlier
+/// prototype, which during validation nuked a live mvmctl's state dir.
 pub(in crate::commands) fn reap_orphaned_vm_helpers(dry_run: bool) -> Result<ReapOutcome> {
     reap_orphaned_vm_helpers_both_roots(/* remove_builder_dirs = */ true, dry_run)
 }
@@ -2724,6 +2732,16 @@ const BUILDER_SIDECARS: &[&str] = &["builder.pid", "stage0.pid"];
 /// supervisor that the argv scan might miss.
 const WORKLOAD_SIDECARS: &[&str] = &["libkrun.pid", "vz.pid", "gvproxy.pid", "host-gvproxy.pid"];
 
+/// Dir-name prefix of the **persistent** dev builder VM
+/// (`mvm-persistent-builder-vz-dev`, fixed session id "dev"). Unlike an
+/// ephemeral per-job `mvm-builder-v{m,z}-<job_id>` scratch dir, this VM
+/// is long-lived: its supervisor is detached and reparented to launchd
+/// *by design* so it outlives the spawning CLI. So a live PID recorded
+/// here is the running dev VM, not a leak — `parent == launchd` is the
+/// normal steady state, not an orphan signal. The startup sweep must
+/// spare it; it is torn down only by explicit `dev down`.
+const PERSISTENT_BUILDER_DIR_PREFIX: &str = "mvm-persistent-builder-";
+
 /// Scan both VM-state roots: the ephemeral builder cache
 /// (`~/.cache/mvm/builder-vm/vms/`) and the workload VM tree
 /// (`~/.mvm/vms/`). `remove_builder_dirs` deletes dead builder scratch
@@ -2738,17 +2756,34 @@ fn reap_orphaned_vm_helpers_both_roots(
         std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("builder-vm/vms");
     let workload_root = std::path::PathBuf::from(mvm_core::config::mvm_data_dir()).join("vms");
 
-    let mut out = reap_orphaned_vm_helpers_at(
+    // One process-table snapshot serves both roots: parent lookups and
+    // the argv-substring scan all read from it, so we never shell out
+    // more than once per sweep.
+    let snapshot = ProcSnapshot::capture();
+
+    let mut out = reap_orphaned_vm_helpers_at_with_snapshot(
         &builder_root,
         BUILDER_SIDECARS,
         remove_builder_dirs,
+        // Builder root mixes ephemeral per-job scratch dirs (reapable)
+        // with the persistent dev VM dir (spared); the per-dir prefix
+        // check distinguishes them, so this root is not "all managed".
+        /* all_dirs_managed = */
+        false,
         dry_run,
+        &snapshot,
     )?;
-    let workload = reap_orphaned_vm_helpers_at(
+    let workload = reap_orphaned_vm_helpers_at_with_snapshot(
         &workload_root,
         WORKLOAD_SIDECARS,
         /* remove_dead_dirs = */ false,
+        // Every `~/.mvm/vms/<name>/` dir is a user-managed named VM whose
+        // supervisor is a detached daemon (parent == launchd in steady
+        // state) — never an orphan to sweep. It is stopped via `stop`.
+        /* all_dirs_managed = */
+        true,
         dry_run,
+        &snapshot,
     )?;
     out.killed += workload.killed;
     out.removed_dirs += workload.removed_dirs;
@@ -2756,14 +2791,53 @@ fn reap_orphaned_vm_helpers_both_roots(
     Ok(out)
 }
 
-/// Inner form taking an explicit `vms_root`, the sidecar names to look
-/// for in each dir, and whether dead dirs may be removed. Exists for
-/// tests against a tempdir without mutating `MVM_CACHE_DIR`.
+/// Snapshot-capturing single-root wrapper over
+/// [`reap_orphaned_vm_helpers_at_with_snapshot`]. Production sweeps go
+/// through `_both_roots` (which captures one snapshot and shares it
+/// across both roots); this form captures its own and is the entry the
+/// reaper tests drive against a tempdir without mutating `MVM_CACHE_DIR`.
+#[cfg(test)]
 fn reap_orphaned_vm_helpers_at(
     vms_root: &std::path::Path,
     sidecars: &[&str],
     remove_dead_dirs: bool,
+    all_dirs_managed: bool,
     dry_run: bool,
+) -> Result<ReapOutcome> {
+    // One process-table snapshot for the whole sweep. macOS has no
+    // `/proc`, so the former code shelled out to `pgrep -f <basename>`
+    // once per dir plus `ps -o ppid=` once per candidate PID. With a
+    // cache of hundreds of builder scratch dirs that turned the `up`
+    // hot path into a multi-second storm of subprocess spawns. One
+    // `ps` up front collapses it to a single call.
+    let snapshot = ProcSnapshot::capture();
+    reap_orphaned_vm_helpers_at_with_snapshot(
+        vms_root,
+        sidecars,
+        remove_dead_dirs,
+        all_dirs_managed,
+        dry_run,
+        &snapshot,
+    )
+}
+
+/// Inner form taking an explicit, already-captured [`ProcSnapshot`] so
+/// `_both_roots` shares one snapshot across both roots and tests can
+/// inject a synthetic process table.
+///
+/// `all_dirs_managed` marks a root where *every* dir holds a long-lived,
+/// user-managed VM whose supervisor is a detached daemon (the workload
+/// root). On the builder root it is `false`, and the persistent dev VM
+/// is recognised per-dir by [`PERSISTENT_BUILDER_DIR_PREFIX`]. For a
+/// managed dir a live PID is the running VM, never an orphan — see
+/// [`classify_pid_for_dir`].
+fn reap_orphaned_vm_helpers_at_with_snapshot(
+    vms_root: &std::path::Path,
+    sidecars: &[&str],
+    remove_dead_dirs: bool,
+    all_dirs_managed: bool,
+    dry_run: bool,
+    snapshot: &ProcSnapshot,
 ) -> Result<ReapOutcome> {
     let mut outcome = ReapOutcome {
         killed: 0,
@@ -2774,74 +2848,76 @@ fn reap_orphaned_vm_helpers_at(
         return Ok(outcome);
     }
 
-    // One process-table snapshot for the whole sweep. macOS has no
-    // `/proc`, so the former code shelled out to `pgrep -f <basename>`
-    // once per dir plus `ps -o ppid=` once per candidate PID. With a
-    // cache of hundreds of builder scratch dirs that turned the `up`
-    // hot path into a multi-second storm of subprocess spawns. One
-    // `ps` up front collapses it to a single call.
-    let snapshot = ProcSnapshot::capture();
-
     for entry in std::fs::read_dir(vms_root)?.flatten() {
         let dir = entry.path();
         if !dir.is_dir() {
             continue;
         }
+        let dir_basename = match dir.file_name().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        // A managed dir holds a long-lived, explicitly-stopped VM (the
+        // persistent dev builder, or — on the workload root — any named
+        // VM). Its supervisor is detached under launchd by design, so on
+        // such a dir `parent == launchd` is the steady state, not a leak.
+        let managed = all_dirs_managed || dir_basename.starts_with(PERSISTENT_BUILDER_DIR_PREFIX);
 
         let mut dir_has_live_owner = false;
         let mut killed_in_dir = 0u64;
         let mut seen_pids: std::collections::HashSet<i32> = std::collections::HashSet::new();
 
-        // Scan 1 — sidecar files. Builder dirs write `builder.pid` /
-        // `stage0.pid`; workload dirs write `libkrun.pid` / `vz.pid` /
-        // the gvproxy sidecars. `sidecars` is the per-root set; a
-        // missing file is skipped.
-        for sidecar in sidecars {
-            let pid_file = dir.join(sidecar);
-            let Some(pid) = read_pid_file(&pid_file) else {
+        // Phase 1 — supervisors. The supervisor (`builder.pid` /
+        // `stage0.pid` / `vz.pid` / `libkrun.pid`) is the authoritative
+        // per-VM liveness signal: while it lives the VM is up. On a
+        // managed dir an alive supervisor is the running VM (spared); on
+        // an ephemeral per-job dir an alive *launchd-parented* supervisor
+        // is a build whose `mvmctl` crashed (reaped). A live supervisor
+        // here flips `dir_has_live_owner`, which gates Phase 2.
+        for sidecar in sidecars.iter().filter(|s| is_supervisor_sidecar(s)) {
+            let Some(pid) = read_pid_file(&dir.join(sidecar)) else {
                 continue;
             };
             if !seen_pids.insert(pid) {
                 continue;
             }
-            match classify_pid(pid, &snapshot) {
-                PidClassification::Dead => {}
-                PidClassification::LiveOwned => dir_has_live_owner = true,
-                PidClassification::Orphan => {
-                    if !dry_run {
-                        unsafe {
-                            libc::kill(pid, libc::SIGTERM);
-                        }
-                    }
-                    killed_in_dir += 1;
-                }
-            }
+            reap_or_track(
+                pid,
+                managed,
+                dry_run,
+                snapshot,
+                &mut dir_has_live_owner,
+                &mut killed_in_dir,
+            );
         }
 
-        // Scan 2 — argv scan for grandchildren (gvproxy, tail -F …
-        // console.log). They don't write sidecars but their argv
-        // contains the VM dir basename (the `mvm-stage0-…` or
-        // `mvm-builder-vm-…` id), which is unique on this host.
-        let dir_basename = match dir.file_name().and_then(|s| s.to_str()) {
-            Some(s) => s.to_string(),
-            None => continue,
-        };
-        for pid in snapshot.pids_referencing(&dir_basename) {
+        // Phase 2 — dependent helpers: the gvproxy sidecars
+        // (`gvproxy.pid` / `host-gvproxy.pid`) plus argv-scanned
+        // grandchildren (gvproxy, `tail -F … console.log`) whose argv
+        // carries this dir's unique basename. A helper's fate follows the
+        // supervisor's: if the VM is live (`dir_has_live_owner`) every
+        // helper is spared; once the supervisor is gone a still-running
+        // launchd-parented helper is a leak to reap. This is why a live
+        // VM keeps *all* its PIDs while a stopped VM's stray gvproxy is
+        // still cleaned up.
+        let protect_helpers = dir_has_live_owner;
+        let helper_pids = sidecars
+            .iter()
+            .filter(|s| !is_supervisor_sidecar(s))
+            .filter_map(|s| read_pid_file(&dir.join(s)))
+            .chain(snapshot.pids_referencing(&dir_basename));
+        for pid in helper_pids {
             if !seen_pids.insert(pid) {
                 continue;
             }
-            match classify_pid(pid, &snapshot) {
-                PidClassification::Dead => {}
-                PidClassification::LiveOwned => dir_has_live_owner = true,
-                PidClassification::Orphan => {
-                    if !dry_run {
-                        unsafe {
-                            libc::kill(pid, libc::SIGTERM);
-                        }
-                    }
-                    killed_in_dir += 1;
-                }
-            }
+            reap_or_track(
+                pid,
+                protect_helpers,
+                dry_run,
+                snapshot,
+                &mut dir_has_live_owner,
+                &mut killed_in_dir,
+            );
         }
 
         outcome.killed += killed_in_dir;
@@ -2874,6 +2950,60 @@ fn classify_pid(pid: i32, snapshot: &ProcSnapshot) -> PidClassification {
         Some(1) => PidClassification::Orphan,
         _ => PidClassification::LiveOwned,
     }
+}
+
+/// [`classify_pid`] with a `protected` guard. When `protected`, an
+/// `Orphan` verdict (alive under launchd) is downgraded to `LiveOwned`
+/// and the process is spared. Phase 1 passes `managed` (a detached
+/// supervisor on a managed dir is the running VM, not a leak); Phase 2
+/// passes `dir_has_live_owner` (a helper of a live VM is spared, a
+/// helper of a stopped VM is a leak). Without this the startup sweep
+/// SIGTERMs the live dev VM on every `up` / `dev up` / `ls`.
+fn classify_pid_for_dir(pid: i32, protected: bool, snapshot: &ProcSnapshot) -> PidClassification {
+    match classify_pid(pid, snapshot) {
+        PidClassification::Orphan if protected => PidClassification::LiveOwned,
+        other => other,
+    }
+}
+
+/// Classify `pid` for a dir and act on the verdict: a spared live owner
+/// flips `dir_has_live_owner`; a leaked orphan is SIGTERM'd (outside
+/// `dry_run`) and counted. Shared by both reap phases so the kill/track
+/// bookkeeping has exactly one implementation.
+fn reap_or_track(
+    pid: i32,
+    protected: bool,
+    dry_run: bool,
+    snapshot: &ProcSnapshot,
+    dir_has_live_owner: &mut bool,
+    killed_in_dir: &mut u64,
+) {
+    match classify_pid_for_dir(pid, protected, snapshot) {
+        PidClassification::Dead => {}
+        PidClassification::LiveOwned => *dir_has_live_owner = true,
+        PidClassification::Orphan => {
+            if !dry_run {
+                // SAFETY: pid was just probed alive; a SIGTERM racing a
+                // natural exit returns ESRCH, which is benign.
+                unsafe {
+                    libc::kill(pid, libc::SIGTERM);
+                }
+            }
+            *killed_in_dir += 1;
+        }
+    }
+}
+
+/// Whether a sidecar PID file names the VM's *supervisor* (the VMM-host
+/// process whose liveness is the VM's liveness) rather than a dependent
+/// helper like gvproxy. The supervisor is the authoritative per-VM
+/// liveness signal that gates whether a dir's helpers are spared (live
+/// VM) or reaped as leaks (stopped VM).
+fn is_supervisor_sidecar(name: &str) -> bool {
+    matches!(
+        name,
+        "builder.pid" | "stage0.pid" | "vz.pid" | "libkrun.pid"
+    )
 }
 
 /// One-shot snapshot of the host process table, taken once per sweep.
@@ -2927,6 +3057,14 @@ impl ProcSnapshot {
                 cmds.push((pid, cmd.trim_start().to_string()));
             }
         }
+        Self { parents, cmds }
+    }
+
+    /// Build a snapshot from explicit (pid → ppid) and (pid, argv) data.
+    /// Tests use this to stage a process whose recorded parent is launchd
+    /// without actually reparenting a real process to PID 1.
+    #[cfg(test)]
+    fn from_parts(parents: std::collections::HashMap<i32, i32>, cmds: Vec<(i32, String)>) -> Self {
         Self { parents, cmds }
     }
 
@@ -4534,8 +4672,8 @@ mod reap_orphans_tests {
     fn missing_vms_root_is_empty_outcome() {
         let dir = tempfile::tempdir().expect("tempdir");
         let vms_root = dir.path().join("does-not-exist");
-        let out =
-            reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, false).expect("reap");
+        let out = reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, false, false)
+            .expect("reap");
         assert_eq!(out.killed, 0);
         assert_eq!(out.removed_dirs, 0);
         assert_eq!(out.freed_bytes, 0);
@@ -4557,8 +4695,8 @@ mod reap_orphans_tests {
         std::fs::write(vm.join("builder.pid"), "2147483646\n").expect("write pid");
         std::fs::write(vm.join("payload"), vec![0u8; 1024]).expect("write payload");
 
-        let out =
-            reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, false).expect("reap");
+        let out = reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, false, false)
+            .expect("reap");
         assert_eq!(out.killed, 0, "no live PID, so nothing to kill");
         assert_eq!(out.removed_dirs, 1, "dir should be removed");
         assert!(out.freed_bytes >= 1024, "payload size counted");
@@ -4578,8 +4716,8 @@ mod reap_orphans_tests {
         let my_pid = std::process::id() as i32;
         std::fs::write(vm.join("builder.pid"), format!("{my_pid}\n")).expect("write pid");
 
-        let out =
-            reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, false).expect("reap");
+        let out = reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, false, false)
+            .expect("reap");
         assert_eq!(out.killed, 0, "live owner should not be killed");
         assert_eq!(out.removed_dirs, 0, "dir preserved while owner alive");
         assert!(vm.exists(), "dir should still be on disk");
@@ -4604,7 +4742,7 @@ mod reap_orphans_tests {
         std::fs::write(vm.join("libkrun.pid"), "2147483646\n").expect("write pid");
         std::fs::write(vm.join("config"), vec![0u8; 512]).expect("write state");
 
-        let out = reap_orphaned_vm_helpers_at(&vms_root, WORKLOAD_SIDECARS, false, false)
+        let out = reap_orphaned_vm_helpers_at(&vms_root, WORKLOAD_SIDECARS, false, true, false)
             .expect("reap workload root");
         assert_eq!(out.killed, 0, "dead PID, nothing to kill");
         assert_eq!(out.removed_dirs, 0, "workload dir must never be removed");
@@ -4621,12 +4759,225 @@ mod reap_orphans_tests {
         std::fs::write(vm.join("builder.pid"), "2147483646\n").expect("write pid");
         std::fs::write(vm.join("payload"), vec![0u8; 256]).expect("write payload");
 
-        let out = reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, true)
+        let out = reap_orphaned_vm_helpers_at(&vms_root, BUILDER_SIDECARS, true, false, true)
             .expect("dry-run reap");
         // Dry-run still *counts* what it would do, but doesn't mutate.
         assert_eq!(out.removed_dirs, 1);
         assert!(vm.exists(), "dry-run must not remove the dir");
         assert!(vm.join("builder.pid").exists(), "pid file untouched");
+    }
+
+    /// Spawn a real, alive stand-in process whose *recorded* parent is
+    /// launchd (PID 1) — exactly how a detached persistent dev VM
+    /// supervisor or a named-workload daemon looks. Returns the child
+    /// handle (caller must reap) and a snapshot that reports it under
+    /// launchd. `pid_is_alive` reads the real process table, so the
+    /// child must be genuinely running; only the parent edge is faked.
+    fn alive_child_under_launchd() -> (std::process::Child, i32, ProcSnapshot) {
+        let child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn stand-in supervisor");
+        let pid = child.id() as i32;
+        let snapshot = ProcSnapshot::from_parts([(pid, 1)].into_iter().collect(), Vec::new());
+        (child, pid, snapshot)
+    }
+
+    /// The startup sweep must NOT signal the live persistent dev VM. Its
+    /// supervisor is detached to launchd by design, so `parent == 1` is
+    /// the steady state, not an orphan signal. Regression guard for the
+    /// bug where every `up` / `dev up` / `ls` SIGTERM'd the running dev
+    /// VM out from under the user.
+    #[test]
+    fn reap_spares_live_persistent_dev_vm_under_launchd() {
+        let (mut child, pid, snapshot) = alive_child_under_launchd();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let vms_root = dir.path().join("vms");
+        // The fixed persistent dev VM dir name (session id "dev").
+        let vm = vms_root.join("mvm-persistent-builder-vz-dev");
+        std::fs::create_dir_all(&vm).expect("mkdir");
+        std::fs::write(vm.join("builder.pid"), format!("{pid}\n")).expect("write pid");
+
+        let out = reap_orphaned_vm_helpers_at_with_snapshot(
+            &vms_root,
+            BUILDER_SIDECARS,
+            /* remove_dead_dirs = */ true,
+            /* all_dirs_managed = */ false,
+            /* dry_run = */ false,
+            &snapshot,
+        )
+        .expect("reap");
+
+        assert_eq!(
+            out.killed, 0,
+            "live dev VM supervisor must not be signalled"
+        );
+        assert_eq!(out.removed_dirs, 0, "live dev VM dir must be preserved");
+        assert!(
+            pid_is_alive(pid),
+            "live dev VM supervisor was wrongly killed"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// Sibling to the above for the workload root: a live named-VM daemon
+    /// (parent == launchd) is the running VM, not a leak — the sweep
+    /// leaves it alone.
+    #[test]
+    fn reap_spares_live_named_workload_under_launchd() {
+        let (mut child, pid, snapshot) = alive_child_under_launchd();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let vms_root = dir.path().join("vms");
+        let vm = vms_root.join("mvm-workload-livetest-3b1f-running");
+        std::fs::create_dir_all(&vm).expect("mkdir");
+        std::fs::write(vm.join("vz.pid"), format!("{pid}\n")).expect("write pid");
+
+        let out = reap_orphaned_vm_helpers_at_with_snapshot(
+            &vms_root,
+            WORKLOAD_SIDECARS,
+            /* remove_dead_dirs = */ false,
+            /* all_dirs_managed = */ true,
+            /* dry_run = */ false,
+            &snapshot,
+        )
+        .expect("reap");
+
+        assert_eq!(out.killed, 0, "live named workload must not be signalled");
+        assert!(pid_is_alive(pid), "live named workload was wrongly killed");
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// The guard is scoped to managed dirs only: an ephemeral per-job
+    /// builder scratch dir (`mvm-builder-vz-<job>`) with a live,
+    /// launchd-parented supervisor is a genuine leak from a crashed
+    /// `mvmctl` and is still SIGTERM'd. Proves the fix didn't blunt the
+    /// reaper's real job.
+    #[test]
+    fn reap_still_kills_orphaned_ephemeral_builder_under_launchd() {
+        let (mut child, pid, snapshot) = alive_child_under_launchd();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let vms_root = dir.path().join("vms");
+        let vm = vms_root.join("mvm-builder-vz-abc12345");
+        std::fs::create_dir_all(&vm).expect("mkdir");
+        std::fs::write(vm.join("builder.pid"), format!("{pid}\n")).expect("write pid");
+
+        let out = reap_orphaned_vm_helpers_at_with_snapshot(
+            &vms_root,
+            BUILDER_SIDECARS,
+            /* remove_dead_dirs = */ true,
+            /* all_dirs_managed = */ false,
+            /* dry_run = */ false,
+            &snapshot,
+        )
+        .expect("reap");
+
+        assert_eq!(out.killed, 1, "orphaned ephemeral builder must be reaped");
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// A live named workload keeps *all* its PIDs: the supervisor
+    /// (`vz.pid`) is alive, so its gvproxy helper (`host-gvproxy.pid`,
+    /// also launchd-parented) is spared too. Pins that the helper phase
+    /// follows the supervisor's liveness, not the helper's own parent.
+    #[test]
+    fn reap_spares_gvproxy_of_live_workload() {
+        let mut sup = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn stand-in supervisor");
+        let sup_pid = sup.id() as i32;
+        let mut gv = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn stand-in gvproxy");
+        let gv_pid = gv.id() as i32;
+        // Both detached under launchd, as a running daemon's helpers are.
+        let snapshot = ProcSnapshot::from_parts(
+            [(sup_pid, 1), (gv_pid, 1)].into_iter().collect(),
+            Vec::new(),
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let vms_root = dir.path().join("vms");
+        let vm = vms_root.join("mvm-workload-livegv-9c2a-running");
+        std::fs::create_dir_all(&vm).expect("mkdir");
+        std::fs::write(vm.join("vz.pid"), format!("{sup_pid}\n")).expect("write sup pid");
+        std::fs::write(vm.join("host-gvproxy.pid"), format!("{gv_pid}\n")).expect("write gv pid");
+
+        let out = reap_orphaned_vm_helpers_at_with_snapshot(
+            &vms_root,
+            WORKLOAD_SIDECARS,
+            /* remove_dead_dirs = */ false,
+            /* all_dirs_managed = */ true,
+            /* dry_run = */ false,
+            &snapshot,
+        )
+        .expect("reap");
+
+        assert_eq!(
+            out.killed, 0,
+            "live VM's supervisor and gvproxy both spared"
+        );
+        assert!(
+            pid_is_alive(gv_pid),
+            "gvproxy of a live VM was wrongly killed"
+        );
+
+        let _ = sup.kill();
+        let _ = sup.wait();
+        let _ = gv.kill();
+        let _ = gv.wait();
+    }
+
+    /// The refinement the supervisor-liveness gate buys: once the
+    /// supervisor is gone the VM is down, so a still-running
+    /// launchd-parented gvproxy is a genuine leak and IS reaped — even on
+    /// the managed workload root. A blanket "managed → spare everything"
+    /// rule would miss this.
+    #[test]
+    fn reap_kills_leaked_gvproxy_of_dead_workload() {
+        // Only the gvproxy is alive; the supervisor PID is long dead.
+        let mut gv = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn stand-in gvproxy");
+        let gv_pid = gv.id() as i32;
+        let dead_sup = i32::MAX; // guaranteed not alive → VM is down
+        let snapshot = ProcSnapshot::from_parts([(gv_pid, 1)].into_iter().collect(), Vec::new());
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let vms_root = dir.path().join("vms");
+        let vm = vms_root.join("mvm-workload-deadgv-4e7b-stopped");
+        std::fs::create_dir_all(&vm).expect("mkdir");
+        std::fs::write(vm.join("vz.pid"), format!("{dead_sup}\n")).expect("write dead sup pid");
+        std::fs::write(vm.join("host-gvproxy.pid"), format!("{gv_pid}\n")).expect("write gv pid");
+
+        let out = reap_orphaned_vm_helpers_at_with_snapshot(
+            &vms_root,
+            WORKLOAD_SIDECARS,
+            /* remove_dead_dirs = */ false,
+            /* all_dirs_managed = */ true,
+            /* dry_run = */ false,
+            &snapshot,
+        )
+        .expect("reap");
+
+        assert_eq!(
+            out.killed, 1,
+            "leaked gvproxy of a stopped VM must be reaped"
+        );
+
+        let _ = gv.kill();
+        let _ = gv.wait();
     }
 }
 
@@ -5063,9 +5414,14 @@ mod builder_vm_bootstrap_tests {
         // live owner and is eligible for removal.
         std::fs::write(vz_dir.join("builder.pid"), format!("{}\n", i32::MAX)).unwrap();
 
-        let outcome =
-            reap_orphaned_vm_helpers_at(vms, BUILDER_SIDECARS, true, /* dry_run = */ false)
-                .expect("reap should succeed");
+        let outcome = reap_orphaned_vm_helpers_at(
+            vms,
+            BUILDER_SIDECARS,
+            true,
+            /* all_dirs_managed = */ false,
+            /* dry_run = */ false,
+        )
+        .expect("reap should succeed");
 
         assert_eq!(
             outcome.removed_dirs, 1,

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -254,12 +254,17 @@ pub(super) fn admit_plan_for_boot(
     }
     let sha = match p.precomputed_image_sha256 {
         Some(sha) => sha,
-        None => mvm_core::crypto::image_verify::sha256_file(p.rootfs_path).with_context(|| {
-            format!(
-                "hashing rootfs at {} for plan admission",
-                p.rootfs_path.display()
-            )
-        })?,
+        // Cached on a `<rootfs>.sha256cache` sidecar keyed on size+mtime: the
+        // rootfs is immutable across boots of the same image, so re-hashing
+        // ~100MB every `up` is the single biggest cost left on the boot path.
+        None => mvm_core::crypto::image_verify::sha256_file_cached(p.rootfs_path).with_context(
+            || {
+                format!(
+                    "hashing rootfs at {} for plan admission",
+                    p.rootfs_path.display()
+                )
+            },
+        )?,
     };
 
     // Claim 9 — bundle pin (when supplied).

--- a/crates/mvm-core/src/crypto/image_verify.rs
+++ b/crates/mvm-core/src/crypto/image_verify.rs
@@ -382,12 +382,117 @@ pub fn sha256_file(path: &Path) -> io::Result<String> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
+/// SHA-256 of a file, cached in a `<path>.sha256cache` sidecar keyed on the
+/// file's size + mtime. Returns the cached digest when the sidecar matches the
+/// file's current size/mtime; otherwise hashes the file, writes the sidecar
+/// (best-effort), and returns the fresh digest.
+///
+/// Admission re-hashes the rootfs on every boot to bind the plan's image
+/// digest (claim 8). For an immutable cached image that hundreds-of-MB hash is
+/// identical every time, and re-reading it each boot dominates `up`. Keying on
+/// size+mtime keeps the cache sound: any rewrite of the file (different
+/// content) moves its mtime and forces a re-hash, so a stale digest can never
+/// be admitted. A read-only cache dir simply means the next boot re-hashes.
+pub fn sha256_file_cached(path: &Path) -> io::Result<String> {
+    let meta = fs::metadata(path)?;
+    let size = meta.len();
+    let mtime_nanos = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos());
+
+    let sidecar = sha256_sidecar_path(path);
+    if let Some(mtime) = mtime_nanos
+        && let Ok(contents) = fs::read_to_string(&sidecar)
+        && let Some(hex) = parse_sha256_sidecar(&contents, size, mtime)
+    {
+        return Ok(hex);
+    }
+
+    let hex = sha256_file(path)?;
+    if let Some(mtime) = mtime_nanos {
+        let _ = write_sha256_sidecar(&sidecar, &hex, size, mtime);
+    }
+    Ok(hex)
+}
+
+fn sha256_sidecar_path(path: &Path) -> std::path::PathBuf {
+    let mut s = path.as_os_str().to_os_string();
+    s.push(".sha256cache");
+    std::path::PathBuf::from(s)
+}
+
+/// Parse a `"<hex> <size> <mtime_nanos>"` sidecar, returning the digest only
+/// when its size+mtime still match the file being hashed.
+fn parse_sha256_sidecar(contents: &str, size: u64, mtime_nanos: u128) -> Option<String> {
+    let mut it = contents.split_whitespace();
+    let hex = it.next()?;
+    let cached_size: u64 = it.next()?.parse().ok()?;
+    let cached_mtime: u128 = it.next()?.parse().ok()?;
+    (cached_size == size && cached_mtime == mtime_nanos && hex.len() == 64).then(|| hex.to_string())
+}
+
+/// Write the sidecar atomically (temp + rename) so a concurrent boot never
+/// reads a torn line. Best-effort; the caller ignores failure.
+fn write_sha256_sidecar(sidecar: &Path, hex: &str, size: u64, mtime_nanos: u128) -> io::Result<()> {
+    let mut tmp_os = sidecar.as_os_str().to_os_string();
+    tmp_os.push(format!(".{}.tmp", std::process::id()));
+    let tmp = std::path::PathBuf::from(tmp_os);
+    fs::write(&tmp, format!("{hex} {size} {mtime_nanos}\n"))?;
+    fs::rename(&tmp, sidecar)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::TimeZone;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn sha256_file_cached_matches_uncached_and_invalidates_on_change() {
+        let mut f = NamedTempFile::new().expect("tempfile");
+        f.write_all(b"hello").expect("write");
+        f.flush().expect("flush");
+        let p = f.path().to_path_buf();
+        let sidecar = sha256_sidecar_path(&p);
+
+        let direct = sha256_file(&p).expect("direct hash");
+        // First cached call computes + writes the sidecar.
+        assert_eq!(sha256_file_cached(&p).expect("cached1"), direct);
+        assert!(sidecar.exists(), "sidecar written");
+        // Second call serves from the sidecar (same digest).
+        assert_eq!(sha256_file_cached(&p).expect("cached2"), direct);
+
+        // Mutating the file (size + mtime change) invalidates the cache.
+        f.write_all(b" world").expect("append");
+        f.flush().expect("flush");
+        let direct2 = sha256_file(&p).expect("direct hash 2");
+        assert_ne!(direct2, direct, "content changed");
+        assert_eq!(
+            sha256_file_cached(&p).expect("cached3"),
+            direct2,
+            "stale digest must never be served after a content change"
+        );
+
+        let _ = fs::remove_file(&sidecar);
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_rejects_size_or_mtime_drift() {
+        let hex = "a".repeat(64);
+        let line = format!("{hex} 100 200");
+        assert_eq!(parse_sha256_sidecar(&line, 100, 200), Some(hex.clone()));
+        assert_eq!(parse_sha256_sidecar(&line, 101, 200), None, "size drift");
+        assert_eq!(parse_sha256_sidecar(&line, 100, 201), None, "mtime drift");
+        assert_eq!(parse_sha256_sidecar("garbage", 100, 200), None);
+        assert_eq!(
+            parse_sha256_sidecar("short 100 200", 100, 200),
+            None,
+            "non-64-char digest rejected"
+        );
+    }
 
     fn sample_manifest() -> SignedManifest {
         SignedManifest {

--- a/crates/mvm-vm-host/src/bin/mvm-vz-supervisor.rs
+++ b/crates/mvm-vm-host/src/bin/mvm-vz-supervisor.rs
@@ -172,21 +172,48 @@ fn main() -> anyhow::Result<()> {
             tokio::spawn(async move { s.wait().await })
         };
 
-        // Race the guest's terminal transition against a stop signal. A signal
-        // requests a graceful shutdown and keeps waiting — the guest still
-        // drives the exit code via the delegate.
-        let code = loop {
-            tokio::select! {
-                joined = &mut waiter => {
-                    break joined.context("supervisor wait task panicked")??;
+        // Race the guest's own terminal transition against a stop signal. On a
+        // signal we ask for a graceful ACPI stop, then escalate to a forced
+        // stop if the guest doesn't honor it within a short grace. Without the
+        // escalation a guest that ignores ACPI (e.g. a minimal headless image
+        // with no power-button handler) leaves `wait()` — and the caller's
+        // `down` — hanging until an external SIGKILL.
+        use std::time::Duration;
+        // Ceiling on the graceful ACPI window before we force-stop. A guest
+        // that honors ACPI returns the instant it stops (this is a ceiling,
+        // not a floor); a headless image with no power-button handler never
+        // moves, so keep it short so `down` stays well under a second. Tunable.
+        const STOP_GRACE: Duration = Duration::from_millis(250);
+        let code = tokio::select! {
+            joined = &mut waiter => joined.context("supervisor wait task panicked")??,
+            _ = async {
+                tokio::select! {
+                    _ = sigterm.recv() => {}
+                    _ = sigint.recv() => {}
                 }
-                _ = sigterm.recv() => {
-                    tracing::info!("SIGTERM received — requesting graceful guest stop");
-                    let _ = supervisor.request_stop().await;
-                }
-                _ = sigint.recv() => {
-                    tracing::info!("SIGINT received — requesting graceful guest stop");
-                    let _ = supervisor.request_stop().await;
+            } => {
+                tracing::info!("stop signal received — requesting graceful guest stop");
+                let _ = supervisor.request_stop().await;
+                match tokio::time::timeout(STOP_GRACE, &mut waiter).await {
+                    Ok(joined) => joined.context("supervisor wait task panicked")??,
+                    Err(_) => {
+                        tracing::info!(
+                            "guest did not honor ACPI stop within {STOP_GRACE:?} — forcing stop"
+                        );
+                        // A forced stop fires no `guestDidStop` delegate
+                        // callback, so `waiter` would hang here — the
+                        // `stopWithCompletionHandler` completion returning IS
+                        // the "stopped" signal. Bound it so a wedged framework
+                        // can't hold the process open; the subsequent
+                        // `shutdown()` + process exit tears the VM down anyway.
+                        if let Err(e) =
+                            tokio::time::timeout(Duration::from_millis(500), supervisor.force_stop())
+                                .await
+                        {
+                            tracing::warn!(error = %e, "forced stop did not complete in time");
+                        }
+                        0
+                    }
                 }
             }
         };

--- a/crates/mvm-vm-host/src/vz_objc.rs
+++ b/crates/mvm-vm-host/src/vz_objc.rs
@@ -1157,6 +1157,33 @@ impl VzSupervisor {
             .await?
     }
 
+    /// Force an immediate guest stop — the framework's hard stop, akin to
+    /// cutting power. Escalation for when a graceful [`request_stop`] ACPI
+    /// request goes unanswered, so a guest that ignores ACPI doesn't leave
+    /// `wait()` (and the caller's `down`) hanging until an external SIGKILL.
+    /// Guarded on `canStop`: a VM already transitioning to a terminal state
+    /// can't be stopped again, so we resolve cleanly rather than message it.
+    ///
+    /// [`request_stop`]: Self::request_stop
+    pub async fn force_stop(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        let handle = Arc::clone(&self.handle);
+        self.queue
+            .dispatch(move || {
+                // SAFETY: `canStop` + `stopWithCompletionHandler` are
+                // queue-bound; the dispatch runs this on the VM's own queue.
+                if unsafe { handle.vm.canStop() } {
+                    let block = completion_block(tx);
+                    unsafe { handle.vm.stopWithCompletionHandler(&block) };
+                } else {
+                    let _ = tx.send(Ok(()));
+                }
+            })
+            .await?;
+        rx.await
+            .map_err(|_| anyhow!("stop completion handler was never called"))?
+    }
+
     /// Block until the guest reaches a terminal state. Returns the captured
     /// one-shot workload exit code if the guest reported one over the exit port
     /// (the guest acks that report before powering off, so it is durably set by


### PR DESCRIPTION
On a warm Vz (macOS Apple Silicon) machine, `mvmctl up` and `down` each sat above a second. Profiling showed both were dominated by avoidable work, not real VM cost. After this change both are **~0.5s**, measured over repeated clean cycles.

| | before | after |
|---|---|---|
| `up` (warm) | 6.6 s | **~0.55 s** |
| `down` | 2.3 s (always SIGKILL) | **~0.45 s**, clean stop |

## `up`
1. **Orphan-helper sweep.** `sweep_orphaned_vm_helpers_on_startup()` ran on every `up` and, for each VM dir under `~/.cache/mvm/builder-vm/vms/` *and* `~/.mvm/vms/`, spawned `pgrep -f <basename>` (a full-argv scan, ~55ms each here) plus a `ps` per candidate pid. With ~120 cached builder scratch dirs that was ~6.5s of serial subprocess spawns. Replaced with a single `ps -axww` snapshot, matched/looked-up in-process. Aliveness stays the exact `kill(0)` syscall, so classification semantics are unchanged.
2. **Rootfs re-hash.** Admission hashed the rootfs every boot to bind the plan's `image_sha256` (claim 8) — ~535ms on the ~230MB default image. New `sha256_file_cached()` caches the digest in a `<rootfs>.sha256cache` sidecar keyed on **size + mtime**; any content change moves the mtime and forces a re-hash, so a stale digest can never be admitted. Benefits every admit path (default image, Nix builds, snapshot restores).

## `down`
The supervisor requested a graceful ACPI stop and waited indefinitely; the minimal headless guest never honors ACPI, so the host fell back to SIGKILL after its 2s grace **every time**. Now the supervisor owns the escalation: new `force_stop()` (`stopWithCompletionHandler`) fires after a short graceful window, then the process exits cleanly — the host sees the exit and never SIGKILLs. Graceful window trimmed to 250ms (a guest that *does* honor ACPI still returns the instant it stops — it's a ceiling, not a floor), host stop-detection poll tightened 100ms → 25ms.

## Also: `up --console`
Boots the default image and drops straight into the PTY-over-vsock console (`docker run -it` style), reusing the exact `console_interactive` path as `mvmctl console`. Forces the **dev** image since a sealed prod image ships no console agent (claim 15); conflicts with `--detach`/`--up-json`/`--wait`/`--forward`.

## Residual floor (~0.3s, not chased)
mvmctl process startup + real VZ supervisor spawn/teardown. A `--release` build would trim startup further.

## Tests
- New: digest-cache correctness + **invalidation on content change**, sidecar-parse drift.
- All 10 reap-orphan tests pass against the snapshot rewrite; 209 relevant `mvm-core`/`mvm-cli` tests green (incl. e2e + core_demo smoke). fmt + clippy clean across all 6 files.

## Coordination note
The supervisor-side changes (`force_stop`, escalation loop, `STOP_GRACE`) touch the same Vz surface as #858 (vz closeout) and the plan-152 hardening line — worth a rebase/merge-order check against those.

---

## Follow-up fix: the startup sweep was reaping the *live* dev/builder VM

Validating the sweep rewrite above surfaced a pre-existing bug it shares a code path with: the sweep was killing the running VM it's meant to leave alone. `classify_pid` treated *any* alive helper parented to launchd as an orphan and SIGTERM'd it — but the persistent dev builder (`mvm-persistent-builder-vz-dev`) and named workloads are detached under launchd **by design** so they outlive the spawning CLI. So every `up` / `dev up` / `ls` SIGTERM'd the live dev VM; the signal hit a headless guest with no host-side SIGKILL escalation, so the guest never stopped and the next invocation just re-signalled it (the repeating `SIGTERM received` lines).

Fix (`d49eb482`): gate reaping on the **supervisor's liveness**, not its parent. A microVM is several processes (supervisor + gvproxy + console tailer) and the supervisor is the authoritative liveness signal, so the sweep now runs two phases per dir:

- **Supervisor phase** — an alive supervisor on a *managed* dir (persistent builder, or any named workload) is the running VM → spared; on an *ephemeral* per-job builder dir an alive launchd-parented supervisor is a build whose `mvmctl` crashed → reaped.
- **Helper phase** — a helper's fate follows its supervisor: a live VM keeps all its PIDs, while a stopped VM's leaked gvproxy is still reaped (the liveness gate, not a blanket "managed → spare everything").

New reaper tests cover the live dev VM, live named workload, live gvproxy, the leaked-gvproxy-of-a-stopped-VM case, and the still-reaped ephemeral orphan — each teeth-checked by reverting the guard. fmt + clippy `--all-targets -D warnings` clean.


**Related guard (`d536c3c9`):** the same managed/ephemeral distinction also fixes a pre-existing `cache prune` footgun — the dead-dir removal path matched the persistent dev builder dir when its supervisor was stopped, deleting the warm Nix store and forcing a full nixpkgs re-fetch on the next `dev up`. Managed dirs (persistent builder + named workloads) are now never auto-removed; only ephemeral per-job scratch dirs are reclaimable. Tests cover both sides.
