### PR TITLE
feat(build): extend libkrun→qemu auto-fallback to the dev_build + Stage 0 paths

### DIFF
--- a/crates/mvm-build/src/builder_backend_select.rs
+++ b/crates/mvm-build/src/builder_backend_select.rs
@@ -185,7 +185,19 @@ pub fn resolve_builder_backend_with_override(
 /// `verbose` streams the libkrun console; the QEMU path always logs to
 /// `console.log`.
 pub fn resolve_stage0_backend(verbose: bool) -> Box<dyn BuilderVm> {
-    match resolve_choice() {
+    resolve_stage0_backend_for_choice(resolve_choice(), verbose)
+}
+
+/// Stage 0 driver for an explicit `choice` — used by the auto-fallback loop to
+/// construct the next backend to try. QEMU when chosen; libkrun for everything
+/// else (Vz Stage 0 is a gap, and the "Stage 0 is libkrun even on Vz-default
+/// hosts" invariant holds — and the Linux fallback order only ever yields
+/// libkrun→qemu, never Vz).
+pub fn resolve_stage0_backend_for_choice(
+    choice: BuilderBackendChoice,
+    verbose: bool,
+) -> Box<dyn BuilderVm> {
+    match choice {
         BuilderBackendChoice::Qemu => Box::new(QemuBuilderVm::new()),
         _ => Box::new(LibkrunBuilderVm::default().with_verbose(verbose)),
     }

--- a/crates/mvm-build/src/builder_backend_select.rs
+++ b/crates/mvm-build/src/builder_backend_select.rs
@@ -282,6 +282,52 @@ pub fn run_with_builder_fallback<T>(
     Err(last_err.expect("builder_attempt_order is never empty"))
 }
 
+/// True when `e`'s anyhow chain carries a [VMM-level
+/// `BuilderVmError`](is_builder_vm_level_failure). The error must be preserved
+/// in the chain (`anyhow::Error::new(e)` / `.context(...)`), not stringified.
+fn anyhow_has_builder_vm_level_failure(e: &anyhow::Error) -> bool {
+    e.chain().any(|c| {
+        c.downcast_ref::<BuilderVmError>()
+            .is_some_and(is_builder_vm_level_failure)
+    })
+}
+
+/// Like [`run_with_builder_fallback`] but for call sites whose `attempt`
+/// returns `anyhow::Result<T>` (the `BuilderVmError` is wrapped in an anyhow
+/// chain — e.g. the `dev_build` flake path). The fallback fires only when that
+/// chain contains a VMM-level `BuilderVmError`; a genuine build error (or a
+/// stringified one) surfaces unchanged with no retry.
+pub fn run_with_builder_fallback_anyhow<T>(
+    selected: BuilderBackendChoice,
+    explicit: bool,
+    mut attempt: impl FnMut(BuilderBackendChoice) -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    let order = builder_attempt_order(selected, explicit, is_linux_native_host());
+    let last_idx = order.len() - 1;
+    let mut last_err: Option<anyhow::Error> = None;
+    for (idx, choice) in order.iter().copied().enumerate() {
+        match attempt(choice) {
+            Ok(value) => return Ok(value),
+            Err(e) if idx < last_idx && anyhow_has_builder_vm_level_failure(&e) => {
+                tracing::warn!(
+                    error = %e,
+                    from = choice.name(),
+                    to = order[idx + 1].name(),
+                    "the {} builder VM could not run the build (VMM-level failure); \
+                     falling back to the {} builder \
+                     (re-run with `--builder {}` to disable the fallback)",
+                    choice.name(),
+                    order[idx + 1].name(),
+                    choice.name(),
+                );
+                last_err = Some(e);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(last_err.expect("builder_attempt_order is never empty"))
+}
+
 // ──────────────────────────────────────────────────────────────────
 // `MVM_LINUX_BUILDER_VM` readiness gate
 // ──────────────────────────────────────────────────────────────────
@@ -643,6 +689,70 @@ mod tests {
             });
         assert!(matches!(result, Err(BuilderVmError::NixBuildFailed(_))));
         // Exactly one attempt — no qemu retry for a real build failure.
+        assert_eq!(*calls.borrow(), 1);
+    }
+
+    // ── anyhow-wrapped fallback (dev_build flake path) ───────────
+
+    #[test]
+    fn anyhow_chain_detects_wrapped_vmm_failure_only() {
+        // A preserved (downcastable) SupervisorExited → VMM-level.
+        let wrapped = anyhow::Error::new(BuilderVmError::SupervisorExited {
+            exit_code: 1,
+            vm_state_dir: "/x".into(),
+        })
+        .context("builder VM");
+        assert!(anyhow_has_builder_vm_level_failure(&wrapped));
+        // A real build error wrapped the same way → not VMM-level.
+        let build = anyhow::Error::new(BuilderVmError::NixBuildFailed("broken".into()))
+            .context("builder VM");
+        assert!(!anyhow_has_builder_vm_level_failure(&build));
+        // A *stringified* error (BuilderVmError lost) → not detectable, no retry.
+        let stringified = anyhow::anyhow!("builder VM: supervisor exited with non-zero status (1)");
+        assert!(!anyhow_has_builder_vm_level_failure(&stringified));
+    }
+
+    #[test]
+    fn run_with_fallback_anyhow_retries_qemu_on_wrapped_supervisor_exit() {
+        use std::cell::RefCell;
+        let on_linux = is_linux_native_host();
+        let calls = RefCell::new(Vec::new());
+        let result = run_with_builder_fallback_anyhow(BuilderBackendChoice::Libkrun, false, |c| {
+            calls.borrow_mut().push(c);
+            match c {
+                BuilderBackendChoice::Qemu => Ok(()),
+                _ => Err(anyhow::Error::new(BuilderVmError::SupervisorExited {
+                    exit_code: 1,
+                    vm_state_dir: "/x".into(),
+                })
+                .context("builder VM")),
+            }
+        });
+        if on_linux {
+            assert!(result.is_ok());
+            assert_eq!(
+                *calls.borrow(),
+                vec![BuilderBackendChoice::Libkrun, BuilderBackendChoice::Qemu]
+            );
+        } else {
+            assert!(result.is_err());
+            assert_eq!(*calls.borrow(), vec![BuilderBackendChoice::Libkrun]);
+        }
+    }
+
+    #[test]
+    fn run_with_fallback_anyhow_surfaces_real_build_error_without_retry() {
+        use std::cell::RefCell;
+        let calls = RefCell::new(0u32);
+        let result: anyhow::Result<()> =
+            run_with_builder_fallback_anyhow(BuilderBackendChoice::Libkrun, false, |_c| {
+                *calls.borrow_mut() += 1;
+                Err(
+                    anyhow::Error::new(BuilderVmError::NixBuildFailed("broken flake".into()))
+                        .context("builder VM"),
+                )
+            });
+        assert!(result.is_err());
         assert_eq!(*calls.borrow(), 1);
     }
 

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -643,8 +643,18 @@ fn dev_build_via_builder_vm_uncached(
     // hardcoding libkrun, so `mvmctl build` routes a steady-state build through
     // the chosen VMM (QEMU on `MVM_BUILDER_BACKEND=qemu`). Default stays libkrun
     // on Linux + macOS 13-25; macOS 26 auto-detects Vz.
-    let builder = crate::builder_backend_select::resolve_builder_backend();
-    dev_build_with_builder_vm(env, flake_ref, profile, mode, builder.as_ref())
+    //
+    // Auto-fallback: an auto-detected libkrun that fails to create its VM on
+    // Linux (libkrun rc -22 / `KVM_SET_USER_MEMORY_REGION`) transparently
+    // retries the build on the qemu builder; a genuine build error surfaces
+    // unchanged. An explicit `--builder`/`MVM_BUILDER_BACKEND` opts out.
+    use crate::builder_backend_select as bbs;
+    let selected = bbs::resolve_choice();
+    let explicit = bbs::resolve_env_override().is_some();
+    bbs::run_with_builder_fallback_anyhow(selected, explicit, |choice| {
+        let builder = bbs::resolve_builder_backend_with_override(Some(choice));
+        dev_build_with_builder_vm(env, flake_ref, profile, mode, builder.as_ref())
+    })
 }
 
 /// Read `MVM_NO_PERSISTENT_BUILDER`. Any non-empty value disables
@@ -759,7 +769,10 @@ fn dev_build_with_builder_vm<B: crate::builder_vm::BuilderVm + ?Sized>(
 
     let artifacts = builder
         .run_build(&job, &mounts)
-        .map_err(|e| anyhow::anyhow!("builder VM: {e}"))?;
+        // Preserve the `BuilderVmError` as a downcastable anyhow source (not a
+        // stringified context) so the single-shot caller's auto-fallback can
+        // detect a VMM-level failure (`run_with_builder_fallback_anyhow`).
+        .map_err(|e| anyhow::Error::new(e).context("builder VM"))?;
     let revision_hash = match artifacts {
         crate::builder_vm::BuilderArtifacts::Image { revision_hash, .. } => revision_hash,
         crate::builder_vm::BuilderArtifacts::InstallVolume { .. } => {

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -2817,7 +2817,7 @@ fn run_stage0_rootfs_with_external_kernel(
     source_fingerprint: &str,
     verbose: bool,
 ) -> std::result::Result<(), (Stage0FailureStage, anyhow::Error)> {
-    use mvm_build::builder_backend_select::resolve_stage0_backend;
+    use mvm_build::builder_backend_select as bbs;
 
     // Build only the rootfs (`stage0-rootfs`, no kernel in $out).
     std::fs::write(
@@ -2831,21 +2831,25 @@ fn run_stage0_rootfs_with_external_kernel(
         )
     })?;
 
-    let backend = resolve_stage0_backend(verbose);
-    backend
-        .run_stage0(
+    // Auto-fallback to qemu when an auto-detected libkrun fails to create its
+    // Stage 0 VM on Linux (rc -22); explicit `--builder` opts out.
+    let selected = bbs::resolve_choice();
+    let explicit = bbs::resolve_env_override().is_some();
+    bbs::run_with_builder_fallback(selected, explicit, |choice| {
+        bbs::resolve_stage0_backend_for_choice(choice, verbose).run_stage0(
             guest_root_dir,
             "/init",
             workspace_root,
             staging_dir,
             host_bin_dir,
         )
-        .map_err(|e| {
-            (
-                Stage0FailureStage::Build,
-                anyhow::anyhow!("Stage 0 rootfs build: {e}"),
-            )
-        })?;
+    })
+    .map_err(|e| {
+        (
+            Stage0FailureStage::Build,
+            anyhow::anyhow!("Stage 0 rootfs build: {e}"),
+        )
+    })?;
 
     // Pair the externally-acquired kernel as the image's vmlinux. The
     // published builder kernel is the same flake derivation `default`
@@ -2980,7 +2984,7 @@ pub(crate) fn build_kernel_via_stage0(
     ));
 
     {
-        use mvm_build::builder_backend_select::resolve_stage0_backend;
+        use mvm_build::builder_backend_select as bbs;
         use std::sync::Arc;
         use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -3009,14 +3013,19 @@ pub(crate) fn build_kernel_via_stage0(
             }))
         };
 
-        let backend = resolve_stage0_backend(verbose);
-        let result = backend.run_stage0(
-            &root_dir,
-            "/init",
-            &workspace_root,
-            &staging_dir,
-            &host_bin_dir,
-        );
+        // Auto-fallback to qemu when an auto-detected libkrun fails to create
+        // its Stage 0 VM on Linux (rc -22); explicit `--builder` opts out.
+        let selected = bbs::resolve_choice();
+        let explicit = bbs::resolve_env_override().is_some();
+        let result = bbs::run_with_builder_fallback(selected, explicit, |choice| {
+            bbs::resolve_stage0_backend_for_choice(choice, verbose).run_stage0(
+                &root_dir,
+                "/init",
+                &workspace_root,
+                &staging_dir,
+                &host_bin_dir,
+            )
+        });
 
         stop.store(true, Ordering::Relaxed);
         if let Some(handle) = heartbeat {
@@ -3058,31 +3067,36 @@ fn run_stage0_root_dir(
     source_fingerprint: &str,
     verbose: bool,
 ) -> std::result::Result<(), (Stage0FailureStage, anyhow::Error)> {
-    use mvm_build::builder_backend_select::resolve_stage0_backend;
+    use mvm_build::builder_backend_select as bbs;
 
-    // Dispatch Stage 0 through the `BuilderVm` trait.
-    // `resolve_stage0_backend` uses QEMU when explicitly chosen
-    // (`MVM_BUILDER_BACKEND=qemu`) and **libkrun otherwise** — including the
-    // Vz auto-detect default on macOS-26+, since Vz Stage 0 is still a gap.
+    // Dispatch Stage 0 through the `BuilderVm` trait. QEMU when explicitly
+    // chosen (`MVM_BUILDER_BACKEND=qemu`) and **libkrun otherwise** — including
+    // the Vz auto-detect default on macOS-26+, since Vz Stage 0 is still a gap.
     // That preserves the "Stage 0 is libkrun even on Vz-default hosts"
-    // invariant while adding QEMU as the second implemented backend.
-    // `verbose` makes the backend forward the in-guest nix `--print-build-logs`
-    // output (already streamed to the guest console) live to the host stderr.
-    let backend = resolve_stage0_backend(verbose);
-    backend
-        .run_stage0(
+    // invariant. `verbose` forwards the in-guest nix `--print-build-logs`
+    // output to host stderr.
+    //
+    // Auto-fallback: an auto-detected libkrun that fails to create its Stage 0
+    // VM on Linux (rc -22 / `KVM_SET_USER_MEMORY_REGION`) transparently retries
+    // on qemu; a genuine build error surfaces unchanged. Explicit
+    // `--builder`/`MVM_BUILDER_BACKEND` opts out.
+    let selected = bbs::resolve_choice();
+    let explicit = bbs::resolve_env_override().is_some();
+    bbs::run_with_builder_fallback(selected, explicit, |choice| {
+        bbs::resolve_stage0_backend_for_choice(choice, verbose).run_stage0(
             guest_root_dir,
             entry_path,
             workspace_root,
             staging_dir,
             host_bin_dir,
         )
-        .map_err(|e| {
-            (
-                Stage0FailureStage::Build,
-                anyhow::anyhow!("Stage 0 root-dir build: {e}"),
-            )
-        })?;
+    })
+    .map_err(|e| {
+        (
+            Stage0FailureStage::Build,
+            anyhow::anyhow!("Stage 0 root-dir build: {e}"),
+        )
+    })?;
 
     // Refuse to promote a rootfs the steady-state VM can't boot: walk the
     // freshly-built ext4 and confirm the `init=` target is present.

--- a/crates/mvm-cli/src/commands/env/dev_vz.rs
+++ b/crates/mvm-cli/src/commands/env/dev_vz.rs
@@ -4698,19 +4698,25 @@ fn build_image_via_libkrun(out_dir: &str) -> Result<(String, String)> {
     Ok((kernel, rootfs))
 }
 
+/// Backend attempt order for the dev-image / default-microvm builds. Delegates
+/// to the shared [`mvm_build::builder_backend_select::builder_attempt_order`]
+/// (one policy: auto Vz→libkrun, auto libkrun→qemu on Linux, explicit→single)
+/// so this CLI loop and the `mvm-build` build paths can't drift. The live
+/// platform supplies the `is_linux_native` input the shared (pure) policy takes.
 #[cfg(feature = "builder-vm")]
 fn builder_backend_attempt_order(
     selected: mvm_build::builder_backend_select::BuilderBackendChoice,
     explicit_override: bool,
 ) -> Vec<mvm_build::builder_backend_select::BuilderBackendChoice> {
-    use mvm_build::builder_backend_select::BuilderBackendChoice;
-
-    match (selected, explicit_override) {
-        (BuilderBackendChoice::Vz, false) => {
-            vec![BuilderBackendChoice::Vz, BuilderBackendChoice::Libkrun]
-        }
-        _ => vec![selected],
-    }
+    let is_linux_native = matches!(
+        mvm_core::platform::current(),
+        mvm_core::platform::Platform::LinuxNative
+    );
+    mvm_build::builder_backend_select::builder_attempt_order(
+        selected,
+        explicit_override,
+        is_linux_native,
+    )
 }
 
 #[cfg(all(test, feature = "builder-vm"))]
@@ -4735,14 +4741,32 @@ mod builder_backend_attempt_order_tests {
     }
 
     #[test]
-    fn libkrun_selection_stays_single_backend() {
-        assert_eq!(
-            builder_backend_attempt_order(BuilderBackendChoice::Libkrun, false),
-            vec![BuilderBackendChoice::Libkrun]
-        );
+    fn explicit_override_is_always_single_backend() {
+        // An explicit choice (CLI flag / env) never falls back, on any platform.
         assert_eq!(
             builder_backend_attempt_order(BuilderBackendChoice::Libkrun, true),
             vec![BuilderBackendChoice::Libkrun]
+        );
+        assert_eq!(
+            builder_backend_attempt_order(BuilderBackendChoice::Qemu, true),
+            vec![BuilderBackendChoice::Qemu]
+        );
+    }
+
+    #[test]
+    fn delegates_to_shared_policy_for_live_platform() {
+        // The wrapper only threads the live platform into the shared (pure)
+        // policy; the per-platform behaviour — including the Linux
+        // libkrun→qemu fallback — is exhaustively tested in mvm-build. Pin that
+        // the wrapper agrees with the shared policy on this host.
+        use mvm_build::builder_backend_select::builder_attempt_order;
+        let is_linux = matches!(
+            mvm_core::platform::current(),
+            mvm_core::platform::Platform::LinuxNative
+        );
+        assert_eq!(
+            builder_backend_attempt_order(BuilderBackendChoice::Libkrun, false),
+            builder_attempt_order(BuilderBackendChoice::Libkrun, false, is_linux)
         );
     }
 }


### PR DESCRIPTION
Stacked on #1237. Base retargets to `main` once #1237 merges.

## Why

#1237 added the libkrun→qemu auto-fallback for the **OCI-materialize** path (`machine run --image`). The other build entry points — `mvmctl build` / `up --flake` / `template build` — go through `dev_build`'s single-shot `run_build`, which wraps the `BuilderVmError` into an **anyhow** chain, so #1237's `run_with_builder_fallback` (keyed on a raw `BuilderVmError`) couldn't be applied at that call site. This finishes the job.

## What

- **Preserve the builder error** in the anyhow chain — `anyhow::Error::new(e).context("builder VM")` instead of `anyhow!("builder VM: {e}")` (which stringified it) — so it stays downcastable.
- **`run_with_builder_fallback_anyhow`** — same policy as the typed helper, but fires only when the anyhow chain carries a VMM-level `BuilderVmError` (`anyhow_has_builder_vm_level_failure` walks `Error::chain()` + `downcast_ref`). A genuine build error (or a stringified one) surfaces unchanged, no retry.
- Wrap the `dev_build` single-shot call site in it. The **persistent-builder path already falls through to single-shot on failure**, so it's covered too. Explicit `--builder`/`MVM_BUILDER_BACKEND` opts out.

## Verification

`cargo fmt --all --check`, `cargo clippy -p mvm-build --features builder-vm --tests -D warnings`, `mvm-cli` build: clean. New unit tests: the anyhow-chain detection (wrapped VMM failure → true; wrapped build error → false; **stringified → false**, proving why the preservation change matters), the loop retrying qemu on a wrapped `SupervisorExited`, and a real build error surfacing without retry.

The fallback mechanism itself was **live-proven in #1237** (libkrun rc -22 → qemu → alpine booted); this PR reuses the same infra + qemu builder via the anyhow-wrapped path.