### PR TITLE
fix(ci): run rvproxy parity gate on merge_group (unblock the merge queue)

### DIFF
--- a/.github/workflows/rvproxy-parity.yml
+++ b/.github/workflows/rvproxy-parity.yml
@@ -23,6 +23,12 @@ on:
   # stable context. A cheap changes job below decides whether to pay for the
   # macOS parity run.
   pull_request:
+  # …and on every merge_group: when `rvproxy gateway parity` is a *required*
+  # check, the merge queue evaluates it on the merge_group ref, so the workflow
+  # must run there too — otherwise the queue waits forever for a context that
+  # never appears, deadlocking every PR. The `changes` job reads the merge_group
+  # base/head below since `github.event.pull_request` is null on this event.
+  merge_group:
   workflow_dispatch:
     inputs:
       rvproxy_ref:
@@ -65,8 +71,15 @@ jobs:
             exit 0
           fi
 
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
+          # On a merge_group (the merge queue) the pull_request context is null;
+          # the event carries the queued range as merge_group.base_sha/head_sha.
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            base="${{ github.event.merge_group.base_sha }}"
+            head="${{ github.event.merge_group.head_sha }}"
+          else
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          fi
           changed="$RUNNER_TEMP/rvproxy-parity-changed-files.txt"
           git diff --name-only "$base" "$head" | tee "$changed"
 


### PR DESCRIPTION
## The problem: the whole merge queue is deadlocked
#1105 added **`rvproxy gateway parity`** to main's *required* status checks, but `rvproxy-parity.yml` only triggers on `pull_request`. GitHub merge queues evaluate required checks on the **`merge_group`** ref — and this workflow never runs there. So the required `rvproxy gateway parity` context never appears in the queue, and the queue waits for it **forever**. Every PR going through the queue is now stuck (e.g. #1102), not just gateway PRs.

**Evidence:** the merge_group runs for a stuck PR carry only `CI` + `Architecture invariants` (both green); `rvproxy gateway parity` is absent.

## The fix
- Add `merge_group` to the workflow triggers, so the always-present `rvproxy gateway parity` shim job (`if: always()`) runs in the queue and reports the required context.
- The `changes` job reads `github.event.merge_group.{base_sha,head_sha}` on a `merge_group` event (the `pull_request` context is null there). So a **gateway-touching** queued change still triggers the macOS parity run in the queue; an unrelated one sets `gateway=false` and the shim passes. Coverage preserved.

YAML validated; triggers `merge_group/pull_request/workflow_dispatch`; jobs unchanged.

## ⚠️ Applying this (chicken-and-egg)
Because `rvproxy gateway parity` is itself required, **this PR can't merge through the deadlocked queue**. Break it by either:
1. Temporarily removing `rvproxy gateway parity` from main's required checks → merge this (and #1102) → re-add it, **or**
2. Admin "merge without waiting for requirements" on this PR.