### PR TITLE
fix(hostd): host-agent daemon self-terminates when idle (follow-up to #1174)

### DIFF
--- a/crates/mvm-hostd/src/bin/mvm-host-agent.rs
+++ b/crates/mvm-hostd/src/bin/mvm-host-agent.rs
@@ -316,6 +316,10 @@ async fn run_worker_once(cfg: HostAgentConfig) -> Result<()> {
         registrations = restored,
         "mvm-host-agent registration journal restored"
     );
+    tokio::spawn(mvm_hostd::host_agent_idle::run_idle_watcher(
+        daemon.clone(),
+        mvm_hostd::host_agent_idle::idle_timeout(),
+    ));
     HostAgentDaemon::run_shared(daemon, &cfg.control_socket).await?;
 
     Ok(())
@@ -343,6 +347,12 @@ async fn supervise_worker(cfg: HostAgentConfig, raw_cfg: Vec<u8>) -> Result<()> 
             Ok(()) => {
                 startup_failures = 0;
                 match worker.wait().await {
+                    Ok(status) if mvm_hostd::host_agent_idle::is_idle_shutdown(status.code()) => {
+                        reap_stale_worker_group(&worker_pid_path);
+                        let _ = std::fs::remove_file(&worker_pid_path);
+                        tracing::info!(tenant_id = %cfg.tenant_id, "mvm-host-agent idle; daemon exiting");
+                        return Ok(());
+                    }
                     Ok(status) => tracing::warn!(
                         tenant_id = %cfg.tenant_id,
                         status = %status,
@@ -394,7 +404,10 @@ fn main() -> Result<()> {
     // The worker cannot tell "wrapper restarting" from "everything gone" by
     // getppid alone, so a getppid-based self-reap would kill it mid-restart
     // (it breaks wrapper_restart_restores_journaled_registration_and_chain).
-    // Cleanup of leaked host-agent trees is the age-based reaper's job instead.
+    // Instead the worker self-terminates via the idle watcher (host_agent_idle)
+    // once it has had no VM registrations for the configured idle timeout; the
+    // age-based reaper remains the long-tail backstop for any trees that escape
+    // that window.
 
     tracing_subscriber::fmt()
         .with_target(true)

--- a/crates/mvm-hostd/src/host_agent_idle.rs
+++ b/crates/mvm-hostd/src/host_agent_idle.rs
@@ -29,10 +29,12 @@ pub const IDLE_SHUTDOWN_EXIT_CODE: i32 = 42;
 /// - `Some(unparseable / negative)` → `Some(300s)` — safe fallback to default.
 pub fn parse_idle_timeout(raw: Option<&str>) -> Option<Duration> {
     const DEFAULT: Duration = Duration::from_secs(300);
-    match raw {
+    // Trim once up front so the disable sentinel and the integer parse agree on
+    // a whitespace-padded value (e.g. `" 0 "` must still disable).
+    match raw.map(str::trim) {
         None => Some(DEFAULT),
         Some("0") => None,
-        Some(s) => match s.trim().parse::<i64>() {
+        Some(s) => match s.parse::<i64>() {
             Ok(n) if n > 0 => Some(Duration::from_secs(n as u64)),
             _ => Some(DEFAULT),
         },
@@ -114,6 +116,12 @@ mod tests {
     #[test]
     fn parse_zero_disables() {
         assert_eq!(parse_idle_timeout(Some("0")), None);
+    }
+
+    #[test]
+    fn parse_whitespace_padded_zero_disables() {
+        assert_eq!(parse_idle_timeout(Some(" 0 ")), None);
+        assert_eq!(parse_idle_timeout(Some("\t0\n")), None);
     }
 
     #[test]

--- a/crates/mvm-hostd/src/host_agent_idle.rs
+++ b/crates/mvm-hostd/src/host_agent_idle.rs
@@ -1,0 +1,213 @@
+//! Idle-registration self-termination logic for `mvm-host-agent`.
+//!
+//! A detached host-agent worker (setsid, ppid=1) leaks when its VMs are gone
+//! and the CLI that would ordinarily reap it dies abnormally. This module
+//! implements the decision logic: once zero VM registrations have persisted for
+//! the configured idle timeout the worker exits with [`IDLE_SHUTDOWN_EXIT_CODE`]
+//! so the wrapper can tear down the tree rather than restart it.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+use crate::broker::daemon::HostAgentDaemon;
+
+/// Exit code the worker uses when it self-terminates due to idle timeout.
+///
+/// A distinct value lets the wrapper distinguish "idle — tear down the tree"
+/// from a crash (non-zero) or a clean stop (0). The wrapper must not restart
+/// on this code.
+pub const IDLE_SHUTDOWN_EXIT_CODE: i32 = 42;
+
+/// Map the raw `MVM_HOST_AGENT_IDLE_TIMEOUT` env value to a `Duration`.
+///
+/// - `None` (env var unset) → `Some(300s)` — the default 5-minute warm window
+///   keeps short-lived dev workflows from racing against idle reap.
+/// - `Some("0")` → `None` — disables idle-exit entirely.
+/// - `Some(positive integer)` → `Some(n seconds)`.
+/// - `Some(unparseable / negative)` → `Some(300s)` — safe fallback to default.
+pub fn parse_idle_timeout(raw: Option<&str>) -> Option<Duration> {
+    const DEFAULT: Duration = Duration::from_secs(300);
+    match raw {
+        None => Some(DEFAULT),
+        Some("0") => None,
+        Some(s) => match s.trim().parse::<i64>() {
+            Ok(n) if n > 0 => Some(Duration::from_secs(n as u64)),
+            _ => Some(DEFAULT),
+        },
+    }
+}
+
+/// Read `MVM_HOST_AGENT_IDLE_TIMEOUT` from the environment and return the
+/// resolved idle timeout.
+pub fn idle_timeout() -> Option<Duration> {
+    parse_idle_timeout(std::env::var("MVM_HOST_AGENT_IDLE_TIMEOUT").ok().as_deref())
+}
+
+/// Return `true` when the daemon should self-exit due to idleness.
+///
+/// All four conditions must hold simultaneously:
+/// - `timeout` is `Some` (idle-exit is enabled),
+/// - `count == 0` (no live registrations),
+/// - `zero_since` is `Some` (we have been at zero continuously since that
+///   instant — a transient dip that recovered resets the clock),
+/// - the elapsed time since `zero_since` has reached `timeout`.
+pub fn should_idle_exit(
+    count: usize,
+    zero_since: Option<Instant>,
+    now: Instant,
+    timeout: Option<Duration>,
+) -> bool {
+    timeout.is_some_and(|t| count == 0 && zero_since.is_some_and(|z| now.duration_since(z) >= t))
+}
+
+/// Return `true` when the worker exit code signals an idle self-termination.
+///
+/// The wrapper uses this to distinguish idle teardown (no restart) from a
+/// crash (back off + restart).
+pub fn is_idle_shutdown(code: Option<i32>) -> bool {
+    code == Some(IDLE_SHUTDOWN_EXIT_CODE)
+}
+
+/// Watcher task that calls `process::exit(IDLE_SHUTDOWN_EXIT_CODE)` once the
+/// daemon has had zero VM registrations for `timeout`.
+///
+/// Spawn this as a sibling task alongside the daemon's main serve loop. If
+/// `timeout` is `None` (idle-exit disabled) the function returns immediately
+/// without blocking.
+///
+/// The lock over `daemon` is held only for the `registration_count()` read and
+/// is dropped before every sleep, so it never serialises against broker request
+/// handling.
+pub async fn run_idle_watcher(daemon: Arc<Mutex<HostAgentDaemon>>, timeout: Option<Duration>) {
+    let Some(timeout) = timeout else {
+        return;
+    };
+    const PROBE: Duration = Duration::from_millis(500);
+    let mut zero_since: Option<Instant> = None;
+    loop {
+        let count = daemon.lock().await.registration_count();
+        if count > 0 {
+            zero_since = None;
+        } else if zero_since.is_none() {
+            zero_since = Some(Instant::now());
+        }
+        if should_idle_exit(count, zero_since, Instant::now(), Some(timeout)) {
+            std::process::exit(IDLE_SHUTDOWN_EXIT_CODE);
+        }
+        tokio::time::sleep(PROBE).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- parse_idle_timeout ---
+
+    #[test]
+    fn parse_none_gives_default() {
+        assert_eq!(parse_idle_timeout(None), Some(Duration::from_secs(300)));
+    }
+
+    #[test]
+    fn parse_zero_disables() {
+        assert_eq!(parse_idle_timeout(Some("0")), None);
+    }
+
+    #[test]
+    fn parse_positive_integer() {
+        assert_eq!(parse_idle_timeout(Some("5")), Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn parse_unparseable_falls_back_to_default() {
+        assert_eq!(
+            parse_idle_timeout(Some("abc")),
+            Some(Duration::from_secs(300))
+        );
+    }
+
+    #[test]
+    fn parse_negative_falls_back_to_default() {
+        assert_eq!(
+            parse_idle_timeout(Some("-3")),
+            Some(Duration::from_secs(300))
+        );
+    }
+
+    // --- should_idle_exit ---
+
+    #[test]
+    fn disabled_timeout_never_exits() {
+        let base = Instant::now();
+        // Simulate count == 0 with an old zero_since: disabled means no exit.
+        let zero_since = base.checked_sub(Duration::from_secs(600));
+        assert!(!should_idle_exit(0, zero_since, base, None));
+    }
+
+    #[test]
+    fn nonzero_count_never_exits() {
+        let base = Instant::now();
+        let timeout = Some(Duration::from_secs(10));
+        let zero_since = base.checked_sub(Duration::from_secs(600));
+        assert!(!should_idle_exit(1, zero_since, base, timeout));
+    }
+
+    #[test]
+    fn zero_count_no_zero_since_does_not_exit() {
+        let base = Instant::now();
+        let timeout = Some(Duration::from_secs(10));
+        assert!(!should_idle_exit(0, None, base, timeout));
+    }
+
+    #[test]
+    fn zero_count_idle_under_timeout_does_not_exit() {
+        let timeout = Duration::from_secs(60);
+        let base = Instant::now();
+        // zero_since is only 1 second ago — still under the 60s threshold.
+        let zero_since = base.checked_sub(Duration::from_secs(1));
+        assert!(!should_idle_exit(0, zero_since, base, Some(timeout)));
+    }
+
+    #[test]
+    fn zero_count_idle_over_timeout_exits() {
+        let timeout = Duration::from_secs(60);
+        let base = Instant::now();
+        // zero_since is 120 seconds ago — well past the threshold.
+        let zero_since = base.checked_sub(Duration::from_secs(120));
+        assert!(should_idle_exit(0, zero_since, base, Some(timeout)));
+    }
+
+    #[test]
+    fn zero_count_idle_exactly_at_timeout_exits() {
+        let timeout = Duration::from_secs(60);
+        let base = Instant::now();
+        // zero_since is exactly `timeout` ago — boundary inclusive.
+        let zero_since = base.checked_sub(timeout);
+        assert!(should_idle_exit(0, zero_since, base, Some(timeout)));
+    }
+
+    // --- is_idle_shutdown ---
+
+    #[test]
+    fn idle_shutdown_code_is_recognized() {
+        assert!(is_idle_shutdown(Some(IDLE_SHUTDOWN_EXIT_CODE)));
+    }
+
+    #[test]
+    fn zero_exit_is_not_idle_shutdown() {
+        assert!(!is_idle_shutdown(Some(0)));
+    }
+
+    #[test]
+    fn one_exit_is_not_idle_shutdown() {
+        assert!(!is_idle_shutdown(Some(1)));
+    }
+
+    #[test]
+    fn none_exit_is_not_idle_shutdown() {
+        assert!(!is_idle_shutdown(None));
+    }
+}

--- a/crates/mvm-hostd/src/lib.rs
+++ b/crates/mvm-hostd/src/lib.rs
@@ -24,6 +24,8 @@ pub mod broker;
 /// from `mvm_core::framing` so `mvm-core`'s default build pulls no
 /// async runtime.
 pub mod framing;
+/// Idle-registration self-termination logic for the `mvm-host-agent` worker.
+pub mod host_agent_idle;
 pub mod host_signer;
 pub mod jailer;
 /// Secret keyholder — the `SecretRef` → credential boundary: the

--- a/crates/mvm-hostd/src/parent_death.rs
+++ b/crates/mvm-hostd/src/parent_death.rs
@@ -4,8 +4,10 @@
 //! substitution-endpoint) are each spawned by a supervisor and are useless the
 //! instant that supervisor is gone. (`mvm-host-agent` deliberately opts out:
 //! its worker is built to outlive a wrapper restart, so a getppid-based
-//! self-reap would kill it mid-restart — the age-based reaper cleans up its
-//! leaked trees instead.) The
+//! self-reap would kill it mid-restart; instead the worker self-terminates via
+//! the idle-registration watcher once it has had no VM registrations for the
+//! configured timeout, with the age-based reaper as the long-tail backstop.)
+//! The
 //! supervisor attaches a parent-death signal on Linux at spawn time
 //! (`PR_SET_PDEATHSIG`, see `supervisor::services::spawn`), but two gaps let a
 //! helper leak as an orphan re-parented to init/launchd:

--- a/crates/mvm-hostd/tests/host_agent_restart.rs
+++ b/crates/mvm-hostd/tests/host_agent_restart.rs
@@ -33,11 +33,22 @@ struct HostAgentFixture {
 
 impl HostAgentFixture {
     async fn start() -> Self {
+        Self::start_inner(None).await
+    }
+
+    async fn start_with_idle_timeout(secs: u64) -> Self {
+        Self::start_inner(Some(secs)).await
+    }
+
+    async fn start_inner(idle_timeout_secs: Option<u64>) -> Self {
         let mut env = TestEnv::new();
         let data_dir = tempfile::tempdir().expect("temp data dir");
         env.set("MVM_DATA_DIR", data_dir.path());
         env.set("MVM_HOST_AGENT_PATH", HOST_AGENT_BIN);
         env.set("MVM_SIGNER_HELPER_PATH", SIGNER_HELPER_BIN);
+        if let Some(secs) = idle_timeout_secs {
+            env.set("MVM_HOST_AGENT_IDLE_TIMEOUT", secs.to_string());
+        }
 
         let keys_dir = config::mvm_keys_dir();
         let signer = host_keypair::load_or_init_at(&keys_dir).expect("host signer");
@@ -112,6 +123,10 @@ impl HostAgentFixture {
     fn chain_entries(&self) -> usize {
         verify_workload_chain(&self.workload_chain, &self.verifying_key).expect("chain verifies")
     }
+
+    fn deregister(&self) {
+        deregister_vm(&self.control_socket, &self.key_bytes, &self.vm_name).expect("deregister vm");
+    }
 }
 
 impl Drop for HostAgentFixture {
@@ -139,6 +154,28 @@ fn kill_process_group(pid: libc::pid_t) {
     unsafe {
         libc::kill(-pid, libc::SIGKILL);
     }
+}
+
+fn pid_alive(pid: libc::pid_t) -> bool {
+    // Reap zombie children before probing: if the process is a zombie, waitpid
+    // removes it from the table so a subsequent kill(pid, 0) returns ESRCH.
+    // SAFETY: WNOHANG never blocks; we discard the status.
+    unsafe {
+        libc::waitpid(pid, std::ptr::null_mut(), libc::WNOHANG);
+    }
+    // SAFETY: kill(pid, 0) probes process existence without delivering a signal.
+    // Returns 0 if alive (including zombies not yet reaped), -1/ESRCH if gone.
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+async fn wait_until_pid_dead(pid: libc::pid_t, deadline: Instant) {
+    while Instant::now() < deadline {
+        if !pid_alive(pid) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("pid {pid} was still alive at deadline");
 }
 
 async fn write_frame(stream: &mut UnixStream, value: &impl serde::Serialize) -> Result<()> {
@@ -273,4 +310,33 @@ async fn daemon_crash_mid_flight_loses_at_most_one_call_and_preserves_chain() {
         &fixture.vm_name,
     )
     .expect("deregister vm");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn idle_daemon_self_terminates_when_last_vm_deregisters() {
+    // 1s idle timeout — the daemon should exit well within our 6s deadline.
+    let fixture = HostAgentFixture::start_with_idle_timeout(1).await;
+
+    // Sanity check: the tree is alive before we pull the registration.
+    let daemon_pid = fixture.daemon_pid().expect("daemon pid");
+    let worker_pid = fixture.worker_pid().expect("worker pid");
+    assert!(
+        pid_alive(daemon_pid),
+        "daemon must be alive before deregister"
+    );
+    assert!(
+        pid_alive(worker_pid),
+        "worker must be alive before deregister"
+    );
+
+    // Deregister the only VM → registration count drops to 0.
+    fixture.deregister();
+
+    // Poll until both the worker and the wrapper (daemon) are gone.
+    // The idle watcher polls every 500ms and the timeout is 1s, so the worker
+    // exits after ~1.5s at most. The wrapper observes the idle exit code and
+    // returns Ok() without restarting. 6s is ample headroom.
+    let deadline = Instant::now() + Duration::from_secs(6);
+    wait_until_pid_dead(worker_pid, deadline).await;
+    wait_until_pid_dead(daemon_pid, deadline).await;
 }


### PR DESCRIPTION
Implements the follow-up specced in #1178 — reaps abandoned `mvm-host-agent` daemons. Follows #1174 (the parent-death watchdog), which deliberately left this case to the age-based reaper.

## Why this, not a worker watchdog

The host-agent supervisor is a **detached resident daemon** (`ensure_host_agent_daemon` → `spawn_detached_with_config` → `setsid` in `pre_exec`; `ppid=1` by design, outlives `mvmctl up`). So the dominant leak is the **daemon itself surviving abnormal CLI/test death** (it keeps running, holding its worker + signer-helper), not the worker outliving its supervisor. A `getppid`/lock-liveness watchdog can't reap a daemon that's *supposed* to be parentless and is alive — so the unit to reap is the daemon **when it has no registrations**. (An earlier flock-liveness approach was built and discarded after this finding; see #1178's history.)

## Design

The daemon already tracks live VMs via `HostAgentDaemon::registration_count()`. New `mvm_hostd::host_agent_idle`:
- The **worker** spawns an idle watcher (sibling task sharing the daemon `Arc<Mutex<…>>`). Once `registration_count()` has been **zero continuously for `MVM_HOST_AGENT_IDLE_TIMEOUT`** (default **300s**; `0` disables → permanently warm), it `process::exit(IDLE_SHUTDOWN_EXIT_CODE=42)`.
- The **wrapper**'s supervise loop recognizes code 42 and **exits the tree instead of restarting** (reaps the worker group, removes the pid file, returns `Ok`). The signer-helper follows via its #1174 parent-death watchdog.
- Warm during active use: any registered VM keeps `count ≥ 1`, so the idle clock never starts.

Pure, testable core: `parse_idle_timeout`, `should_idle_exit`, `is_idle_shutdown` (truth-table unit tests). Uniform across OSes — no prctl/kqueue split.

## Tests
- 16 `host_agent_idle` unit tests (parse/decision/classification truth tables, incl. whitespace-padded `"0"` disables).
- Integration test `idle_daemon_self_terminates_when_last_vm_deregisters`: 1s timeout, registers then deregisters, asserts the daemon **and** worker pids genuinely terminate (the test's `pid_alive` reaps zombies via `waitpid(WNOHANG)` before `kill(pid,0)` so it proves real `ESRCH`, not a zombie) — i.e. the tree is gone, not respawned.
- No regression: `wrapper_restart_*` / `worker_restart_*` / `daemon_crash_mid_flight_*` still pass (they hold a registration, default timeout, idle clock never starts).
- Full workspace green: 5,817 tests pass, doctests pass, `fmt --all` + `clippy --workspace --all-targets -D warnings` clean. (`mvm-backend` excluded locally for the environmental `amfid` SIGKILL; untouched here.)

## Built via subagent-driven development
Two implementer tasks (library core → bin wiring), each with an independent task review, plus a final whole-branch review (verdict: READY TO MERGE). `MVM_HOST_AGENT_IDLE_TIMEOUT=0` remains the escape hatch for a permanently warm daemon; `just reap-helpers` (#1174) stays the long-tail backstop.