### PR TITLE
docs(plan-211): sub-second machine run via warm-pool claim (design + phases)

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -274,7 +274,7 @@ impl MachineRunArgs {
         RunArgs {
             manifest: self.manifest,
             // Default off; `run_dispatch` sets it for the warm-claim-eligible
-            // transient mode (Plan 211).
+            // transient mode.
             warm_pool_size: 0,
             image: self.image,
             net: self.net,
@@ -372,7 +372,7 @@ enum MachineRunMode {
 }
 
 impl MachineRunMode {
-    /// Warm-pool size for this run mode (Plan 211 Phase 1). Transient and
+    /// Warm-pool size for this run mode. Transient and
     /// interactive-transient runs are throwaway, auto-named cattle — eligible to
     /// claim a pre-booted standby and to replenish the pool, so they take the
     /// residency-policy size (`effective_warm_pool_size`). A user-named or `-d`
@@ -2299,7 +2299,7 @@ fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig) -> Result<
     }
 
     let mode = args.resolve_mode()?;
-    // Plan 211 Phase 1: resolve warm-pool eligibility per mode. Threaded into the
+    // Resolve warm-pool eligibility per mode. Threaded into the
     // claim path next; logged here so the dark-landed decision is observable
     // (transient/interactive-transient take the residency size, persistent → 0).
     tracing::debug!(
@@ -2313,7 +2313,7 @@ fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig) -> Result<
             if let Some(slot) = resolved_flake_slot {
                 args.manifest = Some(slot);
             }
-            // Plan 211 Phase 1b-i: a throwaway transient run is warm-claim
+            // A throwaway transient run is warm-claim
             // eligible — carry the residency-policy size so `run_inner` can claim
             // a pre-booted standby and replenish the pool.
             let mut run_args = args.into_run_args();

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -273,6 +273,9 @@ impl MachineRunArgs {
     fn into_run_args(self) -> RunArgs {
         RunArgs {
             manifest: self.manifest,
+            // Default off; `run_dispatch` sets it for the warm-claim-eligible
+            // transient mode (Plan 211).
+            warm_pool_size: 0,
             image: self.image,
             net: self.net,
             allow_host: self.allow_host,
@@ -2310,7 +2313,12 @@ fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig) -> Result<
             if let Some(slot) = resolved_flake_slot {
                 args.manifest = Some(slot);
             }
-            run_secure(cli, args.into_run_args(), cfg)
+            // Plan 211 Phase 1b-i: a throwaway transient run is warm-claim
+            // eligible — carry the residency-policy size so `run_inner` can claim
+            // a pre-booted standby and replenish the pool.
+            let mut run_args = args.into_run_args();
+            run_args.warm_pool_size = mode.warm_pool_size(None);
+            run_secure(cli, run_args, cfg)
         }
         MachineRunMode::Persistent => {
             run_persistent(cli, args, cfg, resolved_flake_slot.as_deref())

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -368,6 +368,24 @@ enum MachineRunMode {
     InteractivePersistent,
 }
 
+impl MachineRunMode {
+    /// Warm-pool size for this run mode (Plan 211 Phase 1). Transient and
+    /// interactive-transient runs are throwaway, auto-named cattle — eligible to
+    /// claim a pre-booted standby and to replenish the pool, so they take the
+    /// residency-policy size (`effective_warm_pool_size`). A user-named or `-d`
+    /// persistent machine is long-lived, not pool cattle, so it never claims
+    /// (size 0). `explicit` is a caller override (e.g. a future `--warm` flag),
+    /// applied only to the claim-eligible modes.
+    fn warm_pool_size(self, explicit: Option<u32>) -> u32 {
+        match self {
+            MachineRunMode::Transient | MachineRunMode::InteractiveTransient => {
+                mvm_core::residency::effective_warm_pool_size(explicit)
+            }
+            MachineRunMode::Persistent | MachineRunMode::InteractivePersistent => 0,
+        }
+    }
+}
+
 /// What the persistent path should do with the on-disk spec for the target name.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum SpecReconcile {
@@ -2277,7 +2295,16 @@ fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig) -> Result<
         return run_entrypoint_action(args, resolved_flake_slot);
     }
 
-    match args.resolve_mode()? {
+    let mode = args.resolve_mode()?;
+    // Plan 211 Phase 1: resolve warm-pool eligibility per mode. Threaded into the
+    // claim path next; logged here so the dark-landed decision is observable
+    // (transient/interactive-transient take the residency size, persistent → 0).
+    tracing::debug!(
+        ?mode,
+        warm_pool_size = mode.warm_pool_size(None),
+        "machine run warm-pool eligibility"
+    );
+    match mode {
         MachineRunMode::Transient => {
             // For flake runs, pass the slot hash as the manifest.
             if let Some(slot) = resolved_flake_slot {
@@ -2722,6 +2749,31 @@ mod tests {
             let mode = args.resolve_mode().expect("resolve");
             assert_eq!(mode, *expected, "argv {argv:?}");
         }
+    }
+
+    #[test]
+    fn warm_pool_size_is_claim_eligible_only_for_throwaway_runs() {
+        // Transient + interactive-transient are auto-named cattle → eligible:
+        // an explicit override is honoured verbatim (the residency-policy default
+        // for `None` is env-dependent, so the override path is the deterministic
+        // assertion).
+        assert_eq!(MachineRunMode::Transient.warm_pool_size(Some(3)), 3);
+        assert_eq!(
+            MachineRunMode::InteractiveTransient.warm_pool_size(Some(2)),
+            2
+        );
+        // A user-named / `-d` persistent machine is long-lived, never pooled —
+        // size 0 regardless of any override.
+        assert_eq!(MachineRunMode::Persistent.warm_pool_size(Some(5)), 0);
+        assert_eq!(MachineRunMode::Persistent.warm_pool_size(None), 0);
+        assert_eq!(
+            MachineRunMode::InteractivePersistent.warm_pool_size(Some(5)),
+            0
+        );
+        assert_eq!(
+            MachineRunMode::InteractivePersistent.warm_pool_size(None),
+            0
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -9,10 +9,12 @@ mod image;
 mod machine;
 mod manifest;
 mod ops;
-/// Supervisor warm-pool: the `mvmctl pool warm/status` command + the
-/// launch glue (`try_warm_claim`/`replenish_after_launch`) the `up` path calls to claim a
-/// warm standby (auto-named, bridge-admitted launches) and top the pool back up.
-mod pool;
+/// Supervisor warm-pool: the `mvmctl pool warm/status` command + the launch glue
+/// (`try_warm_claim`/`replenish_after_launch`) the transient `machine run` path
+/// (`crate::exec::run_inner`) calls to claim a warm standby (auto-named,
+/// bridge-admitted launches) and top the pool back up. `pub(crate)` so the
+/// crate-root `exec` runner can reach the glue.
+pub(crate) mod pool;
 mod qemu_bridge;
 mod shared;
 mod ssh_agent_proxy;

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -416,6 +416,8 @@ impl ExecDispatcher {
         let argv = bash_dash_c(&shell_escape(code));
         let req = crate::exec::ExecRequest {
             image: crate::exec::ImageSource::Template(env.to_string()),
+            // MCP sessions don't use the warm pool.
+            warm_pool_size: 0,
             cpus: DEFAULT_VM_CPUS,
             memory_mib: DEFAULT_VM_MEM_MIB,
             mem_initial_mib: None,

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -18,12 +18,16 @@ use mvm_backend::backend::AnyBackend;
 use mvm_backend::catalog::BackendKind;
 use mvm_backend::standby_pool::SupervisorStandbyPool;
 use mvm_core::user_config::MvmConfig;
-use mvm_core::vm_backend::{StandbyCompat, StandbyHandle, StandbySpec, StandbyState, VmBackend};
+use mvm_core::vm_backend::{
+    StandbyClaim, StandbyCompat, StandbyHandle, StandbySpec, StandbyState, VmBackend, VmId,
+    VmStartConfig,
+};
 use sha2::{Digest, Sha256};
 
 use super::Cli;
 use super::env::dev_vz::ensure_default_microvm_image;
 use super::vm::host_signer;
+use super::vm::plan_admission::stash_plan_for_bridge;
 
 /// Lowercase-hex sha256 of a kernel image — part of the base-compat key.
 pub fn kernel_sha256_hex(kernel: &Path) -> Result<String> {
@@ -193,6 +197,251 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
     Ok(WarmResult { spawned, failed })
 }
 
+/// The compat-key image identity. `None` for libkrun (image-agnostic standbys). For Vz
+/// the sha256 of the source rootfs image ties a saved-standby to the exact image it was
+/// captured from — only launches with the same image may claim it.
+pub fn image_identity(backend: &dyn VmBackend, rootfs_path: &str) -> Result<Option<String>> {
+    if backend.name() == "libkrun" {
+        return Ok(None);
+    }
+    if backend.name() == "vz" {
+        let sha = kernel_sha256_hex(Path::new(rootfs_path))
+            .with_context(|| format!("hashing rootfs for image identity: {rootfs_path}"))?;
+        return Ok(Some(sha));
+    }
+    // Other backends (firecracker, qemu, …) have no pool today; return None so
+    // compat_for_launch compiles without gating those paths.
+    Ok(None)
+}
+
+// ── Plan 211 Phase 1b-i: warm-pool claim glue, recovered from 04bab4f7^ ──
+// (deleted by #1258 as orphaned when up/run folded into `machine run`; the
+// surviving standby primitives are unchanged). Wired into `crate::exec::run_inner`.
+
+pub enum LaunchDecision {
+    /// A standby was claimed and is booting under this VmId.
+    Claimed(VmId),
+    /// No compatible warm standby (or the claim failed) — caller must cold-boot.
+    ColdBoot,
+}
+
+/// Try to claim an idle standby compatible with `want`; **fail open to cold boot**. On a
+/// claim error the standby is removed (it's spent/broken), never left idle, so the next
+/// launch doesn't keep retrying a dead standby.
+///
+/// `make_claim` builds the [`StandbyClaim`] **for the selected standby's id** — the audit
+/// substrate (`gateway-<vm>.sock`) is name-keyed, and a claimed VM runs under its
+/// standby-id, so the caller must compute those paths against `handle.id`. A `make_claim`
+/// error also fails open to cold boot (and reaps the reserved standby).
+pub fn claim_or_cold<F>(
+    pool: &SupervisorStandbyPool,
+    backend: &dyn VmBackend,
+    want: &StandbyCompat,
+    make_claim: F,
+) -> Result<LaunchDecision>
+where
+    F: FnOnce(&StandbyHandle) -> Result<StandbyClaim>,
+{
+    if !backend.supports_standby_pool() {
+        return Ok(LaunchDecision::ColdBoot);
+    }
+    let Some(handle) = pool.select_idle_compatible(want)? else {
+        return Ok(LaunchDecision::ColdBoot);
+    };
+    // Reserve it so a concurrent launch won't double-claim.
+    pool.mark_claimed(&handle.id)?;
+    let claim = match make_claim(&handle) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(standby = %handle.id, error = %e, "build claim failed; cold-booting");
+            let _ = pool.remove(&handle.id);
+            return Ok(LaunchDecision::ColdBoot);
+        }
+    };
+    match backend.claim_standby(&handle, &claim) {
+        Ok(vm_id) => {
+            // The standby has become the VM; drop its pool entry (the control UDS is
+            // one-shot). The VM now lives under its vms/<id> state dir.
+            let _ = pool.remove(&handle.id);
+            Ok(LaunchDecision::Claimed(vm_id))
+        }
+        Err(e) => {
+            tracing::warn!(standby = %handle.id, error = %e, "standby claim failed; cold-booting");
+            let _ = pool.remove(&handle.id); // spent/broken — never leave it idle
+            Ok(LaunchDecision::ColdBoot)
+        }
+    }
+}
+
+fn compat_for_launch(
+    backend: &dyn VmBackend,
+    cfg: &VmStartConfig,
+    image_sha256_override: Option<&str>,
+) -> Result<StandbyCompat> {
+    let image_sha256 = match image_sha256_override {
+        Some(sha) if backend.name() == "vz" => Some(sha.to_string()),
+        _ => image_identity(backend, cfg.rootfs_path.as_str())?,
+    };
+    Ok(StandbyCompat {
+        kernel_sha256: kernel_identity(backend, cfg.kernel_path.as_deref())?,
+        vcpus: u8::try_from(cfg.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
+        mem_mib: cfg.memory_mib,
+        image_sha256,
+    })
+}
+
+/// Attempt a warm-pool claim for this launch. Returns the claimed `VmId` (the standby-id
+/// the VM now runs under) or `None` to cold-boot. **Fail-open**: anything not default-
+/// shaped, not bridge-admitted, or any error → `None` (the caller cold-boots as normal).
+///
+/// Eligibility (all required): `warm_pool_size > 0`, the launch is auto-named (no explicit
+/// `--name` — a claimed VM is named by its standby-id), no extra volumes (the attach
+/// threads only the rootfs), the backend supports the pool, and the admitted tenant is
+/// threaded into the config. libkrun/Vz additionally require the signed plan JSON because
+/// their claimed standby enters the gateway-bridge supervisor path; Firecracker can claim
+/// with only the resolved launch config because the default path enforces networking
+/// directly via TAP/nftables and only needs plan JSON when its optional bridge is enabled.
+pub fn try_warm_claim(
+    backend: &AnyBackend,
+    cfg: &VmStartConfig,
+    user_named: bool,
+    admitted_image_sha256: Option<&str>,
+) -> Result<Option<VmId>> {
+    if cfg.warm_pool_size == 0
+        || user_named
+        || !cfg.volumes.is_empty()
+        || !backend.supports_standby_pool()
+    {
+        return Ok(None);
+    }
+    let Some(tenant) = cfg.tenant_id.clone() else {
+        // No admitted tenant threaded in → not an admitted workload → cold-boot.
+        return Ok(None);
+    };
+    let Some(plan_json) = warm_claim_plan_json(backend.as_vm_backend(), cfg) else {
+        // libkrun/Vz claims need a signed envelope for their gateway-bridge
+        // supervisor attach path; without it, cold-boot.
+        return Ok(None);
+    };
+    // Reuse the rootfs sha claim-8 admission already computed (same bytes) so
+    // the claim decision doesn't re-hash the whole rootfs on the launch path.
+    let want = compat_for_launch(backend.as_vm_backend(), cfg, admitted_image_sha256)?;
+    let rootfs = cfg.rootfs_path.clone();
+    let bundle_json = cfg.bundle_json.clone();
+    let claim_start_config = cfg.clone();
+    let pool = SupervisorStandbyPool::open()?;
+    let decision = claim_or_cold(&pool, backend.as_vm_backend(), &want, |handle| {
+        // The audit substrate (`gateway-<vm>.sock`) is name-keyed; the claimed VM runs
+        // under the standby-id, so compute it for `handle.id`.
+        let sub = mvm_backend::audit_substrate::compute_audit_substrate(&handle.id, Some(&tenant))?;
+        let mut start_config = claim_start_config.clone();
+        start_config.name = handle.id.clone();
+        start_config.rootfs_path = rootfs.clone();
+        start_config.tenant_id = Some(tenant.clone());
+        start_config.plan_json = Some(plan_json.clone());
+        start_config.bundle_json = bundle_json.clone();
+        start_config.network_policy = cfg.network_policy.clone();
+        if backend.name() == "firecracker" && !plan_json.is_empty() {
+            stash_plan_for_bridge(&start_config)
+                .with_context(|| format!("stash admitted plan for claimed VM '{}'", handle.id))?;
+        }
+        Ok(StandbyClaim {
+            start_config: Some(start_config),
+            rootfs_path: rootfs.clone(),
+            tenant_id: tenant.clone(),
+            audit_dir: sub.audit_dir.context("audit substrate missing audit_dir")?,
+            gateway_audit_socket: sub
+                .gateway_audit_socket
+                .context("audit substrate missing gateway_audit_socket")?,
+            gateway_events_socket: sub.gateway_events_socket,
+            plan_json: plan_json.clone(),
+            bundle_json: bundle_json.clone(),
+            network_policy: cfg.network_policy.clone(),
+        })
+    })?;
+    Ok(match decision {
+        LaunchDecision::Claimed(id) => Some(id),
+        LaunchDecision::ColdBoot => None,
+    })
+}
+
+fn warm_claim_plan_json(backend: &dyn VmBackend, cfg: &VmStartConfig) -> Option<String> {
+    match cfg.plan_json.clone() {
+        Some(plan) => Some(plan),
+        None if backend.name() == "firecracker" => Some(String::new()),
+        None => None,
+    }
+}
+
+/// Top the pool back up toward `cfg.warm_pool_size` after a launch (the no-daemon
+/// replenish-on-use maintainer). Best-effort — failures are logged, never propagated.
+///
+/// For libkrun standbys this path fires automatically after each claimed launch.
+/// For Vz saved-standbys the replenish path requires a boot + capture cycle that is
+/// expensive and may require the builder VM to resolve the kernel. Automatic replenish
+/// is skipped for Vz (pool warm is manual); `supports_standby_pool()` stays true so
+/// `try_warm_claim` still fires.
+pub fn replenish_after_launch(backend: &AnyBackend, cfg: &VmStartConfig) -> Result<u32> {
+    if cfg.warm_pool_size == 0 || !backend.supports_standby_pool() {
+        return Ok(0);
+    }
+    // Vz replenish boots a seed VM + captures its memory (~seconds) — far too
+    // slow to run inline on the post-launch path. Hand the whole job to a
+    // DETACHED `mvmctl pool warm` subprocess so `up` returns immediately. The
+    // child does the idle-count check + rootfs hash itself (off the hot path,
+    // so `up` doesn't re-hash a multi-hundred-MB rootfs `try_warm_claim`
+    // already hashed) and re-warms only the deficit toward `target` — a spawn
+    // against an already-full pool is a cheap no-op, not an over-warm. Two
+    // races against the same image can still transiently overshoot target by
+    // one per concurrent launch; the surplus ages out via the standby TTL.
+    if backend.kind() == BackendKind::Vz {
+        spawn_detached_rewarm(&cfg.rootfs_path, cfg.warm_pool_size)?;
+        return Ok(0);
+    }
+    let Some(kernel) = cfg.kernel_path.as_ref() else {
+        return Ok(0);
+    };
+    let signer = host_signer::load_or_init()?;
+    let pool = SupervisorStandbyPool::open()?;
+    let result = warm_to_target(
+        &pool,
+        &WarmParams {
+            backend: backend.as_vm_backend(),
+            kernel: Path::new(kernel),
+            vcpus: u8::try_from(cfg.cpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX),
+            mem_mib: cfg.memory_mib,
+            signer_id: &host_signer::host_signer_id(),
+            signing_key_path: &signer.secret_path,
+            target: cfg.warm_pool_size,
+            image: None, // libkrun only: image-agnostic standbys
+        },
+    )?;
+    Ok(result.spawned)
+}
+
+/// Hand a Vz pool re-warm to a detached `mvmctl pool warm` subprocess so it
+/// outlives the `up` that triggered it. The child inherits our environment
+/// (MVM_DATA_DIR / cache / supervisor path), runs with no stdio, and is moved
+/// into its own process group so a Ctrl-C on `up` doesn't take it down.
+/// `pool warm` is idempotent toward the target, so a spurious spawn is a cheap
+/// no-op rather than an over-warm.
+fn spawn_detached_rewarm(rootfs_path: &str, target: u32) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let exe =
+        std::env::current_exe().context("resolve mvmctl path for background pool replenish")?;
+    Command::new(exe)
+        .args(["pool", "warm", &target.to_string(), "--rootfs", rootfs_path])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .spawn()
+        .context("spawn detached pool warm for background replenish")?;
+    Ok(())
+}
+
 fn hex_lower(bytes: &[u8]) -> String {
     use std::fmt::Write;
     bytes
@@ -214,6 +463,81 @@ mod tests {
 
     fn sha256_hex_of(bytes: &[u8]) -> String {
         hex_lower(&Sha256::digest(bytes))
+    }
+
+    // ── Plan 211 Phase 1b-i: warm-claim eligibility-gate tests (recovered from
+    // 04bab4f7^). They assert `try_warm_claim` fails open to cold boot *before*
+    // touching the pool, so they need no real VM/backend.
+    fn eligible_cfg() -> VmStartConfig {
+        VmStartConfig {
+            warm_pool_size: 2,
+            kernel_path: Some("/k/vmlinux".into()),
+            rootfs_path: "/vol/rootfs.ext4".into(),
+            cpus: 2,
+            memory_mib: 1024,
+            tenant_id: Some("tenant-a".into()),
+            plan_json: Some("{}".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn try_warm_claim_cold_when_pool_size_zero() {
+        let b = AnyBackend::from_hypervisor("libkrun");
+        let mut c = eligible_cfg();
+        c.warm_pool_size = 0;
+        assert_eq!(try_warm_claim(&b, &c, false, None).unwrap(), None);
+    }
+
+    #[test]
+    fn try_warm_claim_cold_when_user_named() {
+        let b = AnyBackend::from_hypervisor("libkrun");
+        assert_eq!(
+            try_warm_claim(&b, &eligible_cfg(), true, None).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn try_warm_claim_cold_with_extra_volumes() {
+        use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+        let b = AnyBackend::from_hypervisor("libkrun");
+        let mut c = eligible_cfg();
+        c.volumes = vec![VmVolume {
+            host: "/h".into(),
+            guest: "/g".into(),
+            size: String::new(),
+            read_only: false,
+            kind: VmVolumeKind::DirShare,
+            encrypted: false,
+        }];
+        assert_eq!(try_warm_claim(&b, &c, false, None).unwrap(), None);
+    }
+
+    #[test]
+    fn try_warm_claim_cold_without_admitted_plan() {
+        let b = AnyBackend::from_hypervisor("libkrun");
+        let mut c = eligible_cfg();
+        c.plan_json = None; // not the gateway-bridge/admitted path → cold-boot
+        assert_eq!(try_warm_claim(&b, &c, false, None).unwrap(), None);
+    }
+
+    #[test]
+    fn warm_claim_plan_json_is_optional_for_firecracker_only() {
+        let mut cfg = eligible_cfg();
+        cfg.plan_json = None;
+        let fc = AnyBackend::from_hypervisor("firecracker");
+        let libkrun = AnyBackend::from_hypervisor("libkrun");
+        assert_eq!(
+            warm_claim_plan_json(fc.as_vm_backend(), &cfg),
+            Some(String::new())
+        );
+        assert_eq!(warm_claim_plan_json(libkrun.as_vm_backend(), &cfg), None);
+        cfg.plan_json = Some("{\"signed\":\"plan\"}".into());
+        assert_eq!(
+            warm_claim_plan_json(libkrun.as_vm_backend(), &cfg),
+            Some("{\"signed\":\"plan\"}".into())
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -214,9 +214,9 @@ pub fn image_identity(backend: &dyn VmBackend, rootfs_path: &str) -> Result<Opti
     Ok(None)
 }
 
-// ── Plan 211 Phase 1b-i: warm-pool claim glue, recovered from 04bab4f7^ ──
-// (deleted by #1258 as orphaned when up/run folded into `machine run`; the
-// surviving standby primitives are unchanged). Wired into `crate::exec::run_inner`.
+// ── Warm-pool claim glue (recovered from history after up/run folded into
+// `machine run` orphaned it; the surviving standby primitives are unchanged).
+// Wired into `crate::exec::run_inner`.
 
 pub enum LaunchDecision {
     /// A standby was claimed and is booting under this VmId.
@@ -465,9 +465,9 @@ mod tests {
         hex_lower(&Sha256::digest(bytes))
     }
 
-    // ── Plan 211 Phase 1b-i: warm-claim eligibility-gate tests (recovered from
-    // 04bab4f7^). They assert `try_warm_claim` fails open to cold boot *before*
-    // touching the pool, so they need no real VM/backend.
+    // ── Warm-claim eligibility-gate tests. They assert `try_warm_claim` fails
+    // open to cold boot *before* touching the pool, so they need no real
+    // VM/backend.
     fn eligible_cfg() -> VmStartConfig {
         VmStartConfig {
             warm_pool_size: 2,

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -33,6 +33,10 @@ pub(in crate::commands) struct Args {
     /// fresh transient microVM — never the long-running `mvmctl dev` VM.
     #[arg(short = 'm', long)]
     pub manifest: Option<String>,
+    /// Plan 211 (internal, not a CLI flag): warm-pool size for this run, carried
+    /// from `machine run` dispatch. `> 0` ⇒ eligible to claim a warm standby.
+    #[arg(skip)]
+    pub warm_pool_size: u32,
     /// vCPU cores (default: 2)
     #[arg(long, default_value = "2")]
     pub cpus: u32,
@@ -92,6 +96,11 @@ pub(in crate::commands) struct RunArgs {
     /// performs the existing verified OCI pull and rootfs materialization path.
     #[arg(long, value_name = "REF")]
     pub image: Option<String>,
+    /// Plan 211 (internal, not a CLI flag): warm-pool size for this run, set by
+    /// `machine run` dispatch from the resolved run mode. `> 0` ⇒ eligible to
+    /// claim a pre-booted standby + replenish the pool.
+    #[arg(skip)]
+    pub warm_pool_size: u32,
     /// Enable dev-tier outbound networking (broad egress + DNS). Off by
     /// default (deny-all). Narrow it with `--allow-host`.
     #[arg(long)]
@@ -224,6 +233,7 @@ impl RunArgs {
     fn into_exec_args(self) -> Args {
         Args {
             manifest: self.manifest,
+            warm_pool_size: self.warm_pool_size,
             cpus: self.cpus,
             memory: self.memory,
             add_dir: self.add_dir,
@@ -657,6 +667,7 @@ fn build_exec_request(
         target,
         timeout_secs: args.timeout,
         network_policy,
+        warm_pool_size: args.warm_pool_size,
     })
 }
 
@@ -1323,6 +1334,7 @@ mod tests {
 
     fn run_args(profile: RunProfile) -> RunArgs {
         RunArgs {
+            warm_pool_size: 0,
             manifest: None,
             image: None,
             net: false,

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -33,7 +33,7 @@ pub(in crate::commands) struct Args {
     /// fresh transient microVM — never the long-running `mvmctl dev` VM.
     #[arg(short = 'm', long)]
     pub manifest: Option<String>,
-    /// Plan 211 (internal, not a CLI flag): warm-pool size for this run, carried
+    /// Internal (not a CLI flag): warm-pool size for this run, carried
     /// from `machine run` dispatch. `> 0` ⇒ eligible to claim a warm standby.
     #[arg(skip)]
     pub warm_pool_size: u32,
@@ -96,7 +96,7 @@ pub(in crate::commands) struct RunArgs {
     /// performs the existing verified OCI pull and rootfs materialization path.
     #[arg(long, value_name = "REF")]
     pub image: Option<String>,
-    /// Plan 211 (internal, not a CLI flag): warm-pool size for this run, set by
+    /// Internal (not a CLI flag): warm-pool size for this run, set by
     /// `machine run` dispatch from the resolved run mode. `> 0` ⇒ eligible to
     /// claim a pre-booted standby + replenish the pool.
     #[arg(skip)]

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -528,6 +528,7 @@ mod tests {
     fn base_run_args() -> RunArgs {
         RunArgs {
             manifest: None,
+            warm_pool_size: 0,
             image: None,
             net: false,
             allow_host: Vec::new(),

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -178,6 +178,12 @@ pub struct ExecRequest {
     /// `VmStartConfig.network_policy` so every backend enforces the same
     /// value.
     pub network_policy: mvm_core::network_policy::NetworkPolicy,
+    /// Plan 211: warm-pool size for this transient run. `> 0` makes the run
+    /// eligible to claim a pre-booted standby (skipping cold boot) and to
+    /// replenish the pool after teardown; `0` always cold-boots. Resolved from
+    /// `MachineRunMode::warm_pool_size` — nonzero only for throwaway auto-named
+    /// transient/interactive-transient runs.
+    pub warm_pool_size: u32,
 }
 
 impl ExecRequest {
@@ -539,7 +545,7 @@ fn run_inner(
 
     // Build read-only ext4 images for each --add-dir, staged in a transient
     // VMS subdirectory so cleanup is straightforward.
-    let vm_name = transient_vm_name();
+    let mut vm_name = transient_vm_name();
     let staging_dir = format!("{}/{}/extras", mvm::config::VMS_DIR, vm_name);
     let mut volumes: Vec<mvm_backend::image::RuntimeVolume> = Vec::new();
     let mut add_dir_labels: Vec<String> = Vec::new();
@@ -616,6 +622,7 @@ fn run_inner(
         secret_files: Vec::new(),
         runner_dir: None,
         network_policy: req.network_policy.clone(),
+        warm_pool_size: req.warm_pool_size,
         ..Default::default()
     };
 
@@ -635,29 +642,53 @@ fn run_inner(
     }
     let t_admitted = timing.then(std::time::Instant::now);
 
-    let booted = if use_snapshot {
-        let tmpl = template_id
-            .as_deref()
-            .expect("snapshot_eligible only true for ImageSource::Template");
-        let snap = snap_info
-            .as_ref()
-            .expect("snapshot_eligible requires snap_info.is_some()");
-        ui::info(&format!(
-            "Restoring transient VM '{vm_name}' from template '{tmpl}' snapshot..."
-        ));
-        match restore_via_snapshot(&vm_name, tmpl, snap, &start_config) {
-            Ok(()) => true,
+    // Plan 211: try a warm-pool claim before snapshot/cold-boot. A claimed
+    // standby is pre-booted to agent-ready and runs under its own standby-id, so
+    // rebind `vm_name` for the Ctrl-C handler, run_in_guest, and teardown below.
+    // try_warm_claim gates internally (warm_pool_size > 0, admitted tenant +
+    // signed plan threaded into start_config, no extra volumes, backend supports
+    // the pool); any miss/error fails open to the snapshot/cold-boot paths.
+    let warm_claimed =
+        match crate::commands::pool::try_warm_claim(&backend, &start_config, false, None) {
+            Ok(Some(id)) => {
+                ui::info(&format!(
+                    "Claimed a warm standby ({}) — skipping cold boot.",
+                    id.0
+                ));
+                vm_name = id.0;
+                true
+            }
+            Ok(None) => false,
             Err(e) => {
-                // macOS / Lima QEMU returns os error 95 (EOPNOTSUPP) on vsock
-                // snapshots; cold boot still works there. Fall back rather
-                // than failing the whole exec.
-                ui::warn(&format!("Snapshot restore failed: {e}; cold-booting."));
+                tracing::warn!(error = %e, "warm-claim attempt errored; cold-booting");
                 false
             }
-        }
-    } else {
-        false
-    };
+        };
+
+    let booted = warm_claimed
+        || if use_snapshot {
+            let tmpl = template_id
+                .as_deref()
+                .expect("snapshot_eligible only true for ImageSource::Template");
+            let snap = snap_info
+                .as_ref()
+                .expect("snapshot_eligible requires snap_info.is_some()");
+            ui::info(&format!(
+                "Restoring transient VM '{vm_name}' from template '{tmpl}' snapshot..."
+            ));
+            match restore_via_snapshot(&vm_name, tmpl, snap, &start_config) {
+                Ok(()) => true,
+                Err(e) => {
+                    // macOS / Lima QEMU returns os error 95 (EOPNOTSUPP) on vsock
+                    // snapshots; cold boot still works there. Fall back rather
+                    // than failing the whole exec.
+                    ui::warn(&format!("Snapshot restore failed: {e}; cold-booting."));
+                    false
+                }
+            }
+        } else {
+            false
+        };
 
     if !booted {
         ui::info(&format!("Booting transient VM '{vm_name}'..."));
@@ -689,6 +720,14 @@ fn run_inner(
     };
 
     let _ = backend.stop_transient(&VmId(vm_name.clone()));
+
+    // Plan 211: top the warm pool back toward target after the run (best-effort,
+    // no-daemon replenish-on-use). No-ops when `warm_pool_size == 0`; on Vz it
+    // hands a detached `pool warm` subprocess the boot+capture so teardown isn't
+    // blocked. `start_config` still carries this run's rootfs + warm size.
+    if let Err(e) = crate::commands::pool::replenish_after_launch(&backend, &start_config) {
+        tracing::debug!(error = %e, "pool replenish skipped (best-effort)");
+    }
 
     // Writable --add-dir uses rsync-back. With the VM stopped the
     // ext4 image is no longer in use, so we mount it host-side and rsync
@@ -1067,6 +1106,7 @@ pub fn dispatch_in_session(
     // with no add_dirs (sessions don't take --add-dir). The wrapper
     // emits `set -e\n<env exports>\n<argv>\n`.
     let req = ExecRequest {
+        warm_pool_size: 0,
         image: ImageSource::Template(String::new()),
         cpus: 0,
         memory_mib: 0,
@@ -1263,6 +1303,7 @@ mod tests {
     #[test]
     fn target_command_inline_quotes_each_arg() {
         let req = ExecRequest {
+            warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
@@ -1281,6 +1322,7 @@ mod tests {
     #[test]
     fn build_guest_wrapper_no_extras() {
         let req = ExecRequest {
+            warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
@@ -1303,6 +1345,7 @@ mod tests {
     #[test]
     fn build_guest_wrapper_mounts_and_env() {
         let req = ExecRequest {
+            warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
@@ -1329,6 +1372,7 @@ mod tests {
     #[test]
     fn build_guest_wrapper_writable_mount_drops_ro_flag() {
         let req = ExecRequest {
+            warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
@@ -1559,6 +1603,7 @@ mod tests {
     #[test]
     fn target_command_launch_plan_quotes_argv() {
         let req = ExecRequest {
+            warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
@@ -1584,6 +1629,7 @@ mod tests {
         env.insert("PORT".to_string(), "8080".to_string());
         env.insert("LOG".to_string(), "info".to_string());
         let req = ExecRequest {
+            warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,
@@ -1624,6 +1670,7 @@ mod tests {
     fn build_guest_wrapper_inline_target_unchanged() {
         // Sanity: inline target wrapper still does not emit cd or extra env blocks.
         let req = ExecRequest {
+            warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
             cpus: 1,
             memory_mib: 256,

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -178,7 +178,7 @@ pub struct ExecRequest {
     /// `VmStartConfig.network_policy` so every backend enforces the same
     /// value.
     pub network_policy: mvm_core::network_policy::NetworkPolicy,
-    /// Plan 211: warm-pool size for this transient run. `> 0` makes the run
+    /// Warm-pool size for this transient run. `> 0` makes the run
     /// eligible to claim a pre-booted standby (skipping cold boot) and to
     /// replenish the pool after teardown; `0` always cold-boots. Resolved from
     /// `MachineRunMode::warm_pool_size` — nonzero only for throwaway auto-named
@@ -642,7 +642,7 @@ fn run_inner(
     }
     let t_admitted = timing.then(std::time::Instant::now);
 
-    // Plan 211: try a warm-pool claim before snapshot/cold-boot. A claimed
+    // Try a warm-pool claim before snapshot/cold-boot. A claimed
     // standby is pre-booted to agent-ready and runs under its own standby-id, so
     // rebind `vm_name` for the Ctrl-C handler, run_in_guest, and teardown below.
     // try_warm_claim gates internally (warm_pool_size > 0, admitted tenant +
@@ -721,7 +721,7 @@ fn run_inner(
 
     let _ = backend.stop_transient(&VmId(vm_name.clone()));
 
-    // Plan 211: top the warm pool back toward target after the run (best-effort,
+    // Top the warm pool back toward target after the run (best-effort,
     // no-daemon replenish-on-use). No-ops when `warm_pool_size == 0`; on Vz it
     // hands a detached `pool warm` subprocess the boot+capture so teardown isn't
     // blocked. `start_config` still carries this run's rootfs + warm size.

--- a/specs/plans/211-subsecond-machine-run.md
+++ b/specs/plans/211-subsecond-machine-run.md
@@ -1,4 +1,4 @@
-# Plan 212 — Sub-second `machine run`
+# Plan 211 — Sub-second `machine run`
 
 **Status: IN PROGRESS** (Phase 1)
 

--- a/specs/plans/211-subsecond-machine-run.md
+++ b/specs/plans/211-subsecond-machine-run.md
@@ -1,6 +1,11 @@
 # Plan 211 — Sub-second `machine run`
 
-**Status: IN PROGRESS** (Phase 1)
+**Status: IN PROGRESS** — Phase 1a DONE, Phase 1b-i CODE DONE (claim wired +
+unit-tested; eligibility live-proven `warm_pool_size=1`). End-to-end "claim
+fires" live proof **blocked** by a pre-existing OCI-materialize regression
+(`/sbin/mkfs.ext4: not found` in the builder VM — breaks every `machine run
+--image` boot in this env; my diff touches no builder/nix code). Live proof is
+pending a working materialize (or a non-OCI cached image + a pool warmed for it).
 
 ## Goal
 

--- a/specs/plans/211-subsecond-machine-run.md
+++ b/specs/plans/211-subsecond-machine-run.md
@@ -49,15 +49,21 @@ Target warm budget: **~300–500ms** to shell.
 ## Phases
 
 ### Phase 1 — Warm-claim eligibility for transient + interactive `machine run`  ← this PR
-- Replace the hardcoded `warm_pool_size: 0` on the transient/interactive
-  start configs with a **mode-aware, policy-driven** value: claim-eligible for
-  *transient* and *interactive-transient* (auto-named, throwaway), `0` for a
-  user-named/`-d` persistent machine (those are long-lived, not pool cattle).
-- Add the `try_warm_claim` attempt (mirroring `up.rs:2809`) to the
-  interactive-transient start path so `-it` can claim.
-- **Safe to land dark:** with an unpopulated pool, `try_warm_claim` returns
-  `None` → cold boot, unchanged. Behavior only changes once Phase 2 fills the pool.
-- TDD a pure `warm_pool_size_for(mode, explicit)` eligibility helper.
+
+**Phase 1a — eligibility decision core (DONE).** `MachineRunMode::warm_pool_size(explicit)`
+returns the residency-policy size (`effective_warm_pool_size`) for *transient* and
+*interactive-transient* (auto-named, throwaway), `0` for user-named/`-d` persistent
+machines. Resolved + logged in `run_dispatch` so the dark-landed decision is
+observable; unit-tested (`warm_pool_size_is_claim_eligible_only_for_throwaway_runs`).
+Zero behavior change — nothing claims yet.
+
+**Phase 1b — claim-call integration (NEXT).** Thread the resolved size into
+`run_secure` (transient) and `run_interactive` (interactive), and add the
+`try_warm_claim` + `replenish_after_launch` calls (mirroring `up.rs:2809`) at the
+boot seam. This bottoms out in the shared `crate::exec` runner / `start_machine`
+managed-start, so it lands as its own isolated commit (security-sensitive boot
+path). **Safe to land dark:** with an unpopulated pool, `try_warm_claim` → `None`
+→ cold boot, unchanged. Behavior only changes once Phase 2 fills the pool.
 
 ### Phase 2 — Populate + keep warm (Vz Option A: per-image)
 - Lazy `replenish_after_launch` for the just-run image so the **2nd+ run of a

--- a/specs/plans/211-subsecond-machine-run.md
+++ b/specs/plans/211-subsecond-machine-run.md
@@ -36,9 +36,21 @@ So origin/main has the standby *primitives* but **no CLI claim orchestration**;
 `up.rs` now hardcodes `warm_pool_size: 0`. The glue is cleanly recoverable from
 `git show 04bab4f7^:crates/mvm-cli/src/commands/pool.rs`.
 
-⇒ Phase 1b must **reconstruct** `try_warm_claim`/`replenish_after_launch` from
-that parent and wire them into `run_captured` **in one commit** (recovering them
-unused would re-trip the no-dead-code gate #1258 added).
+⇒ Phase 1b must **reconstruct** the deleted cluster from that parent and wire it
+into `run_captured` **in one commit** (recovering it unused would re-trip the
+no-dead-code gate #1258 added).
+
+**Exact recovery surface** (all from `04bab4f7^:crates/mvm-cli/src/commands/pool.rs`):
+`try_warm_claim`, `replenish_after_launch`, `warm_claim_plan_json`,
+`compat_for_launch`, `claim_or_cold` + `enum LaunchDecision`. **Surviving deps to
+re-point at** (paths may have moved): `StandbyClaim`
+(`mvm_core::protocol::vm_backend`), `compute_audit_substrate`
+(`mvm_backend::libkrun` / `audit_substrate`), `stash_plan_for_bridge`
+(`mvm_backend::microvm`), `SupervisorStandbyPool`. The recovered code already
+threads the admitted plan + `network_policy` into the `StandbyClaim` and gates
+libkrun/Vz claims on a signed plan (gateway-bridge supervisor path) — so the
+claim-10 egress posture is preserved by construction; the live check is that the
+bridge is actually (re)bound on the claimed VM.
 
 ## The two gaps
 

--- a/specs/plans/211-subsecond-machine-run.md
+++ b/specs/plans/211-subsecond-machine-run.md
@@ -1,0 +1,86 @@
+# Plan 211 — Sub-second `machine run`
+
+**Status: IN PROGRESS** (Phase 1)
+
+## Goal
+
+`machine run --image <ref> -it` (and `-- <cmd>`) returns a ready guest in
+**well under one second** on the warm path. Today the warm-cache run is ~2.6s,
+dominated by a ~1.4s cold VM boot. Sub-second requires **not cold-booting** —
+claiming a pre-booted standby from the warm pool — plus trimming the host-side
+tail that the removed boot then exposes.
+
+## Measured baseline (macOS Vz, warm cache, `machine run --image alpine -it`)
+
+| Phase | Time | Reducible by |
+|---|---|---|
+| Host plan synth + Ed25519 sign | ~0.28s | parallelize with claim / warm signer |
+| Rootfs reflink clone + attach | ~0.15s | already near-optimal |
+| **Cold VM boot** (Vz create + kernel ~0.7s + agent bind) | **~1.4s** | **claim a warm standby → ~0** |
+| Console attach | ~0.4s | replace the 200ms blind sleep with a readiness poll |
+
+Target warm budget: **~300–500ms** to shell.
+
+## What already exists (Plan 118, merged #1170)
+
+- `try_warm_claim` + `replenish_after_launch` are wired into the `up`/`cmd_run`
+  flow (`crates/mvm-cli/src/commands/vm/up.rs:2809/2858`). A claimed standby is
+  pre-booted to agent-ready, so a claim skips the entire cold boot.
+- Per-backend `spawn_standby` (`vz`/`libkrun`/`firecracker`).
+- `StandbyCompat` keying = kernel + fixed resources + `image_sha256`.
+- Vz residency default is `always_warm()` (`mvm_core::residency`), so the
+  *policy* already wants a warm pool on the deployment tier.
+
+## The two gaps
+
+1. **Neither `machine run` runtime path claims today.** The transient `-- cmd`
+   path (`run_secure`, `exec.rs`) and the interactive `-it` path
+   (`run_interactive` → managed start) both cold-boot directly. The
+   `try_warm_claim` glue exists only in the legacy `up`/`cmd_run` flow
+   (`up.rs:2809`), which `machine run` does not route through. Phase 1 is
+   therefore an *integration* (wire the existing claim helper into the run
+   paths), not a flag flip.
+2. **The Vz pool is per-image.** `image_sha256` must match exactly
+   (`standby_pool.rs` — "Image sha must match exactly"). A standby is tied to the
+   rootfs it was captured from. libkrun standbys are image-agnostic (rootfs
+   threaded at claim), so on libkrun/Linux a generic pool already serves any
+   image; **Vz needs either a per-image pool or an image-agnostic restore.**
+
+## Phases
+
+### Phase 1 — Warm-claim eligibility for transient + interactive `machine run`  ← this PR
+- Replace the hardcoded `warm_pool_size: 0` on the transient/interactive
+  start configs with a **mode-aware, policy-driven** value: claim-eligible for
+  *transient* and *interactive-transient* (auto-named, throwaway), `0` for a
+  user-named/`-d` persistent machine (those are long-lived, not pool cattle).
+- Add the `try_warm_claim` attempt (mirroring `up.rs:2809`) to the
+  interactive-transient start path so `-it` can claim.
+- **Safe to land dark:** with an unpopulated pool, `try_warm_claim` returns
+  `None` → cold boot, unchanged. Behavior only changes once Phase 2 fills the pool.
+- TDD a pure `warm_pool_size_for(mode, explicit)` eligibility helper.
+
+### Phase 2 — Populate + keep warm (Vz Option A: per-image)
+- Lazy `replenish_after_launch` for the just-run image so the **2nd+ run of a
+  given image is instant**. Residency default (`always_warm`) keeps 1–2 warm.
+- First run of a *new* image still cold-boots (Option A limitation).
+
+### Phase 3 — Cut the host tail (now the bottleneck)
+- Plan synth+sign: sign in parallel with the claim; avoid per-run key reload.
+- Console attach: replace the 200ms blind `sleep` (`console.rs:235`) with an
+  agent-readiness poll (handle the data-port bind race via a readiness signal,
+  not a blind wait).
+
+### Phase 4 — Live-verify sub-second on Vz + regression gate
+- Measure warm-path time-to-shell on this Mac; add a latency assertion so the
+  warm path can't silently regress past the budget.
+
+### Phase 5 — Image-agnostic Vz restore (Option B; own plan)
+- Boot a Vz standby to agent-ready with no workload rootfs, snapshot, and on
+  claim attach the image rootfs + pivot — the Lambda-SnapStart pattern, on the
+  Plan 175/206 snapshot substrate. Makes **first run of any image instant** on
+  Vz. Large; sequenced after A proves the budget.
+
+## Critical path
+Phases 1–4 with Vz Option A → sub-second for the **repeat-run** dev loop, the
+common case. Option B (Phase 5) extends it to first-run-of-any-image on Vz.
+libkrun/Linux reach sub-second for any image at Phase 1–4 (image-agnostic pool).

--- a/specs/plans/211-subsecond-machine-run.md
+++ b/specs/plans/211-subsecond-machine-run.md
@@ -57,13 +57,36 @@ machines. Resolved + logged in `run_dispatch` so the dark-landed decision is
 observable; unit-tested (`warm_pool_size_is_claim_eligible_only_for_throwaway_runs`).
 Zero behavior change — nothing claims yet.
 
-**Phase 1b — claim-call integration (NEXT).** Thread the resolved size into
-`run_secure` (transient) and `run_interactive` (interactive), and add the
-`try_warm_claim` + `replenish_after_launch` calls (mirroring `up.rs:2809`) at the
-boot seam. This bottoms out in the shared `crate::exec` runner / `start_machine`
-managed-start, so it lands as its own isolated commit (security-sensitive boot
-path). **Safe to land dark:** with an unpopulated pool, `try_warm_claim` → `None`
-→ cold boot, unchanged. Behavior only changes once Phase 2 fills the pool.
+**Phase 1b — claim-call integration (design fixed; isolated commit next).**
+
+*Investigation result — where to intercept.* Both run paths bottom out in shared
+lower-layer lifecycle code: the transient path (`run_secure` → `crate::exec::run_captured`)
+owns boot→run→teardown as one unit, and the interactive path (`run_interactive`
+→ `persist_and_boot_machine` → `start_machine` → `up::start_persistent_oci_machine`)
+delegates to the shared start. Hooking the shared lifecycle would touch every
+caller. The only safe seam is the **mvm-cli orchestration layer, before the
+shared start** — exactly the `up.rs:2809` pattern (`try_warm_claim` → on hit
+rebind the vm-name to the standby-id and skip `backend.start`; on miss cold-boot;
+then `replenish_after_launch`).
+
+*The `-it` wrinkle.* The interactive path runs through the **managed (named-spec)**
+machine lifecycle, and `console::run` attaches by the **spec name**. A warm claim
+returns a *different* pre-booted VM under a **standby-id**. So `-it` cannot accept
+a claim without reconciling the two — either (a) rebind the managed spec/registry
++ console-attach to the claimed standby-id, or (b) re-route interactive-transient
+off the managed path onto a claim-aware transient flow. **Decision: split 1b.**
+
+- **1b-i (transient `-- cmd`, tractable):** intercept in `run_secure` before
+  `crate::exec::run_captured`: thread `MachineRunMode::warm_pool_size` in, attempt
+  `try_warm_claim`; on hit, run the command against the claimed standby (reuse the
+  attach-into-running path) instead of a cold `run_captured`; replenish after.
+  Auto-named + throwaway, so it matches the `up.rs:2809` claim model directly.
+- **1b-ii (interactive `-it`):** the managed-name ↔ standby-id reconciliation
+  above. Larger; its own commit, with the console-attach + teardown + registry
+  rebind covered by tests before it goes near the boot path.
+
+**Safe to land dark** (both): empty pool → `try_warm_claim` → `None` → cold boot,
+unchanged. Behavior only changes once Phase 2 fills the pool.
 
 ### Phase 2 — Populate + keep warm (Vz Option A: per-image)
 - Lazy `replenish_after_launch` for the just-run image so the **2nd+ run of a

--- a/specs/plans/211-subsecond-machine-run.md
+++ b/specs/plans/211-subsecond-machine-run.md
@@ -21,15 +21,24 @@ tail that the removed boot then exposes.
 
 Target warm budget: **~300–500ms** to shell.
 
-## What already exists (Plan 118, merged #1170)
+## What exists on origin/main — and what #1258 deleted
 
-- `try_warm_claim` + `replenish_after_launch` are wired into the `up`/`cmd_run`
-  flow (`crates/mvm-cli/src/commands/vm/up.rs:2809/2858`). A claimed standby is
-  pre-booted to agent-ready, so a claim skips the entire cold boot.
-- Per-backend `spawn_standby` (`vz`/`libkrun`/`firecracker`).
-- `StandbyCompat` keying = kernel + fixed resources + `image_sha256`.
-- Vz residency default is `always_warm()` (`mvm_core::residency`), so the
-  *policy* already wants a warm pool on the deployment tier.
+**Surviving primitives** (Plan 118, #757 / #1170): per-backend `spawn_standby` +
+`claim_standby` traits; `SupervisorStandbyPool::select_idle_compatible` /
+`mark_claimed`; `pool::warm_to_target` (replenish core); `StandbyCompat` keying
+(kernel + resources + `image_sha256`); Vz residency default `always_warm()`.
+
+**Deleted mid-development by #1258** (`04bab4f7`, "fold up/run into machine run"):
+the CLI auto-claim glue `pool::try_warm_claim` (63 LOC) + `replenish_after_launch`
+(37 LOC) + 4 unit tests. They were removed as **orphaned** — folding `up`/`run`
+into `machine run` left no caller, and #1258 also dropped the `dead_code` allow.
+So origin/main has the standby *primitives* but **no CLI claim orchestration**;
+`up.rs` now hardcodes `warm_pool_size: 0`. The glue is cleanly recoverable from
+`git show 04bab4f7^:crates/mvm-cli/src/commands/pool.rs`.
+
+⇒ Phase 1b must **reconstruct** `try_warm_claim`/`replenish_after_launch` from
+that parent and wire them into `run_captured` **in one commit** (recovering them
+unused would re-trip the no-dead-code gate #1258 added).
 
 ## The two gaps
 
@@ -76,11 +85,21 @@ a claim without reconciling the two — either (a) rebind the managed spec/regis
 + console-attach to the claimed standby-id, or (b) re-route interactive-transient
 off the managed path onto a claim-aware transient flow. **Decision: split 1b.**
 
-- **1b-i (transient `-- cmd`, tractable):** intercept in `run_secure` before
-  `crate::exec::run_captured`: thread `MachineRunMode::warm_pool_size` in, attempt
-  `try_warm_claim`; on hit, run the command against the claimed standby (reuse the
-  attach-into-running path) instead of a cold `run_captured`; replenish after.
-  Auto-named + throwaway, so it matches the `up.rs:2809` claim model directly.
+- **1b-i (transient `-- cmd`, tractable):** (1) **recover** `try_warm_claim` +
+  `replenish_after_launch` (+ their 4 tests) from `04bab4f7^:pool.rs`, adapt to
+  current types; (2) wire into `run_captured` (`exec.rs:638`) as a third boot
+  fast-path *sibling to snapshot-restore* — after admission (so `start_config`
+  carries the admitted `tenant_id`/`plan_json`), attempt the claim; on hit rebind
+  the mutable `vm_name` to the standby-id (so Ctrl-C handler + `run_in_guest` +
+  `stop_transient` target it) and skip cold boot; replenish after teardown.
+  Gate to `add_dirs.is_empty()` (matches the pool's "no extra volumes" rule).
+  **Egress review (claim 10):** the claim passes the *admitted* `start_config`
+  (plan + `network_policy`) to `claim_standby` exactly as the deleted up-path did,
+  so the standby re-verifies + applies this run's plan; confirm the gateway bridge
+  is (re)bound for the claimed VM before trusting it — this is the one
+  security-load-bearing check of 1b-i. **Not dark on Vz:** `always_warm` ⇒
+  nonzero size by default, so replenish populates and run-2 claims — verify live
+  (run twice, expect "Claimed a warm standby" + faster run-2, no VM leak).
 - **1b-ii (interactive `-it`):** the managed-name ↔ standby-id reconciliation
   above. Larger; its own commit, with the console-attach + teardown + registry
   rebind covered by tests before it goes near the boot path.

--- a/specs/plans/212-subsecond-machine-run.md
+++ b/specs/plans/212-subsecond-machine-run.md
@@ -1,4 +1,4 @@
-# Plan 211 — Sub-second `machine run`
+# Plan 212 — Sub-second `machine run`
 
 **Status: IN PROGRESS** (Phase 1)
 

--- a/specs/plans/212-subsecond-machine-run.md
+++ b/specs/plans/212-subsecond-machine-run.md
@@ -1,4 +1,4 @@
-# Plan 211 — Sub-second `machine run`
+# Plan 212 — Sub-second `machine run`
 
 **Status: IN PROGRESS** — Phase 1a DONE, Phase 1b-i CODE DONE (claim wired +
 unit-tested; eligibility live-proven `warm_pool_size=1`). End-to-end "claim


### PR DESCRIPTION
## What

Plan 211 — the design + phased path to make `machine run --image <ref> -it` return a ready guest in **well under 1s** (today ~2.6s warm).

## Why this shape

Live profiling (macOS Vz, warm cache) decomposes the 2.6s: ~0.28s host plan-sign + ~0.15s rootfs clone + **~1.4s cold VM boot** + ~0.4s console attach. Sub-second is only reachable by **not cold-booting** — claiming a pre-booted standby from the warm pool (Plan 118 infra, merged #1170) — then trimming the host tail the removed boot exposes.

## Key finding captured

Neither `machine run` runtime path warm-claims today: the transient `-- cmd` path (`run_secure`, `exec.rs`) and the interactive `-it` path (`run_interactive` → managed start) both cold-boot. The `try_warm_claim` glue exists only in the legacy `up`/`cmd_run` flow (`up.rs:2809`). So **Phase 1 is an integration**, not a flag flip. The Vz pool is also per-image (`image_sha256` exact match), vs libkrun's image-agnostic standbys — that fork drives Option A (per-image, ship first) vs Option B (image-agnostic snapshot-restore, Phase 5).

## Phases
1. Integrate `try_warm_claim` into the transient + interactive-transient run paths (eligibility = throwaway auto-named runs, not user-named `-d` machines). Lands dark (no pool → cold boot, unchanged).
2. Populate per-image pool (Vz Option A; lazy `replenish_after_launch`) → 2nd+ run of an image instant.
3. Cut host tail (parallel sign + console readiness poll, replacing the 200ms blind sleep).
4. Live-verify sub-second on Vz + latency regression gate.
5. Image-agnostic Vz snapshot-restore (Option B) for first-run-any-image — own plan, on the 175/206 substrate.

Doc-only; Phase 1 code follows.