### PR TITLE
feat(cli): mvmctl bootstrap — pre-fetch the builder VM image (instant first run)

### DIFF
--- a/crates/mvm-cli/src/commands/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/bootstrap.rs
@@ -1,0 +1,28 @@
+//! `mvmctl bootstrap` — prepare the local environment from scratch.
+//!
+//! Runs the host-tooling setup and **pre-acquires the builder VM image** so
+//! the first `mvmctl dev up` is fast: the expensive first-run image
+//! download (release install) or local build (source checkout) is paid here,
+//! ahead of time, not on the hot path. Idempotent — a fast no-op when the
+//! environment is already set up and the image is cached.
+//!
+//! `install.sh` runs this automatically after installing the binary (unless
+//! `MVM_SKIP_BUILDER_PREFETCH=1`), and users can run it explicitly any time.
+
+use anyhow::Result;
+use clap::Args as ClapArgs;
+
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Production mode (skip Homebrew, assume Linux with apt).
+    #[arg(long)]
+    pub production: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    super::env::bootstrap::bootstrap_environment(args.production)
+}

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -169,6 +169,7 @@ impl Commands {
         match self {
             // `env <sub>` delegates (bootstrap/cleanup/uninstall/update/sign).
             Commands::Env(a) => a.action.verb_name(),
+            Commands::Bootstrap(_) => "bootstrap",
             Commands::Dev(_) => "dev",
             Commands::Logs(_) => "logs",
             Commands::Ls(_) => "ls",

--- a/crates/mvm-cli/src/commands/env/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/bootstrap.rs
@@ -19,11 +19,26 @@ pub(in crate::commands) struct Args {
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
-    run_steps(args.production)
+    bootstrap_environment(args.production)
 }
 
-/// Run the bootstrap steps — exposed so other commands (dev) can re-bootstrap
-/// without going through the dispatcher.
+/// Full environment bootstrap: host-tooling setup **plus** pre-acquiring the
+/// builder VM image so the first `mvmctl dev up` is fast (no first-run
+/// download/build on the hot path). Shared by the top-level `mvmctl bootstrap`
+/// and `mvmctl env bootstrap`.
+pub(in crate::commands) fn bootstrap_environment(production: bool) -> Result<()> {
+    run_steps(production)?;
+    // Pre-fetch the builder VM image. On a release install this downloads the
+    // published, SHA-256-verified image; on a source checkout it builds it
+    // locally (a source checkout never downloads mvm-release artifacts).
+    // Cache-gated, so it is a fast no-op when the image is already present.
+    super::dev_vz::bootstrap_builder_vm_image()?;
+    ui::success("\nBootstrap complete! Run 'mvmctl dev' to enter the development environment.");
+    Ok(())
+}
+
+/// Run the host-tooling bootstrap steps only (no builder-image prefetch) —
+/// exposed so `dev` can re-bootstrap without going through the dispatcher.
 pub(super) fn run_steps(production: bool) -> Result<()> {
     ui::info("Bootstrapping full environment...\n");
 
@@ -39,7 +54,5 @@ pub(super) fn run_steps(production: bool) -> Result<()> {
     // Default sizing for the builder VM; CLI-level overrides ride the
     // setup path.
     run_setup_steps(false, 8, 16)?;
-
-    ui::success("\nBootstrap complete! Run 'mvmctl dev' to enter the development environment.");
     Ok(())
 }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod bootstrap;
 mod build;
 mod bundle;
 mod catalog;
@@ -68,6 +69,12 @@ pub(in crate::commands) struct Cli {
 pub(in crate::commands) enum Commands {
     /// Environment / install lifecycle (bootstrap, update, sign, …)
     Env(env::group::Args),
+    /// Prepare the environment + pre-fetch the builder VM image
+    ///
+    /// Runs host-tooling setup and pre-acquires the builder VM image so the
+    /// first `dev up` is fast. Run automatically by install.sh unless
+    /// `MVM_SKIP_BUILDER_PREFETCH=1`.
+    Bootstrap(bootstrap::Args),
     /// Manage the local dev VM
     Dev(env::dev::Args),
     /// Show console logs from a running microVM
@@ -271,6 +278,7 @@ pub fn run() -> Result<()> {
 
     let result = match cli.command.clone() {
         Commands::Env(a) => env::group::run(&cli, a, &cfg),
+        Commands::Bootstrap(a) => bootstrap::run(&cli, a, &cfg),
         Commands::Dev(a) => env::dev::run(&cli, a, &cfg),
         Commands::Logs(a) => vm::logs::run(&cli, a, &cfg),
         Commands::Ls(a) => vm::ps::run(&cli, a, &cfg),

--- a/install.sh
+++ b/install.sh
@@ -155,4 +155,20 @@ case ":$PATH:" in
   *":$INSTALL_DIR:"*) ;;
   *) say "Add to PATH:  export PATH=\"$INSTALL_DIR:\$PATH\"" ;;
 esac
+
+# Pre-fetch the builder VM image so the first `mvmctl dev up` is fast instead
+# of paying a one-time download/build on the hot path. Opt out with
+# MVM_SKIP_BUILDER_PREFETCH=1 (bandwidth-limited, headless, or CI installs).
+# Non-fatal: a failure just defers the fetch to first `dev up`.
+if [ "${MVM_SKIP_BUILDER_PREFETCH:-}" != "1" ]; then
+  say "Pre-fetching the builder VM image so your first 'dev up' is instant (skip with MVM_SKIP_BUILDER_PREFETCH=1)..."
+  if "$INSTALL_DIR/mvmctl" bootstrap; then
+    say "Builder VM image ready."
+  else
+    warn "builder-image prefetch failed — 'mvmctl dev up' will fetch it on first run, or re-run 'mvmctl bootstrap'."
+  fi
+else
+  say "Skipping builder-image prefetch — run 'mvmctl bootstrap' before your first 'dev up' for a fast start."
+fi
+
 say "Run 'mvmctl doctor' to check your host."

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -69,8 +69,10 @@ verification under `trust`. Domains that already own their own subcommands
 
 | Command | Description |
 |---------|-------------|
-| `mvmctl env bootstrap` | Full setup from scratch: Homebrew deps (macOS), Firecracker, kernel, rootfs (idempotent — safe to re-run) |
-| `mvmctl env bootstrap --production` | Production mode (skip Homebrew, assume Linux with apt) |
+| `mvmctl bootstrap` | Prepare the environment: host tooling **and pre-fetch the builder VM image** so the first `dev up` is fast (no first-run download/build on the hot path). `install.sh` runs this automatically unless `MVM_SKIP_BUILDER_PREFETCH=1`. Idempotent — safe to re-run |
+| `mvmctl bootstrap --production` | Production mode (skip Homebrew, assume Linux with apt) |
+| `mvmctl env bootstrap` | Same as `mvmctl bootstrap` (the `env`-grouped form) |
+| `mvmctl dev [up]` | Auto-bootstrap if needed, start dev VM, drop into shell. On macOS, the dev-image builder auto-detects Vz on macOS 26+ Apple Silicon and retries with libkrun when that auto-selected Vz builder path fails; native KVM is used on Linux. |
 | `mvmctl dev [up]` | Auto-bootstrap if needed, start dev VM, drop into shell. On macOS, the dev-image builder auto-detects Vz on macOS 26+ Apple Silicon and retries with libkrun when that auto-selected Vz builder path fails; native KVM is used on Linux. |
 | `mvmctl dev up --project ~/dir` | Auto-bootstrap then cd into a project directory |
 | `mvmctl dev up --metrics-port PORT` | Bind a Prometheus metrics endpoint (0 = disabled) |

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -350,6 +350,9 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     // Environment / installer surfaces. Plan 178 (D5) — bootstrap/cleanup/
     // uninstall/update/sign grouped under `env <sub>`.
     ("env", AuditPosture::DelegatesToSub(ENV_SUB)),
+    // Top-level `mvmctl bootstrap` — installer surface (host tooling + builder
+    // VM image prefetch). Same posture as `env bootstrap` and `init`.
+    ("bootstrap", AuditPosture::InteractiveOrControl),
     ("dev", AuditPosture::InteractiveOrControl),
     ("doctor", AuditPosture::ReadOnly),
     ("shell-init", AuditPosture::InteractiveOrControl),

--- a/tests/install_sh.rs
+++ b/tests/install_sh.rs
@@ -33,7 +33,11 @@ fn make_tarball(target: &str) -> Vec<u8> {
     use flate2::Compression;
     use flate2::write::GzEncoder;
     let dir = format!("mvmctl-{target}");
-    let stub = b"#!/bin/sh\necho 'mvmctl 9.9.9'\n";
+    // The stub records its argv to `$MVM_TEST_INVOCATION_LOG` (default
+    // /dev/null, so tests that don't set it are unaffected) so a test can
+    // assert whether install.sh invoked `mvmctl bootstrap`.
+    let stub =
+        b"#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"${MVM_TEST_INVOCATION_LOG:-/dev/null}\"\necho 'mvmctl 9.9.9'\n";
     let mut tar = tar::Builder::new(Vec::new());
     let mut hdr = tar::Header::new_gnu();
     hdr.set_size(stub.len() as u64);
@@ -140,6 +144,53 @@ fn install_sh_downloads_verifies_and_installs() {
     assert!(
         install_dir.path().join("mvmctl").exists(),
         "binary installed"
+    );
+}
+
+#[test]
+fn install_sh_prefetches_builder_image_by_default_and_skips_on_optout() {
+    let target = host_target();
+    let tarball = make_tarball(target);
+    let archive = format!("mvmctl-{target}.tar.gz");
+    let checks = format!("{}  {}\n", sha256_hex(&tarball), archive);
+    let routes = vec![
+        (
+            format!("/tinylabscom/mvm/releases/download/v9.9.9/{archive}"),
+            tarball.clone(),
+        ),
+        (
+            "/tinylabscom/mvm/releases/download/v9.9.9/checksums-sha256.txt".to_string(),
+            checks.into_bytes(),
+        ),
+    ];
+    let (base, _stop) = serve(routes);
+
+    let run = |skip_prefetch: bool| -> String {
+        let install_dir = tempfile::tempdir().unwrap();
+        let log = install_dir.path().join("invocations.log");
+        let mut cmd = Command::new("sh");
+        cmd.arg(repo_root().join("install.sh"))
+            .env("MVM_VERSION", "v9.9.9")
+            .env("MVM_UPDATE_DOWNLOAD_URL", &base)
+            .env("MVM_INSTALL_DIR", install_dir.path())
+            .env("MVM_SKIP_CODESIGN", "1")
+            .env("MVM_TEST_INVOCATION_LOG", &log);
+        if skip_prefetch {
+            cmd.env("MVM_SKIP_BUILDER_PREFETCH", "1");
+        }
+        assert!(cmd.status().unwrap().success(), "install.sh should succeed");
+        std::fs::read_to_string(&log).unwrap_or_default()
+    };
+
+    // Default: install.sh runs `mvmctl bootstrap`.
+    assert!(
+        run(false).contains("bootstrap"),
+        "default install must prefetch via `mvmctl bootstrap`"
+    );
+    // Opt-out: MVM_SKIP_BUILDER_PREFETCH=1 suppresses the prefetch.
+    assert!(
+        !run(true).contains("bootstrap"),
+        "MVM_SKIP_BUILDER_PREFETCH=1 must skip the prefetch"
     );
 }
 


### PR DESCRIPTION
Moves the one unavoidable first-run cost — acquiring the builder VM image — **off the `dev up` hot path** and to install/prefetch time, so the first `mvmctl dev up` is fast. From the "feels instant" design discussion: the per-command bring-up is the residency layer's job (Plan 205), but the *first-ever image acquisition* should be paid once, ahead of time.

## What's new
- **`mvmctl bootstrap`** (top-level) — runs host-tooling setup **and pre-acquires the builder VM image**. Reuses the existing `bootstrap_builder_vm_image()`:
  - **Release install** → downloads the published, **SHA-256-verified** image.
  - **Source checkout** → builds it locally (a source checkout never downloads mvm-release artifacts).
  - **Cache-gated** → a fast no-op once present.
  - The codebase already anticipated this — `mvmctl init`'s help says *"Run `mvmctl bootstrap` for environment setup."*
- **`install.sh`** runs `mvmctl bootstrap` after installing the binary, **unless `MVM_SKIP_BUILDER_PREFETCH=1`** (bandwidth-limited / headless / CI). Non-fatal — a failure just defers the fetch to first `dev up`.
- `env bootstrap` and the new top-level `bootstrap` share `bootstrap_environment()` (setup + image prefetch); `run_steps` (host tooling only) stays for `dev`'s re-bootstrap.

## Wiring & tests
- `Commands` enum + dispatch + audit verb-name + `audit_total_coverage` table (classified `InteractiveOrControl`, an installer surface, like `env bootstrap`/`init`).
- New install.sh test: prefetch-by-default **and** opt-out (the fake `mvmctl` stub now records its argv). `audit_total_coverage` covers the new command. Existing `install_sh` + `bootstrap` unit tests green.
- `cargo fmt --all --check`, `cargo clippy -p mvm-cli --all-targets -- -D warnings`, `check-no-spec-refs-in-comments` clean. CLI reference updated.

Pairs with the Plan 205 latency-budget PR (#1098), which explicitly excludes this first-ever download from the per-command "instant" budget.