### PR TITLE
fix(plan-205): harden host_signer gate + document OCI machine warm-pool intent

### DIFF
--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1959,6 +1959,8 @@ pub(in crate::commands) fn start_persistent_oci_machine(
         config_files: &[],
         secret_files: &[],
         port_mappings: &[],
+        // Persistent named machines are long-lived; they are not transient
+        // auto-named launches and are never claimed from the warm standby pool.
         warm_pool_size: 0,
         network_policy,
     }

--- a/scripts/check-builderd-no-authority.sh
+++ b/scripts/check-builderd-no-authority.sh
@@ -31,15 +31,24 @@ else
   fail=1
 fi
 
-for sym in load_host_signing_key host_signer admit_for_run; do
-  if grep -qE "mvm_(builderd|build|core|hostd|backend|cli).*${sym}" <<<"$syms"; then
+# Check absence of each host-authority symbol with the appropriate prefix scope.
+# `host_signer` is narrowed to `mvm_hostd` only: `mvm_core::protocol::host_signer`
+# is a benign wire-type module, not the signing authority, so the broad alternation
+# would false-positive on any binary that links mvm-core.
+check_absent() {
+  local sym="$1" prefix="$2"
+  if grep -qE "${prefix}.*${sym}" <<<"$syms"; then
     echo "::error::host authority symbol \`${sym}\` is PRESENT in mvm-builderd." >&2
-    grep -E "mvm_(builderd|build|core|hostd|backend|cli).*${sym}" <<<"$syms" >&2 || true
+    grep -E "${prefix}.*${sym}" <<<"$syms" >&2 || true
     fail=1
   else
     echo "ok: ${sym} absent from mvm-builderd"
   fi
-done
+}
+
+check_absent load_host_signing_key 'mvm_(builderd|build|core|hostd|backend|cli)'
+check_absent admit_for_run         'mvm_(builderd|build|core|hostd|backend|cli)'
+check_absent host_signer           'mvm_hostd'
 
 if [ "$fail" -ne 0 ]; then
   echo "::error::Builder-daemon authority contract FAILED — see annotations above." >&2

--- a/scripts/check-prod-agent-no-authority.sh
+++ b/scripts/check-prod-agent-no-authority.sh
@@ -30,15 +30,24 @@ else
   fail=1
 fi
 
-for sym in load_host_signing_key host_signer admit_for_run; do
-  if grep -qE "mvm_(guest_agent|core|hostd|backend|cli).*${sym}" <<<"$prod_syms"; then
+# Check absence of each host-authority symbol with the appropriate prefix scope.
+# `host_signer` is narrowed to `mvm_hostd` only: `mvm_core::protocol::host_signer`
+# is a benign wire-type module, not the signing authority, so the broad alternation
+# would false-positive on any binary that links mvm-core.
+check_absent() {
+  local sym="$1" prefix="$2"
+  if grep -qE "${prefix}.*${sym}" <<<"$prod_syms"; then
     echo "::error::host authority symbol \`${sym}\` is PRESENT in the production agent." >&2
-    grep -E "mvm_(guest_agent|core|hostd|backend|cli).*${sym}" <<<"$prod_syms" >&2 || true
+    grep -E "${prefix}.*${sym}" <<<"$prod_syms" >&2 || true
     fail=1
   else
     echo "ok: ${sym} absent from the production agent"
   fi
-done
+}
+
+check_absent load_host_signing_key 'mvm_(guest_agent|core|hostd|backend|cli)'
+check_absent admit_for_run         'mvm_(guest_agent|core|hostd|backend|cli)'
+check_absent host_signer           'mvm_hostd'
 
 if [ "$fail" -ne 0 ]; then
   echo "::error::Production guest-agent authority contract FAILED — see annotations above." >&2


### PR DESCRIPTION
Two small Plan 205 cleanups (the tracked debts from the residency work).

## 3a — harden the `host_signer` no-authority gate (both gates)
`scripts/check-prod-agent-no-authority.sh` and `scripts/check-builderd-no-authority.sh` looped over the forbidden symbols with one broad crate-prefix. The `host_signer` arm could false-positive on `mvm_core::protocol::host_signer` — a benign **wire-type module**, not the signing authority. Replaced the uniform loop with a `check_absent(sym, prefix)` helper: `load_host_signing_key` and `admit_for_run` keep each script's full multi-crate alternation (so a real leak into mvm_backend/mvm_cli/etc. is still caught), while `host_signer` is narrowed to `mvm_hostd` (its actual authority home). Canary + fail logic intact; **both scripts still pass** locally. Fixes the latent false-positive the WS-A/builder-gate final reviews flagged.

## 3b — document the OCI machine warm-pool as intentional (not a residency gap)
Investigated the WS-B "`MVM_RESIDENCY` doesn't reach OCI `run --image`" item. It's **correct by design**, not a gap: `start_persistent_oci_machine` pins `warm_pool_size: 0` because `try_warm_claim` gates on `warm_pool_size == 0` **and** `user_named == false` — a persistent *named* machine fails both and can never join the transient warm standby pool (which is an auto-named launch optimization, not a general residency mechanism). Added a clarifying comment at the field; no behavior change.

Both reviewed (the gate change scrutinized as a security gate) — Approved, no Critical/Important.