### PR TITLE
feat(build): auto-fall-back to the qemu builder on a libkrun VMM failure (Linux)

### DIFF
--- a/crates/mvm-build/src/builder_backend_select.rs
+++ b/crates/mvm-build/src/builder_backend_select.rs
@@ -192,6 +192,97 @@ pub fn resolve_stage0_backend(verbose: bool) -> Box<dyn BuilderVm> {
 }
 
 // ──────────────────────────────────────────────────────────────────
+// Auto-fallback between builder backends on a VMM-level failure
+// ──────────────────────────────────────────────────────────────────
+
+/// Is `e` a VMM-level failure — the builder VM/supervisor couldn't run the
+/// build at all — rather than a genuine build error a different backend would
+/// hit identically? Only these justify an auto-fallback: a real
+/// `NixBuildFailed` (the build ran and failed) or a `DegradedBuilderStore`
+/// (shared Nix store) must surface unchanged.
+pub fn is_builder_vm_level_failure(e: &BuilderVmError) -> bool {
+    matches!(
+        e,
+        BuilderVmError::SupervisorExited { .. } | BuilderVmError::LibkrunUnavailable(_)
+    )
+}
+
+/// Is the live host Linux-with-KVM? The qemu fallback is a Linux concern —
+/// libkrun-on-KVM is the path that fails at VM creation
+/// (`KVM_SET_USER_MEMORY_REGION` EINVAL on some kernels/libkrun versions) where
+/// the qemu/microvm_nix builder works.
+fn is_linux_native_host() -> bool {
+    matches!(current(), Platform::LinuxNative)
+}
+
+/// Backends to try, in order, for a builder job. Pure (the `is_linux_native`
+/// input is injected) so the policy is unit-testable without spoofing the host.
+///
+/// - An **explicit** choice (CLI flag / `MVM_BUILDER_BACKEND`) is honoured with
+///   no fallback — the operator asked for that backend specifically.
+/// - Auto-detected **Vz** falls back to **libkrun** (the long-standing macOS
+///   behaviour: Vz probe passes but the backend trips a runtime issue).
+/// - Auto-detected **libkrun on Linux** falls back to **qemu** — libkrun-on-KVM
+///   can fail at VM creation on hosts the qemu/microvm_nix builder handles fine.
+pub fn builder_attempt_order(
+    selected: BuilderBackendChoice,
+    explicit: bool,
+    is_linux_native: bool,
+) -> Vec<BuilderBackendChoice> {
+    if explicit {
+        return vec![selected];
+    }
+    match selected {
+        BuilderBackendChoice::Vz => vec![BuilderBackendChoice::Vz, BuilderBackendChoice::Libkrun],
+        BuilderBackendChoice::Libkrun if is_linux_native => {
+            vec![BuilderBackendChoice::Libkrun, BuilderBackendChoice::Qemu]
+        }
+        _ => vec![selected],
+    }
+}
+
+/// Run `attempt` over [`builder_attempt_order`], retrying the next backend when
+/// an earlier one fails with a [VMM-level error](is_builder_vm_level_failure).
+/// A genuine build error (or the last backend's error) surfaces unchanged.
+///
+/// Centralizes the "libkrun broke at VM creation; try qemu" policy so every
+/// builder-invocation site — `run_build`, `run_shell_script` materialization,
+/// etc. — shares one decision. `selected` is the resolved choice; `explicit`
+/// is whether it was forced (CLI flag / env), which disables the fallback.
+pub fn run_with_builder_fallback<T>(
+    selected: BuilderBackendChoice,
+    explicit: bool,
+    mut attempt: impl FnMut(BuilderBackendChoice) -> Result<T, BuilderVmError>,
+) -> Result<T, BuilderVmError> {
+    let order = builder_attempt_order(selected, explicit, is_linux_native_host());
+    let last_idx = order.len() - 1;
+    let mut last_err: Option<BuilderVmError> = None;
+    for (idx, choice) in order.iter().copied().enumerate() {
+        match attempt(choice) {
+            Ok(value) => return Ok(value),
+            // Not the last backend, and a VMM-level failure → try the next.
+            Err(e) if idx < last_idx && is_builder_vm_level_failure(&e) => {
+                tracing::warn!(
+                    error = %e,
+                    from = choice.name(),
+                    to = order[idx + 1].name(),
+                    "the {} builder VM could not run the build (VMM-level failure); \
+                     falling back to the {} builder \
+                     (re-run with `--builder {}` to disable the fallback)",
+                    choice.name(),
+                    order[idx + 1].name(),
+                    choice.name(),
+                );
+                last_err = Some(e);
+            }
+            // Last backend, or a genuine build error → surface it unchanged.
+            Err(e) => return Err(e),
+        }
+    }
+    Err(last_err.expect("builder_attempt_order is never empty"))
+}
+
+// ──────────────────────────────────────────────────────────────────
 // `MVM_LINUX_BUILDER_VM` readiness gate
 // ──────────────────────────────────────────────────────────────────
 
@@ -442,6 +533,117 @@ mod tests {
             let _backend =
                 resolve_builder_backend_with_override(Some(BuilderBackendChoice::Libkrun));
         });
+    }
+
+    // ── Auto-fallback policy (pure) ──────────────────────────────
+
+    #[test]
+    fn vmm_level_failures_trigger_fallback_build_errors_do_not() {
+        // Supervisor died / VMM unavailable → try another backend.
+        assert!(is_builder_vm_level_failure(
+            &BuilderVmError::SupervisorExited {
+                exit_code: 1,
+                vm_state_dir: "/x".into(),
+            }
+        ));
+        assert!(is_builder_vm_level_failure(
+            &BuilderVmError::LibkrunUnavailable("no lib".into())
+        ));
+        // A real build error (the build ran and failed) must surface unchanged.
+        assert!(!is_builder_vm_level_failure(
+            &BuilderVmError::NixBuildFailed("guest cmd.sh exited 1".into())
+        ));
+        assert!(!is_builder_vm_level_failure(
+            &BuilderVmError::DegradedBuilderStore {
+                cache_dir: "/c".into(),
+                log_path: "/l".into(),
+                detail: "dangling".into(),
+            }
+        ));
+    }
+
+    #[test]
+    fn attempt_order_linux_libkrun_falls_back_to_qemu_only_when_auto() {
+        use BuilderBackendChoice::*;
+        // Auto-detected libkrun on Linux → libkrun, then qemu.
+        assert_eq!(
+            builder_attempt_order(Libkrun, false, true),
+            vec![Libkrun, Qemu]
+        );
+        // Explicit libkrun → no fallback (operator asked for libkrun).
+        assert_eq!(builder_attempt_order(Libkrun, true, true), vec![Libkrun]);
+        // libkrun off-Linux (e.g. macOS 13-25) → no qemu fallback.
+        assert_eq!(builder_attempt_order(Libkrun, false, false), vec![Libkrun]);
+    }
+
+    #[test]
+    fn attempt_order_preserves_vz_to_libkrun_and_explicit_qemu() {
+        use BuilderBackendChoice::*;
+        // Existing macOS behaviour unchanged.
+        assert_eq!(builder_attempt_order(Vz, false, false), vec![Vz, Libkrun]);
+        assert_eq!(builder_attempt_order(Vz, true, false), vec![Vz]);
+        // Explicit qemu is a single attempt.
+        assert_eq!(builder_attempt_order(Qemu, false, true), vec![Qemu]);
+    }
+
+    #[test]
+    fn run_with_fallback_retries_qemu_on_supervisor_exit_then_succeeds() {
+        use std::cell::RefCell;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        // Force the Linux auto path: selected=libkrun, not explicit. The host
+        // running the test may not be Linux, so drive the order decision
+        // through `builder_attempt_order` directly in a sibling test; here we
+        // assert the loop's retry behaviour with an injected two-element order
+        // via a libkrun failure followed by a qemu success — exercised only
+        // when the live host yields a 2-element order. To stay host-agnostic,
+        // assert the *single-attempt* contract instead: a VMM failure with no
+        // fallback available surfaces unchanged.
+        let on_linux = is_linux_native_host();
+        let calls = RefCell::new(Vec::new());
+        let qemu_ok = AtomicBool::new(false);
+        let result = run_with_builder_fallback(BuilderBackendChoice::Libkrun, false, |c| {
+            calls.borrow_mut().push(c);
+            match c {
+                BuilderBackendChoice::Qemu => {
+                    qemu_ok.store(true, Ordering::SeqCst);
+                    Ok(())
+                }
+                _ => Err(BuilderVmError::SupervisorExited {
+                    exit_code: 1,
+                    vm_state_dir: "/x".into(),
+                }),
+            }
+        });
+        if on_linux {
+            // libkrun fails (VMM-level) → qemu retried → Ok.
+            assert!(result.is_ok());
+            assert_eq!(
+                *calls.borrow(),
+                vec![BuilderBackendChoice::Libkrun, BuilderBackendChoice::Qemu]
+            );
+        } else {
+            // No fallback off-Linux → the libkrun failure surfaces.
+            assert!(matches!(
+                result,
+                Err(BuilderVmError::SupervisorExited { .. })
+            ));
+            assert_eq!(*calls.borrow(), vec![BuilderBackendChoice::Libkrun]);
+        }
+    }
+
+    #[test]
+    fn run_with_fallback_surfaces_real_build_errors_without_retry() {
+        use std::cell::RefCell;
+        let calls = RefCell::new(0u32);
+        // A genuine build error must NOT trigger a fallback, even on Linux.
+        let result: Result<(), _> =
+            run_with_builder_fallback(BuilderBackendChoice::Libkrun, false, |_c| {
+                *calls.borrow_mut() += 1;
+                Err(BuilderVmError::NixBuildFailed("flake is broken".into()))
+            });
+        assert!(matches!(result, Err(BuilderVmError::NixBuildFailed(_))));
+        // Exactly one attempt — no qemu retry for a real build failure.
+        assert_eq!(*calls.borrow(), 1);
     }
 
     // ── MVM_LINUX_BUILDER_VM env predicate ──────────

--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -432,6 +432,20 @@ pub enum BuilderVmError {
     #[error("nix build failed inside builder sandbox: {0}")]
     NixBuildFailed(String),
 
+    /// The builder-VM supervisor exited non-zero — the VM/VMM itself could not
+    /// run the build (e.g. libkrun failing `KVM_SET_USER_MEMORY_REGION` on a
+    /// host that can't map the guest's high-memory region). Distinct from
+    /// [`NixBuildFailed`](Self::NixBuildFailed) — where the build *ran* and
+    /// failed — so the builder dispatch can transparently fall back to another
+    /// backend on a VMM-level failure without masking a genuine build error.
+    #[error("supervisor exited with non-zero status ({exit_code}); guest stderr at {vm_state_dir}")]
+    SupervisorExited {
+        /// The supervisor process's non-zero exit code.
+        exit_code: i32,
+        /// Host path to the per-VM state dir holding the guest console/stderr.
+        vm_state_dir: String,
+    },
+
     /// The persistent builder Nix store has a dangling/GC'd path — every build
     /// re-evals to the same missing path and fails identically, so `dev up`
     /// appears to "loop". Distinguished from a generic build failure so

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -1149,11 +1149,10 @@ pub fn acquire_nix_store_image_lock_named(
 /// exact error from two call sites; lifting it removes the drift risk
 /// if one site changes wording but not the other.
 pub fn supervisor_exit_error(exit_code: i32, vm_state_dir: &Path) -> BuilderVmError {
-    BuilderVmError::NixBuildFailed(format!(
-        "supervisor exited with non-zero status ({exit_code}); \
-         guest stderr at {}",
-        vm_state_dir.display()
-    ))
+    BuilderVmError::SupervisorExited {
+        exit_code,
+        vm_state_dir: vm_state_dir.display().to_string(),
+    }
 }
 
 /// Format the [`BuilderVmError`] returned when the guest's cmd.sh
@@ -1885,10 +1884,22 @@ mod tests {
     #[test]
     fn supervisor_exit_error_names_exit_code_and_state_dir() {
         let err = supervisor_exit_error(42, Path::new("/tmp/vmstate/foo"));
-        let msg = match err {
-            BuilderVmError::NixBuildFailed(s) => s,
+        // Distinct `SupervisorExited` variant (VMM-level failure) so the
+        // builder dispatch can fall back without masking a real build error.
+        let (exit_code, vm_state_dir) = match err {
+            BuilderVmError::SupervisorExited {
+                exit_code,
+                vm_state_dir,
+            } => (exit_code, vm_state_dir),
             other => panic!("wrong variant: {other:?}"),
         };
+        assert_eq!(exit_code, 42);
+        assert_eq!(vm_state_dir, "/tmp/vmstate/foo");
+        // The Display string keeps the operator-facing wording.
+        let msg = format!(
+            "{}",
+            supervisor_exit_error(42, Path::new("/tmp/vmstate/foo"))
+        );
         assert!(msg.contains("non-zero status (42)"), "got: {msg}");
         assert!(msg.contains("/tmp/vmstate/foo"), "got: {msg}");
         assert!(msg.contains("guest stderr at"), "got: {msg}");

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -209,17 +209,23 @@ fn materialize_ext4_in_builder_vm(
         }],
     };
 
-    match ext4_materializer_choice() {
-        BuilderBackendChoice::Libkrun => {
-            LibkrunBuilderVm::default().run_shell_script(&shell_job)?;
+    // Auto-fallback: an auto-detected libkrun materializer that fails at
+    // VM creation on Linux (libkrun rc -22 / `KVM_SET_USER_MEMORY_REGION`)
+    // transparently retries on the qemu builder, which works there. An
+    // explicit `MVM_BUILDER_BACKEND` opts out.
+    let selected = ext4_materializer_choice();
+    let explicit = crate::builder_backend_select::resolve_env_override().is_some();
+    crate::builder_backend_select::run_with_builder_fallback(selected, explicit, |choice| {
+        match choice {
+            BuilderBackendChoice::Libkrun => LibkrunBuilderVm::default()
+                .run_shell_script(&shell_job)
+                .map(|_| ()),
+            BuilderBackendChoice::Qemu => QemuBuilderVm::new()
+                .run_shell_script(&shell_job)
+                .map(|_| ()),
+            BuilderBackendChoice::Vz => VzBuilderVm::new().run_shell_script(&shell_job).map(|_| ()),
         }
-        BuilderBackendChoice::Qemu => {
-            QemuBuilderVm::new().run_shell_script(&shell_job)?;
-        }
-        BuilderBackendChoice::Vz => {
-            VzBuilderVm::new().run_shell_script(&shell_job)?;
-        }
-    }
+    })?;
     Ok(())
 }
 

--- a/crates/mvm-build/tests/app_deps_orchestrator.rs
+++ b/crates/mvm-build/tests/app_deps_orchestrator.rs
@@ -453,6 +453,13 @@ fn clone_builder_err(e: &BuilderVmError) -> BuilderVmError {
             log_path: log_path.clone(),
             detail: detail.clone(),
         },
+        BuilderVmError::SupervisorExited {
+            exit_code,
+            vm_state_dir,
+        } => BuilderVmError::SupervisorExited {
+            exit_code: *exit_code,
+            vm_state_dir: vm_state_dir.clone(),
+        },
     }
 }
 


### PR DESCRIPTION
## Root cause

On some Linux hosts (confirmed on a bare-metal i7-7700, kernel 6.1, libkrun 1.18.0) the auto-detected **libkrun builder cannot create its VM**: libkrun's `KVM_SET_USER_MEMORY_REGION` ioctl returns **EINVAL (rc -22)** for a guest memory region spanning above ~4 GiB (the region above the PCI hole). Verified by experiment — 16 GiB and 8 GiB builder VMs fail at memory setup; 2 GiB boots past it but is too small for a nix build. So libkrun is unusable there, and it's not tunable (the builder needs >4 GiB). The qemu/microvm_nix builder works fine on the same box.

Until now a Linux user hit an opaque `materialize OCI rootfs failed: rc -22` with no hint that `--builder qemu` is the escape.

## What

A transparent, conservative fallback:

- **New typed variant** `BuilderVmError::SupervisorExited { exit_code, vm_state_dir }` — distinguishes a *VMM-level* failure (the supervisor died before/without running the build) from a genuine `NixBuildFailed` (the build ran and failed). `supervisor_exit_error` now returns it.
- **`run_with_builder_fallback`** (in `builder_backend_select`) runs the resolved builder and, when an **auto-detected** (not explicitly forced) **libkrun on Linux** fails with a [VMM-level error](crates/mvm-build/src/builder_backend_select.rs) (`SupervisorExited` / `LibkrunUnavailable`), retries on **qemu** and warns once. A real build error surfaces **unchanged, with no retry** (so a broken flake doesn't get built twice).
- `builder_attempt_order` is one pure, unit-tested policy that also subsumes the existing macOS auto-`Vz → libkrun` fallback.
- The **OCI-materialize path** (`materialize_ext4_in_builder_vm` — the exact `machine run --image` failure) routes through it.
- **Explicit `--builder libkrun` / `MVM_BUILDER_BACKEND=libkrun` opts out** (the operator asked for libkrun specifically).

## Verification

`cargo fmt --all --check`, `cargo clippy -p mvm-build` (default, `--features builder-vm`, `--tests`), and `mvm-cli` build: clean. New unit tests cover: the VMM-vs-build error split, the attempt-order policy (Linux libkrun→qemu only when auto; explicit opts out; macOS Vz→libkrun preserved), the loop retrying qemu on `SupervisorExited`, and a real build error surfacing without retry.

## Scope / follow-up

This wires the centralized helper into the **OCI-materialize** path (`machine run --image`, the confirmed failure). The `dev_build` `run_build` path (`up --flake`) returns a wrapped error type and can adopt the same helper next; this PR keeps the change focused and the helper is ready for it.