### PR TITLE
docs(adr-092): `machine` as the sole workload CLI surface (consolidation)

### DIFF
--- a/specs/adrs/092-machine-as-sole-workload-cli-surface.md
+++ b/specs/adrs/092-machine-as-sole-workload-cli-surface.md
@@ -1,0 +1,168 @@
+# ADR-092 — `machine` is the sole workload-VM CLI surface
+
+**Status:** Proposed
+**Date:** 2026-06-21
+**Relates to:** [ADR-002](002-microvm-security-posture.md),
+[ADR-091](091-unified-machine-run-lifecycle.md),
+[Plan 200](../plans/200-machine-ux-dx-layer.md),
+[Plan 207](../plans/207-machine-run-unified-lifecycle.md)
+
+## Context
+
+`mvmctl --help` lists 28 top-level commands. Daily-driver workload lifecycle
+sits in a flat list next to rarely-touched infrastructure, and — worse — the
+same microVM lifecycle is reachable through **two parallel surfaces**:
+
+- verb-first, project-shaped: `up`, `down`, `run`, `invoke`, `ls`, `logs`,
+  `console`, and the `vm` sub-group (`pause`/`snapshot`/`cp`/`fs`/…);
+- noun-first, Docker-shaped: `machine run`/`create`/`start`/`stop`/`exec`/
+  `shell`/`ls`/`inspect`/`rm`, added by Plan 200.
+
+These are **not** two runtimes. `machine` is a thin translation layer over the
+same code: `machine run` → `vm::exec::run_secure`, `machine start` →
+`vm::up::start_persistent_oci_machine`, `machine stop` → `vm::down::run`,
+`machine shell`/`exec` → `vm::console::run`. The cost is entirely UX: a user
+must learn which of two names operates on the one object, and the split runs
+along the wrong axis. `up` versus `machine run` differs mainly in *image
+source* (Nix flake/manifest vs OCI) and *audience muscle-memory* — neither of
+which deserves a separate command tree. Lifecycle (transient / persistent /
+interactive / operate-on-running) is the dimension users actually reason about,
+and image source is properly a flag, not a noun.
+
+Plan 200 deliberately framed `machine` as "a UX layer over mvm's existing
+primitives, not a parallel runtime stack," and stopped short of touching
+`up`/`down`. ADR-091 / Plan 207 then unified `machine run` itself into
+transient / persistent / interactive modes. With that front door in place, the
+verb-first surface no longer earns its keep — it only re-creates the split.
+
+This ADR records the decision to finish the job: collapse to **one workload
+noun**.
+
+A second object is in scope only to keep it *out* of scope: `dev` (the builder
+VM) is a genuinely different thing — host build substrate, not a workload — and
+stays its own command. ADR-088 already draws that boundary.
+
+## Decision
+
+`machine` becomes the **sole** CLI surface for workload microVMs. Every
+workload lifecycle and operate-on-running verb hangs off it; the verb-first
+commands and the separate `vm` noun are **removed outright** (no aliases).
+
+### 1. Image source is a flag, not a command
+
+`machine run`, `machine create`, and `machine build` accept the source as a
+flag over the path that already exists under the hood:
+
+- `--image <ref>` → OCI path (pull + materialize ext4; no Nix).
+- `--flake <path>` (or a discovered `mvm.toml`) → Nix build path inside the
+  builder VM.
+
+`machine build` is the explicit build step (today's `build image`), producing a
+manifest/image that `machine run --image …` can consume. `machine run --flake .`
+remains the one-step build-and-run. Source detection is exclusive: `--image`
+selects OCI, `--flake`/manifest selects Nix; supplying both errors.
+
+### 2. One noun, every verb — grouped, not split
+
+`vm` is **not** a second noun. Its verbs fold into `machine`; its sub-groups
+stay nested under it. `machine --help` is kept scannable with clap
+`help_heading`s rather than by inventing another object:
+
+- **Lifecycle:** `run` · `build` · `create` · `start` · `stop` · `rm`
+- **Inspect:** `ls` · `logs` · `inspect` · `shell` · `exec`
+- **Advanced:** `pause` · `resume` · `snapshot` · `save` · `restore` ·
+  `checkpoint` · `cp` · `wait` · `set-ttl` · `forward` · `diff` ·
+  `fs` · `proc` · `session` · `volume` · `sandbox`
+
+This is the Docker model done literally: one noun, the overwhelm solved by
+in-`--help` grouping, never by a parallel surface.
+
+### 3. Verb→home mapping (removals)
+
+| Removed top-level command | New home |
+| --- | --- |
+| `up` | `machine run --flake .` (`-d`/`--name` for persistent) |
+| `down` | `machine stop` |
+| `run` | `machine run` |
+| `invoke` | `machine run --entrypoint` |
+| `ls` | `machine ls` |
+| `logs` | `machine logs <name>` |
+| `console` | `machine shell` / `machine console` |
+| `build image` | `machine build` |
+| `vm <verb>` | `machine <verb>` (Advanced group) |
+
+Unchanged: `build compile`/`validate`/`kernel` stay under `build` (build-time
+SDK/kernel work, not VM lifecycle); `dev` stays separate (builder VM).
+
+### 4. Infrastructure commands stay, but get a help heading
+
+`dev`, `pool`, `cache`, `storage`, `doctor`, `init`, `secret`, `bundle`,
+`trust`, `deps`, `artifact`, `network`, `manifest`, `catalog`, `image`, `ops`,
+`env` remain. They move under an **Infrastructure / advanced** `help_heading`
+so the top-level `--help` leads with the daily drivers (`machine`, `dev`,
+`build`, `init`, `doctor`) instead of a flat 28-item wall.
+
+### 5. Hard removal, no aliases
+
+Consistent with the project's pre-1.0 "no backwards compatibility — first
+version" rule, the removed verbs do **not** survive as hidden aliases. `--help`
+advertises exactly one workload noun. Hidden aliases would preserve the
+muscle-memory split this ADR is paying to delete, and a shim layer is debt with
+no offsetting user we owe stability to yet.
+
+## Consequences
+
+**Positive**
+
+- One object, one noun. A user learns `machine` and can reach every workload
+  operation; there is no second name for the same thing.
+- `--help` leads with ~5 daily drivers; the long tail is grouped, not gone.
+- Image source becomes an honest flag; the Nix-vs-OCI distinction stops
+  masquerading as a lifecycle distinction.
+- No security/admission change: every path already routes through the signed
+  `ExecutionPlan` admission and audit chain (claims 8–15 unaffected). This is a
+  surface rename over unchanged enforcement.
+
+**Negative / costs**
+
+- High-churn rename. `up`/`run`/`down`/`vm` are referenced across specs, other
+  in-flight branches, docs, examples, and the SDK machine wrappers; all must
+  move in lockstep with the removal, since there are no aliases to soften it.
+- `machine` grows large. Mitigated by `help_heading` grouping and the nested
+  sub-groups (`fs`/`proc`/`session`/`volume`/`sandbox`), but a single noun
+  carrying ~25 verbs is inherently heavier than the old split.
+- Coordination with ADR-091 / Plan 207: this ADR sits *above* that work and
+  assumes the unified `machine run` modes land first.
+
+## Alternatives considered
+
+- **Keep both surfaces (status quo / Plan 200 as written).** Rejected: it is
+  exactly the two-name-for-one-object confusion that motivated this ADR.
+- **Verb-first wins; delete `machine`.** Coherent, lower churn, but throws away
+  the Docker-shaped onboarding `machine` was added to provide and keeps no
+  single noun for the object. Rejected in favour of the friendlier, newer noun.
+- **Keep `vm` as a second power-user noun.** Pragmatic (smaller `machine`
+  `--help`), but re-introduces the split along a frequency seam instead of a
+  muscle-memory seam — still two names for one running object. Rejected;
+  grouping inside `machine` solves the overwhelm without a second noun.
+- **Hidden aliases for a transition window.** Rejected under the pre-1.0
+  no-backcompat rule; nothing yet depends on the old verbs that we owe
+  stability.
+
+## Sequencing
+
+Land in waves rather than one mega-PR, each green and shippable:
+
+1. **Prerequisite:** ADR-091 / Plan 207 unified `machine run` modes merge.
+2. **Lifecycle fold-in:** retire `up`/`down`/`run`/`invoke`; `machine run`
+   learns `--flake`/`--entrypoint`; `machine build` absorbs `build image`.
+3. **Inspect fold-in:** retire `logs`/`console`; `machine logs`/`console`;
+   confirm `machine ls` covers `ls --all`.
+4. **Advanced fold-in:** retire the `vm` noun; its verbs/sub-groups move under
+   `machine` with the Advanced `help_heading`.
+5. **Help grouping:** apply `help_heading`s to top-level (Infrastructure group)
+   and to `machine`'s subcommands (Lifecycle/Inspect/Advanced).
+
+Each wave updates the affected specs, docs, examples, and SDK machine wrappers
+in the same change. A follow-on implementation plan (next free plan number)
+tracks the task-by-task, TDD breakdown; this ADR records only the decision.

--- a/specs/plans/208-machine-sole-cli-surface-consolidation.md
+++ b/specs/plans/208-machine-sole-cli-surface-consolidation.md
@@ -1,0 +1,299 @@
+# Plan 208 — `machine` as the sole workload CLI surface (consolidation)
+
+**Status:** Proposed — not started
+**Owner:** mvm
+**Date:** 2026-06-21
+**Decision:** [ADR-092](../adrs/092-machine-as-sole-workload-cli-surface.md)
+**Depends on:** [ADR-091](../adrs/091-unified-machine-run-lifecycle.md) /
+[Plan 207](207-machine-run-unified-lifecycle.md) (unified `machine run` modes)
+merged to `main` first.
+**Amends:** [Plan 200](200-machine-ux-dx-layer.md) — supersedes its "UX layer
+over primitives, do not touch `up`/`down`" framing.
+
+> **For agentic workers:** implement task-by-task. Each task is independently
+> testable, ends green (`cargo nextest run --workspace` + `cargo clippy
+> --workspace -- -D warnings` + `cargo fmt --all -- --check`), and is its own
+> commit. Steps use `- [ ]` checkboxes.
+
+## Goal
+
+Collapse the workload-VM CLI to a single noun, `machine`. Remove the verb-first
+commands (`up`, `down`, `run`, `invoke`, `logs`, `console`, `ls`) and the
+separate `vm` noun; fold every lifecycle and operate-on-running verb under
+`machine`, kept scannable with clap `help_heading` groups. Image source becomes
+a flag (`--image` OCI / `--flake` Nix). No aliases — hard removal, per the
+pre-1.0 no-backcompat rule.
+
+This is a **surface rename over unchanged enforcement.** Every retired verb
+already delegates to a handler `machine` will keep calling
+(`vm::exec::run_secure`, `vm::up::*`, `vm::down::run`, `vm::console::run`,
+`vm::logs::run`, `vm::ps::run`, `vm::group::*`). No admission, signing, audit,
+or backend code changes. Claims 8–15 are untouched and must stay untouched.
+
+## Global constraints
+
+- `cargo fmt --all -- --check`, `cargo nextest run --workspace`, `cargo test
+  --workspace --doc`, `cargo clippy --workspace -- -D warnings` all green per
+  task. (`just ci`.)
+- No `#[allow(clippy::too_many_arguments)]`; group args into structs.
+- No spec/PR/ADR citations in code comments (lint-gated).
+- No new dependencies.
+- Hard removal: a retired command name must **not** parse afterward (no hidden
+  clap alias). The negative test for each is "old name → clap error".
+- Handlers are **moved, not rewritten.** A task that retires `Foo` re-points
+  `machine`'s dispatch at the same handler function `Commands::Foo` called.
+- `dev` (builder VM) is out of scope and stays a top-level command.
+
+## The contract to test (end state)
+
+| Removed | New invocation | Backing handler (unchanged) |
+| --- | --- | --- |
+| `up --flake .` | `machine run --flake .` | `vm::up::run` via `machine run` dispatch |
+| `down [name]` | `machine stop [name]` | `vm::down::run` |
+| `run -- cmd` | `machine run -- cmd` | `vm::exec::run_secure` |
+| `invoke … ` | `machine run --entrypoint …` | `vm::invoke::run` |
+| `ls [--all]` | `machine ls [--all]` | `vm::ps::run` |
+| `logs <name>` | `machine logs <name>` | `vm::logs::run` |
+| `console <name>` | `machine console <name>` / `machine shell` | `vm::console::run` |
+| `build image …` | `machine build …` | `build::image` handler |
+| `vm <verb>` | `machine <verb>` (Advanced group) | `vm::group::*` |
+
+`machine --help` groups subcommands under `help_heading`s: **Lifecycle**
+(`run`/`build`/`create`/`start`/`stop`/`rm`), **Inspect**
+(`ls`/`logs`/`inspect`/`shell`/`exec`/`console`), **Advanced** (`pause`/`resume`/
+`snapshot`/`save`/`restore`/`checkpoint`/`cp`/`wait`/`set-ttl`/`forward`/`diff`/
+`fs`/`proc`/`session`/`volume`/`sandbox`).
+
+Top-level `--help` groups the infra commands (`pool`/`cache`/`storage`/
+`manifest`/`catalog`/`image`/`bundle`/`trust`/`deps`/`artifact`/`secret`/
+`network`/`ops`/`env`/`reconcile`) under an **Infrastructure** heading, leaving
+`machine`/`dev`/`build`/`init`/`doctor` ungrouped at the top.
+
+## Key files
+
+- `crates/mvm-cli/src/commands/mod.rs` — top-level `Commands` enum (mod.rs:71)
+  and its dispatch `match`; this is where variants get deleted and `help_heading`
+  is applied.
+- `crates/mvm-cli/src/commands/machine/mod.rs` — `MachineAction` enum
+  (mod.rs:57) and its dispatch (mod.rs:1416); where folded verbs land.
+- `crates/mvm-cli/src/commands/vm/{up,down,exec,invoke,logs,ps,console,group}.rs`
+  — handler bodies (moved, not rewritten).
+- `crates/mvm-cli/tests/cli.rs` — clap parse/help integration tests; primary
+  test surface for every task.
+- SDK machine wrappers (Python/TS/Rust) and `public/src/content/docs/` — updated
+  per wave that retires a verb they reference.
+
+## Test approach
+
+Each task is gated by `tests/cli.rs` assertions using clap's
+`Command::try_get_matches_from` (no VM boot needed to prove the surface):
+
+- **positive:** new path parses and routes to the intended handler args
+  (assert on the parsed `MachineAction` / arg fields).
+- **negative (hard removal):** the retired top-level name returns
+  `clap::error::ErrorKind::InvalidSubcommand`.
+- **help grouping:** `--help` output contains the `help_heading` label and the
+  subcommand under it.
+
+Behavior parity (does the VM actually boot/stop) is already covered by the
+existing handler tests, which keep running unchanged because the handler is the
+same function. Live dev-host boot smoke is the final task.
+
+---
+
+## Task 1: Top-level `--help` grouping (no removals yet)
+
+Pure presentation; lands first so reviewers see the target shape before any
+verb moves. Apply `#[command(help_heading = "Infrastructure")]` to the infra
+variants of `Commands` (mod.rs:71): `Pool`, `Cache`, `Storage`, `Manifest`,
+`Catalog`, `Image`, `Bundle`, `Trust`, `Deps`, `Artifact`, `Secret`, `Network`,
+`Ops`, `Env`, `Reconcile`. Leave `Machine`/`Dev`/`Build`/`Init`/`Doctor`
+ungrouped.
+
+- [ ] Write failing test in `tests/cli.rs`: `top_level_help_groups_infra` —
+  render `Cli::command().render_help()`, assert it contains `"Infrastructure"`
+  and that `"pool"` appears after that heading.
+- [ ] Run it; confirm FAIL (heading absent).
+- [ ] Add `help_heading` attributes to the infra variants.
+- [ ] Run it; confirm PASS. Run `cargo run -- --help` and eyeball the grouping.
+- [ ] `just ci`; commit `docs(cli): group infrastructure commands in --help`.
+
+**Done when:** `--help` leads with the daily drivers; infra is under one
+heading; no command renamed or removed.
+
+## Task 2: `machine` subcommand `help_heading` groups
+
+Add `help_heading` to the existing `MachineAction` variants (mod.rs:57):
+Lifecycle = `Run`/`Create`/`Start`/`Stop`/`Rm`; Inspect = `Ls`/`Inspect`/
+`Shell`/`Exec`. (`Build`/`logs`/`console`/advanced verbs arrive in later tasks
+and are grouped as they land.)
+
+- [ ] Write failing test `machine_help_groups_lifecycle_and_inspect` in
+  `tests/cli.rs`: render `machine --help`, assert `"Lifecycle"` and `"Inspect"`
+  headings present with `run`/`ls` under them.
+- [ ] Run; FAIL. Add the attributes. Run; PASS.
+- [ ] `just ci`; commit `docs(cli): group machine subcommands in --help`.
+
+**Done when:** `machine --help` is grouped; no behavior change.
+
+## Task 3: Fold `build image` → `machine build`
+
+`machine build` is the explicit image build (OCI or Nix-flake) that produces a
+manifest/image `machine run --image` consumes. Add a `Build(MachineBuildArgs)`
+variant to `MachineAction` (Lifecycle heading); its handler **calls the existing
+`build::group` image handler** with the translated args. Remove the `image`
+subcommand from the `build` group (`build compile/validate/kernel` stay).
+
+- [ ] Write failing test `machine_build_parses_image_and_flake`: assert
+  `machine build --image alpine` and `machine build --flake .` both parse and
+  that supplying both is a clap conflict error.
+- [ ] Write failing test `build_image_subcommand_removed`: assert
+  `build image …` → `InvalidSubcommand`.
+- [ ] Run both; FAIL. Add `MachineBuildArgs` (mirror the old `build image` args;
+  reuse the same arg struct if one exists), wire dispatch (mod.rs:1416) to the
+  existing build handler, delete the `Image` arm from `build::group`.
+- [ ] Run; PASS. Add a doctest/handler test asserting the build handler is
+  invoked with equivalent args (assert on the constructed build request struct).
+- [ ] `just ci`; commit `feat(cli): move build image to machine build`.
+
+**Done when:** `machine build` builds; `build image` no longer parses; the build
+pipeline code is unchanged (only its entry point moved).
+
+## Task 4: Fold `up`/`run`/`invoke` → `machine run` (Lifecycle)
+
+ADR-091/Plan 207 already gave `machine run` `--name`/`-d`/`-it`. This task adds
+the two source/entry flags and retires the three transient/persistent runners.
+
+- `machine run --flake <path>` (and manifest discovery) routes to **`vm::up::run`**
+  (the Nix build-and-run path); `--image` keeps routing to `run_secure`.
+- `machine run --entrypoint [args…]` routes to **`vm::invoke::run`** (baked
+  entrypoint).
+- Remove `Commands::Up`, `Commands::Run`, `Commands::Invoke` (mod.rs:103/127/129)
+  and their dispatch arms.
+
+- [ ] Write failing test `machine_run_flake_routes_to_build_and_run`: parse
+  `machine run --flake . --name web`, assert it resolves to the up/build path
+  (assert on the dispatch selector enum the handler branches on).
+- [ ] Write failing test `machine_run_entrypoint_routes_to_invoke`: parse
+  `machine run --entrypoint -- arg1`, assert invoke path selected.
+- [ ] Write failing tests `up_removed`/`run_removed`/`invoke_removed`: each old
+  name → `InvalidSubcommand`.
+- [ ] Run all; FAIL. Add `--flake`/`--entrypoint` to `MachineRunArgs`
+  (exclusive with `--image`), branch dispatch to `vm::up::run`/`vm::invoke::run`,
+  delete the three `Commands` variants + arms.
+- [ ] Run; PASS. Confirm the existing `up`/`invoke`/`run` handler unit tests
+  still pass unchanged (they test the moved functions).
+- [ ] `just ci`; commit `feat(cli): fold up/run/invoke into machine run`.
+
+**Done when:** all three old verbs are gone; `machine run` covers OCI, Nix-flake,
+transient, persistent, and entrypoint via flags; handler bodies unchanged.
+
+## Task 5: Fold `down` → `machine stop`
+
+`machine stop` exists (delegates to `vm::down::run`). This task makes it the
+**only** stop path: extend `machine stop` to accept `down`'s full surface
+(by-name, `--all`, `mvm.toml`-derived set) and remove `Commands::Down`.
+
+- [ ] Write failing test `machine_stop_supports_all_and_named`: assert
+  `machine stop --all` and `machine stop web` parse to the same options `down`
+  accepted.
+- [ ] Write failing test `down_removed`: `down` → `InvalidSubcommand`.
+- [ ] Run; FAIL. Widen `MachineStopArgs` to `down`'s args, ensure dispatch passes
+  them straight to `vm::down::run`, delete `Commands::Down` + arm.
+- [ ] Run; PASS. `just ci`; commit `feat(cli): fold down into machine stop`.
+
+**Done when:** `machine stop` covers every `down` invocation; `down` gone.
+
+## Task 6: Fold `ls`/`logs`/`console` → Inspect group
+
+`machine ls` exists; `logs`/`console` do not yet. Add `Logs(...)` and
+`Console(...)` to `MachineAction` (Inspect heading), each delegating to
+`vm::logs::run` / `vm::console::run`. Confirm `machine ls --all` matches `ls
+--all`. Remove `Commands::Ls`, `Commands::Logs`, `Commands::Console`.
+
+- [ ] Write failing tests: `machine_logs_parses`, `machine_console_parses`,
+  `machine_ls_supports_all`, and `ls_removed`/`logs_removed`/`console_removed`
+  (each old name → `InvalidSubcommand`).
+- [ ] Run; FAIL. Add the two `MachineAction` variants delegating to the existing
+  handlers; verify `machine ls` already forwards `--all`; delete the three
+  `Commands` variants + arms.
+- [ ] Run; PASS. Note: `machine console` keeps the claim-15 `enforce_accessible_gate`
+  because it calls the same `vm::console::run` — add a test asserting it is still
+  refused on a sealed image (reuse the existing `console_refused_on_sealed_image`
+  fixture path).
+- [ ] `just ci`; commit `feat(cli): fold ls/logs/console into machine`.
+
+**Done when:** the three inspect verbs live under `machine`; claim-15 gate
+preserved (test proves it); old names gone.
+
+## Task 7: Fold the `vm` noun → `machine` Advanced group
+
+Move every `vm` subcommand under `machine` and delete `Commands::Vm`. The
+`vm::group` subcommands (`pause`/`resume`/`snapshot`/`save`/`restore`/
+`checkpoint`/`cp`/`wait`/`set-ttl`/`forward`/`diff` + the `fs`/`proc`/`session`/
+`volume`/`sandbox` nested groups) become `MachineAction` variants under the
+**Advanced** `help_heading`, each delegating to the same `vm::group::*` handler.
+
+- [ ] Write failing test `machine_advanced_verbs_parse`: parameterized over
+  `pause`/`snapshot`/`cp`/`fs`/`proc`/`session`/`volume`/`sandbox`, assert each
+  parses under `machine` and routes to the matching `vm::group` handler.
+- [ ] Write failing test `vm_noun_removed`: `vm pause` → `InvalidSubcommand`.
+- [ ] Write failing test `machine_help_groups_advanced`: `machine --help`
+  contains `"Advanced"` with `snapshot` under it.
+- [ ] Run; FAIL. Re-home the `vm::group` action enum under `MachineAction`
+  (prefer flattening the existing group enum as a sub-enum to avoid rewriting 16
+  handlers), apply the Advanced heading, delete `Commands::Vm` + arm.
+- [ ] Run; PASS. Confirm all existing `vm::group` handler tests pass unchanged.
+- [ ] `just ci`; commit `feat(cli): fold the vm noun into machine`.
+
+**Done when:** `machine --help` shows Lifecycle/Inspect/Advanced; `vm` is gone;
+no `vm::group` handler logic changed.
+
+## Task 8: Sweep references — SDK wrappers, docs, examples, specs
+
+Mechanical follow-through so nothing advertises a removed verb.
+
+- [ ] `rg -n '\b(mvmctl|mvm) (up|down|run|invoke|logs|console|ls|vm) ' --type-not
+  rust` across `public/`, `examples/`, `specs/`, SDK wrapper sources; replace
+  each with its `machine` form (use the contract table).
+- [ ] Update Python/TS/Rust SDK machine wrappers that shell out to old verbs.
+- [ ] Update `public/src/content/docs/reference/cli-commands.md` and the
+  quickstart/guides.
+- [ ] Tick the matching boxes in `specs/REFACTOR-STATUS.md` and update Plan 200's
+  status to note ADR-092 supersedes its `up`/`down` framing; bump "Last updated".
+- [ ] `just ci`; run the docs link/spec gates
+  (`cargo build --all-targets`, `xtask check-no-spec-refs-in-comments`,
+  `xtask check-spec-numbers`). Commit `docs(cli): retire verb-first commands across docs/SDK`.
+
+**Done when:** no doc, example, or SDK wrapper invokes a removed verb; status
+rollups current.
+
+## Task 9: Live dev-host verification
+
+Surface tests prove parsing; this proves the moved handlers still boot a VM.
+
+- [ ] On the dev host (macOS 26 / Vz or Linux/KVM box per
+  `[[project_dev_host_runs_builder_via_vz]]`), run, capturing console logs:
+  - `mvmctl machine run --image alpine -- echo hi` (transient OCI)
+  - `mvmctl machine run --flake . --name w -d` then `machine stop w` (Nix persistent)
+  - `mvmctl machine ls` / `machine logs w` while up
+  - `mvmctl machine snapshot w` (one Advanced verb, smoke)
+- [ ] Confirm each succeeds and that no removed verb exists (`mvmctl up` →
+  error). Record timings/log paths in the plan.
+- [ ] Commit `test(cli): record machine-consolidation dev-host verification`.
+
+**Done when:** the daily-driver paths boot and tear down on a real backend
+through the new surface.
+
+## Out of scope
+
+- `dev` (builder VM) — stays a distinct top-level command (ADR-088).
+- Any admission / signing / audit / backend change — this is surface-only.
+- The unified `machine run` *modes* themselves — owned by Plan 207; this plan
+  assumes them present.
+- Renaming infra commands — they keep their names, only gain a help heading.
+
+## Deferred follow-ups
+
+- [ ] Decide whether `manifest`/`catalog`/`image` (image-adjacent infra) should
+  later nest under `machine` too; left as infra for now to bound this plan.


### PR DESCRIPTION
## What

Standalone **docs PR** — the approved decision + plan to make `machine` the
single workload-VM CLI noun, retiring the verb-first surface. No code; the
refactor lands in separate code PRs per Plan 208's task waves.

- **ADR-092** — `specs/adrs/092-machine-as-sole-workload-cli-surface.md`
  (decision, verb→home mapping, alternatives, sequencing)
- **Plan 208** — `specs/plans/208-machine-sole-cli-surface-consolidation.md`
  (9 task-by-task TDD waves)

## Why

`mvmctl --help` has 28 top-level commands and **two parallel surfaces** for the
same microVM lifecycle (`up`/`down`/`run`/`invoke`/`ls`/`logs`/`console`/`vm`
vs `machine *`). They aren't two runtimes — `machine` already delegates to the
same handlers — so the cost is pure UX: two names for one object, split along
image-source/muscle-memory instead of lifecycle.

Decision: one noun. `machine` owns every workload verb; source is a flag
(`--image` OCI / `--flake` Nix); `vm` folds in under `help_heading` groups
(Lifecycle/Inspect/Advanced) rather than staying a second noun;
`up`/`down`/`run`/`invoke`/`ls`/`logs`/`console`/`build image` are **hard-removed,
no aliases** (pre-1.0 no-backcompat). `dev` (builder VM) stays separate.
Surface-only rename — handlers move, not rewritten; claims 8–15 untouched.

## Relationships

- Sits **above** #1220 (ADR-091 / Plan 207 — the narrower unified `machine run`
  *modes*). Plan 208 Task 4 depends on those flags; **implementation waits for
  Plan 207's code to land.**
- **Amends Plan 200** — supersedes its "UX layer, don't touch up/down" framing.

> Note: relative links to ADR-091 / Plan 207 resolve once #1220 merges (named as
> prerequisite wave 1 in the ADR).