### PR TITLE
docs(troubleshooting): Stage 0 BadActivate on a fresh isolated cache (#576)

### DIFF
--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -33,6 +33,30 @@ mvmctl uninstall
 mvmctl bootstrap
 ```
 
+### Stage 0 builder panics with `BadActivate` on a fresh, isolated cache
+
+```
+thread 'fc_vcpu 1' panicked at .../virtio/mmio.rs:320:
+Failed to activate device: BadActivate
+```
+
+**Cause**: A from-scratch Stage 0 builder bootstrap against a *completely
+isolated, empty* cache (every one of `MVM_CACHE_DIR` / `MVM_DATA_DIR` pointed at
+fresh temp dirs at once — e.g. the `core_demo_e2e` smoke test under full
+isolation) can panic in the libkrun guest during virtio device activation,
+before userspace. The Stage 0 device topology is identical to a warm build, so
+this is not a device-count problem; it surfaces in the upstream VMM's
+device-activation path under the bundled Stage 0 kernel. It does **not** occur on
+a normal cold `mvmctl dev up` against the default cache.
+
+**Fix**: Don't run a builder bootstrap against a fully-isolated empty cache. Use
+the default cache, or pre-warm the builder once (`mvmctl dev up` with the default
+cache) before pointing a test at an isolated `MVM_DATA_DIR`. If you must isolate,
+let the run share the default `MVM_CACHE_DIR` so the builder VM image and nix
+store are reused rather than rebuilt from zero. A contributor host with
+`mkfs.ext4` available (e.g. `brew install e2fsprogs`) also avoids the warn-only
+in-guest seed-store fallback that aggravates first-boot geometry on a cold cache.
+
 ## Firecracker Issues
 
 ### "Firecracker socket not responding"


### PR DESCRIPTION
Documents #576 and closes it as artificial-isolation-only.

Re-verification on current `main` found no code regression: the cold and warm Stage 0 paths attach a byte-identical device set, and `BadActivate` originates in the upstream VMM device crate (`virtio/mmio.rs:320`), not mvm code. The panic only reproduces under a fully-isolated empty cache (every `MVM_CACHE_DIR`/`MVM_DATA_DIR` fresh at once, e.g. `core_demo_e2e` under full isolation) — never on a normal default-cache cold `mvmctl dev up`, which is the issue's own (unsatisfied) first triage step.

This adds a Troubleshooting entry under "Builder VM and Dev Shell Issues" with the cause and the practical avoidance (share the default cache / pre-warm; install `mkfs.ext4` to skip the warn-only in-guest seed-store fallback).

## Closes #576