### PR TITLE
fix(cli): name a manifest/source change in the machine-recreate diff

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -421,8 +421,11 @@ fn machine_config_matches(a: &MachineSpec, b: &MachineSpec) -> bool {
 /// "config changed, recreating" notice. Mirrors [`machine_config_matches`].
 fn machine_config_diff(current: &MachineSpec, desired: &MachineSpec) -> String {
     let mut changed = Vec::new();
-    if current.image != desired.image {
-        changed.push("image");
+    // `image` and `manifest` are mutually-exclusive sources; report either as a
+    // single "source" change. `machine_config_matches` already compares both, so
+    // without this a manifest-only swap recreates with an empty `changed` list.
+    if current.image != desired.image || current.manifest != desired.manifest {
+        changed.push("source");
     }
     if current.net != desired.net {
         changed.push("net");
@@ -2803,11 +2806,25 @@ mod tests {
         assert!(err.to_string().contains("different config"), "msg: {err}");
         match reconcile_machine_spec(Some(&different), &desired, true).expect("recreate") {
             SpecReconcile::Recreate { changed } => {
-                assert!(changed.contains("image"), "changed: {changed}");
+                assert!(changed.contains("source"), "changed: {changed}");
                 assert!(changed.contains("cpus"), "changed: {changed}");
             }
             other => panic!("expected Recreate, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn config_diff_names_a_manifest_only_source_change() {
+        // A manifest-only swap (no image) must be named — `machine_config_matches`
+        // compares `manifest`, so without this the recreate notice would be empty.
+        let mut current = spec_fixture("web");
+        current.image = None;
+        current.manifest = Some("slot-aaaa".to_string());
+        let mut desired = spec_fixture("web");
+        desired.image = None;
+        desired.manifest = Some("slot-bbbb".to_string());
+        let changed = machine_config_diff(&current, &desired);
+        assert!(changed.contains("source"), "changed: {changed}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem
`machine_config_matches` compares both `image` and `manifest`, but `machine_config_diff` only checks `image`. So recreating a persistent machine with a different `--manifest` (no `--image`) is correctly detected as a config change, yet the recreate notice's `changed` list comes back **empty** — the user isn't told *what* differed.

## Fix
`image` and `manifest` are mutually-exclusive sources; report either change as a single `"source"` entry in the diff. One line + tests.

## Tests
- New `config_diff_names_a_manifest_only_source_change` — a manifest-only swap now names `"source"`.
- Updated `reconcile_creates_reuses_and_force_recreates_on_config_change` to assert `"source"` (was `"image"`).
- 83/83 machine tests pass; fmt/clippy/spec-ref-gate clean.

Found incidentally while reconciling the (already-merged) Plan 208 Task 4 source-axis work — this is the one genuine residual gap.