### PR TITLE
fix(plan-204): doctor probes the Vz-shaped builderd control socket (live-found)

### DIFF
--- a/crates/mvm-build/src/builderd.rs
+++ b/crates/mvm-build/src/builderd.rs
@@ -488,16 +488,47 @@ pub fn dispatch_with_executor(
 // Host-side client (readiness probe)
 // ============================================================================
 
-/// The per-port vsock socket the resident daemon's control channel is
-/// reachable at, for a builder VM rooted at `vm_state_dir`. Mirrors
-/// `persistent_builder::dispatch_socket_path` — the same
-/// `<vm_state_dir>/vsock-<port>.sock` convention, on the dedicated
-/// builder-control port. Single source of truth shared by the host
-/// client here and the daemon's listener config once boot wiring lands.
+/// The **libkrun**-shape control socket for a builder VM rooted at
+/// `vm_state_dir`: `<vm_state_dir>/vsock-<port>.sock`. libkrun binds one
+/// socket per forwarded port directly in the state dir (matching
+/// `persistent_builder::dispatch_socket_path`).
+///
+/// Vz nests its per-port sockets one level deeper, under a `vsock/`
+/// subdir — use [`builderd_vz_control_socket_path`] there, or
+/// [`builderd_control_socket_candidates`] when the backend is unknown
+/// (e.g. scanning the builder-VM `vms/` root). Mixing the two shapes is
+/// the libkrun-vs-Vz socket-path bug class that has bitten the broker
+/// path before.
 pub fn builderd_control_socket_path(vm_state_dir: &Path) -> PathBuf {
-    vm_state_dir.join(mvm_core::config::vsock_socket_filename(
-        mvm_guest::builder_agent::BUILDERD_CONTROL_PORT,
-    ))
+    vm_state_dir.join(builderd_control_socket_filename())
+}
+
+/// The **Vz**-shape control socket for a builder VM rooted at
+/// `vm_state_dir`: `<vm_state_dir>/vsock/vsock-<port>.sock`. The Vz
+/// supervisor nests per-port sockets under a `vsock/` subdir (see
+/// `mvm_core::config::vm_vz_vsock_dir`).
+pub fn builderd_vz_control_socket_path(vm_state_dir: &Path) -> PathBuf {
+    vm_state_dir
+        .join("vsock")
+        .join(builderd_control_socket_filename())
+}
+
+/// Both candidate control-socket paths (libkrun shape, then Vz shape)
+/// for a builder VM rooted at `vm_state_dir`. Use when the backend isn't
+/// known up front — e.g. `mvmctl doctor` scanning the builder-VM `vms/`
+/// root, where a dir may be a libkrun or a Vz builder VM. Probe whichever
+/// exists.
+pub fn builderd_control_socket_candidates(vm_state_dir: &Path) -> [PathBuf; 2] {
+    [
+        builderd_control_socket_path(vm_state_dir),
+        builderd_vz_control_socket_path(vm_state_dir),
+    ]
+}
+
+/// `vsock-<BUILDERD_CONTROL_PORT>.sock` — the per-port socket filename
+/// both backends use; they differ only in which directory it lives in.
+fn builderd_control_socket_filename() -> String {
+    mvm_core::config::vsock_socket_filename(mvm_guest::builder_agent::BUILDERD_CONTROL_PORT)
 }
 
 /// Outcome of a host-side readiness probe against a builder daemon's
@@ -1187,13 +1218,26 @@ mod tests {
 
     #[test]
     fn control_socket_path_uses_builderd_port() {
-        let p = builderd_control_socket_path(Path::new("/var/lib/mvm/vm-foo"));
+        let port = mvm_guest::builder_agent::BUILDERD_CONTROL_PORT;
+        let dir = Path::new("/var/lib/mvm/vm-foo");
+        // libkrun: directly in the state dir.
         assert_eq!(
-            p,
-            Path::new(&format!(
-                "/var/lib/mvm/vm-foo/vsock-{}.sock",
-                mvm_guest::builder_agent::BUILDERD_CONTROL_PORT
-            ))
+            builderd_control_socket_path(dir),
+            Path::new(&format!("/var/lib/mvm/vm-foo/vsock-{port}.sock"))
+        );
+        // Vz: one subdir deeper, under `vsock/` (the bug the live Vz boot
+        // surfaced — doctor/client must not assume the libkrun shape).
+        assert_eq!(
+            builderd_vz_control_socket_path(dir),
+            Path::new(&format!("/var/lib/mvm/vm-foo/vsock/vsock-{port}.sock"))
+        );
+        // Candidates: libkrun first, then Vz.
+        assert_eq!(
+            builderd_control_socket_candidates(dir),
+            [
+                builderd_control_socket_path(dir),
+                builderd_vz_control_socket_path(dir),
+            ]
         );
     }
 

--- a/crates/mvm-cli/src/doctor.rs
+++ b/crates/mvm-cli/src/doctor.rs
@@ -448,10 +448,15 @@ fn builderd_daemon_summary(vms_root: &std::path::Path) -> String {
         if !dir.is_dir() {
             continue;
         }
-        let sock = mvm_build::builderd::builderd_control_socket_path(&dir);
-        if !sock.exists() {
+        // A builder VM may be libkrun (`<dir>/vsock-<port>.sock`) or Vz
+        // (`<dir>/vsock/vsock-<port>.sock`); probe whichever socket the
+        // backend actually created.
+        let Some(sock) = mvm_build::builderd::builderd_control_socket_candidates(&dir)
+            .into_iter()
+            .find(|p| p.exists())
+        else {
             continue;
-        }
+        };
         let name = entry.file_name().to_string_lossy().into_owned();
         let readiness =
             mvm_build::builderd::probe_builderd_readiness(&sock, BUILDERD_PROBE_TIMEOUT);
@@ -4035,6 +4040,30 @@ mod tests {
 
         let s = builderd_daemon_summary(root.path());
         assert!(s.contains("bv: ready"), "got {s:?}");
+        handle.join().expect("server thread");
+    }
+
+    #[test]
+    fn builderd_daemon_summary_finds_a_vz_shaped_socket() {
+        use std::os::unix::net::UnixListener;
+        // Regression for the live Vz boot: the Vz supervisor nests the
+        // control socket under `<vm_state_dir>/vsock/`. The scan must find
+        // it there, not only at the libkrun `<vm_state_dir>/vsock-*.sock`.
+        let root = tempfile::Builder::new()
+            .prefix("mvmbd")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let vm_dir = root.path().join("bvz");
+        let sock = mvm_build::builderd::builderd_vz_control_socket_path(&vm_dir);
+        std::fs::create_dir_all(sock.parent().unwrap()).unwrap();
+        let listener = UnixListener::bind(&sock).expect("bind");
+        let handle = std::thread::spawn(move || {
+            let (mut conn, _addr) = listener.accept().expect("accept");
+            mvm_build::builderd::serve_connection(&mut conn).expect("serve");
+        });
+
+        let s = builderd_daemon_summary(root.path());
+        assert!(s.contains("bvz: ready"), "got {s:?}");
         handle.join().expect("server thread");
     }
 


### PR DESCRIPTION
A live `mvmctl dev up` on Vz (macOS 26 / Apple Silicon) surfaced a real socket-path bug that green unit tests sailed past.

## The bug
The resident `mvm-builderd` launched and listened correctly on the Vz builder VM — straight from its console.log:
```
mvm-host-vm-init: spawned mvm-builderd (pid 143)
mvm-builderd: listening on AF_VSOCK port 21473
```
…and the Vz launcher forwarded the port (the host-side `vsock-21473.sock` exists). But `mvmctl doctor` reported the daemon **absent**.

**Cause:** `builderd_control_socket_path` hardcoded the **libkrun** shape `<vm_state_dir>/vsock-<port>.sock`, but **Vz** nests per-port sockets one level deeper under `vsock/` — `<vm_state_dir>/vsock/vsock-<port>.sock` (`mvm_core::config::vm_vz_vsock_dir`). The doctor scan looked at a path that never exists for a Vz builder VM. Same libkrun-vs-Vz socket-path bug class as the earlier broker fix; the unit tests bound libkrun-shaped `UnixListener`s, so only a live Vz boot catches it.

## The fix
- `builderd_control_socket_path` is now explicitly the libkrun shape; added **`builderd_vz_control_socket_path`** (Vz shape) and **`builderd_control_socket_candidates`** (both).
- `mvmctl doctor`'s builder-daemon scan probes **whichever** candidate socket exists.

## Tests
- Path-shape unit test (libkrun + Vz + candidates).
- Doctor **regression test**: binds a Vz-shaped socket under `vsock/` and asserts the scan reports it `ready`.
- 74 mvm-build + 4 doctor tests green; clippy `-D warnings` + fmt + no-spec-refs clean.

## Live-validated
After the fix, `mvmctl doctor` against the running Vz builder VM reports:
```
builder daemon: OK (mvm-persistent-builder-vz-dev: ready (protocol v1))
```
— it flipped from "absent" to **ready**: the scan finds the Vz socket, connects, handshakes, and the daemon answers. This confirms the full Plan 204 chain works live on Vz (protocol + daemon + boot launch + Vz port-forward + doctor + host-client handshake).