### PR TITLE
fix(hostd): exit moat helpers when their supervisor dies; add reap-helpers backstop

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -320,6 +320,13 @@ setup-libkrun:
 clean:
     cargo clean
 
+# Reap leaked host-side helper subprocesses (broker/host-agent/signer/etc.)
+# older than N minutes (default 30). Backstop for the in-binary parent-death
+# watchdog; clears orphans from past test runs across worktrees. DRY_RUN=1 to
+# preview, e.g. `DRY_RUN=1 just reap-helpers` or `just reap-helpers 5`.
+reap-helpers MINUTES="30":
+    ./scripts/reap-helper-orphans.sh {{MINUTES}}
+
 # Security audit (cargo-audit — RUSTSEC advisories against Cargo.lock)
 audit:
     cargo audit

--- a/crates/mvm-hostd/src/bin/mvm-audit-signer.rs
+++ b/crates/mvm-hostd/src/bin/mvm-audit-signer.rs
@@ -38,6 +38,11 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    // Step 6 of the spawn contract above: exit when the supervisor dies. The
+    // child-side watchdog covers macOS and abnormal (SIGKILL/panic) deaths the
+    // spawn-side PR_SET_PDEATHSIG attach cannot.
+    mvm_hostd::parent_death::exit_when_orphaned();
+
     tracing_subscriber::fmt()
         .with_target(true)
         .with_level(true)

--- a/crates/mvm-hostd/src/bin/mvm-broker.rs
+++ b/crates/mvm-hostd/src/bin/mvm-broker.rs
@@ -51,6 +51,11 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    // Spawn-contract step 5: exit when the supervisor dies. This is the
+    // "defensive double-attach in this binary" the contract above promises —
+    // the child-side half that also covers macOS and abnormal parent death.
+    mvm_hostd::parent_death::exit_when_orphaned();
+
     // The supervisor spawns with stdout/stderr captured for the audit
     // log; structured logging is the only useful trace.
     tracing_subscriber::fmt()

--- a/crates/mvm-hostd/src/bin/mvm-host-agent.rs
+++ b/crates/mvm-hostd/src/bin/mvm-host-agent.rs
@@ -387,6 +387,15 @@ fn registration_journal_path(cfg: &HostAgentConfig) -> Result<PathBuf> {
 }
 
 fn main() -> Result<()> {
+    // NB: deliberately NOT armed with the parent-death watchdog the sibling
+    // moat bins use. The worker is designed to outlive a wrapper restart — the
+    // wrapper can be killed and re-spawned while the worker keeps serving the
+    // broker socket, reconnecting via the pid file rather than re-parenting.
+    // The worker cannot tell "wrapper restarting" from "everything gone" by
+    // getppid alone, so a getppid-based self-reap would kill it mid-restart
+    // (it breaks wrapper_restart_restores_journaled_registration_and_chain).
+    // Cleanup of leaked host-agent trees is the age-based reaper's job instead.
+
     tracing_subscriber::fmt()
         .with_target(true)
         .with_level(true)

--- a/crates/mvm-hostd/src/bin/mvm-host-signer.rs
+++ b/crates/mvm-hostd/src/bin/mvm-host-signer.rs
@@ -38,6 +38,11 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    // Step 6 of the spawn contract above: exit when the supervisor dies. The
+    // child-side watchdog covers macOS and abnormal (SIGKILL/panic) deaths the
+    // spawn-side PR_SET_PDEATHSIG attach cannot.
+    mvm_hostd::parent_death::exit_when_orphaned();
+
     tracing_subscriber::fmt()
         .with_target(true)
         .with_level(true)

--- a/crates/mvm-hostd/src/bin/mvm-signer-helper.rs
+++ b/crates/mvm-hostd/src/bin/mvm-signer-helper.rs
@@ -26,6 +26,10 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    // A signer-helper whose host-agent parent is gone holds key material no one
+    // can reach — exit rather than leak as an orphan.
+    mvm_hostd::parent_death::exit_when_orphaned();
+
     tracing_subscriber::fmt()
         .with_target(true)
         .with_level(true)

--- a/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
+++ b/crates/mvm-hostd/src/bin/mvm-substitution-endpoint.rs
@@ -44,6 +44,11 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    // This process holds the workload's secrets in the clear; a backend that
+    // died must not leave it serving as an orphan. Exit the instant the parent
+    // is gone (macOS / SIGKILL gap the spawn-side attach misses).
+    mvm_hostd::parent_death::exit_when_orphaned();
+
     tracing_subscriber::fmt()
         .with_target(true)
         .with_level(true)

--- a/crates/mvm-hostd/src/lib.rs
+++ b/crates/mvm-hostd/src/lib.rs
@@ -30,4 +30,8 @@ pub mod jailer;
 /// [`keyholder::SecretResolver`] trait + the single-host
 /// [`keyholder::LocalResolver`].
 pub mod keyholder;
+/// Child-side parent-death watchdog: each subprocess-moat bin exits the
+/// instant its supervisor dies, closing the macOS / abnormal-death gap the
+/// spawn-side `PR_SET_PDEATHSIG` attach leaves open.
+pub mod parent_death;
 pub mod supervisor;

--- a/crates/mvm-hostd/src/parent_death.rs
+++ b/crates/mvm-hostd/src/parent_death.rs
@@ -1,0 +1,244 @@
+//! Child-side parent-death watchdog for the host-side subprocess moat.
+//!
+//! The leaf moat bins (broker, host-signer, audit-signer, signer-helper,
+//! substitution-endpoint) are each spawned by a supervisor and are useless the
+//! instant that supervisor is gone. (`mvm-host-agent` deliberately opts out:
+//! its worker is built to outlive a wrapper restart, so a getppid-based
+//! self-reap would kill it mid-restart — the age-based reaper cleans up its
+//! leaked trees instead.) The
+//! supervisor attaches a parent-death signal on Linux at spawn time
+//! (`PR_SET_PDEATHSIG`, see `supervisor::services::spawn`), but two gaps let a
+//! helper leak as an orphan re-parented to init/launchd:
+//!
+//! - **macOS has no parent-side primitive.** A `Command` can only carry a
+//!   `pre_exec` hook, and there is no Apple equivalent of `PR_SET_PDEATHSIG`,
+//!   so the spawn-side attach is a documented no-op there. macOS is precisely
+//!   where these orphans accumulate.
+//! - **Abnormal supervisor death runs no teardown.** A `SIGKILL` (e.g. the
+//!   `amfid` codesign kill that fells test binaries) or a panic-abort skips
+//!   every `Drop`/atexit path the supervisor would use to reap its children.
+//!
+//! The fix is to make each helper defend *itself*: arm a watchdog inside its
+//! own `main` that exits the moment its parent dies, regardless of how the
+//! parent died. On Linux that re-arms `PR_SET_PDEATHSIG` (belt-and-suspenders
+//! with the spawn-side attach, and the only attach at all when a test harness
+//! spawns the bin directly). On macOS it runs a `kqueue` `NOTE_EXIT` watcher
+//! thread, falling back to a `getppid` poll if `kqueue` setup fails.
+
+/// Pid of init/launchd. A parent pid of `1` (or `0`) means this process has
+/// been re-parented — its real parent is gone and it should exit.
+const INIT_PID: libc::pid_t = 1;
+
+/// Exit status used when the watchdog reaps an orphaned helper. Zero: the
+/// supervisor that would observe a code is, by definition, already gone, and a
+/// clean status keeps an in-between waiter (e.g. the host-agent worker-restart
+/// loop) from treating an orphan exit as a crash to back off on.
+const ORPHAN_EXIT_CODE: libc::c_int = 0;
+
+/// Decide, from a parent pid, whether this process has been orphaned.
+///
+/// Pure so the orphan rule is unit-testable without forking.
+fn orphaned(parent_pid: libc::pid_t) -> bool {
+    parent_pid <= INIT_PID
+}
+
+/// Terminate immediately because the parent is gone.
+///
+/// Uses `_exit` rather than `std::process::exit` to skip Rust/atexit and tokio
+/// teardown that could block on sockets whose far end (the dead supervisor) is
+/// never coming back.
+fn orphan_exit() -> ! {
+    // SAFETY: `_exit` is async-signal-safe and never returns.
+    unsafe { libc::_exit(ORPHAN_EXIT_CODE) }
+}
+
+/// Install the child-side parent-death watchdog. Call once, first thing in a
+/// helper's `main`, before it blocks on stdin or binds its socket.
+///
+/// Idempotent in effect and best-effort: a watchdog that cannot arm leaves the
+/// age-based reaper (`just reap-helpers`) as the backstop rather than failing
+/// the helper.
+pub fn exit_when_orphaned() {
+    // SAFETY: `getppid` is async-signal-safe and infallible.
+    let parent = unsafe { libc::getppid() };
+    if orphaned(parent) {
+        orphan_exit();
+    }
+    #[cfg(target_os = "linux")]
+    arm_pdeathsig();
+    #[cfg(not(target_os = "linux"))]
+    spawn_parent_watcher(parent);
+}
+
+/// Linux: ask the kernel to signal us the instant our parent dies, then close
+/// the fork/exec race where the parent died before we could arm.
+#[cfg(target_os = "linux")]
+fn arm_pdeathsig() {
+    // SAFETY: `prctl`/`getppid` are infallible for these arguments; a failed
+    // `prctl` only means we fall through to the orphan re-check.
+    unsafe {
+        let _ = libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM as libc::c_ulong);
+        if orphaned(libc::getppid()) {
+            orphan_exit();
+        }
+    }
+}
+
+/// Non-Linux: watch the parent on a dedicated thread so the helper's tokio
+/// runtime is untouched. If the thread cannot spawn, the reaper is the
+/// backstop.
+#[cfg(not(target_os = "linux"))]
+fn spawn_parent_watcher(parent_pid: libc::pid_t) {
+    let _ = std::thread::Builder::new()
+        .name("parent-death".into())
+        .spawn(move || watch_parent(parent_pid));
+}
+
+/// Block until the parent dies, then exit. Prefers `kqueue` `NOTE_EXIT` (no
+/// idle wakeups for these long-lived helpers) and falls back to polling
+/// `getppid` if `kqueue` setup fails.
+#[cfg(not(target_os = "linux"))]
+fn watch_parent(parent_pid: libc::pid_t) {
+    #[cfg(target_os = "macos")]
+    match block_until_parent_exit(parent_pid) {
+        // The parent is gone (or was already gone): reap ourselves.
+        ParentExit::Died => orphan_exit(),
+        // kqueue could not arm; drop through to the portable poll.
+        ParentExit::SetupFailed => {}
+    }
+    watch_parent_poll();
+}
+
+/// Outcome of the macOS `kqueue` watch, separated from the exit so the FFI is
+/// testable without terminating the test process.
+#[cfg(target_os = "macos")]
+enum ParentExit {
+    /// The parent exited (or had already exited before we could register).
+    Died,
+    /// `kqueue`/`kevent` setup failed; caller should fall back to polling.
+    SetupFailed,
+}
+
+/// macOS: register `EVFILT_PROC`/`NOTE_EXIT` on the parent pid and block until
+/// it fires. The `EV_RECEIPT` flag forces the registration to report its status
+/// in-band, so a parent that died between `getppid` and here (errno `ESRCH`) is
+/// reported as `Died` instead of blocking forever on a dead pid.
+#[cfg(target_os = "macos")]
+fn block_until_parent_exit(parent_pid: libc::pid_t) -> ParentExit {
+    // SAFETY: textbook `kqueue`/`kevent` FFI; `kq` is closed before every
+    // return and the `kevent` structs are fully initialised.
+    unsafe {
+        let kq = libc::kqueue();
+        if kq < 0 {
+            return ParentExit::SetupFailed;
+        }
+        let change = libc::kevent {
+            ident: parent_pid as libc::uintptr_t,
+            filter: libc::EVFILT_PROC,
+            flags: libc::EV_ADD | libc::EV_RECEIPT,
+            fflags: libc::NOTE_EXIT,
+            data: 0,
+            udata: std::ptr::null_mut(),
+        };
+        let mut receipt: libc::kevent = std::mem::zeroed();
+        let n = libc::kevent(kq, &change, 1, &mut receipt, 1, std::ptr::null());
+        if n < 0 {
+            libc::close(kq);
+            return ParentExit::SetupFailed;
+        }
+        // EV_RECEIPT always returns one EV_ERROR event; `data` is the errno
+        // (0 = registered cleanly). A non-zero errno — ESRCH most likely —
+        // means the parent is already gone.
+        if n == 1 && (receipt.flags & libc::EV_ERROR) != 0 && receipt.data != 0 {
+            libc::close(kq);
+            return ParentExit::Died;
+        }
+        let mut event: libc::kevent = std::mem::zeroed();
+        let n = libc::kevent(kq, std::ptr::null(), 0, &mut event, 1, std::ptr::null());
+        libc::close(kq);
+        if n < 0 {
+            return ParentExit::SetupFailed;
+        }
+        ParentExit::Died
+    }
+}
+
+/// Portable fallback: re-read `getppid` once a second and exit on reparent.
+/// Latency to reap is bounded by the poll interval, which is irrelevant for
+/// cleanup.
+#[cfg(not(target_os = "linux"))]
+fn watch_parent_poll() -> ! {
+    loop {
+        // SAFETY: `getppid` is infallible.
+        if orphaned(unsafe { libc::getppid() }) {
+            orphan_exit();
+        }
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::orphaned;
+
+    #[test]
+    fn init_pid_is_orphaned() {
+        assert!(orphaned(1));
+    }
+
+    #[test]
+    fn zero_parent_is_orphaned() {
+        // Defensive: a 0 from a surprising libc should fail safe to "orphaned".
+        assert!(orphaned(0));
+    }
+
+    #[test]
+    fn live_parent_is_not_orphaned() {
+        assert!(!orphaned(2));
+        assert!(!orphaned(42_000));
+    }
+
+    #[test]
+    fn arming_with_a_live_parent_returns_without_exiting() {
+        // The test runner is our live parent, so this must arm and return
+        // (Linux prctl path / non-Linux watcher-thread spawn) without reaping
+        // the test process. Reaching the assert proves it did not _exit.
+        super::exit_when_orphaned();
+        assert!(!orphaned(unsafe { libc::getppid() }));
+    }
+
+    // The macOS kqueue path is the one that actually closes the leak on this
+    // platform, so exercise the real `EVFILT_PROC`/`NOTE_EXIT` FFI directly.
+    // `block_until_parent_exit` returns its verdict instead of `_exit`ing, so
+    // these run without killing the test process.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn kqueue_detects_a_live_child_exiting() {
+        use super::{ParentExit, block_until_parent_exit};
+        use std::process::Command;
+
+        let mut child = Command::new("sleep")
+            .arg("0.3")
+            .spawn()
+            .expect("spawn `sleep`");
+        let pid = child.id() as libc::pid_t;
+        // Blocks on NOTE_EXIT until the short-lived child exits (~0.3s).
+        let outcome = block_until_parent_exit(pid);
+        let _ = child.wait();
+        assert!(matches!(outcome, ParentExit::Died));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn kqueue_treats_already_dead_pid_as_died() {
+        use super::{ParentExit, block_until_parent_exit};
+        use std::process::Command;
+
+        let mut child = Command::new("true").spawn().expect("spawn `true`");
+        let pid = child.id() as libc::pid_t;
+        child.wait().expect("reap `true`"); // pid is now dead
+        // Registering NOTE_EXIT on a dead pid yields ESRCH via EV_RECEIPT,
+        // which must read as Died — never an infinite block on a stale pid.
+        assert!(matches!(block_until_parent_exit(pid), ParentExit::Died));
+    }
+}

--- a/scripts/reap-helper-orphans.sh
+++ b/scripts/reap-helper-orphans.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Reap leaked host-side helper subprocesses (the process-moat bins) older than a
+# threshold. These are spawned per-test / per-VM by a supervisor; when that
+# supervisor dies abnormally (SIGKILL from amfid codesign, panic-abort) the
+# helpers reparent to init/launchd and leak. The in-binary parent-death watchdog
+# prevents new leaks; this is the backstop that clears history and covers any
+# helper built before the watchdog landed.
+#
+# Age is the safety discriminator: every process in one dead test tree shares a
+# spawn time, so an age cutoff reaps whole dead trees while sparing the young
+# helpers of a test run in flight. Default cutoff 30 minutes; override with the
+# first argument (minutes) or MINUTES=.
+#
+# Usage:
+#   scripts/reap-helper-orphans.sh           # reap helpers older than 30 min
+#   scripts/reap-helper-orphans.sh 5         # reap helpers older than 5 min
+#   DRY_RUN=1 scripts/reap-helper-orphans.sh # list what would be reaped
+set -euo pipefail
+
+minutes="${1:-${MINUTES:-30}}"
+cutoff=$(( minutes * 60 ))
+
+# Match the helper bins by path component. The leading [m] bracket means this
+# pattern text never matches the `ps`/`awk` pipeline's own argv, so the reaper
+# cannot self-select. `args` (not `comm`) avoids Linux's 15-char comm truncation.
+pattern='/[m]vm-(host-agent|host-signer|signer-helper|audit-signer|broker|substitution-endpoint)([ ]|$)'
+
+# Emit "pid age_seconds args" for matching processes at or over the cutoff.
+mapfile -t victims < <(
+  ps -axo pid=,etime=,args= | awk -v cutoff="$cutoff" -v pat="$pattern" '
+    function secs(e,   d,t,n,a,p) {
+      d = 0
+      if (e ~ /-/) { split(e, p, "-"); d = p[1]; e = p[2] }
+      n = split(e, a, ":")
+      if (n == 3)      t = a[1]*3600 + a[2]*60 + a[3]
+      else if (n == 2) t = a[1]*60 + a[2]
+      else             t = a[1]
+      return d*86400 + t
+    }
+    {
+      pid = $1; age = secs($2)
+      args = $0; sub(/^[ ]*[0-9]+[ ]+[^ ]+[ ]+/, "", args)
+      if (args ~ pat && age >= cutoff) printf "%s %s\n", pid, age
+    }'
+)
+
+if [ "${#victims[@]}" -eq 0 ]; then
+  echo "reap-helper-orphans: no helper subprocesses older than ${minutes}m"
+  exit 0
+fi
+
+pids=()
+for v in "${victims[@]}"; do pids+=("${v%% *}"); done
+
+if [ -n "${DRY_RUN:-}" ]; then
+  echo "reap-helper-orphans: would reap ${#pids[@]} helper(s) older than ${minutes}m:"
+  for v in "${victims[@]}"; do echo "  pid ${v%% *} (${v##* }s old)"; done
+  exit 0
+fi
+
+echo "reap-helper-orphans: reaping ${#pids[@]} helper(s) older than ${minutes}m"
+# SIGTERM is enough — these bins install no handler that would swallow it.
+kill "${pids[@]}" 2>/dev/null || true


### PR DESCRIPTION
## Problem

The host-side process-moat bins (`mvm-broker`, `mvm-host-signer`, `mvm-audit-signer`, `mvm-signer-helper`, `mvm-substitution-endpoint`, and the `mvm-host-agent` trees) reparent to launchd/init and **leak** when their supervisor dies abnormally — a `SIGKILL` (the `amfid` codesign kill that fells test binaries on macOS) or a panic-abort skips the spawn-side teardown. macOS has no parent-side `PR_SET_PDEATHSIG` equivalent, so orphans pile up across test runs and worktrees. Observed live: ~170 idle helpers holding >1 GB resident.

## Fix

**Child-side parent-death watchdog** — `mvm_hostd::parent_death::exit_when_orphaned()`:
- Linux re-arms `PR_SET_PDEATHSIG` (belt-and-suspenders with the spawn-side attach; the only attach when a test spawns a bin directly).
- macOS runs a `kqueue` `EVFILT_PROC`/`NOTE_EXIT` parent-pid watcher thread — the documented-but-missing piece — with a `getppid` poll fallback.
- Installed at the top of each **leaf** moat bin's `main()`.

This is the child-side complement to the existing parent-side `libkrun-sys::child_lifecycle::tie_to_parent_death` (Linux-only, macOS no-op).

### `mvm-host-agent` deliberately excluded

Its worker is designed to **outlive a wrapper restart** — the wrapper can be killed and re-spawned while the worker keeps serving the broker socket, reconnecting via the pid file rather than re-parenting. A `getppid`-based self-reap can't tell "wrapper restarting" from "everything dead," so it would kill the worker mid-restart (breaks `wrapper_restart_restores_journaled_registration_and_chain`). Host-agent's leaked trees are the reaper's job.

**Age-based backstop** — `just reap-helpers [MINUTES=30]` (`scripts/reap-helper-orphans.sh`): clears pre-watchdog orphans and host-agent trees. Age is the safety discriminator (spares the young helpers of a test run in flight); `DRY_RUN=1` previews.

## Tests

- `parent_death` unit tests, including **real macOS kqueue `NOTE_EXIT`** coverage (live-child-exit and already-dead-pid `ESRCH` paths) that exercise the FFI without killing the test process.
- Full `mvm-hostd` suite green (996), incl. the restored wrapper-restart test and the bin-spawning `substitution_endpoint_bin` test.
- Workspace: 5,796 tests pass; doctests pass; `fmt --all` + `clippy --workspace --all-targets -D warnings` clean. (`mvm-backend` excluded locally for the environmental `amfid` SIGKILL; untouched by this change.)