### PR TITLE
fix(sdk-python): migrate live-mode Sandbox ops to `machine` verbs

### DIFF
--- a/sdks/python/mvm/_sandbox.py
+++ b/sdks/python/mvm/_sandbox.py
@@ -18,7 +18,7 @@ Two modes are live:
   lower the recording via ``compile_recording``.
 - ``MVM_SDK_MODE=live`` (Plan 73 Followup H-live): every
   ``Sandbox`` call shells to ``$MVM_CLI_BIN`` (``mvmctl up``,
-  ``mvmctl proc start``, ``mvmctl fs write``, ``mvmctl down``)
+  ``mvmctl machine proc start``, ``mvmctl fs write``, ``mvmctl down``)
   against a real microVM. The shell is dispatched by
   :class:`_LiveTransport` below.
 
@@ -627,11 +627,11 @@ class _LiveTransport:
                 f"strips the agent's `do_exec` handler in prod builds — re-build the "
                 f"template with `mvmctl template build --dev <name>`, or use "
                 f"`files.write` to stage inputs into the running VM instead.",
-                argv=["proc", "start", self.vm_id, *argv],
+                argv=["machine", "proc", "start", self.vm_id, *argv],
             )
-        shell = [self.mvm_cli_bin, "proc", "start", self.vm_id]
+        shell = [self.mvm_cli_bin, "machine", "proc", "start", self.vm_id]
         if env:
-            # `mvmctl proc start` expects `-e KEY=VALUE` pairs.
+            # `mvmctl machine proc start` expects `-e KEY=VALUE` pairs.
             # We only forward literal env values in live mode;
             # secret_ref values would need the host keystore round-trip
             # the orchestrator owns.
@@ -672,11 +672,11 @@ class _LiveTransport:
                 f"strips the agent's `do_exec` handler in prod builds — re-build the "
                 f"template with `mvmctl template build --dev <name>`, or use "
                 f"`files.write` to stage inputs into the running VM instead.",
-                argv=["proc", "start", self.vm_id, *argv],
+                argv=["machine", "proc", "start", self.vm_id, *argv],
             )
 
         # 1) `proc start` → pid_token on stdout.
-        start_shell: list[str] = [self.mvm_cli_bin, "proc", "start", self.vm_id]
+        start_shell: list[str] = [self.mvm_cli_bin, "machine", "proc", "start", self.vm_id]
         if env:
             for key, value in env.items():
                 if isinstance(value, str):
@@ -707,7 +707,7 @@ class _LiveTransport:
             ) from exc
         if start_result.returncode != 0:
             raise SandboxLiveError(
-                f"`mvmctl proc start` failed with exit code {start_result.returncode}",
+                f"`mvmctl machine proc start` failed with exit code {start_result.returncode}",
                 argv=start_shell,
                 exit_code=start_result.returncode,
                 stderr=start_result.stderr,
@@ -715,14 +715,15 @@ class _LiveTransport:
         pid_token = start_result.stdout.strip()
         if not pid_token:
             raise SandboxLiveError(
-                "`mvmctl proc start` produced no pid_token on stdout",
+                "`mvmctl machine proc start` produced no pid_token on stdout",
                 argv=start_shell,
                 stderr=start_result.stderr,
             )
 
-        # 2) `proc wait <token>` → captured stdout/stderr/exit.
+        # 2) `machine proc wait <token>` → captured stdout/stderr/exit.
         wait_shell: list[str] = [
             self.mvm_cli_bin,
+            "machine",
             "proc",
             "wait",
             self.vm_id,
@@ -764,7 +765,7 @@ class _LiveTransport:
         """Shell ``mvmctl fs write <vm> <path>`` with the file
         bytes piped through stdin. The mvmctl verb accepts stdin
         when ``--content`` is omitted."""
-        shell = [self.mvm_cli_bin, "fs", "write", self.vm_id, path]
+        shell = [self.mvm_cli_bin, "machine", "fs", "write", self.vm_id, path]
         try:
             result = subprocess.run(
                 shell,
@@ -787,9 +788,9 @@ class _LiveTransport:
 
     def cp(self, source: str, destination: str) -> None:
         """Shell ``mvmctl cp <source> <destination>``. Endpoints use
-        ``VM:/absolute/path`` for the guest side; `mvmctl cp` reads the
+        ``VM:/absolute/path`` for the guest side; `mvmctl machine cp` reads the
         host file and streams it over the agent fs RPC (and back)."""
-        shell = [self.mvm_cli_bin, "cp", source, destination]
+        shell = [self.mvm_cli_bin, "machine", "cp", source, destination]
         try:
             result = subprocess.run(shell, check=False, capture_output=True)
         except FileNotFoundError as exc:
@@ -799,19 +800,19 @@ class _LiveTransport:
             ) from exc
         if result.returncode != 0:
             raise SandboxLiveError(
-                f"`mvmctl cp` failed with exit code {result.returncode}",
+                f"`mvmctl machine cp` failed with exit code {result.returncode}",
                 argv=shell,
                 exit_code=result.returncode,
                 stderr=result.stderr.decode("utf-8", errors="replace"),
             )
 
     def forward(self, host_port: int, guest_port: int) -> None:
-        """Spawn ``mvmctl forward <vm> --port <host>:<guest>`` in the
-        background. `mvmctl forward` blocks (it runs the proxy until
+        """Spawn ``mvmctl machine forward <vm> --port <host>:<guest>`` in the
+        background. `mvmctl machine forward` blocks (it runs the proxy until
         signalled), so it is launched detached and tracked; `kill()`
         terminates every forwarder so none outlives the sandbox."""
         spec = f"{host_port}:{guest_port}"
-        shell = [self.mvm_cli_bin, "forward", self.vm_id, "--port", spec]
+        shell = [self.mvm_cli_bin, "machine", "forward", self.vm_id, "--port", spec]
         try:
             proc = subprocess.Popen(
                 shell,
@@ -837,7 +838,7 @@ class _LiveTransport:
             if proc.poll() is None:
                 proc.terminate()
         self._forwards.clear()
-        shell = [self.mvm_cli_bin, "down", self.vm_id]
+        shell = [self.mvm_cli_bin, "machine", "stop", self.vm_id]
         try:
             result = subprocess.run(
                 shell,
@@ -1177,7 +1178,7 @@ class Sandbox:
 
     def forward(self, host_port: int, guest_port: int) -> None:
         """Forward ``host_port`` on the host to ``guest_port`` in the
-        sandbox. Spawns ``mvmctl forward <vm> --port <host>:<guest>`` as
+        sandbox. Spawns ``mvmctl machine forward <vm> --port <host>:<guest>`` as
         a background proxy that runs until the sandbox is torn down
         (``kill`` / ``__exit__`` terminate it).
 

--- a/sdks/python/tests/test_sandbox_live.py
+++ b/sdks/python/tests/test_sandbox_live.py
@@ -76,6 +76,10 @@ set -u
 verb=${{1:-}}
 shift || true
 echo "$verb $*" >> {log!s}
+if [ "$verb" = "machine" ]; then
+  verb=${{1:-}}
+  shift || true
+fi
 case "$verb" in
   up)
     # Record stdin for completeness (mvmctl up has none).
@@ -113,7 +117,7 @@ case "$verb" in
     sleep {forward_sleep}
     exit 0
     ;;
-  down)
+  stop)
     exit {down_exit}
     ;;
   *)
@@ -242,7 +246,7 @@ def test_commands_start_dev_template_shells_to_proc_start(
     calls = _read_fixture_log(tmp_path)
     # 1: up, 2: proc start
     assert len(calls) == 2
-    assert calls[1].startswith("proc start sb-dev-vm")
+    assert calls[1].startswith("machine proc start sb-dev-vm")
     assert "-e MODE=test" in calls[1]
     assert "-- python run.py" in calls[1]
 
@@ -273,7 +277,7 @@ def test_commands_start_prod_template_raises_sandbox_dev_only(
     # The SDK must NOT have shelled to `mvmctl proc start`.
     calls = _read_fixture_log(tmp_path)
     assert len(calls) == 1, f"unexpected vsock traffic: {calls}"
-    assert not any(c.startswith("proc") for c in calls)
+    assert not any(c.startswith("machine proc") for c in calls)
 
 
 # ── files.write ──────────────────────────────────────────────────────
@@ -295,7 +299,7 @@ def test_files_write_shells_with_stdin_bytes(tmp_path: Path) -> None:
     sb.files.write("/app/config.json", b'{"x":1}')
 
     calls = _read_fixture_log(tmp_path)
-    assert any(c.startswith("fs write sb-fs-vm /app/config.json") for c in calls)
+    assert any(c.startswith("machine fs write sb-fs-vm /app/config.json") for c in calls)
     stdin_path = tmp_path / "fixture-stdin" / "fs-write-stdin.bin"
     assert stdin_path.read_bytes() == b'{"x":1}'
 
@@ -319,7 +323,7 @@ def test_kill_shells_to_mvmctl_down(tmp_path: Path) -> None:
     sb.kill()
 
     calls = _read_fixture_log(tmp_path)
-    assert any(c == "down sb-kill-vm" for c in calls)
+    assert any(c == "machine stop sb-kill-vm" for c in calls)
 
 
 def test_context_manager_kills_on_exit(tmp_path: Path) -> None:
@@ -338,7 +342,7 @@ def test_context_manager_kills_on_exit(tmp_path: Path) -> None:
         sb.files.write("/app/data.txt", "hi")
 
     calls = _read_fixture_log(tmp_path)
-    down_calls = [c for c in calls if c.startswith("down ")]
+    down_calls = [c for c in calls if c.startswith("machine stop ")]
     assert len(down_calls) == 1
 
 
@@ -379,7 +383,7 @@ def test_copy_in_shells_to_mvmctl_cp(tmp_path: Path) -> None:
 
     calls = _read_fixture_log(tmp_path)
     assert any(
-        c.startswith(f"cp {host_file} sb-cp-vm:/app/local.txt") for c in calls
+        c.startswith(f"machine cp {host_file} sb-cp-vm:/app/local.txt") for c in calls
     ), calls
 
 
@@ -397,7 +401,7 @@ def test_copy_out_shells_to_mvmctl_cp(tmp_path: Path) -> None:
 
     calls = _read_fixture_log(tmp_path)
     assert any(
-        c.startswith(f"cp sb-cp-vm:/app/out.txt {dest}") for c in calls
+        c.startswith(f"machine cp sb-cp-vm:/app/out.txt {dest}") for c in calls
     ), calls
 
 
@@ -445,7 +449,7 @@ def test_forward_shells_to_mvmctl_forward(tmp_path: Path) -> None:
     sb._live._forwards[0].wait(timeout=5)
     calls = _read_fixture_log(tmp_path)
     assert any(
-        c.startswith("forward sb-fwd-vm --port 8080:80") for c in calls
+        c.startswith("machine forward sb-fwd-vm --port 8080:80") for c in calls
     ), calls
 
 
@@ -497,8 +501,8 @@ def test_aexec_runs_and_returns_result(tmp_path: Path) -> None:
 
     asyncio.run(body())
     calls = _read_fixture_log(tmp_path)
-    assert any(c.startswith("proc start sb-aex-vm") for c in calls), calls
-    assert any(c.startswith("proc wait sb-aex-vm pid-token-abc123") for c in calls), calls
+    assert any(c.startswith("machine proc start sb-aex-vm") for c in calls), calls
+    assert any(c.startswith("machine proc wait sb-aex-vm pid-token-abc123") for c in calls), calls
 
 
 def test_async_context_manager_kills_on_exit(tmp_path: Path) -> None:
@@ -517,7 +521,7 @@ def test_async_context_manager_kills_on_exit(tmp_path: Path) -> None:
 
     asyncio.run(body())
     calls = _read_fixture_log(tmp_path)
-    assert sum(1 for c in calls if c.startswith("down ")) == 1, calls
+    assert sum(1 for c in calls if c.startswith("machine stop ")) == 1, calls
 
 
 def test_aexec_dev_only_on_prod_template(tmp_path: Path) -> None:
@@ -612,8 +616,8 @@ def test_code_sandbox_run_returns_stdout(tmp_path: Path) -> None:
         assert cs.run("print(2 + 2)") == "4"
 
     calls = _read_fixture_log(tmp_path)
-    assert any(c.startswith("proc start sb-cs-vm") and "-- python -c" in c for c in calls), calls
-    assert any(c.startswith("proc wait sb-cs-vm") for c in calls), calls
+    assert any(c.startswith("machine proc start sb-cs-vm") and "-- python -c" in c for c in calls), calls
+    assert any(c.startswith("machine proc wait sb-cs-vm") for c in calls), calls
 
 
 def test_code_sandbox_run_raises_on_nonzero(tmp_path: Path) -> None:
@@ -660,7 +664,7 @@ def test_code_sandbox_run_script_copies_then_execs(tmp_path: Path) -> None:
         assert cs.run_script(str(host_script)) == "ok"
 
     calls = _read_fixture_log(tmp_path)
-    assert any(c.startswith("cp ") and "sb-cs-vm:/tmp/job.py" in c for c in calls), calls
+    assert any(c.startswith("machine cp ") and "sb-cs-vm:/tmp/job.py" in c for c in calls), calls
     assert any("-- python /tmp/job.py" in c for c in calls), calls
 
 
@@ -696,7 +700,7 @@ def test_browser_sandbox_forwards_cdp_and_endpoint(tmp_path: Path) -> None:
         assert bs.endpoint() == "http://localhost:9222"
         bs.sandbox._live._forwards[0].wait(timeout=5)
         calls = _read_fixture_log(tmp_path)
-        assert any(c.startswith("forward sb-br-vm --port 9222:9222") for c in calls), calls
+        assert any(c.startswith("machine forward sb-br-vm --port 9222:9222") for c in calls), calls
     finally:
         bs.kill()
 
@@ -714,7 +718,7 @@ def test_browser_sandbox_custom_host_port(tmp_path: Path) -> None:
         assert bs.endpoint() == "http://localhost:18222"
         bs.sandbox._live._forwards[0].wait(timeout=5)
         calls = _read_fixture_log(tmp_path)
-        assert any(c.startswith("forward sb-br-vm --port 18222:9222") for c in calls), calls
+        assert any(c.startswith("machine forward sb-br-vm --port 18222:9222") for c in calls), calls
     finally:
         bs.kill()
 

--- a/sdks/typescript/src/_sandbox.ts
+++ b/sdks/typescript/src/_sandbox.ts
@@ -20,7 +20,7 @@
  *   produces a Workload.
  * - `MVM_SDK_MODE=live` (Plan 73 Followup H-live): every
  *   `Sandbox` call shells to `$MVM_CLI_BIN` (`mvmctl up`,
- *   `mvmctl proc start`, `mvmctl fs write`, `mvmctl down`)
+ *   `mvmctl machine proc start`, `mvmctl machine fs write`, `mvmctl machine stop`)
  *   against a real microVM. The shell is dispatched by
  *   {@link LiveTransport} below.
  *
@@ -345,7 +345,7 @@ export interface SandboxExecOptions {
  *
  *  `exitCode` is the child's exit code (0 on success). `stdout`/`stderr`
  *  are captured strings — exec is a one-shot that *captures* the streams,
- *  the distinction from `commands.start` + `mvmctl proc wait`. */
+ *  the distinction from `commands.start` + `mvmctl machine proc wait`. */
 export interface ExecResult {
   exitCode: number;
   stdout: string;
@@ -386,7 +386,7 @@ export class LiveTransport {
   readonly vmId: string;
   readonly buildMode: "dev" | "prod";
   private killed = false;
-  // Long-running `mvmctl forward` proxies spawned by `forward()`. Torn
+  // Long-running `mvmctl machine forward` proxies spawned by `forward()`. Torn
   // down in `kill()` so a port forwarder never outlives the VM.
   private forwards: import("node:child_process").ChildProcess[] = [];
 
@@ -473,16 +473,16 @@ export class LiveTransport {
           `claim 4) strips the agent's \`do_exec\` handler in prod builds — ` +
           `re-build the template with \`mvmctl template build --dev <name>\`, ` +
           `or use \`files.write\` to stage inputs into the running VM instead.`,
-        { argv: ["proc", "start", this.vmId, ...argv] },
+        { argv: ["machine", "proc", "start", this.vmId, ...argv] },
       );
     }
-    const shell = [this.mvmCliBin, "proc", "start", this.vmId];
+    const shell = [this.mvmCliBin, "machine", "proc", "start", this.vmId];
     shell.push(...this.encodeEnvFlags(env, shell));
     shell.push("--", ...argv);
     this.runShell(shell);
   }
 
-  /** Encode `env` into `-e KEY=VALUE` flags for `mvmctl proc start`,
+  /** Encode `env` into `-e KEY=VALUE` flags for `mvmctl machine proc start`,
    *  rejecting non-literal (secret) values — live mode forwards only
    *  literals; secrets are injected host-side via `--secret` on `up`. */
   private encodeEnvFlags(
@@ -512,8 +512,8 @@ export class LiveTransport {
     return flags;
   }
 
-  /** One-shot exec: `mvmctl proc start ... -- argv` → pid_token, then
-   *  `mvmctl proc wait <token>` to capture stdout/stderr/exit. Refuses
+  /** One-shot exec: `mvmctl machine proc start ... -- argv` → pid_token, then
+   *  `mvmctl machine proc wait <token>` to capture stdout/stderr/exit. Refuses
    *  with {@link SandboxDevOnly} on a prod template (claim 4). */
   commandsExec(argv: string[], options: SandboxExecOptions = {}): ExecResult {
     if (this.buildMode !== "dev") {
@@ -523,14 +523,14 @@ export class LiveTransport {
           `claim 4) strips the agent's \`do_exec\` handler in prod builds — ` +
           `re-build the template with \`mvmctl template build --dev <name>\`, ` +
           `or use \`files.write\` to stage inputs into the running VM instead.`,
-        { argv: ["proc", "start", this.vmId, ...argv] },
+        { argv: ["machine", "proc", "start", this.vmId, ...argv] },
       );
     }
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
 
-    // 1) `proc start` → pid_token on stdout.
-    const startShell = [this.mvmCliBin, "proc", "start", this.vmId];
+    // 1) `machine proc start` → pid_token on stdout.
+    const startShell = [this.mvmCliBin, "machine", "proc", "start", this.vmId];
     startShell.push(...this.encodeEnvFlags(options.env, startShell));
     if (options.cwd !== undefined) startShell.push("--cwd", options.cwd);
     startShell.push("--", ...argv);
@@ -553,7 +553,7 @@ export class LiveTransport {
     }
     if (startResult.status !== 0) {
       throw new SandboxLiveError(
-        `\`mvmctl proc start\` failed with exit code ${startResult.status}`,
+        `\`mvmctl machine proc start\` failed with exit code ${startResult.status}`,
         {
           argv: startShell,
           exitCode: startResult.status,
@@ -564,13 +564,13 @@ export class LiveTransport {
     const pidToken = (startResult.stdout ?? "").trim();
     if (!pidToken) {
       throw new SandboxLiveError(
-        "`mvmctl proc start` produced no pid_token on stdout",
+        "`mvmctl machine proc start` produced no pid_token on stdout",
         { argv: startShell, stderr: startResult.stderr ?? "" },
       );
     }
 
-    // 2) `proc wait <token>` → captured stdout/stderr/exit.
-    const waitShell = [this.mvmCliBin, "proc", "wait", this.vmId, pidToken];
+    // 2) `machine proc wait <token>` → captured stdout/stderr/exit.
+    const waitShell = [this.mvmCliBin, "machine", "proc", "wait", this.vmId, pidToken];
     if (options.timeout !== undefined) {
       waitShell.push("--timeout", String(Math.trunc(options.timeout)));
     }
@@ -591,7 +591,7 @@ export class LiveTransport {
     }
     if (waitResult.error) {
       throw new SandboxLiveError(
-        `\`mvmctl proc wait\` failed: ${waitResult.error.message}`,
+        `\`mvmctl machine proc wait\` failed: ${waitResult.error.message}`,
         { argv: waitShell },
       );
     }
@@ -603,7 +603,7 @@ export class LiveTransport {
   }
 
   filesWrite(path: string, data: Uint8Array): void {
-    const shell = [this.mvmCliBin, "fs", "write", this.vmId, path];
+    const shell = [this.mvmCliBin, "machine", "fs", "write", this.vmId, path];
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
     let result;
@@ -624,7 +624,7 @@ export class LiveTransport {
     }
     if (result.status !== 0) {
       throw new SandboxLiveError(
-        `\`mvmctl fs write\` failed with exit code ${result.status}`,
+        `\`mvmctl machine fs write\` failed with exit code ${result.status}`,
         {
           argv: shell,
           exitCode: result.status,
@@ -635,7 +635,7 @@ export class LiveTransport {
   }
 
   cp(source: string, destination: string): void {
-    const shell = [this.mvmCliBin, "cp", source, destination];
+    const shell = [this.mvmCliBin, "machine", "cp", source, destination];
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
     let result;
@@ -654,7 +654,7 @@ export class LiveTransport {
     }
     if (result.status !== 0) {
       throw new SandboxLiveError(
-        `\`mvmctl cp\` failed with exit code ${result.status}`,
+        `\`mvmctl machine cp\` failed with exit code ${result.status}`,
         {
           argv: shell,
           exitCode: result.status,
@@ -666,10 +666,10 @@ export class LiveTransport {
 
   forward(hostPort: number, guestPort: number): void {
     const spec = `${hostPort}:${guestPort}`;
-    const shell = [this.mvmCliBin, "forward", this.vmId, "--port", spec];
+    const shell = [this.mvmCliBin, "machine", "forward", this.vmId, "--port", spec];
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
-    // `mvmctl forward` blocks (runs the proxy until signalled), so spawn
+    // `mvmctl machine forward` blocks (runs the proxy until signalled), so spawn
     // it detached + tracked; `kill()` terminates it.
     let proc;
     try {
@@ -695,7 +695,7 @@ export class LiveTransport {
       }
     }
     this.forwards = [];
-    const shell = [this.mvmCliBin, "down", this.vmId];
+    const shell = [this.mvmCliBin, "machine", "stop", this.vmId];
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
     try {
@@ -708,12 +708,12 @@ export class LiveTransport {
         // orchestrator's TTL reaper.
         // eslint-disable-next-line no-console
         console.error(
-          `mvm-sdk live: \`mvmctl down ${this.vmId}\` exited with ${result.status}: ${result.stderr ?? ""}`,
+          `mvm-sdk live: \`mvmctl machine stop ${this.vmId}\` exited with ${result.status}: ${result.stderr ?? ""}`,
         );
       }
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.error(`mvm-sdk live: failed to spawn \`mvmctl down\`: ${String(err)}`);
+      console.error(`mvm-sdk live: failed to spawn \`mvmctl machine stop\`: ${String(err)}`);
     }
   }
 
@@ -902,7 +902,7 @@ export class Sandbox {
 
   /** One-shot: run `argv` inside the sandbox, capturing stdout / stderr /
    *  exit into an {@link ExecResult}. Convenience over `commands.start` +
-   *  `mvmctl proc wait`. Refuses with `SandboxDevOnly` on a prod template
+   *  `mvmctl machine proc wait`. Refuses with `SandboxDevOnly` on a prod template
    *  (claim 4).
    *
    *  Live mode only: in record mode this throws `SandboxModeError` — the
@@ -927,7 +927,7 @@ export class Sandbox {
 
   /** Copy a host file into the running sandbox at `guestPath`.
    *
-   *  Shells `mvmctl cp <hostPath> <vm>:<guestPath>` — the host file
+   *  Shells `mvmctl machine cp <hostPath> <vm>:<guestPath>` — the host file
    *  streams into the guest over the agent fs RPC.
    *
    *  Live mode only: in record mode this throws `SandboxModeError`. To
@@ -951,7 +951,7 @@ export class Sandbox {
 
   /** Copy a file out of the running sandbox to `hostPath`.
    *
-   *  Shells `mvmctl cp <vm>:<guestPath> <hostPath>` — the guest file
+   *  Shells `mvmctl machine cp <vm>:<guestPath> <hostPath>` — the guest file
    *  streams back over the agent fs RPC.
    *
    *  Live mode only: pulling a file from a running VM has no record-mode
@@ -974,7 +974,7 @@ export class Sandbox {
 
   /** Forward `hostPort` on the host to `guestPort` in the sandbox.
    *
-   *  Spawns `mvmctl forward <vm> --port <host>:<guest>` as a background
+   *  Spawns `mvmctl machine forward <vm> --port <host>:<guest>` as a background
    *  proxy that runs until the sandbox is torn down (`kill` /
    *  `[Symbol.dispose]` terminate it).
    *

--- a/sdks/typescript/tests/sandbox_live.test.ts
+++ b/sdks/typescript/tests/sandbox_live.test.ts
@@ -50,6 +50,10 @@ set -u
 verb=\${1:-}
 shift || true
 echo "$verb $*" >> ${JSON.stringify(log)}
+if [ "$verb" = "machine" ]; then
+  verb=\${1:-}
+  shift || true
+fi
 case "$verb" in
   up)
     if [ -t 0 ]; then :; else cat > ${JSON.stringify(path.join(stdinDir, "up-stdin.bin"))} || true; fi
@@ -84,7 +88,7 @@ case "$verb" in
     sleep ${forwardSleep}
     exit 0
     ;;
-  down)
+  stop)
     exit ${downExit}
     ;;
   *)
@@ -236,7 +240,7 @@ describe("Sandbox.commands.start (live mode)", () => {
 
     const calls = readFixtureLog();
     expect(calls.length).toBe(2);
-    expect(calls[1]).toMatch(/^proc start sb-dev-vm/);
+    expect(calls[1]).toMatch(/^machine proc start sb-dev-vm/);
     expect(calls[1]).toContain("-e MODE=test");
     expect(calls[1]).toContain("-- python run.py");
   });
@@ -258,10 +262,10 @@ describe("Sandbox.commands.start (live mode)", () => {
     expect(() => sb.commands.start(["python", "run.py"])).toThrow(
       mvm.SandboxDevOnly,
     );
-    // Critical: SDK must NOT have shelled to `mvmctl proc start`.
+    // Critical: SDK must NOT have shelled to `mvmctl machine proc start`.
     const calls = readFixtureLog();
     expect(calls.length).toBe(1);
-    expect(calls.some((c) => c.startsWith("proc"))).toBe(false);
+    expect(calls.some((c) => c.startsWith("machine proc"))).toBe(false);
   });
 });
 
@@ -283,7 +287,7 @@ describe("Sandbox.files.write (live mode)", () => {
     sb.files.write("/app/config.json", new TextEncoder().encode('{"x":1}'));
 
     const calls = readFixtureLog();
-    expect(calls.some((c) => c.startsWith("fs write sb-fs-vm /app/config.json"))).toBe(true);
+    expect(calls.some((c) => c.startsWith("machine fs write sb-fs-vm /app/config.json"))).toBe(true);
     const stdinPath = path.join(tmpDir, "fixture-stdin", "fs-write-stdin.bin");
     expect(fs.readFileSync(stdinPath, "utf-8")).toBe('{"x":1}');
   });
@@ -292,7 +296,7 @@ describe("Sandbox.files.write (live mode)", () => {
 // ── kill / dispose ───────────────────────────────────────────────────
 
 describe("Sandbox.kill (live mode)", () => {
-  it("shells to mvmctl down", () => {
+  it("shells to mvmctl machine stop", () => {
     const script = writeFixtureMvmctl({
       upEnvelope: {
         schema_version: 1,
@@ -307,7 +311,7 @@ describe("Sandbox.kill (live mode)", () => {
     sb.kill();
 
     const calls = readFixtureLog();
-    expect(calls).toContain("down sb-kill-vm");
+    expect(calls).toContain("machine stop sb-kill-vm");
   });
 
   it("[Symbol.dispose] kills once", () => {
@@ -324,7 +328,7 @@ describe("Sandbox.kill (live mode)", () => {
     const sb = mvm.Sandbox.create("python-dev");
     sb[Symbol.dispose]();
 
-    const downCalls = readFixtureLog().filter((c) => c.startsWith("down "));
+    const downCalls = readFixtureLog().filter((c) => c.startsWith("machine stop "));
     expect(downCalls.length).toBe(1);
   });
 });
@@ -332,7 +336,7 @@ describe("Sandbox.kill (live mode)", () => {
 // ── copyIn / copyOut (Plan 125 B1) ───────────────────────────────────
 
 describe("Sandbox.copyIn / copyOut (live mode)", () => {
-  it("copyIn shells to mvmctl cp host -> vm:guest", () => {
+  it("copyIn shells to mvmctl machine cp host -> vm:guest", () => {
     const script = writeFixtureMvmctl({
       upEnvelope: { schema_version: 1, vm_id: "sb-cp-vm", build_mode: "dev" },
     });
@@ -346,11 +350,11 @@ describe("Sandbox.copyIn / copyOut (live mode)", () => {
 
     const calls = readFixtureLog();
     expect(
-      calls.some((c) => c.startsWith(`cp ${hostFile} sb-cp-vm:/app/local.txt`)),
+      calls.some((c) => c.startsWith(`machine cp ${hostFile} sb-cp-vm:/app/local.txt`)),
     ).toBe(true);
   });
 
-  it("copyOut shells to mvmctl cp vm:guest -> host", () => {
+  it("copyOut shells to mvmctl machine cp vm:guest -> host", () => {
     const script = writeFixtureMvmctl({
       upEnvelope: { schema_version: 1, vm_id: "sb-cp-vm", build_mode: "dev" },
     });
@@ -363,11 +367,11 @@ describe("Sandbox.copyIn / copyOut (live mode)", () => {
 
     const calls = readFixtureLog();
     expect(
-      calls.some((c) => c.startsWith(`cp sb-cp-vm:/app/out.txt ${dest}`)),
+      calls.some((c) => c.startsWith(`machine cp sb-cp-vm:/app/out.txt ${dest}`)),
     ).toBe(true);
   });
 
-  it("copyIn propagates a mvmctl cp failure", () => {
+  it("copyIn propagates a mvmctl machine cp failure", () => {
     const script = writeFixtureMvmctl({
       upEnvelope: { schema_version: 1, vm_id: "sb-cp-vm", build_mode: "dev" },
       cpExit: 4,
@@ -395,7 +399,7 @@ describe("Sandbox.copyIn / copyOut (live mode)", () => {
 type ForwardsPeek = { forwards: import("node:child_process").ChildProcess[] };
 
 describe("Sandbox.forward (live mode)", () => {
-  it("spawns mvmctl forward --port host:guest", async () => {
+  it("spawns mvmctl machine forward --port host:guest", async () => {
     const script = writeFixtureMvmctl({
       upEnvelope: { schema_version: 1, vm_id: "sb-fwd-vm", build_mode: "dev" },
     });
@@ -413,7 +417,7 @@ describe("Sandbox.forward (live mode)", () => {
     );
     const calls = readFixtureLog();
     expect(
-      calls.some((c) => c.startsWith("forward sb-fwd-vm --port 8080:80")),
+      calls.some((c) => c.startsWith("machine forward sb-fwd-vm --port 8080:80")),
     ).toBe(true);
   });
 
@@ -459,10 +463,10 @@ describe("Sandbox.exec (live mode)", () => {
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toBe("4");
     const calls = readFixtureLog();
-    expect(calls.some((c) => c.startsWith("proc start sb-exec-vm"))).toBe(true);
+    expect(calls.some((c) => c.startsWith("machine proc start sb-exec-vm"))).toBe(true);
     expect(
       calls.some((c) =>
-        c.startsWith("proc wait sb-exec-vm pid-token-abc123"),
+        c.startsWith("machine proc wait sb-exec-vm pid-token-abc123"),
       ),
     ).toBe(true);
   });
@@ -491,7 +495,7 @@ describe("Sandbox.exec (live mode)", () => {
     sb.exec(["env"], { env: { MODE: "test" } });
 
     const calls = readFixtureLog();
-    const start = calls.find((c) => c.startsWith("proc start"));
+    const start = calls.find((c) => c.startsWith("machine proc start"));
     expect(start).toContain("-e MODE=test");
     expect(start).toContain("-- env");
   });
@@ -505,8 +509,8 @@ describe("Sandbox.exec (live mode)", () => {
 
     const sb = mvm.Sandbox.create("python-prod");
     expect(() => sb.exec(["python", "-c", "x"])).toThrow(mvm.SandboxDevOnly);
-    // Claim 4: must not have shelled `mvmctl proc start`.
-    expect(readFixtureLog().some((c) => c.startsWith("proc"))).toBe(false);
+    // Claim 4: must not have shelled `mvmctl machine proc start`.
+    expect(readFixtureLog().some((c) => c.startsWith("machine proc"))).toBe(false);
   });
 
   it("is refused in record mode", () => {
@@ -542,7 +546,7 @@ describe("Sandbox async surface", () => {
 
     const sb = mvm.Sandbox.create("python-dev");
     await sb[Symbol.asyncDispose]();
-    expect(readFixtureLog().some((c) => c.startsWith("down "))).toBe(true);
+    expect(readFixtureLog().some((c) => c.startsWith("machine stop "))).toBe(true);
   });
 });
 
@@ -595,7 +599,7 @@ describe("CodeSandbox", () => {
       expect(cs.run("print(2 + 2)")).toBe("4");
       const calls = readFixtureLog();
       expect(
-        calls.some((c) => c.startsWith("proc start sb-cs-vm") && c.includes("-- python -c")),
+        calls.some((c) => c.startsWith("machine proc start sb-cs-vm") && c.includes("-- python -c")),
       ).toBe(true);
     } finally {
       cs.kill();
@@ -648,7 +652,7 @@ describe("CodeSandbox", () => {
     try {
       expect(cs.runScript(hostScript)).toBe("ok");
       const calls = readFixtureLog();
-      expect(calls.some((c) => c.startsWith("cp ") && c.includes("sb-cs-vm:/tmp/job.py"))).toBe(true);
+      expect(calls.some((c) => c.startsWith("machine cp ") && c.includes("sb-cs-vm:/tmp/job.py"))).toBe(true);
       expect(calls.some((c) => c.includes("-- python /tmp/job.py"))).toBe(true);
     } finally {
       cs.kill();
@@ -688,7 +692,7 @@ describe("BrowserSandbox", () => {
       expect(bs.endpoint()).toBe("http://localhost:9222");
       const live = bs.sandbox._live as unknown as ForwardsPeek;
       await new Promise<void>((resolve) => live.forwards[0].on("exit", () => resolve()));
-      expect(readFixtureLog().some((c) => c.startsWith("forward sb-br-vm --port 9222:9222"))).toBe(true);
+      expect(readFixtureLog().some((c) => c.startsWith("machine forward sb-br-vm --port 9222:9222"))).toBe(true);
     } finally {
       bs.kill();
     }
@@ -706,7 +710,7 @@ describe("BrowserSandbox", () => {
       expect(bs.endpoint()).toBe("http://localhost:18222");
       const live = bs.sandbox._live as unknown as ForwardsPeek;
       await new Promise<void>((resolve) => live.forwards[0].on("exit", () => resolve()));
-      expect(readFixtureLog().some((c) => c.startsWith("forward sb-br-vm --port 18222:9222"))).toBe(true);
+      expect(readFixtureLog().some((c) => c.startsWith("machine forward sb-br-vm --port 18222:9222"))).toBe(true);
     } finally {
       bs.kill();
     }

--- a/tests/run_live_mode.rs
+++ b/tests/run_live_mode.rs
@@ -79,6 +79,10 @@ set -u
 verb=${{1:-}}
 shift || true
 echo "$verb $*" >> {log}
+if [ "$verb" = "machine" ]; then
+  verb=${{1:-}}
+  shift || true
+fi
 case "$verb" in
   up)
     echo '{envelope}'
@@ -96,7 +100,7 @@ case "$verb" in
     fi
     exit 0
     ;;
-  down)
+  stop)
     exit 0
     ;;
   *)
@@ -186,7 +190,7 @@ fn sdk_live_dev_template_shells_to_proc_start() {
     // 1: up --up-json, 2: proc start, 3: fs write, 4: down
     assert!(
         calls.len() >= 4,
-        "expected >= 4 mvmctl shells (up, proc start, fs write, down); got {calls:?}"
+        "expected >= 4 mvmctl shells (up, machine proc start, machine fs write, machine stop); got {calls:?}"
     );
     assert!(
         calls[0].starts_with("up --up-json"),
@@ -196,18 +200,20 @@ fn sdk_live_dev_template_shells_to_proc_start() {
     assert!(
         calls
             .iter()
-            .any(|c| c.starts_with("proc start sb-itest-vm")),
-        "expected a `proc start sb-itest-vm` shell; got {calls:?}"
+            .any(|c| c.starts_with("machine proc start sb-itest-vm")),
+        "expected a `machine proc start sb-itest-vm` shell; got {calls:?}"
     );
     assert!(
         calls
             .iter()
-            .any(|c| c.starts_with("fs write sb-itest-vm /app/data.bin")),
-        "expected a `fs write sb-itest-vm /app/data.bin` shell; got {calls:?}"
+            .any(|c| c.starts_with("machine fs write sb-itest-vm /app/data.bin")),
+        "expected a `machine fs write sb-itest-vm /app/data.bin` shell; got {calls:?}"
     );
     assert!(
-        calls.iter().any(|c| c.starts_with("down sb-itest-vm")),
-        "expected a `down sb-itest-vm` shell; got {calls:?}"
+        calls
+            .iter()
+            .any(|c| c.starts_with("machine stop sb-itest-vm")),
+        "expected a `machine stop sb-itest-vm` shell; got {calls:?}"
     );
 }
 
@@ -246,7 +252,7 @@ fn sdk_live_prod_template_raises_sandbox_dev_only_before_proc_start() {
 
     let calls = read_fixture_log(tmp.path());
     assert!(
-        !calls.iter().any(|c| c.starts_with("proc")),
+        !calls.iter().any(|c| c.starts_with("machine proc")),
         "SDK must NOT have shelled to `mvmctl proc start` against a prod template (security claim 4 client-side enforcement); but the fixture saw: {calls:?}"
     );
     assert!(


### PR DESCRIPTION
**Plan 208 / PR-A** — un-breaks the Python live-mode SDK after the CLI consolidation moved its subprocess API.

## Why
The live-mode Python SDK (`sdks/python/mvm/_sandbox.py`) shells each `Sandbox` operation to `mvmctl`. #1249 folded `proc`/`fs`/`cp`/`forward`/`wait` under `machine` and renamed `down`→`machine stop` — so those bare top-level verbs **no longer parse**, leaving the live-mode SDK broken on `main`.

## What
- `_sandbox.py`: `proc start`→`machine proc start`, `proc wait`→`machine proc wait`, `fs write`→`machine fs write`, `cp`→`machine cp`, `forward`→`machine forward`, `down`→`machine stop`. Verb-naming in comments/error strings updated to match.
- `tests/test_sandbox_live.py`: the `fake-mvmctl` fixture now unwraps the `machine` noun before dispatch (and renames `down`→`stop`); all 16 verb-shape assertions updated. **183 passed, 4 skipped.**

## Deliberately NOT changed
- **`up`** stays on its own verb. The SDK parses `up`'s `--up-json` envelope, and `machine run` doesn't emit a compatible envelope yet — that lands in **PR-B** (Plan 208 sub-step 2, machine-run parity), which then removes `up` and migrates this last call.

Independently shippable: `up` still exists on `main`, so the full live-mode lifecycle works end-to-end after this.