### PR TITLE
fix(cli): pre-open interactive console data ports on Vz/libkrun (Plan 207 regression)

### DIFF
--- a/crates/mvm-backend/src/libkrun.rs
+++ b/crates/mvm-backend/src/libkrun.rs
@@ -303,6 +303,19 @@ fn build_supervisor_config(config: &VmStartConfig, state_dir: &Path) -> Result<S
     krun = krun.with_kernel_format(kernel_format);
     krun.rootfs_path = Some(config.rootfs_path.clone());
 
+    // A dev-accessible managed machine (`machine run -t` / `machine shell` /
+    // `up --console`) pre-opens the interactive-console data range. libkrun
+    // binds one host UDS listener per registered port (`listen=true`, host
+    // dials → guest's vsock server), so the agent's dynamic
+    // `CONSOLE_PORT_BASE + session_id` data port is unreachable unless it was
+    // declared here. Left out of `krun_context_base` so the warm-standby base
+    // (no `VmStartConfig` yet) stays unchanged.
+    if config.dev_console {
+        for port in mvm_guest::vsock::dev_console_data_ports() {
+            krun = krun.add_vsock_port(port);
+        }
+    }
+
     // User-supplied volumes (--volume / MVM_VOLUMES). A directory share
     // is a virtio-fs device; a disk image is an extra virtio-blk device.
     // Tag/id `uvol{idx}` is the coordination key the guest mount manifest
@@ -1268,6 +1281,60 @@ mod tests {
             ..Default::default()
         }];
         assert!(build_supervisor_config(&ro_disk, tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn build_supervisor_config_dev_console_pre_opens_console_data_ports() {
+        // A dev-accessible managed machine must pre-open the console data
+        // range; libkrun binds one host UDS listener per registered port, so
+        // the agent's dynamic data port is otherwise unreachable on attach.
+        let config = VmStartConfig {
+            name: "console".into(),
+            rootfs_path: "/tmp/rootfs.ext4".into(),
+            kernel_path: Some("/tmp/vmlinux".into()),
+            cpus: 1,
+            memory_mib: 256,
+            dev_console: true,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = build_supervisor_config(&config, tmp.path()).expect("build");
+        assert!(
+            cfg.krun
+                .vsock_ports
+                .contains(&mvm_guest::vsock::GUEST_AGENT_PORT)
+        );
+        assert!(
+            cfg.krun
+                .vsock_ports
+                .contains(&(mvm_guest::vsock::CONSOLE_PORT_BASE + 1)),
+            "first console data port must be registered when dev_console is set"
+        );
+        assert!(
+            cfg.krun.vsock_ports.contains(
+                &(mvm_guest::vsock::CONSOLE_PORT_BASE
+                    + mvm_guest::vsock::DEV_CONSOLE_DATA_PORT_COUNT)
+            ),
+            "last console data port must be registered when dev_console is set"
+        );
+
+        // The default (non-dev) boot keeps the tight agent-only port set.
+        let plain = VmStartConfig {
+            name: "plain".into(),
+            rootfs_path: "/tmp/rootfs.ext4".into(),
+            kernel_path: Some("/tmp/vmlinux".into()),
+            cpus: 1,
+            memory_mib: 256,
+            ..Default::default()
+        };
+        let cfg_plain = build_supervisor_config(&plain, tmp.path()).expect("build");
+        assert!(
+            !cfg_plain
+                .krun
+                .vsock_ports
+                .contains(&(mvm_guest::vsock::CONSOLE_PORT_BASE + 1)),
+            "console range must NOT be registered when dev_console is unset"
+        );
     }
 
     #[test]

--- a/crates/mvm-backend/src/mock.rs
+++ b/crates/mvm-backend/src/mock.rs
@@ -403,6 +403,7 @@ mod tests {
             bundle_json: None,
             warm_pool_size: 0,
             network_policy: Default::default(),
+            dev_console: false,
         }
     }
 

--- a/crates/mvm-backend/src/vz.rs
+++ b/crates/mvm-backend/src/vz.rs
@@ -2011,7 +2011,18 @@ fn build_supervisor_config(
         disks,
         virtio_fs,
         vsock: vz::VsockConfig {
-            ports: vec![mvm_guest::vsock::GUEST_AGENT_PORT],
+            // The supervisor binds a host-side UDS listener per port at start.
+            // The agent port is always reachable; a dev-accessible machine
+            // additionally pre-opens the interactive-console data range so
+            // `machine run -t` / `machine shell` / `up --console` can reach the
+            // agent's dynamic `CONSOLE_PORT_BASE + session_id` data port.
+            ports: {
+                let mut ports = vec![mvm_guest::vsock::GUEST_AGENT_PORT];
+                if config.dev_console {
+                    ports.extend(mvm_guest::vsock::dev_console_data_ports());
+                }
+                ports
+            },
             socket_dir: vsock_dir,
             // Host-listens / guest-connects channels. Egress substitution: the
             // guest dials SUBSTITUTION_PORT, the supervisor accepts and splices to
@@ -3071,6 +3082,71 @@ mod tests {
             !tmp.path()
                 .join(crate::substitution_spawn::SUBST_PID_FILE)
                 .exists()
+        );
+    }
+
+    #[test]
+    fn build_supervisor_config_dev_console_pre_opens_console_data_ports() {
+        // A dev-accessible managed machine (`machine run -t` / `machine shell`
+        // / `up --console`) must pre-open the interactive-console data range,
+        // or the post-boot PTY attach can't reach the agent's dynamic
+        // `CONSOLE_PORT_BASE + session_id` data port over Vz's per-port UDS.
+        let mut cfg = VmStartConfig {
+            name: "console".into(),
+            cpus: 1,
+            memory_mib: 256,
+            dev_console: true,
+            ..Default::default()
+        };
+        cfg.kernel_path = Some("/abs/vmlinux".into());
+        cfg.rootfs_path = "/abs/rootfs.ext4".into();
+        let state_dir = Path::new("/tmp/vz-console-state");
+        let gvproxy_info = host_gvproxy::HostGvproxyInfo {
+            socket_path: state_dir.join("gvproxy.sock"),
+            pid: 0,
+        };
+        let built =
+            build_supervisor_config(&cfg, "/abs/vmlinux", state_dir, &gvproxy_info).expect("build");
+
+        assert!(
+            built
+                .vsock
+                .ports
+                .contains(&mvm_guest::vsock::GUEST_AGENT_PORT),
+            "agent port must always be present"
+        );
+        assert!(
+            built
+                .vsock
+                .ports
+                .contains(&(mvm_guest::vsock::CONSOLE_PORT_BASE + 1)),
+            "first console data port must be pre-opened when dev_console is set"
+        );
+        assert!(
+            built.vsock.ports.contains(
+                &(mvm_guest::vsock::CONSOLE_PORT_BASE
+                    + mvm_guest::vsock::DEV_CONSOLE_DATA_PORT_COUNT)
+            ),
+            "last console data port must be pre-opened when dev_console is set"
+        );
+
+        // ...and a non-dev machine keeps the tight default (agent only).
+        let mut plain = VmStartConfig {
+            name: "plain".into(),
+            cpus: 1,
+            memory_mib: 256,
+            ..Default::default()
+        };
+        plain.kernel_path = Some("/abs/vmlinux".into());
+        plain.rootfs_path = "/abs/rootfs.ext4".into();
+        let built_plain = build_supervisor_config(&plain, "/abs/vmlinux", state_dir, &gvproxy_info)
+            .expect("build");
+        assert!(
+            !built_plain
+                .vsock
+                .ports
+                .contains(&(mvm_guest::vsock::CONSOLE_PORT_BASE + 1)),
+            "console range must NOT be opened when dev_console is unset"
         );
     }
 

--- a/crates/mvm-build/src/vz_builder.rs
+++ b/crates/mvm-build/src/vz_builder.rs
@@ -468,7 +468,6 @@ pub const VZ_BUILDER_DEFAULT_MEMORY_MIB: u32 = crate::libkrun_builder::DEFAULT_M
 /// [`crate::libkrun_builder::DEFAULT_NIX_STORE_MIB`] so swapping backends
 /// doesn't change the on-disk cache footprint.
 pub const VZ_BUILDER_DEFAULT_NIX_STORE_MIB: u32 = crate::libkrun_builder::DEFAULT_NIX_STORE_MIB;
-const VZ_DEV_CONSOLE_DATA_PORT_COUNT: u32 = 128;
 
 /// Vz parallel of [`crate::libkrun_builder::LibkrunBuilderVm`]. Implements
 /// [`BuilderVm::run_build`] against the [`VzBuilderBackend`] seam,
@@ -1645,10 +1644,7 @@ fn vz_persistent_guest_vsock_ports(expose_guest_agent: bool) -> Vec<u32> {
     // repeated `mvmctl dev shell` attaches can reach the data channel.
     if expose_guest_agent {
         ports.push(mvm_guest::vsock::GUEST_AGENT_PORT);
-        ports.extend(
-            (1..=VZ_DEV_CONSOLE_DATA_PORT_COUNT)
-                .map(|offset| mvm_guest::vsock::CONSOLE_PORT_BASE + offset),
-        );
+        ports.extend(mvm_guest::vsock::dev_console_data_ports());
     }
     ports
 }
@@ -3431,10 +3427,10 @@ mod tests {
             "Vz dev shell must expose the first PTY data port"
         );
         assert!(
-            with_agent
-                .vsock
-                .ports
-                .contains(&(mvm_guest::vsock::CONSOLE_PORT_BASE + VZ_DEV_CONSOLE_DATA_PORT_COUNT)),
+            with_agent.vsock.ports.contains(
+                &(mvm_guest::vsock::CONSOLE_PORT_BASE
+                    + mvm_guest::vsock::DEV_CONSOLE_DATA_PORT_COUNT)
+            ),
             "Vz dev shell must expose the configured PTY data range"
         );
     }

--- a/crates/mvm-cli/src/commands/vm/up.rs
+++ b/crates/mvm-cli/src/commands/vm/up.rs
@@ -1990,6 +1990,14 @@ pub(in crate::commands) fn start_persistent_oci_machine(
         network_policy,
     }
     .into_start_config();
+    // A persistent named/detached machine is dev-accessible for its lifetime:
+    // `machine run -t` boots through here, and `machine shell` / `machine
+    // console` attach to it later. Pre-open the interactive-console data range
+    // so those attaches reach the agent's dynamic data port on the
+    // per-port-UDS backends (libkrun, Vz). Claim 15 still bars a sealed prod
+    // guest at the agent + `enforce_accessible_gate`, leaving the listeners
+    // inert there.
+    start_config.dev_console = true;
     attach_runtime_overlay_if_cached(&mut start_config, &effective_hypervisor);
     if let Some(ctx) = admission.as_ref() {
         thread_tenant_id(&mut start_config, &ctx.admitted);
@@ -2187,6 +2195,9 @@ pub(super) fn cmd_run(params: RunParams<'_>) -> Result<String> {
             cpus: direct_cpus,
             memory_mib: direct_mem,
             network_policy: network_policy.clone(),
+            // `up --console` attaches an interactive PTY after boot, so the
+            // per-port-UDS backends must pre-open the console data range.
+            dev_console: console,
             ..Default::default()
         };
         // Attach the verity-sealed runtime overlay (Firecracker only, non-fatal).

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -133,6 +133,17 @@ pub struct VmStartConfig {
     /// dev shells) sets this to `NetworkPolicy::unrestricted()` explicitly;
     /// it is never an implicit, backend-specific fallback.
     pub network_policy: crate::network_policy::NetworkPolicy,
+    /// Pre-open the host-side interactive-console data-port range so a PTY can
+    /// attach (`machine run -t`, `machine shell`, `up --console`). The
+    /// per-port-UDS backends (libkrun, Vz) bind a static vsock port list at
+    /// start and otherwise can't reach the agent's dynamic
+    /// `CONSOLE_PORT_BASE + session_id` data port; Firecracker multiplexes
+    /// every port over one UDS and ignores this. Off by default — set only
+    /// for dev-accessible managed machines and `--console`. Claim 15's
+    /// dev-shell-gated agent + the host `enforce_accessible_gate` still bar
+    /// interactive access to a sealed prod guest regardless of this flag, so
+    /// the extra listeners are inert there.
+    pub dev_console: bool,
 }
 
 /// A host:guest port mapping, backend-agnostic.

--- a/crates/mvm-guest/src/vsock.rs
+++ b/crates/mvm-guest/src/vsock.rs
@@ -84,6 +84,24 @@ pub const PORT_FORWARD_BASE: u32 = 10000;
 /// Base vsock port for interactive console PTY sessions.
 pub const CONSOLE_PORT_BASE: u32 = 20000;
 
+/// How many interactive-console data ports a dev-accessible VM pre-opens.
+/// The guest agent allocates `CONSOLE_PORT_BASE + session_id` per
+/// `ConsoleOpen`, with `session_id` incrementing monotonically over the VM's
+/// life (one active session at a time), so this bounds the number of console
+/// attaches before the pre-opened range is exhausted.
+pub const DEV_CONSOLE_DATA_PORT_COUNT: u32 = 128;
+
+/// The host-side console data-port range a dev-accessible VM pre-opens so an
+/// interactive PTY (`machine run -t`, `machine shell`, `up --console`) can
+/// reach the agent-allocated `CONSOLE_PORT_BASE + session_id` data channel.
+///
+/// The per-port-UDS backends (libkrun, Vz) bind a *static* vsock port list at
+/// start, so a dynamic data port is unreachable unless it was pre-declared;
+/// Firecracker multiplexes every port over one UDS and ignores this range.
+pub fn dev_console_data_ports() -> impl Iterator<Item = u32> {
+    (1..=DEV_CONSOLE_DATA_PORT_COUNT).map(|offset| CONSOLE_PORT_BASE + offset)
+}
+
 /// Default connect/read timeout in seconds.
 pub const DEFAULT_TIMEOUT_SECS: u64 = 10;
 
@@ -3165,6 +3183,20 @@ pub fn mount_volume_on(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dev_console_data_ports_cover_the_expected_range() {
+        let ports: Vec<u32> = dev_console_data_ports().collect();
+        assert_eq!(ports.len(), DEV_CONSOLE_DATA_PORT_COUNT as usize);
+        assert_eq!(ports.first().copied(), Some(CONSOLE_PORT_BASE + 1));
+        assert_eq!(
+            ports.last().copied(),
+            Some(CONSOLE_PORT_BASE + DEV_CONSOLE_DATA_PORT_COUNT)
+        );
+        // Disjoint from the agent + control ports (no allowlist overlap).
+        assert!(!ports.contains(&GUEST_AGENT_PORT));
+        assert!(!ports.contains(&CONSOLE_PORT_BASE));
+    }
 
     #[test]
     fn adaptive_backoff_grows_then_caps_and_is_never_zero() {

--- a/specs/plans/207-machine-run-unified-lifecycle.md
+++ b/specs/plans/207-machine-run-unified-lifecycle.md
@@ -169,6 +169,29 @@ stream — leave unchanged), `console::run` (PTY attach to reuse), and
       full nextest suite passes. (One unrelated `mvm-hostd` broker-UDS test flaked
       under parallel load and passes in isolation; not touched by this change.)
 
+## Post-merge regression: interactive PTY data port never reachable on Vz/libkrun
+
+Task 5 verified the `-d` boot over the **agent-port `Exec` transport** and the
+`-t` TTY refusal gate, but assumed (line above) the exec transport "backs the
+interactive shell, so the interactive path's plumbing is exercised here." That
+was wrong: the interactive PTY uses a **second** transport leg. `ConsoleOpen`
+returns a dynamic data port (`CONSOLE_PORT_BASE + session_id`, e.g. 20001) and
+the host then connects to it — a different socket than the agent port. The
+per-port-UDS backends (Vz, libkrun) bind only a *static* vsock port list at
+boot (`vsock.ports = [GUEST_AGENT_PORT]`), so that data-port socket never
+existed and every `machine run -t` / `machine shell` / `up --console` attach
+failed with `Failed to connect to console data port … No such file or
+directory`. Firecracker was unaffected (it multiplexes all ports over one UDS).
+
+Fixed: `VmStartConfig.dev_console` pre-opens the bounded console data range
+(`mvm_guest::vsock::dev_console_data_ports()`, 128 ports — the same range the
+builder VM already opens) on the per-port-UDS backends. `cmd_run` sets it from
+`--console`; `start_persistent_oci_machine` sets it `true` so managed machines
+stay shell-able for their whole life. Claim 15 is unchanged — the dev-shell
+agent + `enforce_accessible_gate` still bar a sealed prod guest, leaving the
+listeners inert there. Live-proven on macOS Vz: a managed alpine boot binds
+`vsock-20001.sock`…`vsock-20128.sock` and the guest agent answers.
+
 ## Out of scope
 
 - Idle auto-stop / TTL reaping of persistent machines (warm-pool/reaper work is


### PR DESCRIPTION
## Problem

`machine run -t` (and `machine shell`, `up --console`) could never connect the interactive PTY on the per-port-UDS backends (**Vz**, **libkrun**):

```
$ mvmctl machine run --image alpine -it
started machine i-542b666d
Error: Failed to connect to console data port
  0: Failed to connect to Vz vsock at .../vsock/vsock-20001.sock
  1: No such file or directory (os error 2)
```

The supervisor binds only a **static** vsock port list at boot (`vsock.ports = [GUEST_AGENT_PORT]`), but the guest agent allocates the console data port **dynamically** (`CONSOLE_PORT_BASE + session_id`, e.g. 20001) and the host then connects to it — a *different* socket than the agent port. So `vsock-20001.sock` never existed. Firecracker (Linux) was unaffected: it multiplexes every port over one UDS with a CONNECT handshake.

This is a gap in the merged Plan 207/208 interactive lifecycle — Task 5 verified the `-d` boot over the agent-port `Exec` transport and the `-t` TTY-refusal gate, but not the literal keystroke loop, which is the only path that exercises the data-port leg.

## Fix

- New `mvm_guest::vsock::dev_console_data_ports()` (128 ports) — single source of truth for the console data range; the builder VM's pre-existing duplicate range is consolidated onto it.
- New `VmStartConfig.dev_console` (defaults `false`). When set, the **vz** and **libkrun** config builders pre-open the console data range.
- `cmd_run` sets it from `--console`; `start_persistent_oci_machine` sets it `true` so managed machines stay shell-able for their whole life (`machine shell` into a `-d` machine works). Plain one-shot transient runs keep the tight agent-only set.

**Claim 15 unchanged:** the dev-shell-gated agent + host `enforce_accessible_gate` still bar interactive access to a sealed prod guest, leaving the extra listeners inert there.

## Verification

- **Unit:** new tests in `vsock.rs`, `vz.rs`, `libkrun.rs` (both on- and off-path); existing default-port assertions unchanged. `fmt --all` + `clippy -D warnings` clean.
- **Pre-fix evidence:** a leftover failed machine's `supervisor-config.json` showed `vsock.ports: [5252]` (agent only).
- **Live on macOS Vz:** rebuilt binary boots a managed alpine machine → supervisor binds `vsock-20001.sock` … `vsock-20128.sock` (the exact socket that hit ENOENT now exists) and the guest agent answers (`Linux 6.12.87`) — both legs the interactive attach needs.