### PR TITLE
feat(plan-205): builder-daemon no-authority gate — trust gradient now covers all three daemons

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -157,6 +157,28 @@ jobs:
       - name: No host-signer / admission symbols in the production agent
         run: ./scripts/check-prod-agent-no-authority.sh
 
+  builderd-no-authority:
+    name: builder daemon carries no host-authority symbols
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-builderd-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-builderd-
+
+      - name: No host-signer / admission symbols in the builder daemon
+        run: ./scripts/check-builderd-no-authority.sh
+
   # ── Lane 2b: Seccomp tier functional denial (ADR-002 §W2.4) ───────
   # Tier-structure unit tests in `mvm-security` cover cumulative-subset
   # and serde shapes; they don't exercise the BPF program at runtime.

--- a/scripts/check-builderd-no-authority.sh
+++ b/scripts/check-builderd-no-authority.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Builder-daemon authority contract.
+#
+# mvm-builderd is the builder-VM control daemon: it runs Nix/build work and
+# serves a typed allowlisted protocol with no shell surface. It is trusted to
+# BUILD, never to sign or admit — so it must link none of the host-only
+# authority symbols. This is the builder tier of the trust gradient
+# (host > builder > workload); authority never reaches a daemon below the host.
+#
+#   canary: the mvm_builderd crate's own symbols are present, proving the symbol
+#           table is populated so the absence checks below are not vacuous.
+#   absent: load_host_signing_key, host_signer, admit_for_run — host-side
+#           authority that lives above the host->builder boundary.
+set -euo pipefail
+
+PKG=mvm-build
+BIN=mvm-builderd
+
+echo "::group::Build mvm-builderd (release)"
+CARGO_PROFILE_RELEASE_STRIP=false \
+  cargo build --release --locked -p "$PKG" --bin "$BIN"
+echo "::endgroup::"
+syms=$(nm "target/release/$BIN")
+
+fail=0
+
+if grep -q 'mvm_builderd' <<<"$syms"; then
+  echo "ok: mvm_builderd symbols present (symbol table populated)"
+else
+  echo "::error::no mvm_builderd symbols — table stripped; absence checks would be vacuous." >&2
+  fail=1
+fi
+
+for sym in load_host_signing_key host_signer admit_for_run; do
+  if grep -qE "mvm_(builderd|build|core|hostd|backend|cli).*${sym}" <<<"$syms"; then
+    echo "::error::host authority symbol \`${sym}\` is PRESENT in mvm-builderd." >&2
+    grep -E "mvm_(builderd|build|core|hostd|backend|cli).*${sym}" <<<"$syms" >&2 || true
+    fail=1
+  else
+    echo "ok: ${sym} absent from mvm-builderd"
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "::error::Builder-daemon authority contract FAILED — see annotations above." >&2
+  exit 1
+fi
+echo "All assertions passed: mvm-builderd carries no host-authority symbols."

--- a/specs/claims/trust-gradient.md
+++ b/specs/claims/trust-gradient.md
@@ -10,10 +10,11 @@ exempt_paths: []
 Machine-checked by `xtask check-trust-gradient`. Authority and resident weight
 decrease monotonically host → builder → workload. No daemon may hold authority
 below its tier; `signing-key`, `plan-admission`, and `audit-writer` never exist
-below the host. The builder row is added once the resident builder daemon binary
-exists.
+below the host. All three daemon tiers are covered: the builder row joined once the
+`mvm-builderd` binary existed.
 
 | Tier | Layer | Daemon | Forbidden authorities | Witnesses |
 | --- | --- | --- | --- | --- |
 | 2 | host | control-daemon | (none — holds all authority) | fn:per_tenant_daemon_paths_are_isolated |
+| 1 | builder | mvm-builderd | signing-key, plan-admission, audit-writer | ci:builderd-no-authority |
 | 0 | workload | guest-agent | signing-key, plan-admission, audit-writer, do-exec, console | ci:prod-agent-no-authority, ci:prod-agent-runentry-contract, ci:prod-agent-no-console |

--- a/specs/notes/plan-205-ws-a-trust-gradient-execution.md
+++ b/specs/notes/plan-205-ws-a-trust-gradient-execution.md
@@ -545,10 +545,10 @@ git commit -m "feat(plan-205): machine-checked trust-gradient ledger via xtask c
 
 ---
 
-## Deferred (one-step follow-up once Plan 204 lands `mvm-builderd`)
+## Deferred (DONE — Plan 204 landed `mvm-builderd`, #1091)
 
-- Add `scripts/check-builderd-no-authority.sh` (same shape as Task 1, target `mvm-builderd`, assert `load_host_signing_key` / `admit_for_run` absent); wire a `builderd-no-authority` security.yml lane.
-- Add the builder row to `specs/claims/trust-gradient.md`: `| 1 | builder | mvm-builderd | signing-key, plan-admission, audit-writer | ci:builderd-no-authority |`. The monotonic check (2 > 1 > 0) and witness resolution then cover all three daemons.
+- [x] Add `scripts/check-builderd-no-authority.sh` (same shape as Task 1, target `mvm-builderd`, assert `load_host_signing_key` / `host_signer` / `admit_for_run` absent); wire a `builderd-no-authority` security.yml lane.
+- [x] Add the builder row to `specs/claims/trust-gradient.md`: `| 1 | builder | mvm-builderd | signing-key, plan-admission, audit-writer | ci:builderd-no-authority |`. The monotonic check (2 > 1 > 0) and witness resolution now cover all three daemons (`check-trust-gradient: clean (3 rows)`).
 
 ## Sequencing for the rest of Plan 205 (not built here)
 


### PR DESCRIPTION
Completes Plan 205 WS-A's **deferred follow-up**, now unblocked: Plan 204 (#1091) landed `mvm-builderd`, so the third tier of the machine-checked trust gradient can finally be witnessed.

## What
- **`scripts/check-builderd-no-authority.sh`** — asserts the builder daemon (`mvm-builderd`) links none of `load_host_signing_key` / `host_signer` / `admit_for_run`. Sibling to `check-prod-agent-no-authority.sh` (same `nm` + canary + crate-prefix-grep pattern).
- **`builderd-no-authority` lane** in `security.yml` (ubuntu-latest, where the real AF_VSOCK serve binary builds).
- **Builder row** in `specs/claims/trust-gradient.md` at tier 1, between host (2) and workload (0): `| 1 | builder | mvm-builderd | signing-key, plan-admission, audit-writer | ci:builderd-no-authority |`.

`mvmctl check-trust-gradient` now reports **clean (3 rows)** — the host > builder > workload gradient is machine-checked end to end, and the witness `ci:builderd-no-authority` resolves to the new lane.

## Why it has teeth (not tautological)
`mvm-build` does not depend on `mvm-backend` / `mvm-hostd` / `mvm-cli` — the crates that define those authority symbols. A future dependency that pulled host-signing or admission code into the builder daemon would emit matching symbols and turn the lane red. Same regression-guard value as the sibling agent gate.

## Verification
- `check-trust-gradient: clean (3 rows)`, `check-no-overclaim` clean locally.
- The gate script **passes** (canary present; all three forbidden symbols absent), verified locally and independently re-built by a security review (most-capable model) → **Ready to merge**, no Critical/Important findings.
- Known latent Minor (inherited from + symmetric with the sibling gate): the `host_signer` substring grep could one day false-positive on `mvm_core::protocol::host_signer` (a benign wire-type module) — zero hits today; left for symmetry, fails closed.

Note: the broader WS-C (resident builder daemon lifecycle) is effectively delivered by Plan 204's `mvm-builderd` ("the resident builder-VM control daemon"); this PR closes the trust-gradient half that Plan 205 WS-A owned.