### PR TITLE
docs(machine): unified `machine run` lifecycle — ADR-091 + Plan 207

### DIFF
--- a/specs/adrs/091-unified-machine-run-lifecycle.md
+++ b/specs/adrs/091-unified-machine-run-lifecycle.md
@@ -1,0 +1,105 @@
+# ADR-091 — Unified `machine run` lifecycle (transient / persistent / interactive)
+
+**Status:** Proposed
+**Date:** 2026-06-21
+**Relates to:** [ADR-002](002-microvm-security-posture.md) (security posture, claim 15),
+[Plan 165](../plans/165-entrypoint-presence-and-sealed-interactivity.md) (sealed interactivity / claim 15),
+[Plan 207](../plans/207-machine-run-unified-lifecycle.md) (implementation),
+design note `specs/notes/2026-06-21-machine-run-unified-lifecycle-design.md`.
+
+## Context
+
+`machine run --image alpine -- /bin/sh` silently exits instead of giving a shell.
+That is not a crash: `machine run` is the one-shot **transient** runner
+(`commands/machine/mod.rs` → `vm::exec::run_secure` → the guest agent `Exec` RPC
+over vsock). The `Exec` transport is output-only — it streams
+`ExecEvent::Stdout`/`Stderr` to the host and never forwards host stdin or
+allocates a PTY. So `/bin/sh` reads EOF, exits `0`, the VM tears down, and
+`mvmctl` returns `0` with no output.
+
+Two capabilities common to comparable microVM tooling are missing:
+
+1. A **persistent** machine without the `create` → `start` → `shell` three-step
+   ceremony — one command that boots, leaves the machine running, and is
+   reconnectable by name.
+2. An **interactive** shell from a single `run` invocation — which the `Exec`
+   stream fundamentally cannot provide.
+
+The naïve fix — teach `Exec` to carry stdin/PTY, or auto-attach a shell whenever
+`/bin/sh` is passed — collides with the security posture: interactive access to a
+**sealed production** microVM is forbidden and CI-gated (claim 15, ADR-002 / Plan
+165). Any solution must keep that invariant intact.
+
+## Decision
+
+Make `machine run` a single front door over **three orthogonal, flag-selected
+axes**, composing the existing machine verbs rather than adding new lifecycle
+code.
+
+### 1. Persistence and interactivity are independent axes
+
+- **Persistence** is decided *solely* by `--name <N>` or `-d`/`--detach`.
+  `--name` persists under a chosen name; `-d` persists under an auto-generated
+  name (printed to stdout and `--json`). There is **no standalone `--persist`**
+  flag — it would be redundant with `--name` and silent on the blocking question.
+- **Interactivity** is `-t`/`--tty` (with `-i` accepted as an alias so the
+  familiar `-it` bundle parses). It controls *how the command attaches*; it is
+  **never consulted to decide persistence**.
+- With neither persistence nor interactivity flag, `run` is the transient,
+  non-interactive one-shot it is today — `run_secure`, byte-for-byte unchanged.
+
+Concretely: `run -it -- /bin/sh` (no name, no detach) is a **transient**
+interactive machine — it lives only for the life of the shell and is torn down on
+exit. Adding `--name`/`-d` is the *only* thing that keeps a machine alive.
+
+### 2. `-t`/`--tty` is dev-only and reuses the existing PTY path
+
+Interactive access goes through `console::run` (the PTY-over-vsock path
+`machine shell` already uses), pointed at the just-booted VM — **not** by
+extending `Exec`. It requires dev mode + a `dev-shell` guest agent + a host TTY,
+and is gated by the existing `enforce_accessible_gate` (claim 15). `--prod`, a
+sealed (dm-verity) image, or an agent built without the console symbol →
+**refused up front, before boot**, with a clear error. Non-TTY stdin with `-t` →
+clear error rather than a hang.
+
+### 3. Persistence composes existing verbs; collisions fail closed
+
+The persistent path writes the same `MachineSpec` that `machine create` writes,
+boots through `start_machine` (same signed-`ExecutionPlan` admission + default-deny
+egress as `machine start`), and is reconnectable through the existing
+`machine shell`/`exec`/`stop`/`ls`/`inspect` (which already key off the on-disk
+spec by name). Auto-names reuse the transient `vm_name` generator — no second
+naming scheme.
+
+When `--name <N>` targets an existing spec with a **different** config, `run`
+**errors** and tells the user to pick another name or pass `--force` (which
+stops, overwrites, and restarts). Silently ignoring the new flags, or silently
+destroying machine state, are both rejected as footguns.
+
+## Consequences
+
+- The original command works in dev (`run -it --image <dev-image> -- /bin/sh`
+  → a shell) and is explicitly refused in prod — claim 15 is preserved, not
+  weakened, and its CI gate is untouched. This ADR introduces **no new claim**;
+  it is an application of claim 15.
+- No change to the `Exec` vsock transport, `run_secure`, or any existing machine
+  verb. Existing tests stay green; the new surface is additive.
+- One mild non-orthogonality remains by design: `-t`/`--tty` is dev-only while
+  persistence is not, so `run -it --prod --name web` is refused for the `-it`
+  even though the persistent part would be valid. This is acceptable — the user
+  is asking for an interactive prod shell, which is the thing claim 15 forbids.
+- Idle auto-stop / TTL reaping of persistent machines is **out of scope**; the
+  in-flight warm-pool/reaper work is the right home if wanted later.
+
+## Alternatives considered
+
+- **Auto-detect interactivity from a TTY** (no `-it` flag). Rejected: the same
+  command would behave differently interactively vs piped, and an explicit flag
+  is the established idiom; the dev-only gate is also clearer when the intent is
+  explicit.
+- **A separate `machine up` verb** for the persistent path. Rejected: a single
+  front door (`run`, mode chosen by flags) is the DX target; `up` would split the
+  mental model and duplicate flag surfaces.
+- **Teach `Exec` to carry stdin/PTY.** Rejected: it would create a second
+  interactive transport to audit against claim 15, for no benefit over the
+  existing PTY console.

--- a/specs/notes/2026-06-21-machine-run-unified-lifecycle-design.md
+++ b/specs/notes/2026-06-21-machine-run-unified-lifecycle-design.md
@@ -1,6 +1,8 @@
 # `machine run` — unified transient / persistent / interactive lifecycle
 
-**Status:** design, approved 2026-06-21. Implementation plan to follow in `specs/plans/`.
+**Status:** design, approved 2026-06-21. Decision recorded in
+[ADR-091](../adrs/091-unified-machine-run-lifecycle.md); implementation tracked in
+[Plan 207](../plans/207-machine-run-unified-lifecycle.md).
 
 ## Problem
 

--- a/specs/notes/2026-06-21-machine-run-unified-lifecycle-design.md
+++ b/specs/notes/2026-06-21-machine-run-unified-lifecycle-design.md
@@ -1,0 +1,149 @@
+# `machine run` — unified transient / persistent / interactive lifecycle
+
+**Status:** design, approved 2026-06-21. Implementation plan to follow in `specs/plans/`.
+
+## Problem
+
+`machine run --image alpine -- /bin/sh` silently exits instead of giving a shell.
+It is not a crash: `machine run` is the one-shot *transient* runner
+(`machine/mod.rs` → `vm::exec::run_secure` → the guest agent `Exec` over vsock).
+That transport is output-only — it streams `ExecEvent::Stdout`/`Stderr` back to the
+host and never forwards host stdin or allocates a PTY. So `/bin/sh` gets EOF on
+stdin, exits `0`, the VM tears down, and `mvmctl` returns `0` with no output.
+
+Two capabilities are missing, both present in comparable microVM tooling:
+
+1. A **persistent** machine without the `create` → `start` → `shell` three-step
+   ceremony — one command that boots a machine, leaves it running, and is
+   reconnectable by name.
+2. An **interactive** shell from a single `run` invocation (the original
+   complaint), which the `Exec` stream fundamentally cannot provide.
+
+## Goal
+
+One front door — `machine run` — that covers three modes selected entirely by
+flags, while leaving every existing verb (`create`/`start`/`shell`/`exec`/
+`stop`/`ls`/`inspect`) and the transient `run_secure` path unchanged.
+
+## Design
+
+### Three orthogonal axes
+
+| Axis | Flag | Meaning |
+|---|---|---|
+| Persistence | `--name <N>` / `-d`, `--detach` | machine survives after the command; named, or auto-named |
+| Interactivity | `-t`, `--tty` (`-i` accepted as alias so `-it` parses) | attach a PTY shell — **dev-only** |
+| Default | (no flag) | transient, non-interactive — today's `run_secure`, untouched |
+
+`--name` and `-d`/`--detach` both imply persistence; they differ only in naming
+and whether the command blocks. There is deliberately **no** standalone
+`--persist` flag — it would be redundant with `--name` and silent on the
+blocking question. `-d`/`--detach` is the canonical persistence-without-a-name
+flag (matches the universal `-d` idiom and carries the "hand me back my prompt"
+lifecycle meaning).
+
+### Dispatch inside `machine run`
+
+Persistence and interactivity are **independent axes**. Persistence is computed
+once from the flags; `--tty` never affects it — it only decides *how the command
+attaches*. Whether a machine is torn down is decided by persistence alone:
+
+```
+let persistent  = args.name.is_some() || args.detach;   // --tty is NOT consulted here
+let interactive = args.tty;                              // dev-only
+
+if interactive {
+    // attach a PTY shell (boot transient, or boot/reuse the named/detached one)
+    boot-or-reuse VM; console::run(...);
+    on exit: tear down  iff !persistent          // -it alone => transient => gone
+} else if persistent {
+    create-or-reuse spec + start + maybe exec;   // leave up
+} else {
+    run_secure(...)                              // unchanged transient one-shot
+}
+```
+
+So `-it` with neither `--name` nor `-d` is a **transient** interactive machine —
+it exists only for the life of the shell.
+
+The interactive and persistent paths **compose existing building blocks** — they
+introduce no new lifecycle code:
+
+- **Auto-name:** reuse the transient `vm_name` generator / `mvm-core` ID helper;
+  no second naming scheme. Surface the chosen name on stdout and in `--json`.
+- **Spec creation:** the persistent path writes the same `MachineSpec` that
+  `machine create` writes today.
+- **Boot:** the persistent path boots through `start_machine` exactly as
+  `machine start` does — same signed-`ExecutionPlan` admission, same
+  default-deny egress. No new trust surface.
+- **Reconnect/teardown:** `machine shell <name>`, `machine exec <name>`,
+  `machine stop <name>`, `machine ls`, `machine inspect <name>` already key off
+  the on-disk `MachineSpec` by name, so an auto-generated name plugs straight in.
+- **Interactive attach:** reuse `console::run` (the PTY-over-vsock path
+  `machine shell` already uses), pointed at the just-booted VM.
+
+### `-t`/`--tty` is dev-only — the security contract
+
+Interactive access requires **dev mode** + a **dev-shell guest agent** + a host
+TTY. It reuses `enforce_accessible_gate` (claim 15: no interactive access to a
+sealed production microVM).
+
+- `machine run -it --image <dev-image> -- /bin/sh` on a TTY → drops into a shell.
+- `--prod`, or a sealed (dm-verity) image, or an agent built without the
+  `dev-shell` console symbol → **refused up front, before boot**, with a clear
+  error. Claim 15 stays intact and CI-gated.
+
+This is not a removable limitation; it is the posture. It aligns cleanly:
+interactive shells are a dev affordance, which is exactly when the flag is used.
+
+### Create-or-reuse collision
+
+When `machine run --name web` targets a name whose on-disk `MachineSpec` already
+exists but with a **different** config (image / cpus / memory / profile / …):
+
+- Default → **error**: `machine 'web' exists with a different config; pass
+  --force to recreate, or use a different name`.
+- `--force` → stop, overwrite the spec, restart with the new config.
+
+Silently ignoring the new flags, or silently destroying machine state, are both
+footguns and are rejected.
+
+### Behavior matrix (the contract to test)
+
+| Command | Persistent | Name | Interactive | Returns | Machine after |
+|---|---|---|---|---|---|
+| `run --image X -- cmd` | no | — | no | after cmd (streamed) | gone |
+| `run -it --image X -- /bin/sh` (dev, TTY) | no | — | yes | on shell exit | gone |
+| `run -it --prod --image X -- /bin/sh` | — | — | — | **refused before boot** | unchanged |
+| `run --name web --image X -- cmd` | yes | web | no | after cmd (streamed) | up |
+| `run -it --name web --image X -- /bin/sh` | yes | web | yes | on shell exit | up |
+| `run -d --image X` | yes | auto, printed | no | after boot | up |
+| `run -d --name web --image X` | yes | web | no | after boot | up |
+| `run --name web` (exists, diff config) | — | — | — | **error** | unchanged |
+| `run --force --name web ...` (diff config) | yes | web | per flags | per flags | recreated |
+
+### Explicitly unchanged
+
+- `create` / `start` / `shell` / `exec` / `stop` / `ls` / `inspect`.
+- The transient `run_secure` path — byte-for-byte; existing tests stay green.
+- The signed-`ExecutionPlan` + default-deny-egress posture on every boot.
+
+## Out of scope
+
+- Idle auto-stop / TTL reaping of persistent machines (separate concern; the
+  warm-pool/reaper work already in flight is the right home if wanted later).
+- Any change to the `Exec` vsock transport itself — interactivity goes through
+  the existing PTY console, not by teaching `Exec` to carry stdin.
+
+## Testing focus
+
+- CLI parse tests for every flag combination in the matrix (incl. `-it`
+  short-flag bundling and the `-i` alias).
+- Dispatch unit tests: `--tty` → interactive, name/`-d` → persistent, neither →
+  `run_secure` (assert the transient path is selected unchanged).
+- Collision: same-config reuse vs different-config error vs `--force` reconcile.
+- Security: `--tty` refused for `--prod` / sealed image via
+  `enforce_accessible_gate`; refused when stdin is not a TTY with a clear message
+  (no hang).
+- Auto-name surfaced on stdout + `--json`; reconnect by the generated name works
+  through `machine shell`/`exec`/`stop`.

--- a/specs/plans/207-machine-run-unified-lifecycle.md
+++ b/specs/plans/207-machine-run-unified-lifecycle.md
@@ -1,0 +1,117 @@
+# Plan 207 — Unified `machine run` lifecycle (transient / persistent / interactive)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task, and superpowers:test-driven-development for every task — each flag combination in the behavior matrix gets a failing test first. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fold three flag-selected modes into `machine run` — transient (today),
+**persistent** (`--name`/`-d`), and **interactive** (`-t`/`--tty`, dev-only) —
+so `machine run --image alpine -- /bin/sh` drops into a shell in dev, and a
+persistent machine no longer needs the `create` → `start` → `shell` ceremony.
+Compose the existing machine verbs; do not add new lifecycle code.
+
+**Design:** ADR-091 (`specs/adrs/091-unified-machine-run-lifecycle.md`) and the
+design note `specs/notes/2026-06-21-machine-run-unified-lifecycle-design.md`.
+Read both first — they are the contract. The locked rules:
+
+- Persistence = `--name <N>` OR `-d`/`--detach` (auto-names, printed). No `--persist`.
+- Interactivity = `-t`/`--tty` (`-i` alias so `-it` parses). **Dev-only**, refused
+  in `--prod`/sealed via `enforce_accessible_gate` (claim 15). `--tty` never
+  affects persistence; `-it` alone = transient interactive (gone on shell exit).
+- Default (no flags) = transient `run_secure`, byte-for-byte unchanged.
+- Collision (named spec exists, different config) = **error** unless `--force`
+  (stop + overwrite + restart).
+
+**Key anchors (verify before editing):**
+`crates/mvm-cli/src/commands/machine/mod.rs` (`MachineRunArgs`, `run()` dispatch,
+`MachineSpec` create/load/save, `start_machine`, `shell_machine`/`exec_machine`),
+`crates/mvm-cli/src/commands/vm/exec.rs` (`run_secure`, the output-only `Exec`
+stream — leave unchanged), `console::run` (PTY attach to reuse), and
+`enforce_accessible_gate` (claim 15 gate).
+
+## Behavior matrix (the contract to test)
+
+| Command | Persistent | Name | Interactive | Returns | Machine after |
+|---|---|---|---|---|---|
+| `run --image X -- cmd` | no | — | no | after cmd (streamed) | gone |
+| `run -it --image X -- /bin/sh` (dev, TTY) | no | — | yes | on shell exit | gone |
+| `run -it --prod --image X -- /bin/sh` | — | — | — | refused before boot | unchanged |
+| `run --name web --image X -- cmd` | yes | web | no | after cmd (streamed) | up |
+| `run -it --name web --image X -- /bin/sh` | yes | web | yes | on shell exit | up |
+| `run -d --image X` | yes | auto, printed | no | after boot | up |
+| `run -d --name web --image X` | yes | web | no | after boot | up |
+| `run --name web` (exists, diff config) | — | — | — | error | unchanged |
+| `run --force --name web ...` (diff config) | yes | web | per flags | per flags | recreated |
+
+---
+
+## Task 1: Flags + dispatch scaffolding (transient stays unchanged)
+
+- [ ] Add to `MachineRunArgs`: `--name <N>`, `-d`/`--detach`, `-t`/`--tty` (with
+      `-i` as an accepted alias so `-it` bundles parse). Keep all existing
+      transient flags intact.
+- [ ] Compute `persistent = name.is_some() || detach` and `interactive = tty`
+      once; do **not** consult `tty` for persistence.
+- [ ] Branch `run()`: `interactive` → interactive path (Task 3); else
+      `persistent` → persistent path (Task 2); else → `run_secure(into_run_args())`
+      unchanged.
+- [ ] Tests: CLI parse coverage for every matrix row incl. `-it` bundling and the
+      `-i` alias; a dispatch unit test asserting the no-flag case still selects
+      `run_secure` (transient path unchanged).
+
+## Task 2: Persistent path (`--name` / `-d`, no `-t`)
+
+- [ ] `run_persistent`: resolve name — given `--name`, use it; given bare `-d`,
+      auto-generate via the existing transient `vm_name` generator / `mvm-core`
+      ID helper (no second scheme). Surface the resolved name on stdout + `--json`.
+- [ ] Create-or-reuse the `MachineSpec` (same struct `create` writes): absent →
+      write; present + config matches → reuse; present + config differs → **error**
+      with a clear message, unless `--force` → stop + overwrite + restart.
+- [ ] Start if not already running — reuse `start_machine` and the liveness check
+      `start`/`stop` already use against `machine_state_dir` (never double-boot).
+- [ ] Post-start behavior: argv + no `-d` → `exec` it, stream, leave machine up;
+      argv + `-d` → `exec` detached, return; no argv + `-d` → boot, print name,
+      return; no argv + no `-d` → boot and print a hint pointing at
+      `machine shell <name>`.
+- [ ] Tests: same-config reuse vs different-config error vs `--force` reconcile;
+      auto-name surfaced + reconnect by it through `machine shell`/`exec`/`stop`;
+      no-double-boot when already running.
+
+## Task 3: Interactive path (`-t`/`--tty`, dev-only)
+
+- [ ] Route to `console::run` (the PTY path `machine shell` uses) against the
+      just-booted VM. For the **transient** case (no name/detach) boot a throwaway
+      VM, attach, and **tear it down on shell exit**; for the persistent case
+      boot/reuse the named machine and **leave it up** on exit.
+- [ ] Dev-only gate: refuse `--tty` under `--prod`, a sealed (dm-verity) image, or
+      a non-`dev-shell` agent — **before boot** — via `enforce_accessible_gate`
+      (claim 15). Clear error.
+- [ ] Refuse `--tty` when host stdin is not a TTY, with a clear message (no hang).
+- [ ] Tests: `--tty` refused for `--prod`/sealed via the gate; non-TTY stdin
+      refused; transient-interactive selects teardown-on-exit, persistent-interactive
+      leaves the machine up. (Live PTY round-trip is Task 5.)
+
+## Task 4: Docs + claim integrity
+
+- [ ] Update `public/src/content/docs/reference/cli-commands.md` for the new
+      `machine run` flags and the three modes; add a troubleshooting note that a
+      bare `run -- /bin/sh` is non-interactive by design and `-it` (dev) gives a
+      shell.
+- [ ] Confirm `xtask check-claim-catalog` stays green — this plan introduces no
+      new claim; `-it` is an application of claim 15. No catalog edits expected.
+
+## Task 5: Verification (dev-host bootable)
+
+- [ ] On this macOS dev host (vz/libkrun): `machine run -it --image <dev-image>
+      -- /bin/sh` drops into a live shell and tears the VM down on exit; capture
+      the session.
+- [ ] `machine run -d --name web --image <dev-image>` returns immediately, prints
+      `web`, `machine ls` shows it, `machine shell web` reconnects, `machine stop
+      web` tears down.
+- [ ] `machine run -it --prod --image <sealed>` is refused before boot with the
+      claim-15 error.
+- [ ] `just ci` green (fmt --all, nextest, doctests, clippy -D warnings).
+
+## Out of scope
+
+- Idle auto-stop / TTL reaping of persistent machines (warm-pool/reaper work is
+  the right home if wanted later).
+- Any change to the `Exec` vsock transport, `run_secure`, or existing machine verbs.


### PR DESCRIPTION
## What

Standalone **docs PR** — the approved design for unifying `machine run` into
transient / persistent / interactive modes. No code; implementation lands in a
separate code-only PR off `main`.

- **Design note** — `specs/notes/2026-06-21-machine-run-unified-lifecycle-design.md`
- **ADR-091** — `specs/adrs/091-unified-machine-run-lifecycle.md` (decision + rationale + alternatives)
- **Plan 207** — `specs/plans/207-machine-run-unified-lifecycle.md` (task-by-task, TDD)

## Why

`machine run --image alpine -- /bin/sh` silently exits — it's the one-shot
transient runner over the output-only `Exec` vsock stream (no stdin/PTY), so
`/bin/sh` hits EOF and the VM tears down. The design adds, under one front door:

- **Persistence** without `create`→`start`→`shell` ceremony — `--name <N>` or
  `-d`/`--detach` (auto-named, printed); reconnect via existing `machine shell`/`exec`/`stop`.
- **Interactivity** — `-t`/`--tty` (`-i` alias) reusing the existing PTY console
  path. **Dev-only**, refused in `--prod`/sealed via `enforce_accessible_gate`
  (claim 15 preserved, no new claim).

Persistence and interactivity are orthogonal: `-it` alone = transient interactive
(gone on shell exit). Default `run` is unchanged (`run_secure`, byte-for-byte).
Collision on a named spec with a different config errors unless `--force`.

## Follow-up

Implementation is tracked in Plan 207 (Tasks 1–5) and ships as its own PR.