### PR TITLE
feat(plan-205): Workstream A — machine-checked trust-gradient invariant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Conformance claim catalog
         run: cargo run -p xtask -- check-claim-catalog
 
+      - name: Trust-gradient ledger
+        run: cargo run -p xtask -- check-trust-gradient
+
       - name: host-binaries manifest parity
         run: cargo run -p xtask -- check-mvm-host-binaries-sync
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -130,6 +130,33 @@ jobs:
       - name: Build prod agent and assert no console symbols
         run: ./scripts/check-prod-agent-no-console.sh
 
+  # ── Lane 1c: No host-authority symbols in a sealed prod agent ─────
+  # The workload agent is the untrusted edge: it must not carry
+  # host-side signing-key loading or plan-admission code. Asserts
+  # load_host_signing_key / host_signer / admit_for_run are ABSENT
+  # (with a handle_run_entrypoint canary against a stripped table).
+  prod-agent-no-authority:
+    name: prod agent carries no host-authority symbols
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-prodagent-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-prodagent-
+
+      - name: No host-signer / admission symbols in the production agent
+        run: ./scripts/check-prod-agent-no-authority.sh
+
   # ── Lane 2b: Seccomp tier functional denial (ADR-002 §W2.4) ───────
   # Tier-structure unit tests in `mvm-security` cover cumulative-subset
   # and serde shapes; they don't exercise the BPF program at runtime.

--- a/crates/mvm-hostd/tests/per_tenant_isolation.rs
+++ b/crates/mvm-hostd/tests/per_tenant_isolation.rs
@@ -9,6 +9,7 @@ use mvm_core::protocol::broker_control::RegisterVm;
 use mvm_core::util::test_env::TestEnv;
 use mvm_hostd::audit::host_keypair;
 use mvm_hostd::audit_signer::verify::verify_workload_chain;
+use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 
@@ -112,6 +113,14 @@ impl Drop for TenantHandle {
     }
 }
 
+/// Owns the shared environment and temp dir so they outlive both tenants' Drop.
+struct Harness {
+    _env: TestEnv,
+    _data_dir: TempDir,
+    a: TenantHandle,
+    b: TenantHandle,
+}
+
 /// Start a host-agent daemon for one tenant and register one VM.
 ///
 /// The env vars (MVM_DATA_DIR etc.) must already be set by the caller before
@@ -150,8 +159,7 @@ async fn start_tenant(id: &str) -> TenantHandle {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn per_tenant_daemon_paths_are_isolated() {
+async fn build_harness() -> Harness {
     let mut env = TestEnv::new();
     let data_dir = tempfile::tempdir().expect("data dir");
     env.set("MVM_DATA_DIR", data_dir.path());
@@ -161,10 +169,29 @@ async fn per_tenant_daemon_paths_are_isolated() {
     let a = start_tenant("tenant-a").await;
     let b = start_tenant("tenant-b").await;
 
-    // Each tenant has its own control socket, worker pid file, and workload chain.
+    Harness {
+        _env: env,
+        _data_dir: data_dir,
+        a,
+        b,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn per_tenant_daemon_paths_are_isolated() {
+    let harness = build_harness().await;
+    let a = &harness.a;
+    let b = &harness.b;
+
+    // Each tenant has its own control socket, worker pid file, broker socket,
+    // and workload chain.
     assert_ne!(
         a.control_socket, b.control_socket,
         "control sockets must differ"
+    );
+    assert_ne!(
+        a.broker_socket, b.broker_socket,
+        "broker sockets must differ"
     );
     assert_ne!(a.chain, b.chain, "workload chains must differ");
     assert_ne!(
@@ -179,7 +206,7 @@ async fn per_tenant_daemon_paths_are_isolated() {
     assert!(pid_b.is_some(), "tenant-b worker must be running");
     assert_ne!(pid_a, pid_b, "worker PIDs must differ");
 
-    // An emit to A's broker lands in A's chain; B's chain stays untouched.
+    // An emit to A's broker lands in A's chain; B's chain must not be created.
     let resp = wait_for_emit(&a.broker_socket, "a-only").await;
     assert!(
         matches!(resp, ServiceResponse::Ok { .. }),
@@ -193,13 +220,10 @@ async fn per_tenant_daemon_paths_are_isolated() {
     let a_entries = verify_workload_chain(&a.chain, &verifying_key).expect("A chain verifies");
     assert_eq!(a_entries, 1, "A chain must have exactly one entry");
 
-    // B's chain either does not exist yet or is empty — A's emit must not
-    // cross the tenant boundary.
-    if b.chain.exists() {
-        let b_entries =
-            verify_workload_chain(&b.chain, &verifying_key).expect("B chain verifies (if present)");
-        assert_eq!(b_entries, 0, "B chain must not receive A's emit");
-    }
+    // B's chain is opened at registration time, not at emit time.  The
+    // isolation guarantee is that A's emit writes zero entries to B's chain.
+    let b_entries = verify_workload_chain(&b.chain, &verifying_key).expect("B chain verifies");
+    assert_eq!(b_entries, 0, "B chain must not receive A's emit");
 
     deregister_vm(&a.control_socket, &a.key_bytes, &a.vm).expect("deregister tenant-a vm");
     deregister_vm(&b.control_socket, &b.key_bytes, &b.vm).expect("deregister tenant-b vm");

--- a/crates/mvm-hostd/tests/per_tenant_isolation.rs
+++ b/crates/mvm-hostd/tests/per_tenant_isolation.rs
@@ -1,0 +1,206 @@
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use mvm_backend::{deregister_vm, ensure_host_agent_daemon, load_host_signing_key, register_vm};
+use mvm_core::config;
+use mvm_core::protocol::broker::{CorrelationId, ServiceCall, ServiceId, ServiceResponse};
+use mvm_core::protocol::broker_control::RegisterVm;
+use mvm_core::util::test_env::TestEnv;
+use mvm_hostd::audit::host_keypair;
+use mvm_hostd::audit_signer::verify::verify_workload_chain;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+const HOST_AGENT_BIN: &str = env!("CARGO_BIN_EXE_mvm-host-agent");
+const SIGNER_HELPER_BIN: &str = env!("CARGO_BIN_EXE_mvm-signer-helper");
+
+fn read_pid(path: &Path) -> Option<libc::pid_t> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+fn kill_process_group(pid: libc::pid_t) {
+    unsafe {
+        libc::kill(-pid, libc::SIGKILL);
+    }
+}
+
+fn kill_pid(pid: libc::pid_t) {
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+    }
+}
+
+async fn write_frame(stream: &mut UnixStream, value: &impl serde::Serialize) -> Result<()> {
+    let body = serde_json::to_vec(value).context("encode frame")?;
+    stream
+        .write_all(&(body.len() as u32).to_be_bytes())
+        .await
+        .context("write frame len")?;
+    stream.write_all(&body).await.context("write frame body")?;
+    stream.flush().await.context("flush frame")?;
+    Ok(())
+}
+
+async fn read_frame<T: serde::de::DeserializeOwned>(stream: &mut UnixStream) -> Result<T> {
+    let mut len = [0u8; 4];
+    stream
+        .read_exact(&mut len)
+        .await
+        .context("read frame len")?;
+    let n = u32::from_be_bytes(len) as usize;
+    let mut body = vec![0u8; n];
+    stream
+        .read_exact(&mut body)
+        .await
+        .context("read frame body")?;
+    serde_json::from_slice(&body).context("decode frame")
+}
+
+async fn emit_audit(sock: &Path, event: &str) -> Result<ServiceResponse> {
+    let mut conn = UnixStream::connect(sock)
+        .await
+        .with_context(|| format!("connect broker socket {}", sock.display()))?;
+    let call = ServiceCall {
+        service: ServiceId::parse("host.audit.v1").expect("service id"),
+        verb: "emit".into(),
+        correlation_id: CorrelationId::new("guest-supplied-ignored"),
+        payload: serde_json::json!({
+            "ts": "2026-06-19T00:00:00Z",
+            "fields": {"event": event},
+        }),
+    };
+    write_frame(&mut conn, &call).await?;
+    read_frame(&mut conn).await
+}
+
+async fn wait_for_emit(sock: &Path, event: &str) -> ServiceResponse {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut last_error = None;
+    while Instant::now() < deadline {
+        match emit_audit(sock, event).await {
+            Ok(resp) => return resp,
+            Err(e) => last_error = Some(e),
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!(
+        "broker at {} did not become ready before deadline: {:#}",
+        sock.display(),
+        last_error.expect("at least one attempt")
+    );
+}
+
+struct TenantHandle {
+    vm: String,
+    control_socket: PathBuf,
+    broker_socket: PathBuf,
+    chain: PathBuf,
+    worker_pid_path: PathBuf,
+    daemon_pid_path: PathBuf,
+    key_bytes: [u8; 32],
+}
+
+impl Drop for TenantHandle {
+    fn drop(&mut self) {
+        if let Some(pid) = read_pid(&self.worker_pid_path) {
+            kill_process_group(pid);
+        }
+        if let Some(pid) = read_pid(&self.daemon_pid_path) {
+            kill_pid(pid);
+        }
+    }
+}
+
+/// Start a host-agent daemon for one tenant and register one VM.
+///
+/// The env vars (MVM_DATA_DIR etc.) must already be set by the caller before
+/// this runs.
+async fn start_tenant(id: &str) -> TenantHandle {
+    let keys_dir = config::mvm_keys_dir();
+    host_keypair::load_or_init_at(&keys_dir).expect("host signer");
+    let key_bytes = load_host_signing_key().expect("host signing key bytes");
+    let vm = format!("{id}-vm-1");
+    let control_socket = ensure_host_agent_daemon(id).expect("start host-agent");
+    let broker_socket = config::host_agent_dir(id).join("broker.sock");
+    let chain = config::workload_audit_path(id, &vm);
+    let worker_pid_path = config::host_agent_worker_pid(id);
+    let daemon_pid_path = config::host_agent_dir(id).join("daemon.pid");
+
+    let reg = RegisterVm {
+        vm_id: vm.clone(),
+        workload_id: Some(format!("wl-{vm}")),
+        tenant_id: id.to_string(),
+        broker_listen_socket: broker_socket.clone(),
+        workload_chain_path: chain.clone(),
+        workload_chain_head_path: Some(config::host_agent_dir(id).join("signer.head")),
+        audit_signer_uds_path: None,
+        services_bindings: vec![],
+    };
+    register_vm(&control_socket, &key_bytes, reg).expect("register vm");
+
+    TenantHandle {
+        vm,
+        control_socket,
+        broker_socket,
+        chain,
+        worker_pid_path,
+        daemon_pid_path,
+        key_bytes,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn per_tenant_daemon_paths_are_isolated() {
+    let mut env = TestEnv::new();
+    let data_dir = tempfile::tempdir().expect("data dir");
+    env.set("MVM_DATA_DIR", data_dir.path());
+    env.set("MVM_HOST_AGENT_PATH", HOST_AGENT_BIN);
+    env.set("MVM_SIGNER_HELPER_PATH", SIGNER_HELPER_BIN);
+
+    let a = start_tenant("tenant-a").await;
+    let b = start_tenant("tenant-b").await;
+
+    // Each tenant has its own control socket, worker pid file, and workload chain.
+    assert_ne!(
+        a.control_socket, b.control_socket,
+        "control sockets must differ"
+    );
+    assert_ne!(a.chain, b.chain, "workload chains must differ");
+    assert_ne!(
+        a.worker_pid_path, b.worker_pid_path,
+        "worker pid files must differ"
+    );
+
+    // Both workers are live and have distinct PIDs.
+    let pid_a = read_pid(&a.worker_pid_path);
+    let pid_b = read_pid(&b.worker_pid_path);
+    assert!(pid_a.is_some(), "tenant-a worker must be running");
+    assert!(pid_b.is_some(), "tenant-b worker must be running");
+    assert_ne!(pid_a, pid_b, "worker PIDs must differ");
+
+    // An emit to A's broker lands in A's chain; B's chain stays untouched.
+    let resp = wait_for_emit(&a.broker_socket, "a-only").await;
+    assert!(
+        matches!(resp, ServiceResponse::Ok { .. }),
+        "A broker emit must succeed"
+    );
+
+    let verifying_key = host_keypair::load_or_init_at(&config::mvm_keys_dir())
+        .expect("host signer")
+        .verifying;
+
+    let a_entries = verify_workload_chain(&a.chain, &verifying_key).expect("A chain verifies");
+    assert_eq!(a_entries, 1, "A chain must have exactly one entry");
+
+    // B's chain either does not exist yet or is empty — A's emit must not
+    // cross the tenant boundary.
+    if b.chain.exists() {
+        let b_entries =
+            verify_workload_chain(&b.chain, &verifying_key).expect("B chain verifies (if present)");
+        assert_eq!(b_entries, 0, "B chain must not receive A's emit");
+    }
+
+    deregister_vm(&a.control_socket, &a.key_bytes, &a.vm).expect("deregister tenant-a vm");
+    deregister_vm(&b.control_socket, &b.key_bytes, &b.vm).expect("deregister tenant-b vm");
+}

--- a/scripts/check-prod-agent-no-authority.sh
+++ b/scripts/check-prod-agent-no-authority.sh
@@ -31,9 +31,9 @@ else
 fi
 
 for sym in load_host_signing_key host_signer admit_for_run; do
-  if grep -qE "mvm_(guest_agent|core|hostd).*${sym}" <<<"$prod_syms"; then
+  if grep -qE "mvm_(guest_agent|core|hostd|backend|cli).*${sym}" <<<"$prod_syms"; then
     echo "::error::host authority symbol \`${sym}\` is PRESENT in the production agent." >&2
-    grep -E "mvm_(guest_agent|core|hostd).*${sym}" <<<"$prod_syms" >&2 || true
+    grep -E "mvm_(guest_agent|core|hostd|backend|cli).*${sym}" <<<"$prod_syms" >&2 || true
     fail=1
   else
     echo "ok: ${sym} absent from the production agent"

--- a/scripts/check-prod-agent-no-authority.sh
+++ b/scripts/check-prod-agent-no-authority.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Production guest-agent authority contract.
+#
+# On the `mvm-guest-agent` binary built in its PRODUCTION configuration (no
+# `dev-shell` feature), assert the workload agent links NONE of the host-only
+# authority symbols. The workload microVM is the untrusted edge: it must not
+# carry signing-key loading or plan-admission code, which live host-side.
+#
+#   canary: `handle_run_entrypoint` PRESENT — proves the symbol table is
+#           populated, so the absence checks below are not vacuously true.
+#   absent: `load_host_signing_key`, `host_signer`, `admit_for_run` — host-side
+#           authority. None may appear in the agent's own crate symbols.
+set -euo pipefail
+
+PKG=mvm-guest
+BIN=mvm-guest-agent
+
+echo "::group::Build production agent (release, no dev-shell)"
+CARGO_PROFILE_RELEASE_STRIP=false \
+  cargo build --release --locked -p "$PKG" --bin "$BIN" --no-default-features
+echo "::endgroup::"
+prod_syms=$(nm "target/release/$BIN")
+
+fail=0
+
+if grep -q 'mvm_guest_agent.*handle_run_entrypoint' <<<"$prod_syms"; then
+  echo "ok: handle_run_entrypoint present (symbol table populated)"
+else
+  echo "::error::handle_run_entrypoint ABSENT — symbol table stripped; absence checks would be vacuous." >&2
+  fail=1
+fi
+
+for sym in load_host_signing_key host_signer admit_for_run; do
+  if grep -qE "mvm_(guest_agent|core|hostd).*${sym}" <<<"$prod_syms"; then
+    echo "::error::host authority symbol \`${sym}\` is PRESENT in the production agent." >&2
+    grep -E "mvm_(guest_agent|core|hostd).*${sym}" <<<"$prod_syms" >&2 || true
+    fail=1
+  else
+    echo "ok: ${sym} absent from the production agent"
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "::error::Production guest-agent authority contract FAILED — see annotations above." >&2
+  exit 1
+fi
+echo "All assertions passed: prod agent carries no host-authority symbols."

--- a/specs/claims/trust-gradient.md
+++ b/specs/claims/trust-gradient.md
@@ -1,3 +1,10 @@
+---
+claim: trust-gradient
+status: Shipped
+gated_phrases: []
+exempt_paths: []
+---
+
 # Trust gradient ledger
 
 Machine-checked by `xtask check-trust-gradient`. Authority and resident weight

--- a/specs/claims/trust-gradient.md
+++ b/specs/claims/trust-gradient.md
@@ -1,0 +1,12 @@
+# Trust gradient ledger
+
+Machine-checked by `xtask check-trust-gradient`. Authority and resident weight
+decrease monotonically host → builder → workload. No daemon may hold authority
+below its tier; `signing-key`, `plan-admission`, and `audit-writer` never exist
+below the host. The builder row is added once the resident builder daemon binary
+exists.
+
+| Tier | Layer | Daemon | Forbidden authorities | Witnesses |
+| --- | --- | --- | --- | --- |
+| 2 | host | control-daemon | (none — holds all authority) | fn:per_tenant_daemon_paths_are_isolated |
+| 0 | workload | guest-agent | signing-key, plan-admission, audit-writer, do-exec, console | ci:prod-agent-no-authority, ci:prod-agent-runentry-contract, ci:prod-agent-no-console |

--- a/xtask/src/check_trust_gradient.rs
+++ b/xtask/src/check_trust_gradient.rs
@@ -1,0 +1,202 @@
+//! `xtask check-trust-gradient`
+//!
+//! Asserts the trust-gradient ledger stays true: tier ranks strictly decrease
+//! down the layers, the workload row forbids the host-only authorities, and
+//! every named witness still exists in the tree.
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+
+const REQUIRED_WORKLOAD_FORBIDDEN: [&str; 3] = ["signing-key", "plan-admission", "audit-writer"];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let path = workspace
+        .join("specs")
+        .join("claims")
+        .join("trust-gradient.md");
+    let source =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let rows = parse_rows(&source).with_context(|| format!("parsing {}", path.display()))?;
+
+    let mut errors: Vec<String> = Vec::new();
+    structural_checks(&rows, &mut errors);
+
+    for row in &rows {
+        for token in &row.witnesses {
+            if !witness_exists(workspace, token)? {
+                errors.push(format!(
+                    "{}: witness `{token}` not found in the tree",
+                    row.layer
+                ));
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        for e in &errors {
+            eprintln!("[error] {e}");
+        }
+        bail!(
+            "check-trust-gradient: {} problem(s) in specs/claims/trust-gradient.md",
+            errors.len()
+        );
+    }
+    eprintln!("check-trust-gradient: clean ({} rows)", rows.len());
+    Ok(())
+}
+
+pub(crate) struct Row {
+    tier: i64,
+    layer: String,
+    forbidden: Vec<String>,
+    witnesses: Vec<String>,
+}
+
+pub(crate) fn parse_rows(md: &str) -> Result<Vec<Row>> {
+    let mut rows = Vec::new();
+    for line in md.lines() {
+        let line = line.trim();
+        if !line.starts_with('|') {
+            continue;
+        }
+        let cells: Vec<String> = line
+            .trim_matches('|')
+            .split('|')
+            .map(|c| c.trim().to_string())
+            .collect();
+        if cells.len() != 5 || cells[0].eq_ignore_ascii_case("tier") || cells[0].starts_with("---")
+        {
+            continue;
+        }
+        let tier: i64 = cells[0]
+            .parse()
+            .with_context(|| format!("tier `{}` not an integer", cells[0]))?;
+        let split = |s: &str| -> Vec<String> {
+            s.split(',')
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty() && !t.starts_with("(none"))
+                .collect()
+        };
+        rows.push(Row {
+            tier,
+            layer: cells[1].clone(),
+            forbidden: split(&cells[3]),
+            witnesses: split(&cells[4]),
+        });
+    }
+    if rows.is_empty() {
+        bail!("no ledger rows parsed");
+    }
+    Ok(rows)
+}
+
+pub(crate) fn structural_checks(rows: &[Row], errors: &mut Vec<String>) {
+    for pair in rows.windows(2) {
+        if pair[1].tier >= pair[0].tier {
+            errors.push(format!(
+                "tiers must be monotonic decreasing: `{}` (tier {}) is not below `{}` (tier {})",
+                pair[1].layer, pair[1].tier, pair[0].layer, pair[0].tier
+            ));
+        }
+    }
+    if let Some(workload) = rows.iter().find(|r| r.layer == "workload") {
+        for required in REQUIRED_WORKLOAD_FORBIDDEN {
+            if !workload.forbidden.iter().any(|f| f == required) {
+                errors.push(format!("workload row must forbid `{required}`"));
+            }
+        }
+    } else {
+        errors.push("ledger has no `workload` row".to_string());
+    }
+}
+
+fn witness_exists(workspace: &Path, token: &str) -> Result<bool> {
+    if let Some(name) = token.strip_prefix("fn:") {
+        let needle = format!("fn {name}(");
+        return Ok(grep_tree(&workspace.join("crates"), &needle)? || grep_tree(workspace, &needle)?);
+    }
+    if let Some(name) = token.strip_prefix("ci:") {
+        return grep_tree(&workspace.join(".github").join("workflows"), name);
+    }
+    bail!("unknown witness token `{token}` (expected fn: or ci:)")
+}
+
+fn grep_tree(root: &Path, needle: &str) -> Result<bool> {
+    if !root.exists() {
+        return Ok(false);
+    }
+    for entry in walkdir(root)? {
+        if let Ok(text) = std::fs::read_to_string(&entry)
+            && text.contains(needle)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn walkdir(root: &Path) -> Result<Vec<std::path::PathBuf>> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in
+            std::fs::read_dir(&dir).with_context(|| format!("reading {}", dir.display()))?
+        {
+            let path = entry?.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|n| n == "target") {
+                    continue;
+                }
+                stack.push(path);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows(md: &str) -> Vec<Row> {
+        parse_rows(md).expect("parse")
+    }
+
+    #[test]
+    fn monotonic_tiers_pass() {
+        let md = "| Tier | Layer | Daemon | Forbidden authorities | Witnesses |\n\
+                  | --- | --- | --- | --- | --- |\n\
+                  | 2 | host | control-daemon | (none) | fn:foo |\n\
+                  | 0 | workload | guest-agent | signing-key, plan-admission, audit-writer | ci:bar |\n";
+        let mut errs = Vec::new();
+        structural_checks(&rows(md), &mut errs);
+        assert!(errs.is_empty(), "{errs:?}");
+    }
+
+    #[test]
+    fn non_decreasing_tiers_fail() {
+        let md = "| Tier | Layer | Daemon | Forbidden authorities | Witnesses |\n\
+                  | --- | --- | --- | --- | --- |\n\
+                  | 0 | host | control-daemon | (none) | fn:foo |\n\
+                  | 2 | workload | guest-agent | signing-key, plan-admission, audit-writer | ci:bar |\n";
+        let mut errs = Vec::new();
+        structural_checks(&rows(md), &mut errs);
+        assert!(errs.iter().any(|e| e.contains("monotonic")), "{errs:?}");
+    }
+
+    #[test]
+    fn workload_missing_forbidden_authority_fails() {
+        let md = "| Tier | Layer | Daemon | Forbidden authorities | Witnesses |\n\
+                  | --- | --- | --- | --- | --- |\n\
+                  | 2 | host | control-daemon | (none) | fn:foo |\n\
+                  | 0 | workload | guest-agent | signing-key | ci:bar |\n";
+        let mut errs = Vec::new();
+        structural_checks(&rows(md), &mut errs);
+        assert!(
+            errs.iter().any(|e| e.contains("plan-admission")),
+            "{errs:?}"
+        );
+    }
+}

--- a/xtask/src/check_trust_gradient.rs
+++ b/xtask/src/check_trust_gradient.rs
@@ -113,7 +113,7 @@ pub(crate) fn structural_checks(rows: &[Row], errors: &mut Vec<String>) {
 fn witness_exists(workspace: &Path, token: &str) -> Result<bool> {
     if let Some(name) = token.strip_prefix("fn:") {
         let needle = format!("fn {name}(");
-        return Ok(grep_tree(&workspace.join("crates"), &needle)? || grep_tree(workspace, &needle)?);
+        return grep_tree(workspace, &needle);
     }
     if let Some(name) = token.strip_prefix("ci:") {
         return grep_tree(&workspace.join(".github").join("workflows"), name);

--- a/xtask/src/check_trust_gradient.rs
+++ b/xtask/src/check_trust_gradient.rs
@@ -187,6 +187,17 @@ mod tests {
     }
 
     #[test]
+    fn equal_tiers_fail() {
+        let md = "| Tier | Layer | Daemon | Forbidden authorities | Witnesses |\n\
+                  | --- | --- | --- | --- | --- |\n\
+                  | 2 | host | control-daemon | (none) | fn:foo |\n\
+                  | 2 | workload | guest-agent | signing-key, plan-admission, audit-writer | ci:bar |\n";
+        let mut errs = Vec::new();
+        structural_checks(&rows(md), &mut errs);
+        assert!(errs.iter().any(|e| e.contains("monotonic")), "{errs:?}");
+    }
+
+    #[test]
     fn workload_missing_forbidden_authority_fails() {
         let md = "| Tier | Layer | Daemon | Forbidden authorities | Witnesses |\n\
                   | --- | --- | --- | --- | --- |\n\

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,6 +24,7 @@ mod check_no_overclaim;
 mod check_no_spec_refs_in_comments;
 mod check_runtime_overlay_version;
 mod check_spec_numbers;
+mod check_trust_gradient;
 mod gen_stubs;
 mod perf;
 
@@ -103,6 +104,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_claim_catalog::run(&workspace)
         }
+        Some("check-trust-gradient") => {
+            let workspace = workspace_root();
+            check_trust_gradient::run(&workspace)
+        }
         Some("check-mvm-host-binaries-sync") => {
             let workspace = workspace_root();
             check_mvm_host_binaries_sync::run(&workspace)
@@ -125,7 +130,7 @@ fn main() -> Result<()> {
             gen_stubs::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-forbidden-deps, check-core-runtime-free, check-closure-budget, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-no-overclaim, check-spec-numbers, check-no-spec-refs-in-comments, check-claim-catalog, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-forbidden-deps, check-core-runtime-free, check-closure-budget, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-no-overclaim, check-spec-numbers, check-no-spec-refs-in-comments, check-claim-catalog, check-trust-gradient, check-mvm-host-binaries-sync, check-runtime-overlay-version, perf, build-dev-image, gen-stubs, check-stubs",
             other
         ),
         None => {
@@ -178,6 +183,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-claim-catalog                    Verify specs/claims/catalog.md witnesses still exist in the tree"
+            );
+            eprintln!(
+                "  check-trust-gradient                   Verify trust-gradient ledger: monotonic tiers, workload forbidden authorities, witnesses"
             );
             eprintln!(
                 "  check-mvm-host-binaries-sync            Plan 115 / ADR-065: assert Rust manifest and Nix attrset agree"


### PR DESCRIPTION
Implements **Plan 205 Workstream A** (trust-gradient invariant) on top of the now-merged ADR-090 / Plan 205 design (#1086). Makes ADR-090's three-daemon trust gradient — host control daemon (keys/admission/audit, TCB) > builder daemon (dev-tier, resident) > workload guest agent (prod-stripped runt, zero authority) — a machine-checked, CI-enforced invariant so later residency work cannot push authority below the host→builder line.

## Three gates

1. **`scripts/check-prod-agent-no-authority.sh`** + a `prod-agent-no-authority` lane in `security.yml`: the production workload agent (`mvm-guest-agent`, `--no-default-features`) links none of `load_host_signing_key` / `host_signer` / `admit_for_run`. Sibling to the existing `prod-agent-no-exec` / `no-console` gates; `handle_run_entrypoint` canary keeps the absence checks non-vacuous. Crate-prefix alternation covers the real home crates (`mvm_backend`/`mvm_cli`/`mvm_core`/`mvm_hostd`).
2. **`crates/mvm-hostd/tests/per_tenant_isolation.rs`**: two tenants get distinct control sockets, worker PID groups, and workload audit chains; an emit to tenant A's broker yields exactly one verified entry in A's chain and zero in B's (chain exists after register, so the check is an exact `== 0`).
3. **`specs/claims/trust-gradient.md`** ledger + **`xtask check-trust-gradient`** (wired as a hard CI lint gate): asserts tiers strictly decrease, the workload row forbids `signing-key`/`plan-admission`/`audit-writer`, and every witness (`ci:`/`fn:`) resolves on disk. Mirrors `check-claim-catalog`.

## Notes
- The **builder-daemon** row + gate are intentionally **deferred** until Plan 204 lands `mvm-builderd` (the binary doesn't exist yet) — documented in the plan's "Deferred" section.
- Verified locally: gate script passes, `per_tenant_isolation` 1/1, `check_trust_gradient` 4/4 unit + `check-trust-gradient: clean (2 rows)`.
- Built via subagent-driven development with per-task + final whole-branch review; the final review caught and fixed a real gate-weakness (symbol-grep crate list was too narrow).

Plan: `specs/notes/plan-205-ws-a-trust-gradient-execution.md`.