### PR TITLE
fix(sdk-ts): migrate live-mode Sandbox ops to `machine` verbs

### DIFF
--- a/sdks/typescript/src/_sandbox.ts
+++ b/sdks/typescript/src/_sandbox.ts
@@ -20,7 +20,7 @@
  *   produces a Workload.
  * - `MVM_SDK_MODE=live` (Plan 73 Followup H-live): every
  *   `Sandbox` call shells to `$MVM_CLI_BIN` (`mvmctl up`,
- *   `mvmctl proc start`, `mvmctl fs write`, `mvmctl down`)
+ *   `mvmctl machine proc start`, `mvmctl machine fs write`, `mvmctl machine stop`)
  *   against a real microVM. The shell is dispatched by
  *   {@link LiveTransport} below.
  *
@@ -345,7 +345,7 @@ export interface SandboxExecOptions {
  *
  *  `exitCode` is the child's exit code (0 on success). `stdout`/`stderr`
  *  are captured strings — exec is a one-shot that *captures* the streams,
- *  the distinction from `commands.start` + `mvmctl proc wait`. */
+ *  the distinction from `commands.start` + `mvmctl machine proc wait`. */
 export interface ExecResult {
   exitCode: number;
   stdout: string;
@@ -386,7 +386,7 @@ export class LiveTransport {
   readonly vmId: string;
   readonly buildMode: "dev" | "prod";
   private killed = false;
-  // Long-running `mvmctl forward` proxies spawned by `forward()`. Torn
+  // Long-running `mvmctl machine forward` proxies spawned by `forward()`. Torn
   // down in `kill()` so a port forwarder never outlives the VM.
   private forwards: import("node:child_process").ChildProcess[] = [];
 
@@ -473,16 +473,16 @@ export class LiveTransport {
           `claim 4) strips the agent's \`do_exec\` handler in prod builds — ` +
           `re-build the template with \`mvmctl template build --dev <name>\`, ` +
           `or use \`files.write\` to stage inputs into the running VM instead.`,
-        { argv: ["proc", "start", this.vmId, ...argv] },
+        { argv: ["machine", "proc", "start", this.vmId, ...argv] },
       );
     }
-    const shell = [this.mvmCliBin, "proc", "start", this.vmId];
+    const shell = [this.mvmCliBin, "machine", "proc", "start", this.vmId];
     shell.push(...this.encodeEnvFlags(env, shell));
     shell.push("--", ...argv);
     this.runShell(shell);
   }
 
-  /** Encode `env` into `-e KEY=VALUE` flags for `mvmctl proc start`,
+  /** Encode `env` into `-e KEY=VALUE` flags for `mvmctl machine proc start`,
    *  rejecting non-literal (secret) values — live mode forwards only
    *  literals; secrets are injected host-side via `--secret` on `up`. */
   private encodeEnvFlags(
@@ -512,8 +512,8 @@ export class LiveTransport {
     return flags;
   }
 
-  /** One-shot exec: `mvmctl proc start ... -- argv` → pid_token, then
-   *  `mvmctl proc wait <token>` to capture stdout/stderr/exit. Refuses
+  /** One-shot exec: `mvmctl machine proc start ... -- argv` → pid_token, then
+   *  `mvmctl machine proc wait <token>` to capture stdout/stderr/exit. Refuses
    *  with {@link SandboxDevOnly} on a prod template (claim 4). */
   commandsExec(argv: string[], options: SandboxExecOptions = {}): ExecResult {
     if (this.buildMode !== "dev") {
@@ -523,14 +523,14 @@ export class LiveTransport {
           `claim 4) strips the agent's \`do_exec\` handler in prod builds — ` +
           `re-build the template with \`mvmctl template build --dev <name>\`, ` +
           `or use \`files.write\` to stage inputs into the running VM instead.`,
-        { argv: ["proc", "start", this.vmId, ...argv] },
+        { argv: ["machine", "proc", "start", this.vmId, ...argv] },
       );
     }
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
 
     // 1) `proc start` → pid_token on stdout.
-    const startShell = [this.mvmCliBin, "proc", "start", this.vmId];
+    const startShell = [this.mvmCliBin, "machine", "proc", "start", this.vmId];
     startShell.push(...this.encodeEnvFlags(options.env, startShell));
     if (options.cwd !== undefined) startShell.push("--cwd", options.cwd);
     startShell.push("--", ...argv);
@@ -553,7 +553,7 @@ export class LiveTransport {
     }
     if (startResult.status !== 0) {
       throw new SandboxLiveError(
-        `\`mvmctl proc start\` failed with exit code ${startResult.status}`,
+        `\`mvmctl machine proc start\` failed with exit code ${startResult.status}`,
         {
           argv: startShell,
           exitCode: startResult.status,
@@ -564,13 +564,13 @@ export class LiveTransport {
     const pidToken = (startResult.stdout ?? "").trim();
     if (!pidToken) {
       throw new SandboxLiveError(
-        "`mvmctl proc start` produced no pid_token on stdout",
+        "`mvmctl machine proc start` produced no pid_token on stdout",
         { argv: startShell, stderr: startResult.stderr ?? "" },
       );
     }
 
     // 2) `proc wait <token>` → captured stdout/stderr/exit.
-    const waitShell = [this.mvmCliBin, "proc", "wait", this.vmId, pidToken];
+    const waitShell = [this.mvmCliBin, "machine", "proc", "wait", this.vmId, pidToken];
     if (options.timeout !== undefined) {
       waitShell.push("--timeout", String(Math.trunc(options.timeout)));
     }
@@ -591,7 +591,7 @@ export class LiveTransport {
     }
     if (waitResult.error) {
       throw new SandboxLiveError(
-        `\`mvmctl proc wait\` failed: ${waitResult.error.message}`,
+        `\`mvmctl machine proc wait\` failed: ${waitResult.error.message}`,
         { argv: waitShell },
       );
     }
@@ -603,7 +603,7 @@ export class LiveTransport {
   }
 
   filesWrite(path: string, data: Uint8Array): void {
-    const shell = [this.mvmCliBin, "fs", "write", this.vmId, path];
+    const shell = [this.mvmCliBin, "machine", "fs", "write", this.vmId, path];
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
     let result;
@@ -624,7 +624,7 @@ export class LiveTransport {
     }
     if (result.status !== 0) {
       throw new SandboxLiveError(
-        `\`mvmctl fs write\` failed with exit code ${result.status}`,
+        `\`mvmctl machine fs write\` failed with exit code ${result.status}`,
         {
           argv: shell,
           exitCode: result.status,
@@ -635,7 +635,7 @@ export class LiveTransport {
   }
 
   cp(source: string, destination: string): void {
-    const shell = [this.mvmCliBin, "cp", source, destination];
+    const shell = [this.mvmCliBin, "machine", "cp", source, destination];
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
     let result;
@@ -654,7 +654,7 @@ export class LiveTransport {
     }
     if (result.status !== 0) {
       throw new SandboxLiveError(
-        `\`mvmctl cp\` failed with exit code ${result.status}`,
+        `\`mvmctl machine cp\` failed with exit code ${result.status}`,
         {
           argv: shell,
           exitCode: result.status,
@@ -666,10 +666,10 @@ export class LiveTransport {
 
   forward(hostPort: number, guestPort: number): void {
     const spec = `${hostPort}:${guestPort}`;
-    const shell = [this.mvmCliBin, "forward", this.vmId, "--port", spec];
+    const shell = [this.mvmCliBin, "machine", "forward", this.vmId, "--port", spec];
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
-    // `mvmctl forward` blocks (runs the proxy until signalled), so spawn
+    // `mvmctl machine forward` blocks (runs the proxy until signalled), so spawn
     // it detached + tracked; `kill()` terminates it.
     let proc;
     try {
@@ -695,7 +695,7 @@ export class LiveTransport {
       }
     }
     this.forwards = [];
-    const shell = [this.mvmCliBin, "down", this.vmId];
+    const shell = [this.mvmCliBin, "machine", "stop", this.vmId];
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const child = require("node:child_process") as typeof import("node:child_process");
     try {
@@ -708,12 +708,12 @@ export class LiveTransport {
         // orchestrator's TTL reaper.
         // eslint-disable-next-line no-console
         console.error(
-          `mvm-sdk live: \`mvmctl down ${this.vmId}\` exited with ${result.status}: ${result.stderr ?? ""}`,
+          `mvm-sdk live: \`mvmctl machine stop ${this.vmId}\` exited with ${result.status}: ${result.stderr ?? ""}`,
         );
       }
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.error(`mvm-sdk live: failed to spawn \`mvmctl down\`: ${String(err)}`);
+      console.error(`mvm-sdk live: failed to spawn \`mvmctl machine stop\`: ${String(err)}`);
     }
   }
 
@@ -902,7 +902,7 @@ export class Sandbox {
 
   /** One-shot: run `argv` inside the sandbox, capturing stdout / stderr /
    *  exit into an {@link ExecResult}. Convenience over `commands.start` +
-   *  `mvmctl proc wait`. Refuses with `SandboxDevOnly` on a prod template
+   *  `mvmctl machine proc wait`. Refuses with `SandboxDevOnly` on a prod template
    *  (claim 4).
    *
    *  Live mode only: in record mode this throws `SandboxModeError` — the
@@ -927,7 +927,7 @@ export class Sandbox {
 
   /** Copy a host file into the running sandbox at `guestPath`.
    *
-   *  Shells `mvmctl cp <hostPath> <vm>:<guestPath>` — the host file
+   *  Shells `mvmctl machine cp <hostPath> <vm>:<guestPath>` — the host file
    *  streams into the guest over the agent fs RPC.
    *
    *  Live mode only: in record mode this throws `SandboxModeError`. To
@@ -951,7 +951,7 @@ export class Sandbox {
 
   /** Copy a file out of the running sandbox to `hostPath`.
    *
-   *  Shells `mvmctl cp <vm>:<guestPath> <hostPath>` — the guest file
+   *  Shells `mvmctl machine cp <vm>:<guestPath> <hostPath>` — the guest file
    *  streams back over the agent fs RPC.
    *
    *  Live mode only: pulling a file from a running VM has no record-mode
@@ -974,7 +974,7 @@ export class Sandbox {
 
   /** Forward `hostPort` on the host to `guestPort` in the sandbox.
    *
-   *  Spawns `mvmctl forward <vm> --port <host>:<guest>` as a background
+   *  Spawns `mvmctl machine forward <vm> --port <host>:<guest>` as a background
    *  proxy that runs until the sandbox is torn down (`kill` /
    *  `[Symbol.dispose]` terminate it).
    *

--- a/sdks/typescript/tests/sandbox_live.test.ts
+++ b/sdks/typescript/tests/sandbox_live.test.ts
@@ -50,6 +50,10 @@ set -u
 verb=\${1:-}
 shift || true
 echo "$verb $*" >> ${JSON.stringify(log)}
+if [ "$verb" = "machine" ]; then
+  verb=\${1:-}
+  shift || true
+fi
 case "$verb" in
   up)
     if [ -t 0 ]; then :; else cat > ${JSON.stringify(path.join(stdinDir, "up-stdin.bin"))} || true; fi
@@ -84,7 +88,7 @@ case "$verb" in
     sleep ${forwardSleep}
     exit 0
     ;;
-  down)
+  stop)
     exit ${downExit}
     ;;
   *)
@@ -236,7 +240,7 @@ describe("Sandbox.commands.start (live mode)", () => {
 
     const calls = readFixtureLog();
     expect(calls.length).toBe(2);
-    expect(calls[1]).toMatch(/^proc start sb-dev-vm/);
+    expect(calls[1]).toMatch(/^machine proc start sb-dev-vm/);
     expect(calls[1]).toContain("-e MODE=test");
     expect(calls[1]).toContain("-- python run.py");
   });
@@ -261,7 +265,7 @@ describe("Sandbox.commands.start (live mode)", () => {
     // Critical: SDK must NOT have shelled to `mvmctl proc start`.
     const calls = readFixtureLog();
     expect(calls.length).toBe(1);
-    expect(calls.some((c) => c.startsWith("proc"))).toBe(false);
+    expect(calls.some((c) => c.startsWith("machine proc"))).toBe(false);
   });
 });
 
@@ -283,7 +287,7 @@ describe("Sandbox.files.write (live mode)", () => {
     sb.files.write("/app/config.json", new TextEncoder().encode('{"x":1}'));
 
     const calls = readFixtureLog();
-    expect(calls.some((c) => c.startsWith("fs write sb-fs-vm /app/config.json"))).toBe(true);
+    expect(calls.some((c) => c.startsWith("machine fs write sb-fs-vm /app/config.json"))).toBe(true);
     const stdinPath = path.join(tmpDir, "fixture-stdin", "fs-write-stdin.bin");
     expect(fs.readFileSync(stdinPath, "utf-8")).toBe('{"x":1}');
   });
@@ -307,7 +311,7 @@ describe("Sandbox.kill (live mode)", () => {
     sb.kill();
 
     const calls = readFixtureLog();
-    expect(calls).toContain("down sb-kill-vm");
+    expect(calls).toContain("machine stop sb-kill-vm");
   });
 
   it("[Symbol.dispose] kills once", () => {
@@ -324,7 +328,7 @@ describe("Sandbox.kill (live mode)", () => {
     const sb = mvm.Sandbox.create("python-dev");
     sb[Symbol.dispose]();
 
-    const downCalls = readFixtureLog().filter((c) => c.startsWith("down "));
+    const downCalls = readFixtureLog().filter((c) => c.startsWith("machine stop "));
     expect(downCalls.length).toBe(1);
   });
 });
@@ -346,7 +350,7 @@ describe("Sandbox.copyIn / copyOut (live mode)", () => {
 
     const calls = readFixtureLog();
     expect(
-      calls.some((c) => c.startsWith(`cp ${hostFile} sb-cp-vm:/app/local.txt`)),
+      calls.some((c) => c.startsWith(`machine cp ${hostFile} sb-cp-vm:/app/local.txt`)),
     ).toBe(true);
   });
 
@@ -363,7 +367,7 @@ describe("Sandbox.copyIn / copyOut (live mode)", () => {
 
     const calls = readFixtureLog();
     expect(
-      calls.some((c) => c.startsWith(`cp sb-cp-vm:/app/out.txt ${dest}`)),
+      calls.some((c) => c.startsWith(`machine cp sb-cp-vm:/app/out.txt ${dest}`)),
     ).toBe(true);
   });
 
@@ -413,7 +417,7 @@ describe("Sandbox.forward (live mode)", () => {
     );
     const calls = readFixtureLog();
     expect(
-      calls.some((c) => c.startsWith("forward sb-fwd-vm --port 8080:80")),
+      calls.some((c) => c.startsWith("machine forward sb-fwd-vm --port 8080:80")),
     ).toBe(true);
   });
 
@@ -459,10 +463,10 @@ describe("Sandbox.exec (live mode)", () => {
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toBe("4");
     const calls = readFixtureLog();
-    expect(calls.some((c) => c.startsWith("proc start sb-exec-vm"))).toBe(true);
+    expect(calls.some((c) => c.startsWith("machine proc start sb-exec-vm"))).toBe(true);
     expect(
       calls.some((c) =>
-        c.startsWith("proc wait sb-exec-vm pid-token-abc123"),
+        c.startsWith("machine proc wait sb-exec-vm pid-token-abc123"),
       ),
     ).toBe(true);
   });
@@ -491,7 +495,7 @@ describe("Sandbox.exec (live mode)", () => {
     sb.exec(["env"], { env: { MODE: "test" } });
 
     const calls = readFixtureLog();
-    const start = calls.find((c) => c.startsWith("proc start"));
+    const start = calls.find((c) => c.startsWith("machine proc start"));
     expect(start).toContain("-e MODE=test");
     expect(start).toContain("-- env");
   });
@@ -506,7 +510,7 @@ describe("Sandbox.exec (live mode)", () => {
     const sb = mvm.Sandbox.create("python-prod");
     expect(() => sb.exec(["python", "-c", "x"])).toThrow(mvm.SandboxDevOnly);
     // Claim 4: must not have shelled `mvmctl proc start`.
-    expect(readFixtureLog().some((c) => c.startsWith("proc"))).toBe(false);
+    expect(readFixtureLog().some((c) => c.startsWith("machine proc"))).toBe(false);
   });
 
   it("is refused in record mode", () => {
@@ -542,7 +546,7 @@ describe("Sandbox async surface", () => {
 
     const sb = mvm.Sandbox.create("python-dev");
     await sb[Symbol.asyncDispose]();
-    expect(readFixtureLog().some((c) => c.startsWith("down "))).toBe(true);
+    expect(readFixtureLog().some((c) => c.startsWith("machine stop "))).toBe(true);
   });
 });
 
@@ -595,7 +599,7 @@ describe("CodeSandbox", () => {
       expect(cs.run("print(2 + 2)")).toBe("4");
       const calls = readFixtureLog();
       expect(
-        calls.some((c) => c.startsWith("proc start sb-cs-vm") && c.includes("-- python -c")),
+        calls.some((c) => c.startsWith("machine proc start sb-cs-vm") && c.includes("-- python -c")),
       ).toBe(true);
     } finally {
       cs.kill();
@@ -648,7 +652,7 @@ describe("CodeSandbox", () => {
     try {
       expect(cs.runScript(hostScript)).toBe("ok");
       const calls = readFixtureLog();
-      expect(calls.some((c) => c.startsWith("cp ") && c.includes("sb-cs-vm:/tmp/job.py"))).toBe(true);
+      expect(calls.some((c) => c.startsWith("machine cp ") && c.includes("sb-cs-vm:/tmp/job.py"))).toBe(true);
       expect(calls.some((c) => c.includes("-- python /tmp/job.py"))).toBe(true);
     } finally {
       cs.kill();
@@ -688,7 +692,7 @@ describe("BrowserSandbox", () => {
       expect(bs.endpoint()).toBe("http://localhost:9222");
       const live = bs.sandbox._live as unknown as ForwardsPeek;
       await new Promise<void>((resolve) => live.forwards[0].on("exit", () => resolve()));
-      expect(readFixtureLog().some((c) => c.startsWith("forward sb-br-vm --port 9222:9222"))).toBe(true);
+      expect(readFixtureLog().some((c) => c.startsWith("machine forward sb-br-vm --port 9222:9222"))).toBe(true);
     } finally {
       bs.kill();
     }
@@ -706,7 +710,7 @@ describe("BrowserSandbox", () => {
       expect(bs.endpoint()).toBe("http://localhost:18222");
       const live = bs.sandbox._live as unknown as ForwardsPeek;
       await new Promise<void>((resolve) => live.forwards[0].on("exit", () => resolve()));
-      expect(readFixtureLog().some((c) => c.startsWith("forward sb-br-vm --port 18222:9222"))).toBe(true);
+      expect(readFixtureLog().some((c) => c.startsWith("machine forward sb-br-vm --port 18222:9222"))).toBe(true);
     } finally {
       bs.kill();
     }


### PR DESCRIPTION
**Plan 208 — TypeScript sibling of #1266** (the Python SDK migration).

## Why
The live-mode TS SDK (`sdks/typescript/src/_sandbox.ts`) shells each `Sandbox` op to `mvmctl`. #1249 folded `proc`/`fs`/`cp`/`forward`/`wait` under `machine` and renamed `down`→`machine stop`, so those bare top-level verbs no longer parse — the TS live-mode SDK is broken on `main`, exactly like Python was.

## What
- `_sandbox.ts`: `proc start`/`proc wait`/`fs write`/`cp`/`forward` → `machine …`; `down`→`machine stop`. Comments + error strings updated.
- `sandbox_live.test.ts`: fake-`mvmctl` fixture unwraps the `machine` noun (+ `down`→`stop`); all 16 verb assertions (`startsWith`/`toContain`/`toMatch`) updated. **114 vitest tests pass; `tsc --noEmit` clean.**

## Deliberately NOT changed
- **`up`** stays on its own verb (the SDK parses its `--up-json` envelope; `machine run` doesn't emit a compatible one yet). That migrates in Plan 208 sub-step 2, same as the Python PR.

Independent of #1266 (different files); both un-break their respective SDKs.