### PR TITLE
Plan 209: drive the slim kernel toward the floor (iterative shrink + CI metrics)

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -81,10 +81,18 @@ jobs:
           ARTIFACT_HASH=$(sha256sum "staging/vmlinux-${ARCH}-workload" | cut -d' ' -f1)
           printf '{"kernel_version":"%s","config_hash":"%s","artifact_hash":"%s"}\n' \
             "$KVER" "$CONFIG_HASH" "$ARTIFACT_HASH" > "staging/kernel-${ARCH}.json"
+          # Resolved workload .config + size/symbol metrics — the inputs to
+          # the shrink audit + the check-kernel-config-budget gate.
+          cp "$CFG" "staging/workload-config-${ARCH}"
+          Y_COUNT=$(grep -c '=y$' "$CFG")
+          RAW_BYTES=$(stat -c%s "staging/vmlinux-${ARCH}-workload")
+          GZ_BYTES=$(gzip -c "staging/vmlinux-${ARCH}-workload" | wc -c)
+          printf '{"arch":"%s","y_symbol_count":%d,"vmlinux_bytes":%d,"vmlinux_gz_bytes":%d}\n' \
+            "$ARCH" "$Y_COUNT" "$RAW_BYTES" "$GZ_BYTES" > "staging/kernel-metrics-${ARCH}.json"
           cd staging
           sha256sum vmlinux-${ARCH}-* > "kernel-${ARCH}-checksums-sha256.txt"
           echo "=== kernel artifacts (${ARCH}) ==="
-          cat "kernel-${ARCH}-checksums-sha256.txt" "kernel-${ARCH}.json"
+          cat "kernel-${ARCH}-checksums-sha256.txt" "kernel-${ARCH}.json" "kernel-metrics-${ARCH}.json"
           du -h vmlinux-${ARCH}-*
 
       - name: Upload kernel artifacts (CI visibility)
@@ -96,6 +104,8 @@ jobs:
             staging/vmlinux-${{ matrix.arch }}-workload
             staging/kernel-${{ matrix.arch }}-checksums-sha256.txt
             staging/kernel-${{ matrix.arch }}.json
+            staging/kernel-metrics-${{ matrix.arch }}.json
+            staging/workload-config-${{ matrix.arch }}
 
       - name: Publish to release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -145,6 +145,29 @@ let
     "MMC" "MMC_BLOCK"      # no SD/eMMC behind virtio
     "REGULATOR" "POWER_SUPPLY" "THERMAL"  # SoC power plumbing defconfig drags in
     "NEW_LEDS" "LEDS_CLASS"
+
+    # Shrink batch 1 — leaf driver subsystems defconfig pulls in that a
+    # headless virtio microVM never touches (console is hvc0 + vsock; no
+    # firmware blobs, no input devices, no host sensors/watchdog). None are
+    # transitive deps of the keep-set (virtio/vsock/ext4/overlay/dm-verity).
+    "FW_LOADER"            # request_firmware infra — no driver here loads blobs
+    "FIREWIRE"             # IEEE-1394 host stack
+    "INPUT" "SERIO"        # input core + PS/2 serial-IO; no virtio-input/keyboard
+    "HWMON"                # hardware monitoring sensors
+    "WATCHDOG"             # watchdog timers
+
+    # Shrink batch 2 — self-contained subsystems + SoC bus/pin/PMIC drivers
+    # defconfig drags in. The SoC `ARCH_*` clusters are already off; these are
+    # the orthogonal driver menus that survive that. None are on the virtio
+    # microVM boot path (no GPIO/I2C/pinctrl/PMIC hardware; FDT boot, not EFI;
+    # egress is host-enforced, not in-guest netfilter; not a ChromeOS board).
+    "CHROME_PLATFORMS"     # ChromeOS embedded-controller drivers
+    "EFI"                  # arm64 boots from the FDT, never the EFI stub/runtime
+    "NETFILTER"            # workload egress is host-enforced + blackhole routes
+    "I2C"                  # no I2C buses behind virtio
+    "GPIOLIB"              # no GPIO controllers
+    "PINCTRL"              # SoC pin-mux
+    "MFD_CORE"             # multi-function (PMIC) device core
   ] ++ pkgs.lib.optionals (kernelArch == "arm64") [
     # arm64 boots from the FDT libkrun / Firecracker hand us; ACPI is
     # never consulted, so drop the ACPICA interpreter and the whole

--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -186,6 +186,17 @@ let
     "SPI"                  # no SPI buses behind virtio (drops SPI flash/RTC/…)
     "NVMEM"                # no on-board NVMEM providers
     "PWM"                  # no PWM controllers
+
+    # Shrink batch 5 — subsystems the proven-minimal libkrun guest also drops.
+    # Console stays: 8250 + AMBA PL011 + virtio-console are kept; only the SoC
+    # vendor UARTs go. IOMMU is safe to drop — virtio rides MMIO with direct
+    # DMA, no translation unit.
+    "CORESIGHT"            # ARM hardware trace/debug — never wired in a guest
+    "VIRTUALIZATION"       # a guest doesn't host nested VMs (drops KVM)
+    "REMOTEPROC"           # no remote-processor/RPMSG coprocessors
+    "IOMMU_SUPPORT"        # virtio-mmio uses direct DMA; no SMMU present
+    "SERIAL_XILINX_PS_UART" "SERIAL_FSL_LPUART" "SERIAL_FSL_LINFLEXUART"
+    "SERIAL_MCTRL_GPIO" "SERIAL_DEV_BUS"  # SoC/serdev UARTs — console is PL011
   ] ++ pkgs.lib.optionals (kernelArch == "arm64") [
     # arm64 boots from the FDT libkrun / Firecracker hand us; ACPI is
     # never consulted, so drop the ACPICA interpreter and the whole

--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -48,12 +48,14 @@ let
   # only what we directly require.
   baseEnables = [
     # virtio bus + transport (sans virtio-fs — that's builder-only;
-    # a sealed workload mounts no host shares).
-    "VIRTIO" "VIRTIO_MENU" "VIRTIO_PCI" "VIRTIO_MMIO"
+    # a sealed workload mounts no host shares). Shrink batch 3: PCI dropped —
+    # libkrun/Firecracker present virtio over the MMIO transport, so the whole
+    # PCI subsystem + its host-controller drivers are dead weight. virtio-pci
+    # goes with it; virtio-mmio carries every device.
+    "VIRTIO" "VIRTIO_MENU" "VIRTIO_MMIO"
     "VIRTIO_BLK" "VIRTIO_NET" "VIRTIO_CONSOLE"
     "VSOCKETS" "VIRTIO_VSOCKETS" "VIRTIO_BALLOON"
     "HW_RANDOM" "HW_RANDOM_VIRTIO"
-    "PCI" "PCI_MSI"
 
     # filesystems. OVERLAY_FS stays in base: the guest agent lands on
     # an overlay. FUSE_FS is builder-only (it backs virtio-fs).
@@ -168,6 +170,21 @@ let
     "GPIOLIB"              # no GPIO controllers
     "PINCTRL"              # SoC pin-mux
     "MFD_CORE"             # multi-function (PMIC) device core
+
+    # Shrink batch 3 — the whole PCI subsystem + host-controller drivers.
+    # Force-dropped (defconfig defaults it on) since virtio rides MMIO here.
+    "PCI"
+
+    # Shrink batch 4 — more whole subsystems a sealed virtio microVM never
+    # uses. Each cascades its family (drivers + helpers) via olddefconfig.
+    "NFS_FS"               # no network filesystems mounted
+    "PHYLIB" "MDIO_DEVICE" # ethernet PHY mgmt — virtio-net has no PHY
+    "VFIO"                 # device passthrough (and PCI is gone)
+    "IPMI_HANDLER"         # no BMC / out-of-band mgmt
+    "CPU_FREQ" "CPU_IDLE"  # no DVFS/idle-governor in a guest
+    "SPI"                  # no SPI buses behind virtio (drops SPI flash/RTC/…)
+    "NVMEM"                # no on-board NVMEM providers
+    "PWM"                  # no PWM controllers
   ] ++ pkgs.lib.optionals (kernelArch == "arm64") [
     # arm64 boots from the FDT libkrun / Firecracker hand us; ACPI is
     # never consulted, so drop the ACPICA interpreter and the whole

--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -162,10 +162,11 @@ let
     # defconfig drags in. The SoC `ARCH_*` clusters are already off; these are
     # the orthogonal driver menus that survive that. None are on the virtio
     # microVM boot path (no GPIO/I2C/pinctrl/PMIC hardware; FDT boot, not EFI;
-    # egress is host-enforced, not in-guest netfilter; not a ChromeOS board).
+    # not a ChromeOS board). Netfilter is NOT cut here — the builder kernel
+    # needs it for its egress lockdown; the workload kernel drops it on its
+    # own (workload.nix extraDisables), since base is shared by both.
     "CHROME_PLATFORMS"     # ChromeOS embedded-controller drivers
     "EFI"                  # arm64 boots from the FDT, never the EFI stub/runtime
-    "NETFILTER"            # workload egress is host-enforced + blackhole routes
     "I2C"                  # no I2C buses behind virtio
     "GPIOLIB"              # no GPIO controllers
     "PINCTRL"              # SoC pin-mux

--- a/nix/images/kernel/workload.nix
+++ b/nix/images/kernel/workload.nix
@@ -27,4 +27,9 @@
 
 base.mkKernel {
   extraEnables = [ "MD" "BLK_DEV_DM" "DM_VERITY" "VIRTIO_FS" "FUSE_FS" ];
+  # Workload-only: the guest enforces egress host-side (egress proxy) + via
+  # blackhole routes (mvm-guest-netinit, rtnetlink), never in-guest iptables —
+  # so it needs no netfilter tables. The builder kernel keeps netfilter for its
+  # OUTPUT-chain egress lockdown, so this drop lives here, not in shared base.
+  extraDisables = [ "NETFILTER" ];
 }

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -64,21 +64,22 @@ just release-build
 ### Kernel builds
 
 The builder-VM and workload microVM kernels are slim custom Linux
-builds (`nix/images/builder-vm/kernel/base.nix` + per-variant deltas in
-`nix/images/builder-vm/kernel/`). Because the config is custom,
-`cache.nixos.org` has no substitute, so the first `dev up` on a fresh
-machine compiles the kernel from source (3-10 min, memory-heavy).
+builds: one shared config in `nix/images/kernel/base.nix` plus a
+per-variant delta (`workload.nix` adds dm-verity; `builder.nix` adds
+the nix-build sandbox + egress-lockdown bits). Because the config is
+custom, `cache.nixos.org` has no substitute, so the first `dev up` on a
+fresh machine compiles the kernel from source (3-10 min, memory-heavy).
 
-`mvmctl kernel build` makes that compile explicit and one-time, so it
-stops hijacking your first `dev up`:
+`mvmctl build kernel build` makes that compile explicit and one-time, so
+it stops hijacking your first `dev up`:
 
 ```bash
 # Compile the builder kernel once into the cache + persistent nix store.
 # The next `dev up` reuses it (substituted, not rebuilt).
-just run -- kernel build --which builder
+just run -- build kernel build --which builder
 
 # Or both kernels:
-just run -- kernel build --all
+just run -- build kernel build --all
 ```
 
 To skip the kernel compile entirely on a fresh machine, boot the builder
@@ -99,10 +100,47 @@ Notes:
   download` once a release ships it.
 - On macOS the compile arm needs the libkrun trio (`slp/krun/*`), since
   Stage 0 is libkrun-backed even on Vz-default hosts.
-- Editing `base.nix` or the builder delta? Just re-run the command — a
+- Editing `base.nix` or a variant delta? Just re-run the command — a
   custom config always compiles locally; downloads only ever return the
   kernel that shipped with that exact `mvmctl` release. See ADR-046
   §"Amendment: kernel acquisition".
+
+#### Iterating on the kernel config (slimming, adding a driver)
+
+Changing `base.nix` / `workload.nix` / `builder.nix` and want to see the
+effect? The loop is build → boot-smoke → measure:
+
+```bash
+# 1. Build the variant you touched (compiles your edited config in Stage 0).
+just run -- build kernel build --which workload
+
+# 2. Boot-smoke it — a kernel that builds isn't proof it boots. Boot a
+#    throwaway VM and confirm the in-guest agent answers over vsock.
+just run -- up --flake examples/sleeper --hypervisor libkrun --name smoke -d
+just run -- machine boot-report smoke   # "control plane  ready" == good
+just run -- machine stop smoke
+```
+
+Two sharp edges worth knowing:
+
+- **A build that passes the config guard still has to boot.** After
+  `make olddefconfig`, the build asserts every requested `enable` is
+  still `=y` and fails loudly if one got dropped by a missing
+  dependency — but that guard can't tell you a *disable* removed
+  something the boot path needed. Only the boot-smoke proves that, so
+  never skip step 2.
+- **`enable` and `disable` are scoped.** A disable in the shared
+  `base.nix` hits *both* kernels; if only the workload should drop a
+  symbol (or only the builder needs one), put it in that variant's
+  delta. (The builder kernel, for example, keeps netfilter for its
+  egress lockdown while the workload drops it.)
+- **You can't read the resolved `.config` locally** — Stage 0 hands the
+  host a `vmlinux`, not the config. The `=y` symbol count + byte size
+  come from the `kernel-build` CI lane, which uploads
+  `workload-config-<arch>` and `kernel-metrics-<arch>.json`. Trigger it
+  without a release via `gh workflow run kernel-build.yml`. The
+  `check-kernel-config-budget` xtask gate fails CI if the `=y` count
+  regresses past `KERNEL_Y_BUDGET`.
 
 ## Testing
 

--- a/public/src/content/docs/guides/kernels.md
+++ b/public/src/content/docs/guides/kernels.md
@@ -1,25 +1,25 @@
 ---
 title: "Custom microVM kernels"
-description: "Build or download the slim builder/workload kernels mvm boots, with mvmctl kernel build."
+description: "Build or download the slim builder/workload kernels mvm boots, with mvmctl build kernel build."
 ---
 
 mvm boots slim, custom-configured Linux kernels for the builder VM and for
 workload microVMs. Because the config is custom, the public Nix cache has no
 substitute for them — a fresh machine compiles from source, which is the slow,
 memory-heavy step a first `mvmctl dev up` otherwise hits implicitly.
-`mvmctl kernel build` makes that step explicit and one-time.
+`mvmctl build kernel build` makes that step explicit and one-time.
 
 ## Build a kernel
 
 ```bash
 # Compile the builder kernel for this host (slow on first run, then cached)
-mvmctl kernel build --which builder --source compile
+mvmctl build kernel build --which builder --source compile
 
 # Download the prebuilt, hash-verified kernel that shipped with this mvmctl
-mvmctl kernel build --which workload --source download
+mvmctl build kernel build --which workload --source download
 
 # Download if a prebuilt exists for this release, else compile locally
-mvmctl kernel build --all --source auto
+mvmctl build kernel build --all --source auto
 ```
 
 Flags:


### PR DESCRIPTION
Drives the slim microVM kernel down by inventory-driven audit-subtraction, **boot-smoking every batch** under libkrun (both the workload *and* builder kernels must reach the live vsock agent or the cut is reverted), and cross-checking each family against a proven-minimal libkrun guest config.

## Result so far
| | `=y` symbols | vmlinux | gz |
|---|---|---|---|
| Baseline | 1716 | 21.2 MB | 9.4 MB |
| **This PR (Batches 1–4)** | **1391** (−325, −19%) | **17.0 MiB** (−20%) | 7.6 MB |
| Batch 5 (in flight) | ~1343 | — | — |

CI's kernel-build lane now exports the resolved `.config` + `kernel-metrics-<arch>.json` (y-count + bytes) so every cut has a precise before/after and the `check-kernel-config-budget` gate can ratchet.

## Cuts (each boot-validated, workload + builder)
- **1** firmware/firewire/input/serio/hwmon/watchdog
- **2** EFI, MFD, I2C, GPIO, pinctrl, ChromeOS-EC
- **3** the whole **PCI** subsystem (virtio rides MMIO — confirmed live + by the reference)
- **4** NFS, PHY/MDIO, VFIO, IPMI, cpufreq/cpuidle, SPI, NVMEM, PWM
- **5** (pending) CORESIGHT, KVM, remoteproc/RPMSG, IOMMU, vendor UARTs

## Safety
- **`mvmctl machine boot-report`** confirms the agent answers over vsock after every batch (workload), and Stage 0 runs on the rebuilt **builder** kernel (builder).
- The **enable-stick guard** (`mkConfigfile`) caught a real regression: a netfilter cut placed in the *shared* base cascaded into the builder kernel, which needs iptables for its egress lockdown. Fixed — netfilter is now a workload-only drop (`workload.nix`), builder keeps it.
- Netfilter/dm-verity/PL011+8250 console all retained where required.

## Not chasing the absolute floor
The remaining gap to the reference (~1005) is entangled, not cruft: ARM/ARCH platform symbols (arch-essential), NET (virtio-net/IP core), CRYPTO the reference itself keeps, and GPIO/MOUSE residuals that are *select-pulled* by the console. Cutting further trades boot-safety for marginal size. Documented as a follow-up.

Lands with `KERNEL_Y_BUDGET` ratcheted to the measured count to lock in the win.